### PR TITLE
Breadcrumbs updates

### DIFF
--- a/src/styles/00-base/base/_03-mixins.scss
+++ b/src/styles/00-base/base/_03-mixins.scss
@@ -36,11 +36,11 @@
   @include breakpoint($container-max-width) {
     padding-left:
       calc(
-        #{$h-padding} + calc(-50vw + calc(#{$container-max-width} / 2))
+        #{$h-padding} + calc(50vw - calc(#{$container-max-width} / 2))
       );
     padding-right:
       calc(
-        #{$h-padding} + calc(-50vw + calc(#{$container-max-width} / 2))
+        #{$h-padding} + calc(50vw - calc(#{$container-max-width} / 2))
       );
   }
 }

--- a/src/styles/02-molecules/menus/breadcrumbs/_breadcrumbs.scss
+++ b/src/styles/02-molecules/menus/breadcrumbs/_breadcrumbs.scss
@@ -2,6 +2,8 @@ $break-breadcrumbs: $medium; // $medium = 600px
 $break-breadcrumbs-mobile: max-width 599px;
 
 .breadcrumbs {
+  @include breakout;
+
   background-color: $nypl-turquoise-dark;
   padding: $space-xs 0;
 }
@@ -65,13 +67,4 @@ $break-breadcrumbs-mobile: max-width 599px;
 
 .breadcrumbs__link:hover {
   text-decoration: underline;
-}
-
-// Styles only for Pattern Lab
-.pl {
-  #molecules-breadcrumbs {
-    nav {
-      @include breakout;
-    }
-  }
 }

--- a/src/styles/CHANGELOG.md
+++ b/src/styles/CHANGELOG.md
@@ -7,6 +7,13 @@ This repo is in Prerelease. When it is released, this project will adhere to [Se
 
 ========
 ## Prerelease
+## [0.0.4] - 2019-11-15
+### Changed
+- The breakout() mixin now has swapped signs
+
+### Removed
+- Removes PatternLab-specific styles
+
 ## [0.0.3] - 2019-11-15
 ### Changed
 - System-font now gets imported properly


### PR DESCRIPTION
## **This PR does the following:**
- Includes the breakout() mixin on the breadcrumbs directly, as breadcrumbs always break out. Also deletes PL specific code