### PR TITLE
#127 update the hover color of RNSectionTitle Links on Dark Backgrounds

### DIFF
--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -1,102 +1,127 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
+Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
-## [0.3.5]
-- Improve the hover color contrasts for `RNSectionTitle` links on dark backgrounds
 
 ## [0.3.4]
+
 - Exported `searchValue` and `selectedField` in `RNHeaderWithSearch`
 
-## [0.3.3] 
+## [0.3.3]
+
 - Added `blockName` handling to `DateRangeForm`
 
 ## [0.3.1]
+
 - Exports `SectionName` and `Image`
 
 ## [0.3.0]
+
 ### Breaking Changes
+
 - Edition Card no longer accepts strings for links and descriptions
 
 ### Changed
+
 - Added `iconName` as an optional prop in `IconLink`
 
 ## [0.2.1] - 2020-04-23
+
 ### Removed
+
 - `HeaderWithImageRight` component and corresponding story
 
 ## [0.2.0] - 2020-04-13
+
 ### Changed
+
 - Reworks `HeaderWithImageRight` into `Hero`, which accepts values from an enum to display different kinds of heros based on [this documentation page](https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=10968%3A5314)
 
-## [0.1.1] 
+## [0.1.1]
+
 ### Changed
+
 - `Textfield` id is no longer duplicated
 - `Dropdown` now applies `bem` `blockName`
 - `Pagination` now passes in `blockName` into `Dropdown`
 
 ## [0.1.0]
+
 ### Breaking Changes
-- Large classes now have `Opts` inteface that allows for the component to be built over multiple steps. This affects: 
-    - `HelperErrorText`
-    - `Label`
-    - `TextField`
-    - `Button`
+
+- Large classes now have `Opts` inteface that allows for the component to be built over multiple steps. This affects:
+  - `HelperErrorText`
+  - `Label`
+  - `TextField`
+  - `Button`
 - Deprecated `SearchResultsList`, `IconLinkList` and `EditionsList` in favor of `UnorderedList`
-- `type` in `Button` now corresponds to html button types.  `buttonType` in button corresponds to the visual categories of buttons (eg: `filled`, `outline`)
+- `type` in `Button` now corresponds to html button types. `buttonType` in button corresponds to the visual categories of buttons (eg: `filled`, `outline`)
 - `subtitle` in `SearchResultsItem` changed to `subtitleContent` to take a JSX
 - `Label` and `Button` only accept children when called directly
 
-### Added: 
+### Added:
+
 - `Checkbox`
-- `DateRangeForm` 
+- `DateRangeForm`
 - `Input`
-- `Accordion` 
+- `Accordion`
 - `UnorderedList`
-- `Modal`
-========
+- # `Modal`
 
 ## [0.0.17] - 2020-03-17
+
 - Changelog update
 
 ## [0.0.16]
+
 - `HeaderImgRight` accepts elements
 
 ## [0.0.15] - 2020-03-3
+
 ### Changed
+
 - `Button` component accepts content to render from its `content` prop or its `children` prop.
 
-## [0.0.14] - 2020-02-18 
+## [0.0.14] - 2020-02-18
+
 ### Changed
+
 - `EditionCard` `EditionInfo` fields accept elements
 - `EditionCard` `ReadOnline` and `Download` fields accept elements
 
 ### [0.0.14] - 2020-02-18
+
 - added `noLinkElement` to `EditionCard` to receive an element
 
 ## [0.0.11] — 2020-01-23
-### Added 
+
+### Added
+
 - `EditionsList`
 
-## [0.0.10] - 2020-01-14 
-### Added 
+## [0.0.10] - 2020-01-14
+
+### Added
+
 - `Dropdown` which controls `FormDropdown` and its corresponding `Label`
-- `Label` 
-- `HelperErrorText` 
+- `Label`
+- `HelperErrorText`
 - `Pagination`
 - `EditionCard` component
-- `SearchResultItem` component that uses `EditionCard` 
-- `RN Header With Search` 
+- `SearchResultItem` component that uses `EditionCard`
+- `RN Header With Search`
 - a story for `RN Section Title`, which is just a collection of styles
 - `SearchResultsList` component
 
 ### Changed
+
 - added `iconModifiers` to `Button`
 - `buttonId` in `Button` is now required
 - refactored `FormDropdown` to not include its own `label`
-- `RN Header With Search` 
+- `RN Header With Search`
 - a story for `RN Section Title`, which is just a collection of styles
 - `Link` -> `BasicLink` for clarity
 - Bugfixes in `UnderlineLink` and `IconLink`
@@ -104,58 +129,73 @@ Currently, this repo is in Prerelease.  When it is released, this project will a
 - `Link` missing URL error message
 - Consolidated `Heading` and `PageTitle`
 - `Heading` now only takes a single span
-- Added ResearchNow specific `SearchBar` error state 
+- Added ResearchNow specific `SearchBar` error state
 - A11Y changes for `SearchBar` and `HeaderWithSearch`
 - Added stories for AT-79, AT-264 and AT-3
 - `selectedOption` added to `FormDropdown` stores selected state
 
 ## [0.0.7] - 2020-01-03
+
 ### Added
+
 - A webpack file in order to build and distribute a compiled version of the react components. Does not replace the /lib folder usage, but the main file is now pointing to `/dist/design-system-react-components.min.js`.
 
 ## [0.0.6] - 2019-12-31
+
 ### Added
+
 - `Image` for 2:1 ratio
 - `PageTitle`
 - `Header with Image Right`
 - `FormDropdown`
 - `SearchPromo`
 
-### Changed 
-- Moved heading-related atoms from `01-atoms/Text` into `01-atoms/Text/Heading` 
+### Changed
+
+- Moved heading-related atoms from `01-atoms/Text` into `01-atoms/Text/Heading`
 - Updated `Searchbar` component to include Parameters
-- Changed `Breadcrumb` export from `Breadcrumbs` 
+- Changed `Breadcrumb` export from `Breadcrumbs`
 
 ## [0.0.5] - 2019-12-06
+
 ### Changed
+
 - `Icon` import
 
 ## [0.0.4] - 2019-12-06
+
 ### Added
+
 - `Body text` component for plain-text elements
 - `UnderlineLink` and `IconLink` for links
 - `Icon` component that uses the `design-system-icons` package.
 - `SectionTitle` and `Heading` for heading components
-- `IconLink-List`for the list of subject links 
-- `Button` and `TextField` for the searchbar 
+- `IconLink-List`for the list of subject links
+- `Button` and `TextField` for the searchbar
 - `SearchBar` component
 
-### Changed 
+### Changed
+
 - `Breadcrumb` now shows icon in mobile view
 
 ## [0.0.3] - 2019-11-15
+
 ### Changed
+
 - Changed `Breadcrumb` to `Breadcrumbs` to match Twig
 - Changed the Breadcrumbs props to accept components
 
 ## [0.0.2] - 2019-11-13
+
 ### Added
+
 - Started a change log
 - Added the Breadcrumb React Component
 
 ### Changed
+
 - Changed folder structure to match Twig
 
 ## [0.0.1] - 2019-11-13
-- Published as a test
 
+- Published as a test

--- a/src/react-components/CHANGELOG.md
+++ b/src/react-components/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease.  When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
+## [0.3.5]
+- Improve the hover color contrasts for `RNSectionTitle` links on dark backgrounds
+
 ## [0.3.4]
 - Exported `searchValue` and `selectedField` in `RNHeaderWithSearch`
 

--- a/src/react-components/package.json
+++ b/src/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "Design System React Components",
   "repository": {
     "type": "git",

--- a/src/react-components/src/__tests__/components/Hero-test.tsx
+++ b/src/react-components/src/__tests__/components/Hero-test.tsx
@@ -12,107 +12,158 @@ import Hero from "../../components/03-organisms/Hero/Hero";
 
 describe("Hero Test", () => {
   it("Generates a Hero with a background image", () => {
-    let wrapper = Enzyme.shallow(<Hero
-      heroType={HeroTypes.Primary}
-      heading={<Heading
-        level={1}
-        id={"1"}
-        text={"Hero Primary"}
-        blockName={"hero"}
-      />}
-      backgroundImageSrc="https://placeimg.com/1600/800/arch">
-    ></Hero>);
-    expect(wrapper.prop("style")).to.deep.equal({ backgroundImage: "url(https://placeimg.com/1600/800/arch)" });
-
+    let wrapper = Enzyme.shallow(
+      <Hero
+        heroType={HeroTypes.Primary}
+        heading={
+          <Heading
+            level={1}
+            id={"1"}
+            text={"Hero Primary"}
+            blockName={"hero"}
+          />
+        }
+        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+      ></Hero>
+    );
+    expect(wrapper.prop("style")).to.deep.equal({
+      backgroundImage: "url(https://placeimg.com/1600/800/arch)",
+    });
   });
 
   it("Generates a Hero with a foreground image", () => {
-    let wrapper = Enzyme.shallow(<Hero
-      heroType={HeroTypes.Secondary}
-      heading={<Heading
-        level={1}
-        id={"1"}
-        text={"Hero Secondary"}
-        blockName={"hero"}
-      />}
-      image={<Image
-        src="https://placeimg.com/800/400/arch"
-        isDecorative={true}
-        imageBlockname={"hero"}
-      />}
-    ></Hero>);
+    let wrapper = Enzyme.shallow(
+      <Hero
+        heroType={HeroTypes.Secondary}
+        heading={
+          <Heading
+            level={1}
+            id={"1"}
+            text={"Hero Secondary"}
+            blockName={"hero"}
+          />
+        }
+        image={
+          <Image
+            src="https://placeimg.com/800/400/arch"
+            isDecorative={true}
+            imageBlockname={"hero"}
+          />
+        }
+      ></Hero>
+    );
     expect(wrapper.find("Image").dive().find("img")).to.have.lengthOf(1);
   });
 
   it("On primary hero, background image is required", () => {
-    expect(() => Enzyme.mount(<Hero
-      heroType={HeroTypes.Primary}
-      heading={<Heading
-        level={1}
-        id={"1"}
-        text={"Hero Primary"}
-        blockName={"hero"}
-      />}
-      image={<Image
-        src="https://placeimg.com/800/400/arch"
-        isDecorative={true}
-        imageBlockname={"hero"}
-      />}
-    ></Hero>))
-    .to.throw("backgroundImageSrc required on PRIMARY heroTypes");
+    expect(() =>
+      Enzyme.mount(
+        <Hero
+          heroType={HeroTypes.Primary}
+          heading={
+            <Heading
+              level={1}
+              id={"1"}
+              text={"Hero Primary"}
+              blockName={"hero"}
+            />
+          }
+          image={
+            <Image
+              src="https://placeimg.com/800/400/arch"
+              isDecorative={true}
+              imageBlockname={"hero"}
+            />
+          }
+        ></Hero>
+      )
+    ).to.throw("backgroundImageSrc required on PRIMARY heroTypes");
   });
 
   it("Throws error if both backgroundImage and foregroundImage are passed", () => {
-    expect(() => Enzyme.mount(<Hero
-      heroType={HeroTypes.Secondary}
-      heading={<Heading
-        level={1}
-        id={"1"}
-        text={"Hero Secondary"}
-        blockName={"hero"}
-      />}
-      image={<Image
-        src="https://placeimg.com/800/400/arch"
-        isDecorative={true}
-        imageBlockname={"hero"}
-      />}
-      backgroundImageSrc="https://placeimg.com/1600/800/arch"
-    ></Hero>))
-    .to.throw("Please only either backgroundImageSrc or image into Hero, got both");
+    expect(() =>
+      Enzyme.mount(
+        <Hero
+          heroType={HeroTypes.Secondary}
+          heading={
+            <Heading
+              level={1}
+              id={"1"}
+              text={"Hero Secondary"}
+              blockName={"hero"}
+            />
+          }
+          image={
+            <Image
+              src="https://placeimg.com/800/400/arch"
+              isDecorative={true}
+              imageBlockname={"hero"}
+            />
+          }
+          backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        ></Hero>
+      )
+    ).to.throw(
+      "Please only either backgroundImageSrc or image into Hero, got both"
+    );
   });
 
   it("Throws error if locationDetails are based to non-primary hero types", () => {
-    expect(() => Enzyme.mount(<Hero
-      heroType={HeroTypes.Secondary}
-      heading={<Heading
-        level={1}
-        id={"1"}
-        text={"Hero Secondary"}
-        blockName={"hero"}
-      />}
-      image={<Image
-        src="https://placeimg.com/800/400/arch"
-        isDecorative={true}
-        imageBlockname={"hero"}
-      />}
-      locationDetails={<Placeholder>Placeholder for locationDetails, which doesn't exist yet</Placeholder>}
-    ></Hero>))
-    .to.throw("Please provide locationDetails only to PRIMARY heroTypes");
+    expect(() =>
+      Enzyme.mount(
+        <Hero
+          heroType={HeroTypes.Secondary}
+          heading={
+            <Heading
+              level={1}
+              id={"1"}
+              text={"Hero Secondary"}
+              blockName={"hero"}
+            />
+          }
+          image={
+            <Image
+              src="https://placeimg.com/800/400/arch"
+              isDecorative={true}
+              imageBlockname={"hero"}
+            />
+          }
+          locationDetails={
+            <Placeholder>
+              Placeholder for locationDetails, which doesn't exist yet
+            </Placeholder>
+          }
+        ></Hero>
+      )
+    ).to.throw("Please provide locationDetails only to PRIMARY heroTypes");
   });
 
   it("Throws error if only one var is passed between foregroundColor and backgroundColor", () => {
-    expect(() => Enzyme.mount(<Hero
-      heroType={HeroTypes.Primary}
-      heading={<Heading
-        level={1}
-        id={"1"}
-        text={"Syncretic Vibrations: Exploring the Mosaic of Blackness through the Melville J. and Frances S.Herskovits Collection"}
-        blockName={"hero"}
-      />}
-      locationDetails={<Placeholder>Placeholder for locationDetails, which doesn't exist yet</Placeholder>}
-      foregroundColor="#ffffff"
-      backgroundImageSrc="https://p24.f4.n0.cdn.getcloudapp.com/items/NQuDO4xO/index.jpeg?v=d49888fbe420dd2fd163adc2ad0cdac6"
-    />))
-    .to.throw("Please provide both foregroundColor and backgroundColor to Hero, only got foregroundColor");
+    expect(() =>
+      Enzyme.mount(
+        <Hero
+          heroType={HeroTypes.Primary}
+          heading={
+            <Heading
+              level={1}
+              id={"1"}
+              text={
+                "Syncretic Vibrations: Exploring the Mosaic of Blackness through the Melville J. and Frances S.Herskovits Collection"
+              }
+              blockName={"hero"}
+            />
+          }
+          locationDetails={
+            <Placeholder>
+              Placeholder for locationDetails, which doesn't exist yet
+            </Placeholder>
+          }
+          foregroundColor="#ffffff"
+          backgroundImageSrc="https://p24.f4.n0.cdn.getcloudapp.com/items/NQuDO4xO/index.jpeg?v=d49888fbe420dd2fd163adc2ad0cdac6"
+        />
+      )
+    ).to.throw(
+      "Please provide both foregroundColor and backgroundColor to Hero, only got foregroundColor"
+    );
   });
 });

--- a/src/react-components/src/components/01-atoms/Text/Headings/RNSectionTitle.stories.tsx
+++ b/src/react-components/src/components/01-atoms/Text/Headings/RNSectionTitle.stories.tsx
@@ -5,15 +5,21 @@ import bem from "../../../../utils/bem";
 
 export default {
   title: "Research Now Section Title",
-  component: RNSectionTitle
+  component: RNSectionTitle,
 };
 
-
-
-export const researchNowSectionTitle = () => <RNSectionTitle>
-  <a className={`${bem("rn-section-title", [])} rn-section-title`} href={"researchNow-home-url"}>
-    <span id={"research-now-title"}>
-      Research<span className={bem("emphasis", [], "rn-section-title")}>Now</span>
-    </span>
-  </a>
-</RNSectionTitle>;
+export const researchNowSectionTitle = () => (
+  <RNSectionTitle>
+    <a
+      className={`${bem("rn-section-title", [
+        "dark-background",
+      ])} rn-section-title`}
+      href={"researchNow-home-url"}
+    >
+      <span id={"research-now-title"}>
+        Research
+        <span className={bem("emphasis", [], "rn-section-title")}>Now</span>
+      </span>
+    </a>
+  </RNSectionTitle>
+);

--- a/src/styles/01-atoms/text/headings/_research-now-section-title.scss
+++ b/src/styles/01-atoms/text/headings/_research-now-section-title.scss
@@ -1,5 +1,6 @@
 .rn-section-title {
   @include heading-xl;
+  @include link;
 
   background-color: $nypl-turquoise-regular;
   color: $white;

--- a/src/styles/CHANGELOG.md
+++ b/src/styles/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Changelog
+
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
@@ -6,43 +7,64 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 
 ========
+
+## [0.3.5]
+
+- Improve the hover color contrasts for `RNSectionTitle` links on dark backgrounds
+
 ## [0.0.21]
+
 ### [Changed]
+
 - `Edition Card` doesn't collapse on webkit browsers
 - `Accordion` button is not outlined
 - `DateRangeForm` elements stack properly
 
-##[0.0.20] 
+##[0.0.20]
+
 ### Changed
+
 - `Edition Card` image is now centered in mobile
 - `RNHeaderWithSearch` applies the `--dark-background` link modifier
 
 ## [0.0.19]
-### Changed 
+
+### Changed
+
 - `Edition card` `card-info-link` is generalized and does not apply button-like styles
 - `more-link` icon margins use `--icon-left` and `--icon-right` modifiers instead of `left` and `right` modifiers to separate them from rotation
 
 ## [0.0.18] - 2020-04-24
+
 ### Changed
+
 - Updates the top of the font stack to include `-apple-system, BlinkMacSystemFont` to fix the Apple typefaces from not loading in Mac Firefox
 
 ## [0.0.17] - 2020-04-23
+
 ### Changed
+
 - Reverted `@link` and `@more-link` mixins to content pre-0.0.16
 - Reverts link-color to `nypl-blue-regular` and `nypl-blue-dark` for default and hover states respectively
 
 ## [0.0.16] - 2020-04-21
+
 ### Breaking Changes
+
 - Reworks `HeaderWithImageRight` into `Hero`, which accepts values from an enum to display different kinds of heros based on [this documentation page](https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=10968%3A5314)
 
-## [0.0.15] 
+## [0.0.15]
+
 ### Changed
+
 - Styles fixes to dropdown, accordion, pagination
 
-## [0.0.14] 
-### Added 
-- Styles for `modal`, 
-- `link` and `justify-right` variations to `button` 
+## [0.0.14]
+
+### Added
+
+- Styles for `modal`,
+- `link` and `justify-right` variations to `button`
 - `unordered-list` class to `text`
 - `checkbox`
 - `date-range`
@@ -50,39 +72,51 @@ This repo is in Prerelease. When it is released, this project will adhere to [Se
 - `accordion`
 
 ### Changed
-- `dropdown` labels now scale and fill page as needed. 
+
+- `dropdown` labels now scale and fill page as needed.
 
 ## [0.0.13] - 2020-03-17
+
 - `edition-card` mobile fixes
 - `header-with-search` has an inset
 
 ## [0.0.12] - 2020-02-18
+
 - `missing-link` span width
 
 ## [0.0.9] — 2020-01-23
-### Added 
+
+### Added
+
 - Styles for `editions-list`
 
 ## [0.0.8] - 2020-01-15
+
 ### Added
+
 - Styles for `edition-card`
 - Styles for `header-with-search`
 - Styles for `search-results-list`
 - Styles for `pagination`
 
 ### Changed
+
 - Updated `_text.scss` to accomodate the change from Kievit > `system-font-ui`
 - `heading-xl` mixin `font weight: normal` -> `lighter`
 - `button` type-size and letter-spacing
 
 ## [0.0.7] - 2020-01-03
+
 ### Changes
+
 - Changes the `$nypl-turquoise` variables to match what is in `IA + Templates` in Figma
 - Tightens up media queries on header-with-image-right
 - Changes `breakpoint` in `wrapper` mixin so that it reads `max-width` correctly
 
 ## [0.0.6] - 2019-12-06
+
 ### Added
+
 - Styles for `page-title`
 - Styles for `header-with-image-right`
 - Adds color variable for `$form-focus`
@@ -90,40 +124,54 @@ This repo is in Prerelease. When it is released, this project will adhere to [Se
 - Styles for `search-promo`
 
 ### Changed
+
 - Refactors `select` styles to use BEM
 
 ## [0.0.5] - 2019-12-06
+
 ### Added
+
 - Styles for `iconlink-list`
 
 ### Changed
+
 - `more-link` can now take an icon on the right or left
 - Moved `icons` from within `atoms/images` to `atoms` with a `_` prefix so it is globbed before other atoms
 - `_pl-base.scss_` renamed to `_storybook-only-styles.scss`
 
 ### Removed
+
 - Removes patternlab-specific styles
 
 ## [0.0.4] - 2019-11-15
+
 ### Changed
+
 - The breakout() mixin now has swapped signs
 
 ### Removed
+
 - Removes PatternLab-specific styles
 
 ## [0.0.3] - 2019-11-15
+
 ### Changed
+
 - System-font now gets imported properly
 
 ## [0.0.2] - 2019-11-13
+
 ### Added
+
 - Started a change log
 - Added mixins from Reno to keep up to parity
 
 ### Changed
+
 - Added a margin to Breadcrumb's trailing slash.
 - Breadcrumb uses `inline` instead of `inline-flex` so that word breaks wrap properly
 - Changed the breakpoint for mobile to be smaller
 
 ## [0.0.1] - 2019-11-13
+
 - Published as a test


### PR DESCRIPTION
Resolves: https://github.com/NYPL/nypl-design-system/issues/127

## **This PR does the following:**
- Updates the link hover color of `RNSectionTitle` to be a light grey instead of default link color
- Fixes a syntax issue in `Hero-test.tsx` which had an extra `>`

### Front End Review:
- [ ] View [the example in Storybook](http://localhost:9001/?path=/story/research-now-section-title--research-now-section-title)
- [ ] Check against the [Metronome documentation](http://themetronome.co/components/xxx/?fresh=true)
