### PR TITLE
Not ignoring the static storybook folder.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules
 dependencyGraph.json
 public
 .DS_Store
-storybook/storybook-static/
 src/react-components/lib/
 src/react-components/dist/
 src/icons/dist

--- a/README.md
+++ b/README.md
@@ -51,4 +51,6 @@ Once the Design System Styles package is imported, follow the steps in the React
 
 ### Storybook
 
+There should be no need to run the static Storybook instances. Following the instructions above, the two development Storybook instances can run on a server that tracks changes. If the static Storybook npm script is run, make sure to not commit the `storybook/storybook-static` directory.
+
 When change are merged into `master` (currently using `development`), Travis CI will automatically build the two Twig and React Storybook instances as static sites and deploy them to the `gh-pages` branch. If this needs to be tested locally, run `npm run storybook:static` and then view the `storybook/index.html` file in a browser. No server needs to be running since this is a static web site.

--- a/storybook/package.json
+++ b/storybook/package.json
@@ -15,7 +15,6 @@
     "typescript": "^3.6.4"
   },
   "scripts": {
-    "build-storybook": "build-storybook",
     "start:twig": "node ../node_modules/@storybook/html/bin/index -p 8001 -c .storybook-html",
     "start:react": "node ../node_modules/@storybook/react/bin/index -p 9001 -c .storybook-react",
     "static:twig": "node ../node_modules/.bin/build-storybook -c .storybook-html -o ./storybook-static/twig",


### PR DESCRIPTION
### Front End Review:
- Made this a PR because it's important: the static sites will need the local directory `storybook/storybook-static` that gets generated by Storybook. Unfortunately, this cannot be git-ignored. It just needs to be known that this subfolder cannot/should not be committed to the repo and that the static script is only used by Travis.