### PR TITLE
SFR-135 Changed Editioncard fields to accept elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,9 @@ By default, the repo links everything under `src` for local development.  Someti
 
 ## Publishing
 You can publish npm modules from this repo by running:
-```lerna publish```
+```lerna publish from-git```
+Publishing from sub-folders using `npm publish` will result in broken components - don't do this!
+Please only use `from-git`
 
 `storybook` repo is private - Its version will be bumped, but it will not be published
 

--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -4,13 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
-## PRERELELEASE
+## [0.0.14] - 2020-02-18 
 ### Changed
 - `EditionCard` `EditionInfo` fields accept elements
 - `EditionCard` `ReadOnline` and `Download` fields accept elements
 
-## [0.0.14] - 2020-02-18 
-### Changed
+### [0.0.14] - 2020-02-18
 - added `noLinkElement` to `EditionCard` to receive an element
 
 ## [0.0.11] — 2020-01-23

--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -3,7 +3,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
-## PRERELEASE
+
+## PRERELELEASE
+### Changed
+- `EditionCard` `EditionInfo` fields accept elements
+- `EditionCard` `ReadOnline` and `Download` fields accept elements
+
+## [0.0.14] - 2020-02-18 
 ### Changed
 - added `noLinkElement` to `EditionCard` to receive an element
 

--- a/src/react-components/package-lock.json
+++ b/src/react-components/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/react-components/package.json
+++ b/src/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "0.0.13",
+  "version": "0.0.15",
   "description": "Design System React Components",
   "repository": {
     "type": "git",

--- a/src/react-components/src/__tests__/components/EditionCard-test.tsx
+++ b/src/react-components/src/__tests__/components/EditionCard-test.tsx
@@ -20,7 +20,7 @@ describe("EditionCard", () => {
     blockName=""
     coverUrl="https://placeimg.com/300/400/arch"
     editionHeadingElement={<a href="edition-link" >2004 Edition</a>}
-    editionInfo={[<span id="pub-span">Publisher</span>, "Written in English", <span>License</span>]}
+    editionInfo={[<span id="pub-span">Publisher</span>, "Written in English", <a id="licenceId" href="/licence-page">License</a>]}
     readOnlineLink="#readOnlineUrl"
     downloadLink="#downloadUrl" />;
 
@@ -30,6 +30,16 @@ describe("EditionCard", () => {
     coverUrl="https://placeimg.com/300/400/arch"
     editionHeadingElement={<a href="edition-link">2004 Edition</a>}
     editionInfo={["Published in New York by Random House", "Written in English", "Under Creative Commons License"]}
+  />;
+
+  let elementLinkEditionCard = <EditionCard
+    id="card#1"
+    blockName=""
+    coverUrl="https://placeimg.com/300/400/arch"
+    editionHeadingElement={<a href="edition-link" >2004 Edition</a>}
+    editionInfo={["Published in New York by Random House", "Written in English", "Under Creative Commons License"]}
+    readOnlineLink={<span id="readOnlineSpan">Reading</span>}
+    downloadLink={<span id="downloadSpan">Download</span>}
   />;
 
   let missingLinkNoLinkElement = <EditionCard
@@ -84,5 +94,15 @@ describe("EditionCard", () => {
     expect(card.find("h3")).to.have.lengthOf(1);
     expect(card.find("h3").find("a")).to.have.lengthOf(1);
     expect(card.find("img")).to.have.lengthOf(1);
+    expect(card.find("#pub-span").text()).to.equal("Publisher");
+    expect(card.find("a#licenceId").text()).to.equal("License");
+  });
+
+  it("Passes call-to-action links if it is given as span", () => {
+    let card = Enzyme.mount(elementLinkEditionCard);
+    expect(card.find("h3")).to.have.lengthOf(1);
+    expect(card.find("h3").find("a")).to.have.lengthOf(1);
+    expect(card.find("img")).to.have.lengthOf(1);
+    expect(card.find("#downloadSpan").text()).to.equal("Download");
   });
 });

--- a/src/react-components/src/__tests__/components/EditionCard-test.tsx
+++ b/src/react-components/src/__tests__/components/EditionCard-test.tsx
@@ -15,6 +15,15 @@ describe("EditionCard", () => {
     readOnlineLink="#readOnlineUrl"
     downloadLink="#downloadUrl" />;
 
+  let elementEditionCard = <EditionCard
+    id="card#1"
+    blockName=""
+    coverUrl="https://placeimg.com/300/400/arch"
+    editionHeadingElement={<a href="edition-link" >2004 Edition</a>}
+    editionInfo={[<span id="pub-span">Publisher</span>, "Written in English", <span>License</span>]}
+    readOnlineLink="#readOnlineUrl"
+    downloadLink="#downloadUrl" />;
+
   let missingLinkEditionCard = <EditionCard
     id="card#1"
     blockName=""
@@ -68,5 +77,12 @@ describe("EditionCard", () => {
     expect(card.find("h3").find("a")).to.have.lengthOf(1);
     expect(card.find("img")).to.have.lengthOf(1);
     expect(card.find({className: "edition-card__missing-links"})).to.have.lengthOf(1);
+  });
+
+  it("Generates Edition Card if Edition Info is passed as spans", () => {
+    let card = Enzyme.mount(elementEditionCard);
+    expect(card.find("h3")).to.have.lengthOf(1);
+    expect(card.find("h3").find("a")).to.have.lengthOf(1);
+    expect(card.find("img")).to.have.lengthOf(1);
   });
 });

--- a/src/react-components/src/components/02-molecules/Cards/EditionCard.stories.tsx
+++ b/src/react-components/src/components/02-molecules/Cards/EditionCard.stories.tsx
@@ -47,6 +47,16 @@ export const editionCardWithSomeEditionInfo = () => <EditionCard
   downloadLink="#downloadUrl">
 </EditionCard>;
 
+export const editionCardWithComponentInfo = () => <EditionCard
+  id="card#1"
+  blockName=""
+  coverUrl="https://placeimg.com/300/400/arch"
+  editionHeadingElement={<a href="edition-link" className={bem("link", [], "heading")} >2004 Edition</a>}
+  editionInfo={[<span>Published in New York</span>, "Under Creative Commons License"]}
+  readOnlineLink={<span>Read Online</span>}
+  downloadLink="#downloadUrl">
+</EditionCard>;
+
 export const editionCardWithEmptyEditionInfo = () => <EditionCard
   id="card#1"
   blockName=""

--- a/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
+++ b/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
@@ -9,10 +9,10 @@ export type EditionDetails = {
   editionYearHeading: JSX.Element,
   publisherAndLocation: string,
   coverUrl: string,
-  language: string,
-  license: string,
-  readOnlineLink: string,
-  downloadLink: string,
+  language: string | JSX.Element,
+  license: string | JSX.Element,
+  readOnlineLink: string | JSX.Element,
+  downloadLink: string | JSX.Element,
   /** Element to render when there are no links. */
   noLinkElement?: JSX.Element
 };
@@ -25,10 +25,10 @@ export interface EditionCardProps {
   coverUrl: string;
 
   editionHeadingElement: JSX.Element;
-  editionInfo: string[];
+  editionInfo: (string|JSX.Element)[];
 
-  readOnlineLink?: string;
-  downloadLink?: string;
+  readOnlineLink?: string|JSX.Element;
+  downloadLink?: string|JSX.Element;
 
   noLinkElement?: JSX.Element;
 }
@@ -50,14 +50,20 @@ export default function EditionCard(props: React.PropsWithChildren<EditionCardPr
   } = props;
   const baseClass = "edition-card";
   const noLinksElem = <div className={(bem("missing-links", [], baseClass))}>{noLinkElement}</div>;
-  const getButtonsElem = (readOnlineLink: string, downloadLink: string, baseClass: string) =>
+  const getElem = (link: string|JSX.Element, text: string) => {
+    if (typeof link === "string") {
+      return <BasicLink className={bem("card-info-link", [], baseClass)} url={link}>{text}</BasicLink>;
+    } else {
+      return link;
+    }
+  };
+
+  const getButtonsElem = (readOnlineLink: string | JSX.Element, downloadLink: string | JSX.Element, baseClass: string) =>
     <div className={bem("card-ctas", [], baseClass)}>
       {readOnlineLink &&
-        <BasicLink className={bem("card-info-link", [], baseClass)} url={readOnlineLink}>Read Online</BasicLink>
-      }
+        getElem(readOnlineLink, "Read Online") }
       {downloadLink &&
-        <BasicLink className={bem("card-info-link", [], baseClass)} url={downloadLink}>Download</BasicLink>
-      }
+        getElem(downloadLink, "Download") }
     </div>;
 
   const btns = readOnlineLink || downloadLink ? getButtonsElem(readOnlineLink, downloadLink, baseClass) : noLinksElem;

--- a/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
+++ b/src/react-components/src/components/02-molecules/Cards/EditionCard.tsx
@@ -11,8 +11,14 @@ export type EditionDetails = {
   coverUrl: string,
   language: string | JSX.Element,
   license: string | JSX.Element,
+
+  /** readOnlineLink and downloadLink take in either urls as a string,
+   *  link-type (<a>, <ReactRouter.Link>) elements
+   * TODO: make it so that it only takes elements.
+   * Having it take URLs is confusing and the logic shouldn't live here.*/
   readOnlineLink: string | JSX.Element,
   downloadLink: string | JSX.Element,
+
   /** Element to render when there are no links. */
   noLinkElement?: JSX.Element
 };

--- a/src/styles/CHANGELOG.md
+++ b/src/styles/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ========
-## PRERELEASE 
+## [0.0.12] - 2020-02-18
 - `missing-link` span width
 
 ## [0.0.9] — 2020-01-23


### PR DESCRIPTION
[Project Reno Jira Ticket](http://jira.nypl.org/browse/RENO-XXX)

[ResearchNow Jira Ticket](http://jira.nypl.org/browse/SFR-135)

## **This PR does the following:**
- EditionCard is a bit more flexible
- Made those changes to ReadOnlineLink and DownloadLink while I'm here
- Should I do the same to CoverURL? 

### Front End Review:
- [ ] View [the example in Storybook](https://reno-XXX-nypl.pantheonsite.io/themes/custom/nypl_emulsify/pattern-lab/public)
- [ ] Check against the [Metronome documentation](http://themetronome.co/components/xxx/?fresh=true)
