### PR TITLE
add image caption and image credit to Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 -   Fixes bug in former `FormDropdown` (now `Select`) where the select value would not change if `selectedOption` were passed
 -   `Link`'s scss now references `$ui-link-primary` instead of `$nypl-blue-regular`
 -   Changes `Select`'s SCSS to use the updated styling from Filament Group
+-   `Image` is wrapped in `figure` when `imageCaption` or `imageCredit` is passed to `Image`
 
 ## 0.6.0
 

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -44,7 +44,7 @@ export const heroSecondary = () => (
             <Image
                 src="https://placeimg.com/800/400/arch"
                 isDecorative={true}
-                imageBlockname={"hero"}
+                blockName={"hero"}
             />
         }
     />
@@ -122,7 +122,7 @@ export const DigitalResearchBooksHeader = () => (
                 <Image
                     src="https://placeimg.com/200/100/arch"
                     isDecorative={true}
-                    imageBlockname={"hero"}
+                    blockName={"hero"}
                 />
             }
         />

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -47,7 +47,7 @@ describe("Hero Test", () => {
                     <Image
                         src="https://placeimg.com/800/400/arch"
                         isDecorative={true}
-                        imageBlockname={"hero"}
+                        blockName={"hero"}
                     />
                 }
             ></Hero>
@@ -72,7 +72,7 @@ describe("Hero Test", () => {
                         <Image
                             src="https://placeimg.com/800/400/arch"
                             isDecorative={true}
-                            imageBlockname={"hero"}
+                            blockName={"hero"}
                         />
                     }
                 ></Hero>
@@ -97,7 +97,7 @@ describe("Hero Test", () => {
                         <Image
                             src="https://placeimg.com/800/400/arch"
                             isDecorative={true}
-                            imageBlockname={"hero"}
+                            blockName={"hero"}
                         />
                     }
                     backgroundImageSrc="https://placeimg.com/1600/800/arch"
@@ -125,7 +125,7 @@ describe("Hero Test", () => {
                         <Image
                             src="https://placeimg.com/800/400/arch"
                             isDecorative={true}
-                            imageBlockname={"hero"}
+                            blockName={"hero"}
                         />
                     }
                     locationDetails={

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -8,7 +8,7 @@ export default {
     component: Image,
 };
 
-export const ImageWithCaption = () => [
+export const ImageWithOptionalCaptionandCredit = () => [
     <Image
         src="https://placeimg.com/400/200/arch"
         isDecorative={true}

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -2,45 +2,59 @@ import * as React from "react";
 
 import Image from "./Image";
 import { action } from "@storybook/addon-actions";
+import { text, boolean, select } from "@storybook/addon-knobs";
 
 export default {
     title: "Image",
     component: Image,
 };
 
-export const ImageWithOptionalCaptionandCredit = () => [
-    <Image
-        src="https://placeimg.com/400/200/arch"
-        isDecorative={true}
-        imageCaption={"Image Caption"}
-    />,
-];
+let showCaption, showCredit, circleMask;
 
-export const ImageWithCredit = () => [
-    <Image
-        src="https://placeimg.com/400/200/arch"
-        isDecorative={true}
-        imageCaption={"Image Credit"}
-    />,
-];
+const imageRatios = {
+    "1x1": "https://placeimg.com/100/100/animals",
+    "2x1": "https://placeimg.com/200/100/animals",
+    "3x4": "https://placeimg.com/150/200/animals",
+    "4x1": "https://placeimg.com/400/100/animals",
+    "4x3": "https://placeimg.com/200/150/animals",
+    "16x9": "https://placeimg.com/400/225/animals",
+};
 
-export const ImageWithCreditAndCaption = () => [
-    <Image
-        src="https://placeimg.com/400/200/arch"
-        isDecorative={true}
-        imageCaption={"Image Caption"}
-        imageCredit={"Image Credit"}
-    />,
-];
+export const ImageWithOptionalCaptionandCredit = () => (
+    <>
+        {boolean("Show Caption", true)
+            ? (showCaption = true)
+            : (showCaption = false)}
+        {boolean("Show Credit", true)
+            ? (showCredit = true)
+            : (showCredit = false)}
+        <Image
+            src={select(
+                "Initial Selected Option",
+                imageRatios,
+                imageRatios["2x1"]
+            )}
+            isDecorative={true}
+            imageCaption={
+                showCaption
+                    ? text("Image Caption", "Deserted Islander Relocator")
+                    : null
+            }
+            imageCredit={
+                showCredit ? text("Image Credit", "Taken by Tom Nook") : null
+            }
+            modifiers={boolean("Apply Circle Mask", false) ? ["circle"] : null}
+        />
+    </>
+);
 
-export const twoByOne = () => [
-    <Image src="https://placeimg.com/200/100/arch" isDecorative={true} />,
-    <Image src="https://placeimg.com/400/200/arch" isDecorative={true} />,
-    <Image src="https://placeimg.com/1600/800/arch" isDecorative={true} />,
-    <Image src="https://placeimg.com/2000/1000/arch" isDecorative={true} />,
-];
-
-export const threeByFour = () => [
-    <Image src="https://placeimg.com/150/200/arch" isDecorative={true} />,
-    <Image src="https://placeimg.com/300/400/arch" isDecorative={true} />,
-];
+ImageWithOptionalCaptionandCredit.story = {
+    name: "Image with Optional Caption and Credit",
+    parameters: {
+        design: {
+            type: "figma",
+            url:
+                "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=11896%3A45379",
+        },
+    },
+};

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -8,6 +8,31 @@ export default {
     component: Image,
 };
 
+export const ImageWithCaption = () => [
+    <Image
+        src="https://placeimg.com/400/200/arch"
+        isDecorative={true}
+        imageCaption={"Image Caption"}
+    />,
+];
+
+export const ImageWithCredit = () => [
+    <Image
+        src="https://placeimg.com/400/200/arch"
+        isDecorative={true}
+        imageCaption={"Image Credit"}
+    />,
+];
+
+export const ImageWithCreditAndCaption = () => [
+    <Image
+        src="https://placeimg.com/400/200/arch"
+        isDecorative={true}
+        imageCaption={"Image Caption"}
+        imageCredit={"Image Credit"}
+    />,
+];
+
 export const twoByOne = () => [
     <Image src="https://placeimg.com/200/100/arch" isDecorative={true} />,
     <Image src="https://placeimg.com/400/200/arch" isDecorative={true} />,

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -21,22 +21,17 @@ describe("Images", () => {
                 imageCaption={"caption"}
             />
         );
-        expect(wrapper.find("p")).to.have.lengthOf(1);
-        expect(wrapper.find("p").text()).to.equal("caption");
+        expect(wrapper.find("figcaption")).to.have.lengthOf(1);
+        expect(wrapper.find("figcaption").text()).to.equal("caption");
     });
 
     it("Shows Image with credit when provided ImageCredit", () => {
         wrapper = Enzyme.shallow(
             <Image src="test.png" isDecorative={true} imageCredit={"credit"} />
         );
-<<<<<<< HEAD:src/components/Image/Image.test.tsx
 
-        expect(wrapper.find("p").text()).to.equal("credit");
-        expect(wrapper.find("p")).to.have.lengthOf(1);
-=======
-        expect(wrapper.find("p")).to.have.lengthOf(1);
-        expect(wrapper.find("p").text()).to.equal("Credit: credit");
->>>>>>> prepend credit with 'credit:':src/react-components/src/__tests__/components/Image-test.tsx
+        expect(wrapper.find("figcaption")).to.have.lengthOf(1);
+        expect(wrapper.find("figcaption").text()).to.equal("credit");
     });
 
     it("Shows Image with credit and caption when provided ImageCredit and ImageCaption", () => {
@@ -48,7 +43,7 @@ describe("Images", () => {
                 imageCredit={"credit"}
             />
         );
-        expect(wrapper.find("p")).to.have.lengthOf(2);
+        expect(wrapper.find("figcaption")).to.have.lengthOf(2);
     });
 
     it("Throws error when meaningful image is passed without alt text", () => {

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -29,9 +29,14 @@ describe("Images", () => {
         wrapper = Enzyme.shallow(
             <Image src="test.png" isDecorative={true} imageCredit={"credit"} />
         );
+<<<<<<< HEAD:src/components/Image/Image.test.tsx
 
         expect(wrapper.find("p").text()).to.equal("credit");
         expect(wrapper.find("p")).to.have.lengthOf(1);
+=======
+        expect(wrapper.find("p")).to.have.lengthOf(1);
+        expect(wrapper.find("p").text()).to.equal("Credit: credit");
+>>>>>>> prepend credit with 'credit:':src/react-components/src/__tests__/components/Image-test.tsx
     });
 
     it("Shows Image with credit and caption when provided ImageCredit and ImageCaption", () => {

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -13,7 +13,7 @@ describe("Images", () => {
         wrapper = Enzyme.shallow(<Image src="test.png" isDecorative={true} />);
         expect(wrapper.find("img")).to.have.lengthOf(1);
     });
-    it("Shows Image with caption when provided ImageCaption", () => {
+    it("Shows Image wrapped in figure when provided ImageCaption", () => {
         wrapper = Enzyme.shallow(
             <Image
                 src="test.png"
@@ -21,20 +21,20 @@ describe("Images", () => {
                 imageCaption={"caption"}
             />
         );
+        expect(wrapper.find("figure")).to.have.lengthOf(1);
         expect(wrapper.find("figcaption")).to.have.lengthOf(1);
-        expect(wrapper.find("div").text()).to.equal("caption");
     });
 
-    it("Shows Image with credit when provided ImageCredit", () => {
+    it("Shows Image wrapped in figure when provided ImageCredit", () => {
         wrapper = Enzyme.shallow(
             <Image src="test.png" isDecorative={true} imageCredit={"credit"} />
         );
 
+        expect(wrapper.find("figure")).to.have.lengthOf(1);
         expect(wrapper.find("figcaption")).to.have.lengthOf(1);
-        expect(wrapper.find("div").text()).to.equal("credit");
     });
 
-    it("Shows Image with credit and caption when provided ImageCredit and ImageCaption", () => {
+    it("Shows Image wrapped in figure with credit and caption when provided ImageCredit and ImageCaption", () => {
         wrapper = Enzyme.shallow(
             <Image
                 src="test.png"

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -13,6 +13,38 @@ describe("Images", () => {
         wrapper = Enzyme.shallow(<Image src="test.png" isDecorative={true} />);
         expect(wrapper.find("img")).to.have.lengthOf(1);
     });
+    it("Shows Image with caption when provided ImageCaption", () => {
+        wrapper = Enzyme.shallow(
+            <Image
+                src="test.png"
+                isDecorative={true}
+                imageCaption={"caption"}
+            />
+        );
+        expect(wrapper.find("p")).to.have.lengthOf(1);
+        expect(wrapper.find("p").text()).to.equal("caption");
+    });
+
+    it("Shows Image with credit when provided ImageCredit", () => {
+        wrapper = Enzyme.shallow(
+            <Image src="test.png" isDecorative={true} imageCredit={"credit"} />
+        );
+        expect(wrapper.find("p")).to.have.lengthOf(1);
+        expect(wrapper.find("p").text()).to.equal("credit");
+    });
+
+    it("Shows Image with credit and caption when provided ImageCredit and ImageCaption", () => {
+        wrapper = Enzyme.shallow(
+            <Image
+                src="test.png"
+                isDecorative={true}
+                imageCaption={"caption"}
+                imageCredit={"credit"}
+            />
+        );
+        expect(wrapper.find("p")).to.have.lengthOf(2);
+    });
+
     it("Throws error when meaningful image is passed without alt text", () => {
         expect(() =>
             Enzyme.mount(<Image src="test.png" isDecorative={false} />)

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -22,7 +22,7 @@ describe("Images", () => {
             />
         );
         expect(wrapper.find("figcaption")).to.have.lengthOf(1);
-        expect(wrapper.find("figcaption").text()).to.equal("caption");
+        expect(wrapper.find("div").text()).to.equal("caption");
     });
 
     it("Shows Image with credit when provided ImageCredit", () => {
@@ -31,7 +31,7 @@ describe("Images", () => {
         );
 
         expect(wrapper.find("figcaption")).to.have.lengthOf(1);
-        expect(wrapper.find("figcaption").text()).to.equal("credit");
+        expect(wrapper.find("div").text()).to.equal("credit");
     });
 
     it("Shows Image with credit and caption when provided ImageCredit and ImageCaption", () => {
@@ -43,7 +43,8 @@ describe("Images", () => {
                 imageCredit={"credit"}
             />
         );
-        expect(wrapper.find("figcaption")).to.have.lengthOf(2);
+        expect(wrapper.find("figcaption")).to.have.lengthOf(1);
+        expect(wrapper.find("div")).to.have.lengthOf(2);
     });
 
     it("Throws error when meaningful image is passed without alt text", () => {

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -29,8 +29,9 @@ describe("Images", () => {
         wrapper = Enzyme.shallow(
             <Image src="test.png" isDecorative={true} imageCredit={"credit"} />
         );
-        expect(wrapper.find("p")).to.have.lengthOf(1);
+
         expect(wrapper.find("p").text()).to.equal("credit");
+        expect(wrapper.find("p")).to.have.lengthOf(1);
     });
 
     it("Shows Image with credit and caption when provided ImageCredit and ImageCaption", () => {

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -50,7 +50,11 @@ export default function Image(props: ImageProps) {
                     )}
                     {imageCredit && (
                         <p className={bem(image_base_class, [], "credit")}>
+<<<<<<< HEAD:src/components/Image/Image.tsx
                             {imageCredit}
+=======
+                            Credit: {imageCredit}
+>>>>>>> prepend credit with 'credit:':src/react-components/src/components/Image/Image.tsx
                         </p>
                     )}
                 </div>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -40,9 +40,9 @@ export default function Image(props: ImageProps) {
 
     return (
         <>
-            <img {...imageProps} />
-            {(imageCaption || imageCredit) && (
+            {imageCaption || imageCredit ? (
                 <figure className={bem(image_base_class, [], "figure")}>
+                    <img {...imageProps} />
                     <figcaption
                         className={bem(image_base_class, [], "figure__caption")}
                     >
@@ -62,6 +62,8 @@ export default function Image(props: ImageProps) {
                         )}
                     </figcaption>
                 </figure>
+            ) : (
+                <img {...imageProps} />
             )}
         </>
     );

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -3,25 +3,42 @@ import * as React from "react";
 import bem from "../../utils/bem";
 
 export interface ImageProps {
+    /** The src attribute is required, and contains the path to the image you want to embed. */
     src: string;
+
+    /** Decorative images are skipped by screenreaders */
     isDecorative: boolean;
+
+    /** Text description of the image */
     altText?: string;
-    imageModifiers?: string[];
-    imageBlockname?: string;
-    figureBlockname?: string;
+
+    /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
+    modifiers?: string[];
+
+    /** BlockName for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
+    blockName?: string;
+
+    /** ClassName you can add in addition to 'image' */
+    className?: string;
+
+    /** Adding will wrap the image in a <figure> */
     imageCaption?: string;
+
+    /** Adding will wrap the image in a <figure> */
     imageCredit?: string;
 }
 
 export default function Image(props: ImageProps) {
     const image_base_class = "image";
     const {
-        src,
-        isDecorative,
         altText,
-        imageModifiers,
+        blockName,
+        className,
         imageCaption,
         imageCredit,
+        isDecorative,
+        modifiers,
+        src,
     } = props;
 
     if (!isDecorative && !altText) {
@@ -32,11 +49,12 @@ export default function Image(props: ImageProps) {
         throw new Error("Alt Text must be less than 300 characters");
     }
 
-    let imageBlockname;
-    imageBlockname = imageCaption || imageCredit ? "figure" : null;
+    let figureBlockName = imageCaption || imageCredit ? "figure" : blockName;
 
     let imageProps = {
-        className: bem(image_base_class, imageModifiers, imageBlockname),
+        className: bem(image_base_class, modifiers, figureBlockName, [
+            className,
+        ]),
         src: src,
         alt: isDecorative ? "" : altText,
     };

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -42,22 +42,24 @@ export default function Image(props: ImageProps) {
         <>
             <img {...imageProps} />
             {(imageCaption || imageCredit) && (
-                <div className={bem(image_base_class, [], "annotation")}>
+                <figure
+                    className={bem(image_base_class, [], "figure__caption")}
+                >
                     {imageCaption && (
-                        <p className={bem(image_base_class, [], "caption")}>
+                        <figcaption
+                            className={bem(image_base_class, [], "caption")}
+                        >
                             {imageCaption}
-                        </p>
+                        </figcaption>
                     )}
                     {imageCredit && (
-                        <p className={bem(image_base_class, [], "credit")}>
-<<<<<<< HEAD:src/components/Image/Image.tsx
+                        <figcaption
+                            className={bem(image_base_class, [], "credit")}
+                        >
                             {imageCredit}
-=======
-                            Credit: {imageCredit}
->>>>>>> prepend credit with 'credit:':src/react-components/src/components/Image/Image.tsx
-                        </p>
+                        </figcaption>
                     )}
-                </div>
+                </figure>
             )}
         </>
     );

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -42,23 +42,25 @@ export default function Image(props: ImageProps) {
         <>
             <img {...imageProps} />
             {(imageCaption || imageCredit) && (
-                <figure
-                    className={bem(image_base_class, [], "figure__caption")}
-                >
-                    {imageCaption && (
-                        <figcaption
-                            className={bem(image_base_class, [], "caption")}
-                        >
-                            {imageCaption}
-                        </figcaption>
-                    )}
-                    {imageCredit && (
-                        <figcaption
-                            className={bem(image_base_class, [], "credit")}
-                        >
-                            {imageCredit}
-                        </figcaption>
-                    )}
+                <figure className={bem(image_base_class, [], "figure")}>
+                    <figcaption
+                        className={bem(image_base_class, [], "figure__caption")}
+                    >
+                        {imageCaption && (
+                            <div
+                                className={bem(image_base_class, [], "caption")}
+                            >
+                                {imageCaption}
+                            </div>
+                        )}
+                        {imageCredit && (
+                            <div
+                                className={bem(image_base_class, [], "credit")}
+                            >
+                                {imageCredit}
+                            </div>
+                        )}
+                    </figcaption>
                 </figure>
             )}
         </>

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -8,6 +8,7 @@ export interface ImageProps {
     altText?: string;
     imageModifiers?: string[];
     imageBlockname?: string;
+    figureBlockname?: string;
     imageCaption?: string;
     imageCredit?: string;
 }
@@ -19,7 +20,6 @@ export default function Image(props: ImageProps) {
         isDecorative,
         altText,
         imageModifiers,
-        imageBlockname,
         imageCaption,
         imageCredit,
     } = props;
@@ -32,6 +32,9 @@ export default function Image(props: ImageProps) {
         throw new Error("Alt Text must be less than 300 characters");
     }
 
+    let imageBlockname;
+    imageBlockname = imageCaption || imageCredit ? "figure" : null;
+
     let imageProps = {
         className: bem(image_base_class, imageModifiers, imageBlockname),
         src: src,
@@ -41,22 +44,18 @@ export default function Image(props: ImageProps) {
     return (
         <>
             {imageCaption || imageCredit ? (
-                <figure className={bem(image_base_class, [], "figure")}>
+                <figure className={bem("figure")}>
                     <img {...imageProps} />
                     <figcaption
-                        className={bem(image_base_class, [], "figure__caption")}
+                        className={bem("figcaption", [], "figure", ["image"])}
                     >
                         {imageCaption && (
-                            <div
-                                className={bem(image_base_class, [], "caption")}
-                            >
+                            <div className={bem("caption", [], "figcaption")}>
                                 {imageCaption}
                             </div>
                         )}
                         {imageCredit && (
-                            <div
-                                className={bem(image_base_class, [], "credit")}
-                            >
+                            <div className={bem("credit", [], "figcaption")}>
                                 {imageCredit}
                             </div>
                         )}

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -49,7 +49,7 @@ export default function Image(props: ImageProps) {
                         </p>
                     )}
                     {imageCredit && (
-                        <p className={bem(image_base_class, [], "heading")}>
+                        <p className={bem(image_base_class, [], "credit")}>
                             {imageCredit}
                         </p>
                     )}

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -8,6 +8,8 @@ export interface ImageProps {
     altText?: string;
     imageModifiers?: string[];
     imageBlockname?: string;
+    imageCaption?: string;
+    imageCredit?: string;
 }
 
 export default function Image(props: ImageProps) {
@@ -18,6 +20,8 @@ export default function Image(props: ImageProps) {
         altText,
         imageModifiers,
         imageBlockname,
+        imageCaption,
+        imageCredit,
     } = props;
 
     if (!isDecorative && !altText) {
@@ -34,5 +38,23 @@ export default function Image(props: ImageProps) {
         alt: isDecorative ? "" : altText,
     };
 
-    return <img {...imageProps} />;
+    return (
+        <>
+            <img {...imageProps} />
+            {(imageCaption || imageCredit) && (
+                <div className={bem(image_base_class, [], "annotation")}>
+                    {imageCaption && (
+                        <p className={bem(image_base_class, [], "caption")}>
+                            {imageCaption}
+                        </p>
+                    )}
+                    {imageCredit && (
+                        <p className={bem(image_base_class, [], "heading")}>
+                            {imageCredit}
+                        </p>
+                    )}
+                </div>
+            )}
+        </>
+    );
 }

--- a/src/components/Image/_Image.scss
+++ b/src/components/Image/_Image.scss
@@ -2,11 +2,19 @@
     display: block;
     height: auto;
     max-width: 100%;
+
+    &--circle {
+        border-radius: 50%;
+    }
 }
 
 .figure {
     &__image {
         @include space-stack-xxs;
+
+        &--circle {
+            border-radius: 50%;
+        }
     }
 
     &__figcaption {

--- a/src/components/Image/_Image.scss
+++ b/src/components/Image/_Image.scss
@@ -1,18 +1,22 @@
-@mixin image {
+.image {
     display: block;
     height: auto;
     max-width: 100%;
 }
 
-img,
-picture {
-    @include image;
+.figure {
+    &__image {
+        @include space-stack-xxs;
+    }
+
+    &__figcaption {
+        font-style: italic;
+    }
 }
 
-figure {
-    margin: 0; //override normalize
-}
-
-.figure__caption {
-    font-style: italic;
+.figcaption {
+    &__credit,
+    &__caption {
+        @include space-stack-xxs;
+    }
 }

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -3,10 +3,10 @@ import bem from "../../utils/bem";
 import Icon from "../Icons/Icon";
 
 export interface SelectProps {
-    /** className you can add in addition to 'select' */
+    /** ClassName you can add in addition to 'select' */
     className?: string;
 
-    /** blockName for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
+    /** BlockName for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     blockName?: string;
 
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */

--- a/src/styles/01-atoms/_images/image/_image.scss
+++ b/src/styles/01-atoms/_images/image/_image.scss
@@ -16,10 +16,6 @@ figure {
 .figure__caption {
     font-style: italic;
 }
-// p {
-//     background-color: orange;
-//     line-height: 50%;
-// }
 
 .annotation__image {
     p {

--- a/src/styles/01-atoms/_images/image/_image.scss
+++ b/src/styles/01-atoms/_images/image/_image.scss
@@ -15,7 +15,4 @@ figure {
 
 .figure__caption__image {
     font-style: italic;
-    figcaption:nth-child(odd) {
-        @include space-stack-none;
-    }
 }

--- a/src/styles/01-atoms/_images/image/_image.scss
+++ b/src/styles/01-atoms/_images/image/_image.scss
@@ -13,18 +13,9 @@ figure {
     margin: 0; //override normalize
 }
 
-.figure__caption {
+.figure__caption__image {
     font-style: italic;
-}
-
-.annotation__image {
-    p {
-        font-style: italic;
-    }
-    p:nth-child(odd) {
-        margin-bottom: 0;
-    }
-    p:nth-child(even) {
-        margin-top: 0;
+    figcaption:nth-child(odd) {
+        @include space-stack-none;
     }
 }

--- a/src/styles/01-atoms/_images/image/_image.scss
+++ b/src/styles/01-atoms/_images/image/_image.scss
@@ -1,0 +1,34 @@
+@mixin image {
+    display: block;
+    height: auto;
+    max-width: 100%;
+}
+
+img,
+picture {
+    @include image;
+}
+
+figure {
+    margin: 0; //override normalize
+}
+
+.figure__caption {
+    font-style: italic;
+}
+// p {
+//     background-color: orange;
+//     line-height: 50%;
+// }
+
+.annotation__image {
+    p {
+        font-style: italic;
+    }
+    p:nth-child(odd) {
+        margin-bottom: 0;
+    }
+    p:nth-child(even) {
+        margin-top: 0;
+    }
+}


### PR DESCRIPTION
## **This PR does the following:**
- Adds optional imageCredit and imageCaption to `Image`
- Wraps `Image` in `figure` when imageCredit and imageCaption are passed

### Front End Review:
- [ ] View [Image in Storybook](http://localhost:9001/?path=/story/image--image-with-optional-captionand-credit)
- [ ] View [Hero in Storybook](http://localhost:9001/?path=/story/hero--hero-primary)
