### PR TITLE
Minor updates to form-related components.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 -   Adds `IconNames` enum to make `allSVGs` array globally accessible
 -   Adds `width: 100%` globally to SVGs
 -   `Card` now constrains items in its `image` column to the column width
+-   Adds the `forwardRef` implementation to the `Input` component
 
 ### Changes
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nypl/design-system-react-components",
-    "version": "0.6.2",
+    "version": "0.6.3",
     "description": "Design System React Components",
     "repository": {
         "type": "git",

--- a/src/components/Checkbox/Checkbox.stories.tsx
+++ b/src/components/Checkbox/Checkbox.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import Checkbox from "./Checkbox";
 import { action } from "@storybook/addon-actions";
+import { boolean, text } from "@storybook/addon-knobs";
 
 export default {
     title: "Checkbox",
@@ -13,8 +14,9 @@ export const checkbox = () => (
         checkboxId="checkbox"
         labelOptions={{
             id: "label",
-            labelContent: <>Label Text</>,
+            labelContent: <>{text("Label Text", "Label Text")}</>,
         }}
+        isSelected={boolean("isSelected", false)}
         onChange={action("changed")}
     />
 );

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -22,4 +22,25 @@ describe("Checkbox Test", () => {
         );
         expect(container.exists("#checkbox")).to.equal(true);
     });
+
+    it("Updates its check value based on the `isSelected` prop", () => {
+        let callback = stub();
+
+        const container = Enzyme.mount(
+            <Checkbox
+                checkboxId="checkbox"
+                labelOptions={{
+                    id: "label",
+                    labelContent: <>Label Text</>,
+                }}
+                onChange={callback}
+            />
+        );
+
+        // `false` by default.
+        expect(container.find("input").prop("checked")).to.equal(false);
+
+        container.setProps({ isSelected: true });
+        expect(container.find("input").prop("checked")).to.equal(true);
+    });
 });

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -38,9 +38,26 @@ describe("Checkbox Test", () => {
         );
 
         // `false` by default.
-        expect(container.find("input").prop("checked")).to.equal(false);
+        expect(container.find("input").prop("defaultChecked")).to.equal(false);
 
         container.setProps({ isSelected: true });
-        expect(container.find("input").prop("checked")).to.equal(true);
+        expect(container.find("input").prop("defaultChecked")).to.equal(true);
+    });
+
+    it("Passes the ref to the input element", () => {
+        const ref = React.createRef<HTMLInputElement>();
+        let callback = stub();
+        const container = Enzyme.mount(
+            <Checkbox
+                checkboxId="CheckboxID-attributes"
+                labelOptions={{
+                    id: "label",
+                    labelContent: <>Label Text</>,
+                }}
+                onChange={callback}
+                ref={ref}
+            ></Checkbox>
+        );
+        expect(container.find("input").instance()).to.equal(ref.current);
     });
 });

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 import bem from "../../utils/bem";
 import Label, { LabelOptions } from "../Label/Label";
 
-interface CheckboxProps {
+export interface CheckboxProps {
     /** name of the checkbox */
     name?: string;
 
@@ -19,39 +19,43 @@ interface CheckboxProps {
     /* The current selected state of the checkbox */
     isSelected?: boolean;
     /** The action to perform on the <input>'s onChange function  */
-    onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+    onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
 /**
  * A Form Checkbox component that can be selected and deselected.
  */
+let Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
+    (props, ref?) => {
+        const {
+            name,
+            modifiers = [],
+            blockName = "",
+            checkboxId,
+            labelOptions,
+            isSelected = false,
+            onChange,
+        } = props;
 
-export default function Checkbox(props: CheckboxProps) {
-    const {
-        name,
-        modifiers = [],
-        blockName = "",
-        checkboxId,
-        labelOptions,
-        isSelected = false,
-        onChange,
-    } = props;
+        const baseClass = "checkbox";
+        return (
+            <div className={bem(baseClass, modifiers, blockName)}>
+                <input
+                    id={checkboxId}
+                    name={name}
+                    className={bem("input", [], baseClass)}
+                    onChange={onChange}
+                    type="checkbox"
+                    aria-checked={isSelected}
+                    defaultChecked={isSelected}
+                    ref={ref}
+                ></input>
+                <Label htmlFor={checkboxId} id={labelOptions.id}>
+                    {labelOptions.labelContent}
+                </Label>
+            </div>
+        );
+    }
+);
 
-    const baseClass = "checkbox";
-    return (
-        <div className={bem(baseClass, modifiers, blockName)}>
-            <input
-                id={checkboxId}
-                name={name}
-                className={bem("input", [], baseClass)}
-                onChange={onChange}
-                type="checkbox"
-                aria-checked={isSelected}
-                checked={isSelected}
-            ></input>
-            <Label htmlFor={checkboxId} id={labelOptions.id}>
-                {labelOptions.labelContent}
-            </Label>
-        </div>
-    );
-}
+export default Checkbox;

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -33,7 +33,7 @@ export default function Checkbox(props: CheckboxProps) {
         blockName = "",
         checkboxId,
         labelOptions,
-        isSelected,
+        isSelected = false,
         onChange,
     } = props;
 

--- a/src/components/HelperErrorText/HelperErrorText.stories.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
 import HelperErrorText from "./HelperErrorText";
+import { boolean, text } from "@storybook/addon-knobs";
 
 export default {
     title: "HelperErrorText",
@@ -27,5 +28,17 @@ export const longHelperText = () => (
         tiramisu biscuit cookie cake. Cookie chocolate jelly-o topping. Halvah
         bear claw wafer cupcake tiramisu ice cream tart gummi bears. Lemon drops
         chocolate cake croissant lemon drops gummies ice cream sugar plum.
+    </HelperErrorText>
+);
+
+export const withAriaProps = () => (
+    <HelperErrorText
+        id="withAriaProps"
+        isError={true}
+        ariaAtomic={boolean("ariaAtomic", false)}
+        ariaLive="assertive"
+    >
+        We'll be making a water landing,{" "}
+        <span>but that's OK because this is a seaplane.</span>
     </HelperErrorText>
 );

--- a/src/components/HelperErrorText/HelperErrorText.test.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.test.tsx
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import * as Enzyme from "enzyme";
 import * as React from "react";
-import * as Mocha from "mocha";
 
 import HelperErrorText from "./HelperErrorText";
 
@@ -32,5 +31,30 @@ describe("HelperErrorText Test", () => {
         );
         expect(container.find("div").props()["aria-live"]).to.equal("polite");
         expect(container.find("div").props()["aria-atomic"]).to.equal(true);
+    });
+
+    it("Accepts an aria-atomic value of false", () => {
+        let container = Enzyme.mount(
+            <HelperErrorText id="helperTextWithLink" isError={true}>
+                Text
+            </HelperErrorText>
+        );
+        // The default is "true".
+        expect(container.find("div").props()["aria-atomic"]).to.equal(true);
+
+        container = Enzyme.mount(
+            <HelperErrorText
+                id="helperTextWithLink"
+                isError={true}
+                ariaAtomic={false}
+            >
+                <p>
+                    This is static <span>but this part changes often!</span>
+                </p>
+            </HelperErrorText>
+        );
+        // But the prop accepts false in case only part of the helper text
+        // should only be read instead of the whole region.
+        expect(container.find("div").props()["aria-atomic"]).to.equal(false);
     });
 });

--- a/src/components/HelperErrorText/HelperErrorText.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.tsx
@@ -23,7 +23,7 @@ interface HelperErrorTextProps {
     /** Optional baseClass for use with BEM. See how to work with blockNames and BEM here: http://getbem.com/introduction/ */
     baseClass?: string;
     /** Added prop when HelperText is errored */
-    ariaLive?: boolean;
+    ariaLive?: "polite" | "off" | "assertive";
     /** Added prop when HelperText is errored */
     ariaAtomic?: boolean;
 }
@@ -34,14 +34,21 @@ interface HelperErrorTextProps {
 export default function HelperErrorText(
     props: React.PropsWithChildren<HelperErrorTextProps>
 ) {
-    const { id, blockName, baseClass = "helper-text", isError } = props;
+    const {
+        id,
+        blockName,
+        baseClass = "helper-text",
+        isError,
+        ariaLive = "polite",
+        ariaAtomic = true,
+    } = props;
 
     let modifiers = [];
-    let ariaLive, ariaAtomic;
+    let announceAriaLive = false;
 
     if (isError) {
         modifiers.push("error");
-        ariaLive = true;
+        announceAriaLive = true;
     }
 
     if (props.modifiers) {
@@ -52,8 +59,8 @@ export default function HelperErrorText(
         <div
             id={id}
             className={bem(baseClass, modifiers, blockName)}
-            aria-live={ariaLive ? "polite" : "off"}
-            aria-atomic={ariaLive}
+            aria-live={announceAriaLive ? ariaLive : "off"}
+            aria-atomic={ariaAtomic}
         >
             {props.children}
         </div>

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -153,24 +153,16 @@ inputGroup.story = {
 
 export const inputAttributes = () => (
     <>
-        <Label
-            htmlFor="inputID-attrs"
-            optReqFlag={select(
-                "Optional/Required Flag",
-                ["Required", "Optional", ""],
-                "Required"
-            )}
-            id={"label"}
-        >
-            {text("Input Label", "Choose your islander name: ")}
+        <Label htmlFor="inputID-attrs" optReqFlag={"Required"} id={"label"}>
+            Choose your islander name:
         </Label>
         <Input
             id="inputID-attrs"
             ariaLabel="Input Label"
             helperTextId="helperText-attrs"
-            required={boolean("Input Required", false)}
-            placeholder={text("Input Placeholder", "CoolPerson42")}
-            type={select("Input Type", InputTypes, InputTypes.text)}
+            required={false}
+            placeholder={"CoolPerson42"}
+            type={InputTypes.text}
             attributes={{
                 onBlur: action("onBlur"),
                 onChange: action("onChange"),

--- a/src/components/Input/Input.stories.tsx
+++ b/src/components/Input/Input.stories.tsx
@@ -6,7 +6,7 @@ import Label from "../Label/Label";
 import Button from "../Button/Button";
 import { ButtonTypes } from "../Button/ButtonTypes";
 import HelperErrorText from "../HelperErrorText/HelperErrorText";
-import { text, boolean, select } from "@storybook/addon-knobs";
+import { text, boolean, select, number } from "@storybook/addon-knobs";
 import { action } from "@storybook/addon-actions";
 
 export default {
@@ -150,3 +150,38 @@ inputGroup.story = {
         },
     },
 };
+
+export const inputAttributes = () => (
+    <>
+        <Label
+            htmlFor="inputID-attrs"
+            optReqFlag={select(
+                "Optional/Required Flag",
+                ["Required", "Optional", ""],
+                "Required"
+            )}
+            id={"label"}
+        >
+            {text("Input Label", "Choose your islander name: ")}
+        </Label>
+        <Input
+            id="inputID-attrs"
+            ariaLabel="Input Label"
+            helperTextId="helperText-attrs"
+            required={boolean("Input Required", false)}
+            placeholder={text("Input Placeholder", "CoolPerson42")}
+            type={select("Input Type", InputTypes, InputTypes.text)}
+            attributes={{
+                onBlur: action("onBlur"),
+                onChange: action("onChange"),
+                maxLength: number("maxLength", 10),
+                tabIndex: number("tabIndex", 0),
+            }}
+        ></Input>
+        <HelperErrorText isError={false} id="helperText-attrs">
+            Change the max length for "text" input as an example! And note the
+            actions being called for the passed object in the `attributes`
+            props.
+        </HelperErrorText>
+    </>
+);

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import * as Enzyme from "enzyme";
 import * as React from "react";
-import * as Mocha from "mocha";
+import { stub } from "sinon";
 
 import Label from "../Label/Label";
 import HelperErrorText from "../HelperErrorText/HelperErrorText";
@@ -150,5 +150,65 @@ describe("Input Group", () => {
         expect(
             container.find("#input-input2").prop("aria-labelledby")
         ).to.equal("label2 helperText2 sharedHelperText");
+    });
+});
+
+describe("Renders HTML attributes passed through the `attributes` prop", () => {
+    const onChangeSpy = stub();
+    const onBlurSpy = stub();
+    let container;
+    before(() => {
+        container = Enzyme.mount(
+            <Input
+                id="inputID-attributes"
+                ariaLabel="Input Label"
+                helperTextId={"helperText-attributes"}
+                placeholder={"Input Placeholder"}
+                type={InputTypes.text}
+                attributes={{
+                    onChange: onChangeSpy,
+                    onBlur: onBlurSpy,
+                    maxLength: 10,
+                    tabIndex: 0,
+                }}
+            ></Input>
+        );
+    });
+
+    it("Has a maxlength for the input element", () => {
+        expect(container.find("input").prop("maxLength")).to.equal(10);
+    });
+
+    it("Has a tabIndex", () => {
+        expect(container.find("input").prop("tabIndex")).to.equal(0);
+    });
+
+    it("Calls the onChange function", () => {
+        expect(onChangeSpy.callCount).to.equal(0);
+        container.find("input").simulate("change");
+        expect(onChangeSpy.callCount).to.equal(1);
+    });
+
+    it("Calls the onBlur function", () => {
+        expect(onBlurSpy.callCount).to.equal(0);
+        container.find("input").simulate("blur");
+        expect(onBlurSpy.callCount).to.equal(1);
+    });
+});
+
+describe("Forwarding refs", () => {
+    it("Passes the ref to the input element", () => {
+        const ref = React.createRef<HTMLInputElement>();
+        const container = Enzyme.mount(
+            <Input
+                id="inputID-attributes"
+                ariaLabel="Input Label"
+                helperTextId={"helperText-attributes"}
+                placeholder={"Input Placeholder"}
+                type={InputTypes.text}
+                ref={ref}
+            ></Input>
+        );
+        expect(container.find("input").instance()).to.equal(ref.current);
     });
 });

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -45,7 +45,7 @@ export interface InputProps {
     attributes?: {};
 }
 
-export default function Input(props: InputProps) {
+let Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref?) => {
     const {
         ariaLabel,
         ariaLabelledBy,
@@ -74,6 +74,7 @@ export default function Input(props: InputProps) {
         value: value,
         "aria-label": ariaLabel,
         "aria-labelledby": ariaLabelledBy,
+        ...attributes,
     };
 
     if (required) {
@@ -89,8 +90,15 @@ export default function Input(props: InputProps) {
     }
 
     let transformedInput = (
-        <input id={`input-${id}`} {...inputProps} placeholder={placeholder} />
+        <input
+            id={`input-${id}`}
+            {...inputProps}
+            placeholder={placeholder}
+            ref={ref}
+        />
     );
 
     return transformedInput;
-}
+});
+
+export default Input;

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -1,0 +1,25 @@
+import * as React from "react";
+
+import Label from "../Label/Label";
+import { text, boolean, select } from "@storybook/addon-knobs";
+
+export default {
+    title: "Label",
+    component: Label,
+};
+
+export const label = () => (
+    <div style={{ width: "500px" }}>
+        <Label
+            htmlFor="some-input-element"
+            optReqFlag={select(
+                "Optional/Required Flag",
+                ["Required", "Optional", ""],
+                "Required"
+            )}
+            id="label"
+        >
+            {text("Input Label", "A label for a villager.")}
+        </Label>
+    </div>
+);

--- a/src/components/Label/Label.test.tsx
+++ b/src/components/Label/Label.test.tsx
@@ -1,7 +1,6 @@
 import { expect } from "chai";
 import * as Enzyme from "enzyme";
 import * as React from "react";
-import * as Mocha from "mocha";
 
 import Label from "./Label";
 
@@ -23,5 +22,30 @@ describe("Label Test", () => {
             </Label>
         );
         expect(wrapper.find("label")).to.have.lengthOf(1);
+    });
+
+    it("Renders the optional or required helper text", () => {
+        wrapper = Enzyme.shallow(
+            <Label id="label" htmlFor="so-lonely">
+                <span>Cupcakes</span>
+            </Label>
+        );
+        expect(wrapper.find("div")).to.have.lengthOf(0);
+
+        wrapper = Enzyme.shallow(
+            <Label id="label" htmlFor="so-lonely" optReqFlag="Optional">
+                <span>Cupcakes</span>
+            </Label>
+        );
+        expect(wrapper.find("div")).to.have.lengthOf(1);
+        expect(wrapper.find("div").text()).to.equal("Optional");
+
+        wrapper = Enzyme.shallow(
+            <Label id="label" htmlFor="so-lonely" optReqFlag="Required">
+                <span>Cupcakes</span>
+            </Label>
+        );
+        expect(wrapper.find("div")).to.have.lengthOf(1);
+        expect(wrapper.find("div").text()).to.equal("Required");
     });
 });

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -15,7 +15,7 @@ interface LabelProps {
     htmlFor?: string;
 
     /** Displays "Required" or "Optional" string alongside label */
-    optReqFlag?: string;
+    optReqFlag?: "Optional" | "Required" | "" | null;
 
     /** Optional blockName for use with BEM. See how to work with blockNames and BEM here: http://getbem.com/introduction/ */
     blockName?: string;
@@ -29,21 +29,13 @@ interface LabelProps {
  */
 export default function Label(props: React.PropsWithChildren<LabelProps>) {
     const { id, htmlFor, optReqFlag, modifiers, blockName } = props;
-
+    const baseClass = "label";
     let helperString;
 
-    const baseClass = "label";
-
-    if (optReqFlag === "Optional") {
+    if (optReqFlag) {
         helperString = (
             <div className={bem("required-helper", [], baseClass)}>
-                Optional
-            </div>
-        );
-    } else if (optReqFlag === "Required") {
-        helperString = (
-            <div className={bem("required-helper", [], baseClass)}>
-                Required
+                {optReqFlag}
             </div>
         );
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { default as Checkbox } from "./components/Checkbox/Checkbox";
 export { default as Container } from "./components/Container/Container";
 export { default as HeaderWithSearch } from "./components/RNHeaderWithSearch/RNHeaderWithSearch";
 export { default as Heading } from "./components/Heading/Heading";
+export { default as HelperErrorText } from "./components/HelperErrorText/HelperErrorText";
 export { default as Hero } from "./components/Hero/Hero";
 export { HeroTypes } from "./components/Hero/HeroTypes";
 export { default as Icon } from "./components/Icons/Icon";

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,14 @@ module.exports = {
         rules: [
             {
                 test: /\.tsx?$/,
-                loader: "ts-loader",
+                use: [
+                    {
+                        loader: "ts-loader",
+                    },
+                    {
+                        loader: "react-docgen-typescript-loader",
+                    },
+                ],
             },
             {
                 test: /\.svg$/,


### PR DESCRIPTION
Issue numbers: #273 and #261 

## **This PR does the following:**
- Adds some changes so I could get `Label`, `Input`, `HelperErrorText`, and `Checkbox` to work in the Library Card app. Specifically:

* The `HelperErrorText` component wasn't exported.
* The Library Card app uses refs to focus on input elements for specific errors. So if there are 10 input elements on the page and the 6th one has an error because the email (for example) is invalid, the app creates a dynamic anchor error link to that input. But this doesn't seem to work if the `Input` component doesn't implement `forwardRef` to pass down the `ref` but not as a prop.
* Used the `attributes` prop in the `Input` component.
* Fixed the issue with the prop table not showing up in the "Info" tab in Storybook. The webpack config was removed...
* Updated the stories for some of the components.

Let me know if I'm missing anything else for this PR. I'll create a draft PR in the Library Card app that uses these changes.

### Front End Review:
- [ ] View [the example in Storybook]()
