### PR TITLE
SFR-821 added SearchValue to RNHeaderWithSearch element

### DIFF
--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
+## [0.3.4]
+- Exported `searchValue` and `selectedField` in `RNHeaderWithSearch`
+
 ## [0.3.3] 
 - Added `blockName` handling to `DateRangeForm`
 

--- a/src/react-components/src/components/02-molecules/SearchBar/SearchBar.tsx
+++ b/src/react-components/src/components/02-molecules/SearchBar/SearchBar.tsx
@@ -37,15 +37,26 @@ export interface SearchBarProps {
 
 export default function SearchBar(props: SearchBarProps) {
 
-  const { blockName,
-    searchBarId, buttonId,
-    searchBarAriaLabel, searchBarAriaLabelledBy,
-    dropdownId, dropdownOptions, dropdownAriaLabel,
-    selectedField, searchValue,
+  const {
+    blockName,
+    searchBarId,
+    buttonId,
+    searchBarAriaLabel,
+    searchBarAriaLabelledBy,
+    dropdownId,
+    dropdownOptions,
+    dropdownAriaLabel,
+    selectedField,
+    searchValue,
     placeholderText,
     helperVariant,
-    hasError, errorMessage,
-    selectBlurHandler, searchSubmitHandler, selectChangeHandler, searchChangeHandler } = props;
+    hasError,
+    errorMessage,
+    selectBlurHandler,
+    searchSubmitHandler,
+    selectChangeHandler,
+    searchChangeHandler
+  } = props;
 
   if (dropdownOptions) {
     if (!(dropdownId && dropdownAriaLabel && selectBlurHandler && selectChangeHandler)) {
@@ -69,7 +80,6 @@ export default function SearchBar(props: SearchBarProps) {
 
   let searchbar__base_class = "search-bar";
 
-  /* TODO: after SFR-637 is merged, Replace Error with MT-51 and add its id to TextField's aria-labelledBy*/
   let textfieldProps = {
     id: searchBarId + "-input-textfield",
     ariaLabelledBy: buttonId,
@@ -112,7 +122,6 @@ export default function SearchBar(props: SearchBarProps) {
     <div className={bem("input-group", [], searchbar__base_class)}>
       <TextField {...textfieldProps}></TextField>
       <Button callback={searchSubmitHandler} {...buttonProps} >{buttonProps.content}</Button>
-      {/* TODO: after SFR-637 is merged, Replace Error with MT-51 and add its id to TextField's aria-labelledBy*/}
       {hasError && !helperVariant && <span className={bem("input-description", modifiers, searchbar__base_class)}>{errorMessage}</span>}
     </div>
   </form>;

--- a/src/react-components/src/components/03-organisms/Headers/RNHeaderWithSearch.tsx
+++ b/src/react-components/src/components/03-organisms/Headers/RNHeaderWithSearch.tsx
@@ -4,12 +4,13 @@ import SearchBar from "../../02-molecules/SearchBar/SearchBar";
 import bem from "../../../utils/bem";
 import RNSectionTitle from "../../01-atoms/Text/Headings/RNSectionTitle";
 
-
 export interface RNHeaderWithSearchProps {
   modifiers?: [];
   searchBarId: string;
   searchButtonId: string;
   searchBarAriaLabel: string;
+  searchValue?: string;
+  selectedField?: string;
   dropdownId: string;
   sectionTitle: JSX.Element;
   textFieldAriaLabel: string;
@@ -27,11 +28,22 @@ export interface RNHeaderWithSearchProps {
 
 export default function RNHeaderWithSearch(props: React.PropsWithChildren<RNHeaderWithSearchProps>) {
 
-  const { sectionTitle, searchBarId, searchBarAriaLabel,
-    searchButtonId, hasError, errorMessage,
-    dropdownId, searchDropdownOptions,
-    textFieldAriaLabel, advancedSearchElem,
-    selectChangeHandler, selectBlurHandler, searchSubmitHandler, textChangeHandler } = props;
+  const { sectionTitle,
+    searchBarId,
+    searchBarAriaLabel,
+    searchValue,
+    selectedField,
+    searchButtonId,
+    hasError,
+    errorMessage,
+    dropdownId,
+    searchDropdownOptions,
+    textFieldAriaLabel,
+    advancedSearchElem,
+    selectChangeHandler,
+    selectBlurHandler,
+    searchSubmitHandler,
+    textChangeHandler } = props;
   const base_class = "search-header";
 
   return (
@@ -43,6 +55,8 @@ export default function RNHeaderWithSearch(props: React.PropsWithChildren<RNHead
         <SearchBar
           searchBarId={searchBarId}
           searchBarAriaLabel={searchBarAriaLabel}
+          searchValue={searchValue}
+          selectedField={selectedField}
           blockName={base_class}
           buttonId={searchButtonId}
           dropdownId={dropdownId}


### PR DESCRIPTION
[Project Reno Jira Ticket](http://jira.nypl.org/browse/RENO-XXX)

[ResearchNow Jira Ticket](http://jira.nypl.org/browse/SFR-821)

## **This PR does the following:**
- Exports `SelectedField` and `SearchValue` in the Header with Search components as optional values so they can be used to prepopulate 

### Front End Review:
- [ ] View [the example in Storybook](https://reno-XXX-nypl.pantheonsite.io/themes/custom/nypl_emulsify/pattern-lab/public)
- [ ] Check against the [Metronome documentation](http://themetronome.co/components/xxx/?fresh=true)
