### PR TITLE
[font-stack-fix] Updates the font-stack

### DIFF
--- a/src/styles/00-base/02-typography/01-typefaces/_typefaces.scss
+++ b/src/styles/00-base/02-typography/01-typefaces/_typefaces.scss
@@ -1,5 +1,5 @@
 // Typography Variables
 @import '~system-font-css/_system-font.scss';
 
-$font-body: system-ui, sans-serif;
-$font-heading: system-ui, sans-serif;
+$font-body: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+$font-heading: -apple-system, BlinkMacSystemFont, system-ui, sans-serif;

--- a/src/styles/CHANGELOG.md
+++ b/src/styles/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ========
+## [0.0.18] - 2020-04-24
+### Changed
+- Updates the top of the font stack to include `-apple-system, BlinkMacSystemFont` to fix the Apple typefaces from not loading in Mac Firefox
+
 ## [0.0.17] - 2020-04-23
 ### Changed
 - Reverted `@link` and `@more-link` mixins to content pre-0.0.16

--- a/src/styles/package.json
+++ b/src/styles/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-styles",
-  "version": "0.0.17",
+  "version": "0.0.18",
   "description": "Design System Styles",
   "scripts": {
     "test": "echo \"There are no tests for styles\" "


### PR DESCRIPTION
## **This PR does the following:**
- Updates the font-stack to include `-apple-system` and `BlinkMacSystemFont` for Firefox to have access to the Mac stack
- Doesn't identify why this fix is even needed, though 🤔

### Front End Review:
- [ ] View [Storybook in Firefox on Mac](https://reno-XXX-nypl.pantheonsite.io/themes/custom/nypl_emulsify/pattern-lab/public)
- [ ] Check that the font(s) loaded in the Font Panel in the Inspector are ".SF NS"