### PR TITLE
SFR-89 allows passing in of missing link component to editioncard

### DIFF
--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+## PRERELEASE
+### Changed
+- added `noLinkElement` to `EditionCard` to recieve an element
+
 ## [0.0.11] — 2020-01-23
 ### Added 
 - `EditionsList`

--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ## PRERELEASE
 ### Changed
-- added `noLinkElement` to `EditionCard` to recieve an element
+- added `noLinkElement` to `EditionCard` to receive an element
 
 ## [0.0.11] — 2020-01-23
 ### Added 

--- a/src/react-components/src/__tests__/components/EditionCard-test.tsx
+++ b/src/react-components/src/__tests__/components/EditionCard-test.tsx
@@ -23,6 +23,15 @@ describe("EditionCard", () => {
     editionInfo={["Published in New York by Random House", "Written in English", "Under Creative Commons License"]}
   />;
 
+  let missingLinkNoLinkElement = <EditionCard
+    id="card#1"
+    blockName=""
+    coverUrl="https://placeimg.com/300/400/arch"
+    editionHeadingElement={<a href="edition-link">2004 Edition</a>}
+    editionInfo={["Published in New York by Random House", "Written in English", "Under Creative Commons License"]}
+    noLinkElement={<span id="noLinkElement">No Links</span>}
+  />;
+
   let editionCardNoInfo = <EditionCard
     id="card#1"
     blockName=""
@@ -40,12 +49,17 @@ describe("EditionCard", () => {
     })).to.have.lengthOf(2);
   });
 
-  it("Shows an error span if Links are missing", () => {
+  it("Shows an error span if Links are missing and not passed a link element", () => {
     let card = Enzyme.mount(missingLinkEditionCard);
     expect(card.find("h3")).to.have.lengthOf(1);
     expect(card.find("h3").find("a")).to.have.lengthOf(1);
     expect(card.find("img")).to.have.lengthOf(1);
     expect(card.find({className: "edition-card__missing-links"})).to.have.lengthOf(1);
+  });
+
+  it("Shows an error span if Links are missing and not passed a link element", () => {
+    let card = Enzyme.mount(missingLinkNoLinkElement);
+    expect(card.find("#noLinkElement")).to.have.lengthOf(1);
   });
 
   it("Generates Edition Card if no Edition Info is passed", () => {

--- a/src/react-components/src/components/01-atoms/Links/UnderlineLink.tsx
+++ b/src/react-components/src/components/01-atoms/Links/UnderlineLink.tsx
@@ -12,7 +12,7 @@ export interface UnderlineLinkProps {
 
 export default class UnderlineLink extends React.Component<UnderlineLinkProps, {}> {
   constructor(props: UnderlineLinkProps) {
-    super(props);
+  super(props);
   }
 
   render(): JSX.Element {

--- a/src/react-components/src/components/01-atoms/Links/UnderlineLink.tsx
+++ b/src/react-components/src/components/01-atoms/Links/UnderlineLink.tsx
@@ -12,7 +12,7 @@ export interface UnderlineLinkProps {
 
 export default class UnderlineLink extends React.Component<UnderlineLinkProps, {}> {
   constructor(props: UnderlineLinkProps) {
-  super(props);
+    super(props);
   }
 
   render(): JSX.Element {

--- a/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
+++ b/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
@@ -12,7 +12,8 @@ export type EditionDetails = {
   language: string,
   license: string,
   readOnlineLink: string,
-  downloadLink: string
+  downloadLink: string,
+  noLinkElement?: JSX.Element
 };
 
 export interface EditionCardProps {
@@ -28,21 +29,30 @@ export interface EditionCardProps {
 
   readOnlineLink?: string;
   downloadLink?: string;
+
+  noLinkElement?: JSX.Element;
 }
 
 /**
  * EditionCard component that renders information for an edition.
  */
 export default function EditionCard(props: React.PropsWithChildren<EditionCardProps>) {
-  const { id, blockName, modifiers = [], coverUrl,
+  const {
+    id,
+    blockName,
+    modifiers = [],
+    coverUrl,
     editionHeadingElement,
     editionInfo = [],
-    readOnlineLink, downloadLink } = props;
+    readOnlineLink,
+    downloadLink,
+    noLinkElement = <>Unavailable to read online</>
+  } = props;
   const baseClass = "edition-card";
 
   const getButtonsElement = (readOnlineLink: string, downloadLink: string, baseClass: string) => {
     if (!readOnlineLink && !downloadLink) {
-      return <div className={(bem("missing-links", [], baseClass))}>Unavailable to read online</div>;
+      return <div className={(bem("missing-links", [], baseClass))}>{noLinkElement}</div>;
     }
 
     return <div className={bem("card-ctas", [], baseClass)}>

--- a/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
+++ b/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
@@ -13,6 +13,7 @@ export type EditionDetails = {
   license: string,
   readOnlineLink: string,
   downloadLink: string,
+  /** Element to render when there are no links. */
   noLinkElement?: JSX.Element
 };
 
@@ -24,7 +25,6 @@ export interface EditionCardProps {
   coverUrl: string;
 
   editionHeadingElement: JSX.Element;
-
   editionInfo: string[];
 
   readOnlineLink?: string;
@@ -49,13 +49,9 @@ export default function EditionCard(props: React.PropsWithChildren<EditionCardPr
     noLinkElement = <>Unavailable to read online</>
   } = props;
   const baseClass = "edition-card";
-
-  const getButtonsElement = (readOnlineLink: string, downloadLink: string, baseClass: string) => {
-    if (!readOnlineLink && !downloadLink) {
-      return <div className={(bem("missing-links", [], baseClass))}>{noLinkElement}</div>;
-    }
-
-    return <div className={bem("card-ctas", [], baseClass)}>
+  const noLinksElem = <div className={(bem("missing-links", [], baseClass))}>{noLinkElement}</div>;
+  const getButtonsElem = (readOnlineLink: string, downloadLink: string, baseClass: string) =>
+    <div className={bem("card-ctas", [], baseClass)}>
       {readOnlineLink &&
         <BasicLink className={bem("card-info-link", [], baseClass)} url={readOnlineLink}>Read Online</BasicLink>
       }
@@ -63,7 +59,8 @@ export default function EditionCard(props: React.PropsWithChildren<EditionCardPr
         <BasicLink className={bem("card-info-link", [], baseClass)} url={downloadLink}>Download</BasicLink>
       }
     </div>;
-  };
+
+  const btns = readOnlineLink || downloadLink ? getButtonsElem(readOnlineLink, downloadLink, baseClass) : noLinksElem;
 
   return (
     <div className={bem(baseClass, modifiers, blockName)}>
@@ -79,7 +76,7 @@ export default function EditionCard(props: React.PropsWithChildren<EditionCardPr
             })}
           </div>
         }
-        {getButtonsElement(readOnlineLink, downloadLink, baseClass)}
+        {btns}
       </div>
     </div>
   );

--- a/src/react-components/src/components/02-molecules/Cards/SearchResultItem.tsx
+++ b/src/react-components/src/components/02-molecules/Cards/SearchResultItem.tsx
@@ -57,6 +57,7 @@ export default function SearchResultItem(props: React.PropsWithChildren<SearchRe
         editionInfo={[editionInfo.publisherAndLocation, editionInfo.language, editionInfo.license]}
         readOnlineLink={editionInfo.readOnlineLink}
         downloadLink={editionInfo.downloadLink}
+        noLinkElement={editionInfo.noLinkElement}
       ></EditionCard>
       <div className={bem("all-editions", [], baseClass)}>
         {editionsLinkElement}

--- a/src/react-components/src/components/03-organisms/EditionsList/EditionsList.tsx
+++ b/src/react-components/src/components/03-organisms/EditionsList/EditionsList.tsx
@@ -23,7 +23,8 @@ export default function SearchResultsList(props: SearchResultsListProps) {
           editionHeadingElement={edition.editionYearHeading}
           editionInfo={[edition.publisherAndLocation, edition.language, edition.license]}
           readOnlineLink={edition.readOnlineLink}
-          downloadLink={edition.downloadLink} />
+          downloadLink={edition.downloadLink}
+          noLinkElement={edition.noLinkElement} />
       </li>
     )}
   </ul>;

--- a/src/styles/02-molecules/edition-card/_edition-card.scss
+++ b/src/styles/02-molecules/edition-card/_edition-card.scss
@@ -75,6 +75,7 @@
   &__missing-links {
     @include space-inset-s;
 
+    flex: 0 0 200px;
     background-color: $gray-light;
 
     @include breakpoint($medium) {

--- a/src/styles/CHANGELOG.md
+++ b/src/styles/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ========
+## PRERELEASE 
+- `missing-link` span width
+
 ## [0.0.9] — 2020-01-23
 ### Added 
 - Styles for `editions-list`


### PR DESCRIPTION


[ResearchNow Jira Ticket](http://jira.nypl.org/browse/SFR-89)

## **This PR does the following:**
- in EditionCard, changes component that shows when no links are available to something that can be custom passed by the consumer

### Front End Review:
- [ ] View [the example in Storybook](https://reno-XXX-nypl.pantheonsite.io/themes/custom/nypl_emulsify/pattern-lab/public)
- [ ] Check against the [Metronome documentation](http://themetronome.co/components/xxx/?fresh=true)
