### PR TITLE
SFR-865 fixed spacing in buttons and 'unavailable' in Edition card

### DIFF
--- a/src/styles/02-molecules/edition-card/_edition-card.scss
+++ b/src/styles/02-molecules/edition-card/_edition-card.scss
@@ -39,7 +39,9 @@
 
   &__card-ctas {
     display: flex;
+    width: 100%;
     flex-flow: row nowrap;
+    justify-content: center;
 
     @include breakpoint($medium) {
       @include space-inline-s;
@@ -55,7 +57,6 @@
     @include button--filled;
 
     flex: 1 1 100%;
-
     &:not(:last-child) {
       @include space-inline-s;
     }
@@ -73,7 +74,8 @@
   &__missing-links {
     @include space-inset-s;
 
-    flex: 0 0 200px;
+    flex: 0 0 auto;
+    width: 200px;
     background-color: $gray-light;
 
     @include breakpoint($medium) {

--- a/src/styles/CHANGELOG.md
+++ b/src/styles/CHANGELOG.md
@@ -6,11 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ========
-## [0.0.13] 
-- `edition-card` image now has a max-size in mobile 
+## [0.0.12] 
+- `edition-card` mobile fixes
 - `header-with-search` has an inset
-
-## [0.0.12] - 2020-02-18
 - `missing-link` span width
 
 ## [0.0.9] — 2020-01-23


### PR DESCRIPTION
[Project Reno Jira Ticket](http://jira.nypl.org/browse/RENO-XXX)

[ResearchNow Jira Ticket](http://jira.nypl.org/browse/SFR-865)

## **This PR does the following:**
- edition card spacing fixes:  Compare https://nypl.github.io/nypl-design-system/storybook/storybook-static/react/index.html?path=/story/edition-card--edition-card-missing-links (mobile view) with 
![Screen Shot 2020-03-17 at 9 15 04 AM](https://user-images.githubusercontent.com/3579472/76859603-059b3c80-6830-11ea-88e2-29998a047112.png)
- Compare https://nypl.github.io/nypl-design-system/storybook/storybook-static/react/index.html?path=/story/edition-card--edition-card-with-full-data with 
![Screen Shot 2020-03-17 at 9 14 54 AM](https://user-images.githubusercontent.com/3579472/76859760-4c893200-6830-11ea-9c62-da6e885fab53.png)



### Front End Review:
- [ ] View [the example in Storybook](https://reno-XXX-nypl.pantheonsite.io/themes/custom/nypl_emulsify/pattern-lab/public)
- [ ] Check against the [Metronome documentation](http://themetronome.co/components/xxx/?fresh=true)
