### PR TITLE
Fixing webpack compiler config and updating name for list component.

### DIFF
--- a/src/react-components/src/components/03-organisms/EditionsList/EditionsList.tsx
+++ b/src/react-components/src/components/03-organisms/EditionsList/EditionsList.tsx
@@ -3,13 +3,13 @@ import * as React from "react";
 import bem from "../../../utils/bem";
 import EditionCard, { EditionDetails } from "../../02-molecules/Cards/EditionCard";
 
-export interface SearchResultsListProps {
+export interface EditionsListProps {
   baseClass?: string;
   modifiers?: string[];
   blockName?: string;
   editions: EditionDetails[];
 }
-export default function SearchResultsList(props: SearchResultsListProps) {
+export default function EditionsList(props: EditionsListProps) {
   const { baseClass = "edition-list", modifiers = [], blockName, editions } = props;
 
   return <ul className={bem(baseClass, modifiers, blockName)}>

--- a/storybook/.storybook-react/webpack.config.js
+++ b/storybook/.storybook-react/webpack.config.js
@@ -46,35 +46,7 @@ module.exports = async ({ config, mode }) => {
     include: [path.resolve(__dirname, './styles/**/*')]
   });
 
-  // Include stories in babel loader
-  const babelRules = config.module.rules.filter(rule => {
-    let isBabelLoader = false;
-
-    if (rule.loader && rule.loader.includes('babel-loader')) {
-      isBabelLoader = true;
-    }
-
-    if (rule.use) {
-      rule.use.forEach(use => {
-        if (typeof use === 'string' && use.includes('babel-loader')) {
-          isBabelLoader = true;
-        } else if (
-          typeof use === 'object' &&
-          use.loader &&
-          use.loader.includes('babel-loader')
-        ) {
-          isBabelLoader = true;
-        }
-      });
-    }
-
-    return isBabelLoader;
-  });
-
-  babelRules.forEach(rule => {
-    rule.include = /../;
-    rule.exclude = /node_modules/;
-  });
+  config.resolve.extensions.push(".ts", ".tsx");
 
   // Return the altered config
   return config;


### PR DESCRIPTION
## **This PR does the following:**
- Fixes webpack compilation error due to ts-loader and babel both being configured. ts-loader uses babel so removing it and allowing it to (along with the doc-gen loader) to compile the code. This is to fix a _production_ issue with the storybook:static command (but development runs just fine).

So now the [production site](https://nypl.github.io/nypl-design-system/storybook/storybook-static/react/index.html?path=/story/*) won't be broken:
![Screen Shot 2020-02-24 at 11 11 37 AM](https://user-images.githubusercontent.com/1280564/75169496-a9dd0800-56f6-11ea-949a-d6bf2e35cabb.png)
 
Also, updated a component name but if that's wrong I can change it back.

### Front End Review:
- [ ] Tested locally using the development and production build.
