### PR TITLE
Fixes #360

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.11.4
+
+### Changes
+
+-   Removes the `description` tag from the `<span>` element wrapping svg icons (#360)
+
 ## 0.11.3
 
 ### Changes

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -89,7 +89,6 @@ export default function Icon(props: React.PropsWithChildren<IconProps>) {
         "aria-labelledby": title ? "title-" + name : undefined,
         "aria-describedby": desc ? "desc-" + name : undefined,
         title: title ? `title-${name}` : undefined,
-        description: desc ? `title-${name}` : undefined,
     };
 
     let svg;


### PR DESCRIPTION
Issue number: #360 

## **This PR does the following:**
- Removes the `description` prop from the `<span>` element that wraps SVG icons. It belongs ultimately (with a number of other props) on the `<svg>` tag itself, not on the wrapping `<span>` element.

### Front End Review:
- [ ] View [the example in Storybook](https://deploy-preview-365--stoic-murdock-c7f044.netlify.app/?path=/story/button--button)
