### PR TITLE
Configuring the a11y storybook addon for the twig instance.

### DIFF
--- a/storybook/.storybook-html/config.js
+++ b/storybook/.storybook-html/config.js
@@ -1,8 +1,13 @@
 import '!style-loader!css-loader!sass-loader!import-glob-loader!@nypl/design-system-styles/style.scss';
-import { configure, load, addDecorator } from '@storybook/html';
+import { configure, addDecorator } from '@storybook/html';
+import { withA11y } from '@storybook/addon-a11y';
 const twig = require('twig');
 import bem from '@nypl/design-system-twig/_twig-components/functions/bem';
 import attach_library from '@nypl/design-system-twig/_twig-components/functions/sb_attach-library';
+
+// Add all the addons when starting up. Right now, only the accessibility
+// addon is configured.
+addDecorator(withA11y);
 
 twig.extendFunction("bem", bem);
 twig.extendFunction("attach_library", attach_library);

--- a/storybook/.storybook-html/main.js
+++ b/storybook/.storybook-html/main.js
@@ -1,0 +1,10 @@
+/**
+ * Add Storybook Addons to the instance.
+ */
+module.exports = {
+  addons: [
+    '@storybook/addon-a11y/register',
+    '@storybook/addon-actions/register'
+  ]
+};
+

--- a/storybook/.storybook-html/webpack.config.js
+++ b/storybook/.storybook-html/webpack.config.js
@@ -6,16 +6,16 @@ module.exports = ({ config, mode }) => {
   config.resolve.alias['components'] = path.resolve(
     __dirname,
     '../templates/components/'
-  )
+  );
   // `mode` has a value of 'DEVELOPMENT' or 'PRODUCTION'
   // You can change the configuration based on that.
   // 'PRODUCTION' is used when building the static version of storybook.
 
-  config.module.rules.push( {
+  config.module.rules.push({
     test: /\.svg$/,
     include: [path.join(__dirname, "./icons/")],
     loader: "file-loader?name=assets/[name].[ext]"
-});
+  });
 
   // Adds SCSS support
   config.module.rules.push({


### PR DESCRIPTION
## **This PR does the following:**
- Configures the storybook addon-a11y plugin. I'm not sure why but the React configurations picks up the `addons.js` correctly but the twig instance needs a `main.js` file. In any case, any addon can now be used but only enabled the accessibility one for now.

![Screen Shot 2020-03-02 at 11 24 40 AM](https://user-images.githubusercontent.com/1280564/75695947-d05fed80-5c78-11ea-91e2-c17528c5fb48.png)

I do have a question about the breadcrumb storybook: it fails. It can't find the `@nypl/design-system-icons` package. [Example](https://nypl.github.io/nypl-design-system/storybook/storybook-static/twig/index.html?path=/story/breadcrumbs--short-breadcrumbs). It looks like you can remove this block and the story works fine: https://github.com/NYPL/nypl-design-system/blob/development/src/twig/_patterns/02-molecules/menus/breadcrumbs/breadcrumbs.twig#L14
The actual error comes from https://github.com/NYPL/nypl-design-system/blob/development/src/twig/_patterns/01-atoms/images/icons/_icon.twig#L19 . It seems this icon is only used for the mobile responsive view. Was this ever working for this story?

### Front End Review:
- [ ] View local instance of Twig Storybook.
