### PR TITLE
Deprecates SectionName

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.10.0
+
+### Removes
+
+-   Deprecates `SectionName` in favor of the stories under `Colors—Brand`
+
 ## 0.9.3
 
 ### Adds

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -4,7 +4,6 @@ import Image from "../Image/Image";
 import Heading from "../Heading/Heading";
 import { HeroTypes } from "./HeroTypes";
 import Hero from "./Hero";
-import SectionName from "../SectionName/SectionName";
 import Placeholder from "../Placeholder/Placeholder";
 
 export default {
@@ -99,7 +98,7 @@ export const ExhibitionsHero = () => (
 );
 
 export const DigitalResearchBooksHeader = () => (
-    <SectionName>
+    <>
         <Hero
             heroType={HeroTypes.Secondary}
             heading={
@@ -125,5 +124,5 @@ export const DigitalResearchBooksHeader = () => (
                 />
             }
         />
-    </SectionName>
+    </>
 );

--- a/src/components/SectionName/SectionName.tsx
+++ b/src/components/SectionName/SectionName.tsx
@@ -1,8 +1,0 @@
-import * as React from "react";
-import bem from "../../utils/bem";
-
-const SectionName = ({ children }) => (
-    <div className={bem("main", ["research"])}>{children}</div>
-);
-
-export default SectionName;

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,5 @@ export { default as Modal } from "./components/Modal/Modal";
 export { default as Pagination } from "./components/Pagination/Pagination";
 export { default as SearchBar } from "./components/SearchBar/SearchBar";
 export { default as SearchResultItem } from "./components/SearchResultItem/SearchResultItem";
-export { default as SectionName } from "./components/SectionName/SectionName";
 export { default as SectionTitle } from "./components/SectionTitle/SectionTitle";
 export { default as Select } from "./components/Select/Select";


### PR DESCRIPTION
Issue number: #279

## **This PR does the following:**
- Removes the `SectionName` component in favor of the Color-Brand stories

### Front End Review:
- [ ] View [the example in Storybook](https://nypl.github.io/nypl-design-system/storybook-static/?path=/story/colors--colors-brand)
