### PR TITLE
Allowing the Button component to render content passed as children.

### DIFF
--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
+## [0.0.15] - 2020-03-3
+### Changed
+- `Button` component accepts content to render from its `content` prop or its `children` prop.
+
 ## [0.0.14] - 2020-02-18 
 ### Changed
 - `EditionCard` `EditionInfo` fields accept elements

--- a/src/react-components/src/__tests__/components/Button-test.tsx
+++ b/src/react-components/src/__tests__/components/Button-test.tsx
@@ -20,11 +20,6 @@ describe("Button", () => {
     wrapper.simulate("click");
     expect(callback.callCount).to.equal(1);
   });
-  it("optionally renders custom text", () => {
-    expect(wrapper.text()).to.equal("Submit");
-    wrapper.setProps({ content: "Some other string" });
-    expect(wrapper.text()).to.equal("Some other string");
-  });
   it("optionally renders a component", () => {
     let content = <span>Element!</span>;
     wrapper.setProps({ content });
@@ -47,5 +42,40 @@ describe("Button", () => {
     expect(callback.callCount).to.equal(0);
     wrapper.simulate("mouseDown");
     expect(callback.callCount).to.equal(1);
+  });
+
+  describe("rendering content from the content prop", () => {
+    it("should render custom content as a string", () => {
+      wrapper = Enzyme.shallow(<Button id="button" callback={callback} content="Submit" />);
+      expect(wrapper.text()).to.equal("Submit");
+      wrapper.setProps({ content: "Some other string" });
+      expect(wrapper.text()).to.equal("Some other string");
+    });
+    it("should render custom content as an element", () => {
+      const content = <span>I'm a span element</span>;
+      wrapper = Enzyme.shallow(<Button id="button" callback={callback} content={content} />);
+      expect(wrapper.text()).to.equal("I'm a span element");
+      expect(wrapper.find("span")).to.have.lengthOf(1);
+    });
+  });
+
+  describe("rendering content from its children prop", () => {
+    it("should render string children", () => {
+      wrapper = Enzyme.shallow(
+        <Button id="button" callback={callback}>
+          Submit
+        </Button>
+      );
+      expect(wrapper.text()).to.equal("Submit");
+    });
+    it("should render element children", () => {
+      wrapper = Enzyme.shallow(
+        <Button id="button" callback={callback}>
+          <span>I'm a span element</span>
+        </Button>
+      );
+      expect(wrapper.text()).to.equal("I'm a span element");
+      expect(wrapper.find("span")).to.have.lengthOf(1);
+    });
   });
 });

--- a/src/react-components/src/components/01-atoms/Button/Button.stories.tsx
+++ b/src/react-components/src/components/01-atoms/Button/Button.stories.tsx
@@ -8,6 +8,38 @@ export default {
   component: Button,
 };
 
-export const buttonFilledIcon = () => <Button callback={action("clicked")} id="button" content="search" type="filled" iconPosition="left" iconName="search-small" iconDecorative={true}/>;
+export const buttonFilledIcon = () =>
+  <Button
+    callback={action("clicked")}
+    id="button"
+    content="search"
+    type="filled"
+    iconPosition="left"
+    iconName="search-small"
+    iconDecorative={true}
+  />
+;
 export const buttonOutline = () => <Button callback={action("clicked")} id="button" content="Hello World" type="outline" />;
 export const buttonWithSpan = () => <Button callback={action("clicked")} id="button" type="outline" content={<span>Style my span!</span>}/>;
+export const buttonIconChildrenString = () =>
+  <Button
+    callback={action("clicked")}
+    id="button"
+    type="filled"
+    iconPosition="right"
+    iconName="search-small"
+    iconDecorative={true}
+  >Search!</Button>
+;
+export const buttonIconChildrenElement = () =>
+  <Button
+    callback={action("clicked")}
+    id="button"
+    type="outline"
+    iconPosition="right"
+    iconName="search-small"
+    iconDecorative={true}
+  >
+    <span>I'm wrapped in a span!</span>
+  </Button>
+;

--- a/src/react-components/src/components/01-atoms/Button/Button.tsx
+++ b/src/react-components/src/components/01-atoms/Button/Button.tsx
@@ -8,14 +8,18 @@ export interface ButtonProps {
   id: string;
   /** The action to perform on the <button>'s onClick function */
   callback: (event: React.MouseEvent) => void;
-  content: string | JSX.Element;
+  /** The content to render inside the the button. An alternative
+   * to passing children elements. */
+  content?: string | JSX.Element;
   attributes?: {};
+  /** Used for BEM css convention. */
   modifiers?: string[];
+  /** Used for BEM css convention. */
   blockName?: string;
   large?: boolean;
   type?: string;
   mouseDown?: boolean;
-
+  /** If an icon is to be rendered, an `iconPosition` prop is required. */
   iconPosition?: string;
   iconName?: string;
   iconModifiers?: string[];
@@ -34,7 +38,8 @@ export default class Button extends React.Component<ButtonProps, {}> {
 
   render(): JSX.Element {
     const { id, callback, content, attributes, modifiers, blockName, type, mouseDown,
-      iconPosition, iconName, iconModifiers, iconDecorative, iconRole } = this.props;
+      iconPosition, iconName, iconModifiers, iconDecorative, iconRole, children } = this.props;
+
     if (type) {
       if (!(type === "outline" || type === "filled")) {
         throw new Error("Type can only be 'outline' or 'filled'");
@@ -47,26 +52,37 @@ export default class Button extends React.Component<ButtonProps, {}> {
     }
 
     let btnContent: BtnContent[] = [];
-    btnContent.push(typeof(content) === "string" ? content : React.cloneElement(content, {key: `${id}-button-content`}));
+
+    // Use either the content prop or the children prop for the rendered content.
+    const contentToRender = content ? content : children;
+    if (contentToRender) {
+      // Make sure we can handle both string and element cases.
+      const contentProp = typeof(contentToRender) === "string" ?
+        contentToRender :
+        React.cloneElement(contentToRender as any, {key: `${id}-button-content`});
+      btnContent.push(contentProp);
+    }
 
     let button_base_class = "button";
 
-    let iconProps = {
-      name: iconName,
-      key: `icon-${id}`,
-      blockName: button_base_class,
-      modifiers: ["small"],
-      decorative: iconDecorative,
-      desc: iconDecorative,
-      role: iconDecorative ? undefined : iconRole,
-      title: iconDecorative
-    };
-
-    if (iconModifiers) {
-      iconProps.modifiers.push(...iconModifiers);
-    }
-
+    // An icon needs a position in order for it to be created and
+    // rendered in the button.
     if (iconPosition) {
+      let iconProps = {
+        name: iconName,
+        key: `icon-${id}`,
+        blockName: button_base_class,
+        modifiers: ["small"],
+        decorative: iconDecorative,
+        desc: iconDecorative,
+        role: iconDecorative ? undefined : iconRole,
+        title: iconDecorative
+      };
+
+      if (iconModifiers) {
+        iconProps.modifiers.push(...iconModifiers);
+      }
+
       buttonModifiers.push("icon");
 
       if (iconPosition === "left") {


### PR DESCRIPTION
Fixes an [issue](https://github.com/NYPL/nypl-design-system/projects/2#card-33030028) found in the backlog. Also adding more inline comments here and there.

## **This PR does the following:**
- Allows the `Button` component to either render content from its `render` prop or with content passed down as children.

### Front End Review:
- [ ] View [the example in Storybook](https://reno-XXX-nypl.pantheonsite.io/themes/custom/nypl_emulsify/pattern-lab/public)

