### PR TITLE
Breadcrumbs Background Modifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## 0.9.1
 
-### Adds
+### Changes
 
--   Section modifiers for `Breadcrumbs`, including: `--locations`, `--whats-on`, `--research`, and `--books-and-more`
+-   `Breadcrumbs`'s background color now reflects the app's globally applied section modifier, such as `.nypl--locations`. It recognizes these for `--locations`, `--whats-on`, `--research`, and `--books-and-more`.
 
 ## 0.9.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.9.1
+
+### Adds
+
+-   Section modifiers for `Breadcrumbs`, including: `--locations`, `--whats-on`, `--research`, and `--books-and-more`
+
 ## 0.9.0
 
 ### Breaking Changes

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,10 +1,15 @@
 import * as React from "react";
+import { select } from "@storybook/addon-knobs";
+import { withDesign } from "storybook-addon-designs";
 
 import Breadcrumbs from "./Breadcrumbs";
+import Heading from "../Heading/Heading";
+import Link from "../Link/Link";
 
 export default {
     title: "Breadcrumb",
     component: Breadcrumbs,
+    decorators: [withDesign],
 };
 
 const shortItems = [
@@ -27,5 +32,38 @@ const longItems = [
     },
 ];
 
-export const shortBreadcrumbs = () => <Breadcrumbs breadcrumbs={shortItems} />;
-export const longBreadcrumbs = () => <Breadcrumbs breadcrumbs={longItems} />;
+const sections = ["locations", "books-and-more", "research", "whats-on"];
+
+const breadcrumbsLengths = [shortItems, longItems];
+
+export const breadcrumbs = () => (
+    <>
+        <Heading level={1}>Breadcrumbs</Heading>
+        <p>
+            Breadcrumbs background color matches the secondary section color of
+            the website section they're placed into. See more about brand colors{" "}
+            <Link href="?path=/story/colors--colors-brand">here</Link>.
+        </p>
+        <Breadcrumbs
+            breadcrumbs={select(
+                "Length of beadcrumbs",
+                breadcrumbsLengths,
+                breadcrumbsLengths[0]
+            )}
+            modifiers={[select("Section", sections, sections[0])]}
+        />
+    </>
+);
+
+// export const longBreadcrumbs = () => <Breadcrumbs breadcrumbs={longItems} />;
+
+breadcrumbs.story = {
+    name: "Breadcrumbs",
+    parameters: {
+        design: {
+            type: "figma",
+            url:
+                "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=10766%3A1031",
+        },
+    },
+};

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -32,7 +32,12 @@ const longItems = [
     },
 ];
 
-const sections = ["locations", "books-and-more", "research", "whats-on"];
+const sections = [
+    "nypl--books-and-more",
+    "nypl--locations",
+    "nypl--research",
+    "nypl--whats-on",
+];
 let showLongItems;
 
 export const breadcrumbs = () => (
@@ -46,10 +51,9 @@ export const breadcrumbs = () => (
             the website section they're placed into. See more about brand colors{" "}
             <Link href="?path=/story/colors--colors-brand">here</Link>.
         </p>
-        <Breadcrumbs
-            breadcrumbs={showLongItems ? longItems : shortItems}
-            modifiers={[select("Section", sections, sections[0])]}
-        />
+        <div className={select("Section", sections, sections[0])}>
+            <Breadcrumbs breadcrumbs={showLongItems ? longItems : shortItems} />
+        </div>
     </>
 );
 

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { select } from "@storybook/addon-knobs";
+import { select, boolean } from "@storybook/addon-knobs";
 import { withDesign } from "storybook-addon-designs";
 
 import Breadcrumbs from "./Breadcrumbs";
@@ -33,11 +33,13 @@ const longItems = [
 ];
 
 const sections = ["locations", "books-and-more", "research", "whats-on"];
-
-const breadcrumbsLengths = [shortItems, longItems];
+let showLongItems;
 
 export const breadcrumbs = () => (
     <>
+        {boolean("Show Long Items", false)
+            ? (showLongItems = true)
+            : (showLongItems = false)}
         <Heading level={1}>Breadcrumbs</Heading>
         <p>
             Breadcrumbs background color matches the secondary section color of
@@ -45,17 +47,11 @@ export const breadcrumbs = () => (
             <Link href="?path=/story/colors--colors-brand">here</Link>.
         </p>
         <Breadcrumbs
-            breadcrumbs={select(
-                "Length of beadcrumbs",
-                breadcrumbsLengths,
-                breadcrumbsLengths[0]
-            )}
+            breadcrumbs={showLongItems ? longItems : shortItems}
             modifiers={[select("Section", sections, sections[0])]}
         />
     </>
 );
-
-// export const longBreadcrumbs = () => <Breadcrumbs breadcrumbs={longItems} />;
 
 breadcrumbs.story = {
     name: "Breadcrumbs",

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -83,3 +83,12 @@ $break-breadcrumbs-mobile: max-width 599px;
         background-color: var(--section-whats-on-secondary);
     }
 }
+
+.storybook-breadcrumbsExample {
+    .breadcrumbs {
+        flex: 1 1 50%;
+        margin-left: unset;
+        margin-right: var(--space-l);
+        max-height: 42px;
+    }
+}

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -3,67 +3,83 @@ $break-breadcrumbs-mobile: max-width 599px;
 .breadcrumbs {
     @include breakout;
 
-    background-color: var(--section-research-secondary);
+    background-color: var(--ui-black);
     padding-bottom: var(--space-xs);
     padding-top: var(--space-xs);
-}
 
-.breadcrumbs__list {
-    @include list-reset;
-    @include wrapper;
+    &__item {
+        @include space-inline-xxs;
 
-    color: var(--ui-white);
-}
+        align-items: center;
+        display: inline;
+        font-size: var(--font-size--1);
+        line-height: 1.5;
+        position: relative;
+        word-break: break-word;
 
-.breadcrumbs__item {
-    @include space-inline-xxs;
+        &:not(:last-child) {
+            &::after {
+                content: "/";
+                padding-left: var(--space-xxs);
+            }
 
-    align-items: center;
-    display: inline;
-    font-size: var(--font-size--1);
-    line-height: 1.5;
-    position: relative;
-    word-break: break-word;
-
-    &:not(:last-child) {
-        &::after {
-            content: "/";
-            padding-left: var(--space-xxs);
+            @include breakpoint($break-breadcrumbs-mobile) {
+                display: none;
+            }
         }
 
-        @include breakpoint($break-breadcrumbs-mobile) {
+        &:last-child {
+            @include breakpoint($break-breadcrumbs-mobile) {
+                padding-left: var(--space-m);
+            }
+        }
+    }
+
+    &__icon {
+        @include icon;
+
+        left: 0;
+        position: absolute;
+        top: 50%;
+        transform: rotate(90deg) translateX(-50%);
+
+        @include breakpoint($breakpoint-medium) {
             display: none;
         }
     }
 
-    &:last-child {
-        @include breakpoint($break-breadcrumbs-mobile) {
-            padding-left: var(--space-m);
-        }
+    &__link,
+    &__link:link,
+    &__link:visited,
+    &__link:focus {
+        color: inherit;
+        text-decoration: none;
     }
-}
 
-.breadcrumbs__icon {
-    @include icon;
-
-    left: 0;
-    position: absolute;
-    top: 50%;
-    transform: rotate(90deg) translateX(-50%);
-
-    @include breakpoint($breakpoint-medium) {
-        display: none;
+    &__link:hover {
+        text-decoration: underline;
     }
-}
 
-.breadcrumbs__link,
-.breadcrumbs__link:link,
-.breadcrumbs__link:visited,
-.breadcrumbs__link:focus {
-    color: inherit;
-    text-decoration: none;
-}
+    &__list {
+        @include list-reset;
+        @include wrapper;
 
-.breadcrumbs__link:hover {
-    text-decoration: underline;
+        color: var(--ui-white);
+    }
+
+    &--books-and-more {
+        background-color: var(--section-books-and-more-secondary);
+    }
+
+    &--locations {
+        background-color: var(--section-locations-secondary);
+    }
+
+    &--research {
+        background-color: var(--section-research-secondary);
+    }
+
+    &--whats-on {
+        background-color: var(--section-whats-on-secondary);
+    }
 }

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -67,19 +67,19 @@ $break-breadcrumbs-mobile: max-width 599px;
         color: var(--ui-white);
     }
 
-    &--books-and-more {
+    .nypl--books-and-more & {
         background-color: var(--section-books-and-more-secondary);
     }
 
-    &--locations {
+    .nypl--locations & {
         background-color: var(--section-locations-secondary);
     }
 
-    &--research {
+    .nypl--research & {
         background-color: var(--section-research-secondary);
     }
 
-    &--whats-on {
+    .nypl--whats-on & {
         background-color: var(--section-whats-on-secondary);
     }
 }

--- a/src/components/Colors/Colors.stories.tsx
+++ b/src/components/Colors/Colors.stories.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 
-import { boolean, text } from "@storybook/addon-knobs";
+import { boolean, text, select } from "@storybook/addon-knobs";
 import cssVariables from "../../helpers/CSSVariablesHelper";
 import getCSSVariable from "../../helpers/getCSSVariable";
 import UIDocCard from "./UIDocCard";
+import Breadcrumbs from "../Breadcrumbs/Breadcrumbs";
 import Card from "../Card/Card";
 import List from "../List/List";
 import Heading from "../Heading/Heading";
@@ -45,16 +46,59 @@ for (const [key, value] of Object.entries(grayScaleVariables)) {
     makeUIDocCard(key, value, grayscaleDocs);
 }
 
+const sections = [
+    "nypl--books-and-more",
+    "nypl--locations",
+    "nypl--research",
+    "nypl--whats-on",
+];
+
+const sectionDefault = sections[3];
+
 export const colorsBrand = () => (
     <>
         <Heading level={1}>Section Colors</Heading>
         <Heading level={2}>What's On</Heading>
         <p>
-            Section colors are branding colors only in use at NYPL. These are
-            used with components that consume theme colors such as
-            `Breadcrumbs`.
+            Section colors are branding colors only in use at NYPL. Certain
+            components, such as Breadcrumbs below, change color based on the
+            modifier applied the body tag.
         </p>
-        <p>What's On is used for Exhibitions & Events.</p>
+        <div
+            className={
+                select("Section", sections, sectionDefault) +
+                " storybook-breadcrumbsExample"
+            }
+            style={{ marginBottom: "2%", display: "flex", width: "100%" }}
+        >
+            <Breadcrumbs
+                breadcrumbs={[
+                    { url: "#", text: "Parent" },
+                    { url: "#", text: "Home" },
+                ]}
+            />
+            <div
+                style={{
+                    flex: "1 1 50%",
+                    backgroundColor: "var(--ui-gray-xlight)",
+                    padding: "2%",
+                }}
+            >
+                <pre>
+                    <code>
+                        {"<div className="}
+                        {"'" +
+                            select("Section", sections, sectionDefault) +
+                            "'"}
+                        {">\n"}
+                        {"    <Breadcrumbs...></Breadcrumbs>"}
+                        {"\n"}
+                        {"</div>"}
+                    </code>
+                </pre>
+            </div>
+        </div>
+        <p>What's On is used for Events, Exhibitions & Audio Guides.</p>
         <List
             type={ListTypes.Unordered}
             modifiers={["no-list-styling"]}


### PR DESCRIPTION
Issue number: #301 + #283 

## **This PR does the following:**
- Adds modifiers for Breadcrumbs: `--locations`, `--whats-on`, `--books-and-more`, `--research`
- Updates stories for Breadcrumbs: adds designs, adds knobs

### Front End Review:
- [ ] View [the Breadcrumbs in Storybook](https://deploy-preview-312--stoic-murdock-c7f044.netlify.app/?path=/story/breadcrumb--breadcrumbs)
- [ ] View [Colors in Storybook](https://deploy-preview-312--stoic-murdock-c7f044.netlify.app/?path=/story/colors--colors-brand)
