### PR TITLE
Link component update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.10.4
+
+### Changes
+
+-   Updates the `Link` component's `linkType` prop to `type`, implements `React.forwardRef` to use with other libraries, and updates the stories.
+
 ## 0.10.3
 
 ### Changes

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -12,7 +12,7 @@ export default {
     component: Accordion,
 };
 const checkboxes = [
-    <li>
+    <li key="one">
         <Checkbox
             onChange={action("changed")}
             checkboxId="checkbox-1"
@@ -22,7 +22,7 @@ const checkboxes = [
             }}
         ></Checkbox>
     </li>,
-    <li>
+    <li key="two">
         <Checkbox
             onChange={action("changed")}
             checkboxId="checkbox-2"
@@ -32,7 +32,7 @@ const checkboxes = [
             }}
         ></Checkbox>
     </li>,
-    <li>
+    <li key="three">
         <Checkbox
             onChange={action("changed")}
             checkboxId="checkbox-3"

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -111,13 +111,13 @@ export const ExampleCard = () => (
         }
         ctas={
             <>
-                <Link linkType={LinkTypes.Button} href="blah">
+                <Link type={LinkTypes.Button} href="blah">
                     Reserve
                 </Link>
                 <div className="italicized ui-gray-dark">
                     0 of 11 copies available. 3 patrons in the queue.
                 </div>
-                <Link href="#url" linkType={LinkTypes.Forwards}>
+                <Link href="#url" type={LinkTypes.Forwards}>
                     View Book Details
                 </Link>
             </>

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -64,11 +64,11 @@ describe("Card", () => {
             }
             ctas={
                 <div className="edition-card__ctas">
-                    <Link linkType={LinkTypes.Button} href="blah">
+                    <Link type={LinkTypes.Button} href="blah">
                         Read Online
                     </Link>
                     <div className="edition-card__download">
-                        <Link href="#url" linkType={LinkTypes.Action}>
+                        <Link href="#url" type={LinkTypes.Action}>
                             <Icon
                                 name={IconNames.download}
                                 blockName="more-link"
@@ -139,11 +139,11 @@ describe("Card", () => {
             }
             ctas={
                 <div className="edition-card__ctas">
-                    <Link linkType={LinkTypes.Button} href="blah">
+                    <Link type={LinkTypes.Button} href="blah">
                         Read Online
                     </Link>
                     <div className="edition-card__download">
-                        <Link href="#url" linkType={LinkTypes.Action}>
+                        <Link href="#url" type={LinkTypes.Action}>
                             <Icon
                                 name={IconNames.download}
                                 blockName="more-link"
@@ -173,11 +173,11 @@ describe("Card", () => {
             }
             ctas={
                 <div className="edition-card__ctas">
-                    <Link linkType={LinkTypes.Button} href="blah">
+                    <Link type={LinkTypes.Button} href="blah">
                         Read Online
                     </Link>
                     <div className="edition-card__download">
-                        <Link href="#url" linkType={LinkTypes.Action}>
+                        <Link href="#url" type={LinkTypes.Action}>
                             <Icon
                                 name={IconNames.download}
                                 blockName="more-link"

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -15,19 +15,19 @@ export default {
 };
 
 export const passedInAnchorElement = () => (
-    <Link linkType={LinkTypes.Default}>
+    <Link type={LinkTypes.Default}>
         <a href="#passed-in-link">I'm an anchor element link!</a>
     </Link>
 );
 
 export const generatedLink = () => (
-    <Link href="#passed-in-link" linkType={LinkTypes.Default}>
+    <Link href="#passed-in-link" type={LinkTypes.Default}>
         I'm just a string
     </Link>
 );
 
 export const buttonLink = () => (
-    <Link linkType={LinkTypes.Button} href="#passed-in-link">
+    <Link type={LinkTypes.Button} href="#passed-in-link">
         I look like a button but I'm actually a link
     </Link>
 );
@@ -37,7 +37,7 @@ export const forwardsLink = () => (
         This link's icon is predefined and set with the `Forwards` `linkType`
         prop.
         <br />
-        <Link href="#passedinlink" linkType={LinkTypes.Forwards}>
+        <Link href="#passedinlink" type={LinkTypes.Forwards}>
             content
         </Link>
     </>
@@ -48,7 +48,7 @@ export const backwardsLink = () => (
         This link's icon is predefined and set with the `Backwards` `linkType`
         prop.
         <br />
-        <Link href="#passed-in-link" linkType={LinkTypes.Backwards}>
+        <Link href="#passed-in-link" type={LinkTypes.Backwards}>
             content
         </Link>
     </>
@@ -59,7 +59,7 @@ export const actionLinkWithDownloadIcon = () => (
         A custom icon is added to the anchor child element.
         <br />
         {/* To Pass in an icon and its link, make sure that the link tag wraps the icon. */}
-        <Link linkType={LinkTypes.Action} id="beepbeep">
+        <Link type={LinkTypes.Action} id="beepbeep">
             <a href="#passed-link">
                 <Icon
                     name={IconNames.download}
@@ -79,7 +79,7 @@ export const LinkWithReactRouter = () => (
         The Design System's `Link` component should wrap around react-router's
         own `Link` component.
         <br />
-        <Link linkType={LinkTypes.Action}>
+        <Link type={LinkTypes.Action}>
             <ReactRouterLink to="#">
                 <Icon
                     name={IconNames.download}
@@ -105,7 +105,7 @@ export const LinkWithNextJSRouter = () => (
         component wraps around with the `href` and `passHref` props.
         <br />
         <NextJsLink href="#" passHref>
-            <Link linkType={LinkTypes.Action}>Next Page</Link>
+            <Link type={LinkTypes.Action}>Next Page</Link>
         </NextJsLink>
     </>
 );

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -34,9 +34,10 @@ export const buttonLink = () => (
 
 export const forwardsLink = () => (
     <>
-        This link's icon is predefined and set with the `Forwards` `linkType`
-        prop.
-        <br />
+        <p>
+            This link's icon is predefined and set with the `Forwards`
+            `linkType` prop.
+        </p>
         <Link href="#passedinlink" type={LinkTypes.Forwards}>
             content
         </Link>
@@ -45,9 +46,10 @@ export const forwardsLink = () => (
 
 export const backwardsLink = () => (
     <>
-        This link's icon is predefined and set with the `Backwards` `linkType`
-        prop.
-        <br />
+        <p>
+            This link's icon is predefined and set with the `Backwards`
+            `linkType` prop.
+        </p>
         <Link href="#passed-in-link" type={LinkTypes.Backwards}>
             content
         </Link>
@@ -56,8 +58,7 @@ export const backwardsLink = () => (
 
 export const actionLinkWithDownloadIcon = () => (
     <>
-        A custom icon is added to the anchor child element.
-        <br />
+        <p>A custom icon is added to the anchor child element.</p>
         {/* To Pass in an icon and its link, make sure that the link tag wraps the icon. */}
         <Link type={LinkTypes.Action} id="beepbeep">
             <a href="#passed-link">
@@ -75,23 +76,26 @@ export const actionLinkWithDownloadIcon = () => (
 );
 
 export const LinkWithReactRouter = () => (
-    <Router>
-        The Design System's `Link` component should wrap around react-router's
-        own `Link` component.
-        <br />
-        <Link type={LinkTypes.Action}>
-            <ReactRouterLink to="#">
-                <Icon
-                    name={IconNames.download}
-                    blockName="more-link"
-                    modifiers={["left"]}
-                    decorative={true}
-                    iconRotation={IconRotationTypes.rotate0}
-                ></Icon>
-                Download
-            </ReactRouterLink>
-        </Link>
-    </Router>
+    <>
+        <p>
+            The Design System's `Link` component should wrap around
+            react-router's own `Link` component.
+        </p>
+        <Router>
+            <Link type={LinkTypes.Action}>
+                <ReactRouterLink to="#">
+                    <Icon
+                        name={IconNames.download}
+                        blockName="more-link"
+                        modifiers={["left"]}
+                        decorative={true}
+                        iconRotation={IconRotationTypes.rotate0}
+                    ></Icon>
+                    Download
+                </ReactRouterLink>
+            </Link>
+        </Router>
+    </>
 );
 
 /**
@@ -101,9 +105,10 @@ const NextJsLink = (props: any) => <div>{props.children}</div>;
 
 export const LinkWithNextJSRouter = () => (
     <>
-        NextJS's `Link` component should wrap the Design System's `Link`
-        component wraps around with the `href` and `passHref` props.
-        <br />
+        <p>
+            NextJS's `Link` component should wrap the Design System's `Link`
+            component with `href` and `passHref` props.
+        </p>
         <NextJsLink href="#" passHref>
             <Link type={LinkTypes.Action}>Next Page</Link>
         </NextJsLink>

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -14,54 +14,71 @@ export default {
     component: Link,
 };
 
-export const passedInLink = () => (
+export const passedInAnchorElement = () => (
     <Link linkType={LinkTypes.Default}>
-        <a href="#passed-in-link">I'm cold</a>
+        <a href="#passed-in-link">I'm an anchor element link!</a>
     </Link>
 );
 
 export const generatedLink = () => (
     <Link href="#passed-in-link" linkType={LinkTypes.Default}>
-        I'm very cold
+        I'm just a string
     </Link>
 );
 
 export const buttonLink = () => (
     <Link linkType={LinkTypes.Button} href="#passed-in-link">
-        I'm very cold
+        I look like a button but I'm actually a link
     </Link>
 );
 
 export const forwardsLink = () => (
-    <Link linkType={LinkTypes.Forwards}>
-        <a href="#passedinlink">content</a>
-    </Link>
+    <>
+        This link's icon is predefined and set with the `Forwards` `linkType`
+        prop.
+        <br />
+        <Link href="#passedinlink" linkType={LinkTypes.Forwards}>
+            content
+        </Link>
+    </>
 );
 
 export const backwardsLink = () => (
-    <Link href="#passed-in-link" linkType={LinkTypes.Backwards}>
-        content
-    </Link>
+    <>
+        This link's icon is predefined and set with the `Backwards` `linkType`
+        prop.
+        <br />
+        <Link href="#passed-in-link" linkType={LinkTypes.Backwards}>
+            content
+        </Link>
+    </>
 );
 
 export const actionLinkWithDownloadIcon = () => (
-    // To Pass in an icon and its link, make sure that the link tag wraps the icon.
-    <Link linkType={LinkTypes.Action} id="beepbeep">
-        <a href="#passed-link">
-            <Icon
-                name={IconNames.download}
-                blockName="more-link"
-                modifiers={["left"]}
-                decorative={true}
-                iconRotation={IconRotationTypes.rotate0}
-            ></Icon>
-            Download
-        </a>
-    </Link>
+    <>
+        A custom icon is added to the anchor child element.
+        <br />
+        {/* To Pass in an icon and its link, make sure that the link tag wraps the icon. */}
+        <Link linkType={LinkTypes.Action} id="beepbeep">
+            <a href="#passed-link">
+                <Icon
+                    name={IconNames.download}
+                    blockName="more-link"
+                    modifiers={["left"]}
+                    decorative={true}
+                    iconRotation={IconRotationTypes.rotate0}
+                ></Icon>
+                Download
+            </a>
+        </Link>
+    </>
 );
 
 export const LinkWithReactRouter = () => (
     <Router>
+        The Design System's `Link` component should wrap around react-router's
+        own `Link` component.
+        <br />
         <Link linkType={LinkTypes.Action}>
             <ReactRouterLink to="#">
                 <Icon
@@ -75,4 +92,20 @@ export const LinkWithReactRouter = () => (
             </ReactRouterLink>
         </Link>
     </Router>
+);
+
+/**
+ * Dummy component as a NextJS `Link` example component.
+ */
+const NextJsLink = (props: any) => <div>{props.children}</div>;
+
+export const LinkWithNextJSRouter = () => (
+    <>
+        NextJS's `Link` component should wrap the Design System's `Link`
+        component wraps around with the `href` and `passHref` props.
+        <br />
+        <NextJsLink href="#" passHref>
+            <Link linkType={LinkTypes.Action}>Next Page</Link>
+        </NextJsLink>
+    </>
 );

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -99,9 +99,19 @@ export const LinkWithReactRouter = () => (
 );
 
 /**
- * Dummy component as a NextJS `Link` example component.
+ * Dummy component as a NextJS `Link` example component. In real life, NextJS's
+ * `Link` component will do something similar but with pass down props and ref
+ * and make it workable. This is just an example wrapper.
  */
-const NextJsLink = (props: any) => <div>{props.children}</div>;
+const NextJsLink = (props: any) => (
+    <div>
+        {React.cloneElement(
+            props.children,
+            { ...props },
+            props.children.props.children
+        )}
+    </div>
+);
 
 export const LinkWithNextJSRouter = () => (
     <>

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -2,7 +2,6 @@ import { expect } from "chai";
 import { stub } from "sinon";
 import * as Enzyme from "enzyme";
 import * as React from "react";
-import * as Mocha from "mocha";
 
 import Link from "./Link";
 import { LinkTypes } from "./LinkTypes";
@@ -129,5 +128,15 @@ describe("Link", () => {
                 </Link>
             )
         ).to.throw("Please pass only one child into Link");
+    });
+
+    it("Passes the ref to the input element", () => {
+        const ref = React.createRef<HTMLAnchorElement>();
+        const container = Enzyme.mount(
+            <Link href="/some-link" ref={ref}>
+                Go to page
+            </Link>
+        );
+        expect(container.find("a").instance()).to.equal(ref.current);
     });
 });

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -17,7 +17,7 @@ describe("Link", () => {
 
     it("Can pass in icon, text as child and url as props", () => {
         wrapper = Enzyme.mount(
-            <Link href="#passed-in-link" linkType={LinkTypes.Action}>
+            <Link href="#passed-in-link" type={LinkTypes.Action}>
                 <Icon
                     name={IconNames.download}
                     blockName="more-link"
@@ -43,7 +43,7 @@ describe("Link", () => {
 
     it("Can pass a link with <a> tag and an icon", () => {
         wrapper = Enzyme.mount(
-            <Link linkType={LinkTypes.Action}>
+            <Link type={LinkTypes.Action}>
                 <a href="#test2">
                     <Icon
                         name={IconNames.download}
@@ -62,7 +62,7 @@ describe("Link", () => {
 
     it("Generated back link has icon", () => {
         wrapper = Enzyme.mount(
-            <Link href="#passed-in-link" linkType={LinkTypes.Backwards}>
+            <Link href="#passed-in-link" type={LinkTypes.Backwards}>
                 content
             </Link>
         );
@@ -73,7 +73,7 @@ describe("Link", () => {
 
     it("Generated forwards link has icon", () => {
         wrapper = Enzyme.mount(
-            <Link href="#passed-in-link" linkType={LinkTypes.Forwards}>
+            <Link href="#passed-in-link" type={LinkTypes.Forwards}>
                 content
             </Link>
         );
@@ -90,7 +90,7 @@ describe("Link", () => {
     it("Can pass in a ReactRouter Link", () => {
         wrapper = Enzyme.mount(
             <Router>
-                <Link linkType={LinkTypes.Action}>
+                <Link type={LinkTypes.Action}>
                     <ReactRouterLink to="#">
                         <Icon
                             name={IconNames.download}

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -16,7 +16,7 @@ export interface LinkProps {
     /** ID */
     id?: string;
     /** Controls the link visuals—action, button, or default. */
-    linkType?: LinkTypes;
+    type?: LinkTypes;
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     modifiers?: string[];
     /** Any child node passed to the component. */
@@ -30,7 +30,7 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
         className,
         href,
         id,
-        linkType = LinkTypes.Default,
+        type = LinkTypes.Default,
         modifiers,
         children,
     } = props;
@@ -50,22 +50,22 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
     }
 
     if (
-        linkType === LinkTypes.Action ||
-        linkType === LinkTypes.Forwards ||
-        linkType === LinkTypes.Backwards
+        type === LinkTypes.Action ||
+        type === LinkTypes.Forwards ||
+        type === LinkTypes.Backwards
     ) {
         link_base_class = "more-link";
-    } else if (linkType === LinkTypes.Button) {
+    } else if (type === LinkTypes.Button) {
         link_base_class = "button";
     }
 
     let navigationIconProps, iconRotation, iconPosition, iconLeft, iconRight;
     // An icon needs a position in order for it to be created and
     // rendered in the link.
-    if (linkType === LinkTypes.Backwards) {
+    if (type === LinkTypes.Backwards) {
         iconRotation = IconRotationTypes.rotate90;
         iconPosition = "left";
-    } else if (linkType === LinkTypes.Forwards) {
+    } else if (type === LinkTypes.Forwards) {
         iconRotation = IconRotationTypes.rotate270;
         iconPosition = "right";
     }
@@ -77,9 +77,9 @@ const Link = React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref) => {
         decorative: "true",
     };
 
-    if (linkType === LinkTypes.Backwards) {
+    if (type === LinkTypes.Backwards) {
         iconLeft = <Icon {...navigationIconProps} />;
-    } else if (linkType === LinkTypes.Forwards) {
+    } else if (type === LinkTypes.Forwards) {
         iconRight = <Icon {...navigationIconProps} />;
     }
     let linkClassName = bem(link_base_class, modifiers, blockName, [className]);

--- a/src/components/Link/_Link.scss
+++ b/src/components/Link/_Link.scss
@@ -5,6 +5,11 @@
         text-decoration: none;
     }
 
+    // .button links have a blue background
+    &.button:hover {
+        color: var(--ui-white);
+    }
+
     &:hover {
         color: var(--ui-link-secondary);
     }

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -74,11 +74,11 @@ const exampleCard = (
         }
         ctas={
             <>
-                <Link linkType={LinkTypes.Button} href="blah">
+                <Link type={LinkTypes.Button} href="blah">
                     Reserve
                 </Link>
                 <div>0 of 11 copies available. 3 patrons in the queue.</div>
-                <Link href="#url" linkType={LinkTypes.Forwards}>
+                <Link href="#url" type={LinkTypes.Forwards}>
                     View Book Details
                 </Link>
             </>

--- a/src/components/SearchResultItem/SearchResultItem.stories.tsx
+++ b/src/components/SearchResultItem/SearchResultItem.stories.tsx
@@ -32,11 +32,11 @@ let cardContent = (
 
 let cardCTAs = (
     <div className="edition-card__ctas">
-        <Link linkType={LinkTypes.Button} href="blah">
+        <Link type={LinkTypes.Button} href="blah">
             Read Online
         </Link>
         <div className="edition-card__download">
-            <Link href="#url" linkType={LinkTypes.Action}>
+            <Link href="#url" type={LinkTypes.Action}>
                 <Icon
                     name={IconNames.download}
                     blockName="more-link"
@@ -63,12 +63,12 @@ let exampleEditionInfo = {
         <>Under Creative Commons License</>,
     ],
     readOnlineLink: (
-        <Link href="blah" blockName="edition-card" linkType={LinkTypes.Button}>
+        <Link href="blah" blockName="edition-card" type={LinkTypes.Button}>
             Read Online
         </Link>
     ),
     downloadLink: (
-        <Link href="#passed-in-link" linkType={LinkTypes.Action}>
+        <Link href="#passed-in-link" type={LinkTypes.Action}>
             <Icon
                 name={IconNames.download}
                 blockName="more-link"

--- a/src/components/SectionTitle/SectionTitle.tsx
+++ b/src/components/SectionTitle/SectionTitle.tsx
@@ -62,7 +62,7 @@ export default class SectionTitle extends React.Component<
             };
 
             link = (
-                <Link href="#passed-in-link" linkType={LinkTypes.Forwards}>
+                <Link href="#passed-in-link" type={LinkTypes.Forwards}>
                     See All
                 </Link>
             );


### PR DESCRIPTION
Issue number: #309 #338

## **This PR does the following:**
- This updates the `Link` component to not render custom props in the generated anchor element, updates `linkType` to `type`, updates the stories with some explanations, adds an example using it with the Nextjs `Link` component, and implements `forwardRef` to use with other libraries.

Note: I branched this branch off `logo-icons` by accident so leaving that branch as the base for now so you don't see unnecessary changes.

### Front End Review:
- [ ] View [the example in Storybook]()
