### PR TITLE
Adding storybook npm scripts to build static sites and a Travis hook to build to gh-pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,11 @@ install:
   - npm run install-all
 script: npm test
 
+deploy:
+  provider: pages
+  skip_cleanup: true
+  keep-history: true
+  github_token: $GITHUB_TOKEN
+  on:
+    branch: development
+  local_dir: storybook

--- a/README.md
+++ b/README.md
@@ -48,3 +48,7 @@ Make sure to include `glob-importer` in your (sass-loader)[https://github.com/NY
 
 ### Importing React Components
 Once the Design System Styles package is imported, follow the steps in the React Components [README](https://github.com/NYPL/nypl-design-system/blob/development/src/react-components/README.md) to import and use the React Components.
+
+### Storybook
+
+When change are merged into `master` (currently using `development`), Travis CI will automatically build the two Twig and React Storybook instances as static sites and deploy them to the `gh-pages` branch. If this needs to be tested locally, run `npm run storybook:static` and then view the `storybook/index.html` file in a browser. No server needs to be running since this is a static web site.

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "install-all": "npm install; lerna run prepare; lerna exec npm install",
     "storybook:twig": "lerna exec --scope storybook npm run start:twig",
     "storybook:react": "lerna exec --scope storybook npm run start:react",
+    "storybook:static": "npm run storybook:static:twig && npm run storybook:static:react",
+    "storybook:static:twig": "lerna exec --scope storybook npm run static:twig",
+    "storybook:static:react": "lerna exec --scope storybook npm run static:react",
     "test": "lerna exec npm test"
   },
   "devDependencies": {

--- a/storybook/.storybook-html/config.js
+++ b/storybook/.storybook-html/config.js
@@ -1,8 +1,8 @@
 import '!style-loader!css-loader!sass-loader!import-glob-loader!@nypl/design-system-styles/style.scss';
 import { configure, load, addDecorator } from '@storybook/html';
 const twig = require('twig');
-import bem from 'design-system-twig/_twig-components/functions/bem';
-import attach_library from 'design-system-twig/_twig-components/functions/sb_attach-library'
+import bem from '@nypl/design-system-twig/_twig-components/functions/bem';
+import attach_library from '@nypl/design-system-twig/_twig-components/functions/sb_attach-library';
 
 twig.extendFunction("bem", bem);
 twig.extendFunction("attach_library", attach_library);

--- a/storybook/index.html
+++ b/storybook/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML>
+<html lang="en">
+<head><meta charset="utf8"></head>
+<body>
+  <ul style="margin: 30px;">
+    <li><a href="storybook-static/react/index.html">React Storybook</a></li>
+    <li><a href="storybook-static/twig/index.html">Twig Storybook</a></li>
+  </ul>
+</body>
+</html>

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -18,6 +18,8 @@
     "build-storybook": "build-storybook",
     "start:twig": "node ../node_modules/@storybook/html/bin/index -p 8001 -c .storybook-html",
     "start:react": "node ../node_modules/@storybook/react/bin/index -p 9001 -c .storybook-react",
+    "static:twig": "node ../node_modules/.bin/build-storybook -c .storybook-html -o ./storybook-static/twig",
+    "static:react": "node ../node_modules/.bin/build-storybook -c .storybook-react -o ./storybook-static/react",
     "clean": "rimraf node-modules",
     "test": "echo \"No Storybook Tests\" "
   },


### PR DESCRIPTION
## **This PR does the following:**
- POC to get two instances of storybook running at the same time and trying to use Github pages for it.
- Travis will run `npm run storybook:static` and then deploy it to `gh-pages`. Locally, this can be tested locally with `npm run storybook:static` and then opening up `storybook/index.html` in a browser (no server needed).

Notes:
1 - Already created a `gh-pages` branch based off `development`.
2 - Already added a Github personal token to the Travis repo so it can run the npm commands and deploy to `gh-pages`.