### PR TITLE
Select component update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.7.1
+
+### Changes
+
+-   Updated the Select component to take in a ref using ForwardRef and also a `name` prop.
+
 ## 0.7.0
 
 ### Breaking Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -12937,6 +12937,41 @@
                 "loose-envify": "^1.1.0",
                 "object-assign": "^4.1.1",
                 "prop-types": "^15.6.2"
+            },
+            "dependencies": {
+                "js-tokens": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+                    "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+                },
+                "loose-envify": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+                    "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+                    "requires": {
+                        "js-tokens": "^3.0.0 || ^4.0.0"
+                    }
+                },
+                "object-assign": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+                    "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+                },
+                "prop-types": {
+                    "version": "15.7.2",
+                    "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+                    "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+                    "requires": {
+                        "loose-envify": "^1.4.0",
+                        "object-assign": "^4.1.1",
+                        "react-is": "^16.8.1"
+                    }
+                },
+                "react-is": {
+                    "version": "16.13.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+                }
             }
         },
         "react-addons-create-fragment": {

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -31,7 +31,7 @@ export interface InputProps {
     value?: string | number;
 }
 
-let Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref?) => {
+const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref?) => {
     const {
         ariaLabel,
         ariaLabelledBy,

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -2,9 +2,9 @@ import { expect } from "chai";
 import { stub } from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
-import * as Mocha from "mocha";
 
 import Pagination from "./Pagination";
+import Select from "../Select/Select";
 
 describe("Pagination Test", () => {
     let wrapper: Enzyme.ShallowWrapper<{}, {}>;
@@ -37,7 +37,7 @@ describe("Pagination Test", () => {
             />
         );
         expect(wrapper.find("Button")).to.have.lengthOf(2);
-        expect(wrapper.find("Select")).to.have.lengthOf(1);
+        expect(wrapper.find(Select)).to.have.lengthOf(1);
     });
 
     it("Renders two buttons and a Select when there are zero pages", () => {
@@ -57,6 +57,6 @@ describe("Pagination Test", () => {
             />
         );
         expect(wrapper.find("Button")).to.have.lengthOf(2);
-        expect(wrapper.find("Select")).to.have.lengthOf(1);
+        expect(wrapper.find(Select)).to.have.lengthOf(1);
     });
 });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -76,7 +76,11 @@ export default function Pagination(props: PaginationProps) {
             <Label htmlFor="pagination-dropdown" id={dropdownProps.labelId}>
                 {dropdownProps.labelText}
             </Label>
-            <Select blockName={pagination__base_class} {...dropdownProps}>
+            <Select
+                name="pagination-select"
+                blockName={pagination__base_class}
+                {...dropdownProps}
+            >
                 {paginationDropdownOptions.map((item) => (
                     <option aria-selected={false}>{item}</option>
                 ))}

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -99,6 +99,7 @@ export const searchBar = () => (
         >
             {showSelect && (
                 <Select
+                    name="nhItemSearch"
                     ariaLabel="Filter Search"
                     disabled={formDisabled}
                     helperTextId={"helperText"}

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -32,6 +32,7 @@ export const selectWithOptionalLabel = () => (
             </Label>
         )}
         <Select
+            name="optionalLabelSelect"
             id={"select"}
             isRequired={false}
             ariaLabel="Select Label"

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -1,9 +1,7 @@
 import { expect } from "chai";
-import { stub } from "sinon";
+import { stub, spy } from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
-
-import * as Mocha from "mocha";
 
 import Select from "./Select";
 
@@ -13,22 +11,39 @@ describe("Select", () => {
     let changeCallback;
 
     beforeEach(() => {
-        changeCallback = stub();
+        changeCallback = spy();
         blurCallback = stub();
     });
 
-    it("Renders a Select", () => {
+    it("Renders a select DOM element", () => {
         wrapper = Enzyme.mount(
             <Select
                 isRequired={false}
                 onChange={changeCallback}
                 onBlur={blurCallback}
+                name="test"
             >
                 <option aria-selected={true}>test1</option>
                 <option aria-selected={false}>test2</option>
             </Select>
         );
-        expect(wrapper.find("Select")).to.have.lengthOf(1);
+        expect(wrapper.find("select")).to.have.lengthOf(1);
+    });
+
+    it("Renders a name attribute to use in forms", () => {
+        wrapper = Enzyme.mount(
+            <Select
+                isRequired={false}
+                onChange={changeCallback}
+                onBlur={blurCallback}
+                ariaLabel="arialabel"
+                name="test2"
+            >
+                <option aria-selected={true}>test1</option>
+                <option aria-selected={false}>test2</option>
+            </Select>
+        );
+        expect(wrapper.find("select").prop("name")).to.equal("test2");
     });
 
     it("Renders an aria-label", () => {
@@ -37,7 +52,8 @@ describe("Select", () => {
                 isRequired={false}
                 onChange={changeCallback}
                 onBlur={blurCallback}
-                ariaLabel={"arialabel"}
+                ariaLabel="arialabel"
+                name="test3"
             >
                 <option aria-selected={true}>test1</option>
                 <option aria-selected={false}>test2</option>
@@ -54,19 +70,20 @@ describe("Select", () => {
                 isRequired={false}
                 onChange={changeCallback}
                 onBlur={blurCallback}
-                labelId={"1"}
-                helperTextId={"2"}
+                labelId="labelId"
+                helperTextId="helperTextId"
+                name="test4"
             >
                 <option aria-selected={true}>test1</option>
                 <option aria-selected={false}>test2</option>
             </Select>
         );
         expect(wrapper.find("select").props()["aria-labelledby"]).to.equal(
-            "1 2"
+            "labelId helperTextId"
         );
     });
 
-    it("Sends callback with value on change", () => {
+    it("Calls the onChange callback", () => {
         wrapper = Enzyme.mount(
             <Select
                 labelId="label"
@@ -74,18 +91,57 @@ describe("Select", () => {
                 id="hi"
                 onChange={changeCallback}
                 onBlur={blurCallback}
+                name="test5"
             >
                 <option aria-selected={true}>test1</option>
                 <option aria-selected={false}>test2</option>
             </Select>
         );
 
-        wrapper.find("select").simulate("change", "", { value: ["val"] });
+        wrapper
+            .find("select")
+            .simulate("change", { target: { value: "test2" } });
 
         expect(changeCallback.callCount).to.equal(1);
     });
 
-    it("Sends callback with no value on blur", () => {
+    it("Calls the callback onChange function with the updated value", () => {
+        let currentValue = "";
+        const onChange = (event) => {
+            currentValue = event?.target?.value;
+        };
+        wrapper = Enzyme.mount(
+            <Select
+                labelId="label"
+                isRequired={false}
+                id="update-value"
+                onChange={onChange}
+                onBlur={blurCallback}
+                name="test6"
+            >
+                <option aria-selected={false}>value1</option>
+                <option aria-selected={false}>value2</option>
+                <option aria-selected={false}>value3</option>
+            </Select>
+        );
+
+        wrapper
+            .find("select")
+            .simulate("change", { target: { value: "value2" } });
+        expect(currentValue).to.equal("value2");
+
+        wrapper
+            .find("select")
+            .simulate("change", { target: { value: "value3" } });
+        expect(currentValue).to.equal("value3");
+
+        wrapper
+            .find("select")
+            .simulate("change", { target: { value: "value1" } });
+        expect(currentValue).to.equal("value1");
+    });
+
+    it("Calls the onBlur callback", () => {
         wrapper = Enzyme.mount(
             <Select
                 id="hi"
@@ -93,14 +149,51 @@ describe("Select", () => {
                 isRequired={false}
                 onChange={changeCallback}
                 onBlur={blurCallback}
+                name="test7"
             >
                 <option aria-selected={true}>test1</option>
                 <option aria-selected={false}>test2</option>
             </Select>
         );
-        wrapper.find("select").simulate("blur", "");
+        wrapper.find("select").simulate("blur", { target: { value: "" } });
 
         expect(blurCallback.callCount).to.equal(1);
+    });
+
+    it("Calls the callback onBlur function with the updated value", () => {
+        let currentValue = "";
+        const onBlur = (event) => {
+            currentValue = event?.target?.value;
+        };
+        wrapper = Enzyme.mount(
+            <Select
+                labelId="label"
+                isRequired={false}
+                id="update-value"
+                onChange={changeCallback}
+                onBlur={onBlur}
+                name="test8"
+            >
+                <option aria-selected={false}>value1</option>
+                <option aria-selected={false}>value2</option>
+                <option aria-selected={false}>value3</option>
+            </Select>
+        );
+
+        wrapper
+            .find("select")
+            .simulate("blur", { target: { value: "value2" } });
+        expect(currentValue).to.equal("value2");
+
+        wrapper
+            .find("select")
+            .simulate("blur", { target: { value: "value3" } });
+        expect(currentValue).to.equal("value3");
+
+        wrapper
+            .find("select")
+            .simulate("blur", { target: { value: "value1" } });
+        expect(currentValue).to.equal("value1");
     });
 
     it("Displays the selected option onLoad when passed selectedOption", () => {
@@ -109,14 +202,61 @@ describe("Select", () => {
                 labelId="label"
                 isRequired={false}
                 id="hi"
-                selectedOption={"test2"}
+                selectedOption="test2"
                 onChange={changeCallback}
                 onBlur={blurCallback}
+                name="test9"
             >
                 <option aria-selected={true}>test1</option>
                 <option aria-selected={false}>test2</option>
             </Select>
         );
         expect(wrapper.find("select").props().value).to.equal("test2");
+    });
+
+    it("Updates the component's state when a new value is selected", () => {
+        wrapper = Enzyme.mount(
+            <Select
+                labelId="label"
+                isRequired={false}
+                id="state-change"
+                onChange={changeCallback}
+                onBlur={blurCallback}
+                selectedOption="value1"
+                name="test10"
+            >
+                <option aria-selected={false}>value1</option>
+                <option aria-selected={false}>value2</option>
+                <option aria-selected={false}>value3</option>
+            </Select>
+        );
+        expect(wrapper.find("select").props().value).to.equal("value1");
+
+        wrapper
+            .find("select")
+            .simulate("change", { target: { value: "value2" } });
+        expect(wrapper.find("select").props().value).to.equal("value2");
+
+        wrapper
+            .find("select")
+            .simulate("blur", { target: { value: "value3" } });
+        expect(wrapper.find("select").props().value).to.equal("value3");
+    });
+
+    it("Passes the ref to the select element", () => {
+        const ref = React.createRef<HTMLSelectElement>();
+        const container = Enzyme.mount(
+            <Select
+                labelId="label"
+                isRequired={false}
+                id="ref-test"
+                name="test11"
+                ref={ref}
+            >
+                <option aria-selected={false}>test1</option>
+                <option aria-selected={false}>test2</option>
+            </Select>
+        );
+        expect(container.find("select").instance()).to.equal(ref.current);
     });
 });

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -78,7 +78,8 @@ describe("Select", () => {
                 <option aria-selected={false}>test2</option>
             </Select>
         );
-        expect(wrapper.find("select").props()["aria-labelledby"]).to.equal(
+
+        expect(wrapper.find("select").prop("aria-labelledBy")).to.equal(
             "labelId helperTextId"
         );
     });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -23,8 +23,9 @@ export interface SelectProps {
     labelId?: string;
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     modifiers?: string[];
-    /**  */
+    /** The name of the select element to use in form submission */
     name: string;
+    /** Passes selects' current value to the React state handler */
     onBlur?: (event: React.FormEvent) => void;
     /** Passes selects' current value to the React state handler */
     onChange?: (event: React.FormEvent) => void;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -56,7 +56,9 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             if (target) {
                 setSelectedOption(target.value);
             }
-            additionalChange && additionalChange(event);
+            if (additionalChange) {
+                additionalChange(event);
+            }
         };
         const {
             ariaLabel = null,

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -1,6 +1,5 @@
-import * as React from "react";
+import React, { useState } from "react";
 import bem from "../../utils/bem";
-import Icon from "../Icons/Icon";
 
 export interface SelectProps {
     /** When passed, will populate the aria-label on the select */
@@ -11,44 +10,53 @@ export interface SelectProps {
     blockName?: string;
     /** ClassName you can add in addition to 'select' */
     className?: string;
+    children?: React.ReactNode;
     /** When true, disables the select */
     disabled?: boolean;
     /** ID of associated HelperText */
     helperTextId?: string;
     /** ID that other components can cross reference for accessibility purposes */
     id?: string;
-    /** ID of associated label */
-    labelId?: string;
     /** Attribute indicating that an option with a non-empty string value must be selected */
     isRequired: boolean;
-    onBlur: (event: React.FormEvent) => void;
-    /** Passes selects' current value to the React state handler */
-    onChange: (event: React.FormEvent) => void;
+    /** ID of associated label */
+    labelId?: string;
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     modifiers?: string[];
+    /**  */
+    name: string;
+    onBlur?: (event: React.FormEvent) => void;
+    /** Passes selects' current value to the React state handler */
+    onChange?: (event: React.FormEvent) => void;
     /** Sets whatever string you pass it as the default selected */
     selectedOption?: string;
 }
 
-export default class Select extends React.Component<
-    SelectProps,
-    { selectedOption: string }
-> {
-    constructor(props: SelectProps) {
-        super(props);
-        this.state = { selectedOption: props.selectedOption };
-        this.onSelectChange.bind(this);
-    }
-
-    onSelectChange(event: React.FormEvent, additionalChange: Function) {
-        let target = event.target as HTMLSelectElement;
-        if (target) {
-            this.setState({ selectedOption: target.value });
-        }
-        additionalChange(event);
-    }
-
-    render() {
+/**
+ * Select
+ * A component that renders a `select` DOM element along with its `option`
+ * children.
+ */
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+    (props, ref?) => {
+        const [selectedOption, setSelectedOption] = useState(
+            props.selectedOption
+        );
+        /**
+         * onSelectChange
+         * Update the state value for the option that was selected and fire off
+         * any additional callbacks.
+         */
+        const onSelectChange = (
+            event: React.FormEvent,
+            additionalChange: Function
+        ) => {
+            let target = event.target as HTMLSelectElement;
+            if (target) {
+                setSelectedOption(target.value);
+            }
+            additionalChange && additionalChange(event);
+        };
         const {
             ariaLabel,
             blockName,
@@ -60,17 +68,18 @@ export default class Select extends React.Component<
             labelId,
             onBlur,
             onChange,
-            selectedOption,
-        } = this.props;
+            name,
+            attributes,
+            disabled = false,
+        } = props;
 
-        const modifiers = this.props.modifiers ? this.props.modifiers : [];
-        const disabled = this.props.disabled ? this.props.disabled : false;
+        const modifiers = props.modifiers ? props.modifiers : [];
 
         let selectProps = {
             id: id,
             className: bem("select", modifiers, blockName, [className]),
             "aria-required": isRequired,
-            value: this.state.selectedOption,
+            value: selectedOption,
             disabled: disabled,
             "aria-label": ariaLabel,
         };
@@ -85,18 +94,22 @@ export default class Select extends React.Component<
 
         return (
             <select
+                name={name}
                 {...selectProps}
-                onBlur={(e) => this.onSelectChange(e, onBlur)}
-                onChange={(e) => this.onSelectChange(e, onChange)}
+                {...attributes}
+                ref={ref}
+                onBlur={(e) => onSelectChange(e, onBlur)}
+                onChange={(e) => onSelectChange(e, onChange)}
             >
                 {React.Children.map(children, (child, key) =>
                     React.cloneElement(child as React.ReactElement<any>, {
                         "aria-selected":
-                            children[key].props.children ===
-                            this.state.selectedOption,
+                            children[key].props.children === selectedOption,
                     })
                 )}
             </select>
         );
     }
-}
+);
+
+export default Select;

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -41,7 +41,7 @@ export interface SelectProps {
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     (props, ref?) => {
         const [selectedOption, setSelectedOption] = useState(
-            props.selectedOption
+            props.selectedOption || null
         );
         /**
          * onSelectChange
@@ -59,7 +59,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             additionalChange && additionalChange(event);
         };
         const {
-            ariaLabel,
+            ariaLabel = null,
             blockName,
             children,
             className,
@@ -73,34 +73,31 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
             attributes,
             disabled = false,
         } = props;
-
         const modifiers = props.modifiers ? props.modifiers : [];
-
-        let selectProps = {
-            id: id,
-            className: bem("select", modifiers, blockName, [className]),
-            "aria-required": isRequired,
-            value: selectedOption,
-            disabled: disabled,
-            "aria-label": ariaLabel,
-        };
+        let ariaLabelledBy = null;
 
         if (labelId && !helperTextId) {
-            selectProps["aria-labelledby"] = labelId;
+            ariaLabelledBy = labelId;
         } else if (helperTextId && !labelId) {
-            selectProps["aria-labelledby"] = helperTextId;
+            ariaLabelledBy = helperTextId;
         } else if (labelId && helperTextId) {
-            selectProps["aria-labelledby"] = labelId + " " + helperTextId;
+            ariaLabelledBy = labelId + " " + helperTextId;
         }
 
         return (
             <select
                 name={name}
-                {...selectProps}
-                {...attributes}
+                id={id}
+                className={bem("select", modifiers, blockName, [className])}
+                aria-required={isRequired}
+                disabled={disabled}
+                aria-label={ariaLabel}
+                aria-labelledBy={ariaLabelledBy}
+                value={selectedOption}
                 ref={ref}
                 onBlur={(e) => onSelectChange(e, onBlur)}
                 onChange={(e) => onSelectChange(e, onChange)}
+                {...attributes}
             >
                 {React.Children.map(children, (child, key) =>
                     React.cloneElement(child as React.ReactElement<any>, {


### PR DESCRIPTION
Issue number: #285 

## **This PR does the following:**
- This PR updates the `Select` by giving it a `name` prop and implement it with `ForwardRef`. All HTML form elements should have a `name` attribute so that form submissions can pick up the value. The `forwardRef` is for libraries that need it, such as `react-hook-form` or for any other ref that a dev wants to pass.

There are some components that use the `Select` component so I had to update those components simply by adding a `name` prop.

I converted the `Select` component to a functional component and used the `useState` hook to keep track of the selected value.

### Front End Review:
- [ ] View [the example in Storybook]()
