### PR TITLE
Removes Icon props from Button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.13.0
+
+### Breaking Changes
+
+-   Removes all icon props from `Button`. Button now uses `Icon` as a child
+-   Removes `ButtonIconPositions`
+
+### Changes
+
+-   Makes `Button`'s `onClick` property optional
+
 ## 0.12.0
 
 ### Breaking Changes

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 import Button from "../Button/Button";
 import bem from "../../utils/bem";
 import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import Icon from "../Icons/Icon";
+import { IconNames } from "../Icons/IconTypes";
 
 export interface AccordionProps {
     /** Inner label on the button that opens the accordion */
@@ -55,12 +57,16 @@ export default class Accordion extends React.Component<
                     id={labelId}
                     type="button"
                     blockName="accordion"
-                    iconPosition={ButtonIconPositions.JustifyRight}
-                    iconName={this.state.isOpen ? "minus" : "plus"}
-                    iconModifiers={["medium"]}
                     buttonType={ButtonTypes.Secondary}
                 >
                     {accordionLabel}
+                    <Icon
+                        name={
+                            this.state.isOpen ? IconNames.minus : IconNames.plus
+                        }
+                        decorative={true}
+                        modifiers={["small"]}
+                    />
                 </Button>
                 {this.state.isOpen && (
                     <div className="accordion-content">

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Button from "../Button/Button";
 import bem from "../../utils/bem";
-import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import { ButtonTypes } from "../Button/ButtonTypes";
 import Icon from "../Icons/Icon";
 import { IconNames } from "../Icons/IconTypes";
 

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -6,6 +6,10 @@
     &__button {
         @include button--outline;
 
+        align-items: center;
         border: none;
+        display: inline-flex;
+        justify-content: space-between;
+        width: 100%;
     }
 }

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import Button from "./Button";
-import { ButtonTypes, ButtonIconPositions } from "./ButtonTypes";
+import { ButtonTypes } from "./ButtonTypes";
 import Icon from "../Icons/Icon";
 import { IconRotationTypes, IconNames } from "../Icons/IconTypes";
 import { action } from "@storybook/addon-actions";

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -14,11 +14,17 @@ export default {
     decorators: [withDesign],
 };
 
-let showIcon;
+let showIconLeft;
+let showIconRight;
 
 export const button = () => (
     <>
-        {boolean("Show Icon", true) ? (showIcon = true) : (showIcon = false)}
+        {boolean("Show Icon on Left", true)
+            ? (showIconLeft = true)
+            : (showIconLeft = false)}
+        {boolean("Show Icon on Right", false)
+            ? (showIconRight = true)
+            : (showIconRight = false)}
         <Button
             onClick={action("clicked")}
             id="button"
@@ -26,7 +32,7 @@ export const button = () => (
             type="submit"
             disabled={boolean("Disabled", false)}
         >
-            {showIcon && (
+            {showIconLeft && (
                 <Icon
                     name={select("Icon", IconNames, IconNames.search_small)}
                     decorative={true}
@@ -34,6 +40,13 @@ export const button = () => (
                 />
             )}
             {text("Button Text", "Search")}
+            {showIconRight && (
+                <Icon
+                    name={select("Icon", IconNames, IconNames.search_small)}
+                    decorative={true}
+                    modifiers={["small", "icon-right"]}
+                />
+            )}
         </Button>
     </>
 );

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import Button from "./Button";
 import { ButtonTypes, ButtonIconPositions } from "./ButtonTypes";
+import Icon from "../Icons/Icon";
 import { IconRotationTypes, IconNames } from "../Icons/IconTypes";
 import { action } from "@storybook/addon-actions";
 import { withDesign } from "storybook-addon-designs";
@@ -24,22 +25,14 @@ export const button = () => (
             buttonType={select("Button Type", ButtonTypes, ButtonTypes.Primary)}
             type="submit"
             disabled={boolean("Disabled", false)}
-            iconPosition={
-                showIcon
-                    ? select(
-                          "Icon Position",
-                          ButtonIconPositions,
-                          ButtonIconPositions.Left
-                      )
-                    : null
-            }
-            iconName={
-                showIcon
-                    ? select("Icon", IconNames, IconNames.search_small)
-                    : null
-            }
-            iconDecorative={true}
         >
+            {showIcon && (
+                <Icon
+                    name={select("Icon", IconNames, IconNames.search_small)}
+                    decorative={true}
+                    modifiers={["small", "icon-left"]}
+                />
+            )}
             {text("Button Text", "Search")}
         </Button>
     </>

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -24,7 +24,6 @@ describe("Button", () => {
         expect(onClick.callCount).to.equal(1);
     });
     it("optionally renders a component", () => {
-        expect(wrapper.find("span").length).to.equal(1);
         expect(wrapper.text()).to.equal("Submit");
     });
     it("has 'button' class", () => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -4,24 +4,6 @@ import bem from "../../utils/bem";
 import { ButtonTypes, ButtonIconPositions } from "./ButtonTypes";
 import { IconRotationTypes } from "../Icons/IconTypes";
 
-export interface ButtonOptions {
-    content?: JSX.Element;
-    id?: string;
-    onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
-    attributes?: {};
-    modifiers?: string[];
-    blockName?: string;
-    buttonType?: ButtonTypes;
-    type?: "submit" | "button" | "reset";
-    mouseDown?: boolean;
-    iconPosition?: ButtonIconPositions;
-    iconName?: string;
-    iconRotation?: IconRotationTypes;
-    iconModifiers?: string[];
-    iconDecorative?: boolean;
-    iconRole?: string;
-}
-
 interface ButtonProps {
     /** Additional attributes passed to the button */
     attributes?: {};
@@ -33,19 +15,7 @@ interface ButtonProps {
     className?: string;
     /** Adds 'disabled' property to the button */
     disabled?: boolean;
-    /** Is the icon decorative */
-    iconDecorative?: boolean;
-    /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
-    iconModifiers?: string[];
-    /** The name of the icon.  Corresponds with the name of the icon's svg file */
-    iconName?: string;
-    /** If an icon is to be rendered, an `iconPosition` prop is required. */
-    iconPosition?: ButtonIconPositions;
-    /** The role for the icon, if not decorative */
-    iconRole?: string;
-    /** Optional amount of degrees to rotate icon */
-    iconRotation?: IconRotationTypes;
-    /** ID that other components can cross reference for accessibility purposes */
+
     id?: string;
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     modifiers?: string[];
@@ -73,12 +43,6 @@ export default class Button extends React.Component<ButtonProps, {}> {
             children,
             className,
             disabled,
-            iconDecorative,
-            iconModifiers = ["small"],
-            iconName,
-            iconPosition,
-            iconRole,
-            iconRotation,
             id,
             modifiers,
             mouseDown,
@@ -92,52 +56,6 @@ export default class Button extends React.Component<ButtonProps, {}> {
         }
 
         let button_base_class = "button";
-        let iconProps;
-        // An icon needs a position in order for it to be created and
-        // rendered in the button.
-        if (iconPosition) {
-            iconProps = {
-                name: iconName,
-                key: `icon-${id}`,
-                blockName: button_base_class,
-                modifiers: iconModifiers,
-                decorative: iconDecorative,
-                desc: iconDecorative,
-                role: iconDecorative ? undefined : iconRole,
-                title: iconDecorative,
-            };
-
-            if (iconModifiers) {
-                iconProps.modifiers.push(...iconModifiers);
-            }
-
-            if (iconRotation) {
-                iconProps.modifiers.push(iconRotation);
-            }
-
-            buttonModifiers.push("icon");
-
-            switch (iconPosition) {
-                case ButtonIconPositions.Left: {
-                    buttonModifiers.push("icon-left");
-                    iconProps.modifiers.push("icon-left");
-                    break;
-                }
-                case ButtonIconPositions.Right: {
-                    buttonModifiers.push("icon-right");
-                    iconProps.modifiers.push("icon-right");
-                    break;
-                }
-                case ButtonIconPositions.JustifyRight: {
-                    buttonModifiers.push("justify-right");
-                    iconProps.modifiers.push("justify-right");
-                    break;
-                }
-                default: {
-                    break;
-                }
-            }
-        }
 
         let btnCallback = mouseDown
             ? { onMouseDown: onClick }
@@ -157,12 +75,7 @@ export default class Button extends React.Component<ButtonProps, {}> {
                 {...attributes}
                 {...btnCallback}
             >
-                <span
-                    className={bem("label", buttonModifiers, button_base_class)}
-                >
-                    {children}
-                </span>
-                {iconProps && <Icon {...iconProps} />}
+                {children}
             </button>
         );
     }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -21,7 +21,7 @@ interface ButtonProps {
     modifiers?: string[];
     mouseDown?: boolean;
     /** The action to perform on the <button>'s onClick function */
-    onClick: (event: React.MouseEvent | React.KeyboardEvent) => void;
+    onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
     /** The html button attribute */
     type?: "submit" | "button" | "reset";
 }

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 import Icon, { IconProps } from "../Icons/Icon";
 import bem from "../../utils/bem";
-import { ButtonTypes, ButtonIconPositions } from "./ButtonTypes";
+import { ButtonTypes } from "./ButtonTypes";
 import { IconRotationTypes } from "../Icons/IconTypes";
 
 interface ButtonProps {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -15,7 +15,7 @@ interface ButtonProps {
     className?: string;
     /** Adds 'disabled' property to the button */
     disabled?: boolean;
-
+    /** ID that other components can cross reference for accessibility purposes */
     id?: string;
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     modifiers?: string[];

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -4,9 +4,3 @@ export enum ButtonTypes {
     Pill = "pill",
     Link = "link",
 }
-
-export enum ButtonIconPositions {
-    Left = "icon-left",
-    Right = "icon-right",
-    JustifyRight = "justify-right",
-}

--- a/src/components/Button/_Button.scss
+++ b/src/components/Button/_Button.scss
@@ -3,6 +3,7 @@
 
     border-radius: 2px;
     cursor: pointer;
+    display: flex;
     text-align: center;
     text-decoration: none;
 
@@ -25,7 +26,7 @@
         width: 100%;
     }
 
-    &__icon {
+    .icon {
         @include icon;
 
         fill: currentColor;

--- a/src/components/Button/_Button.scss
+++ b/src/components/Button/_Button.scss
@@ -76,6 +76,11 @@
     &:hover {
         background-color: var(--ui-gray-xxlight);
     }
+
+    &:disabled {
+        background-color: var(--ui-gray-light);
+        color: var(--ui-gray-dark);
+    }
 }
 
 @mixin button--link {
@@ -90,6 +95,11 @@
     &:hover {
         background-color: transparent;
         color: var(--ui-link-secondary);
+    }
+
+    &:disabled {
+        background-color: transparent;
+        color: var(--ui-gray-dark);
     }
 }
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -11,7 +11,7 @@ import Link from "../Link/Link";
 import Icon from "../Icons/Icon";
 import { IconRotationTypes, IconNames } from "../Icons/IconTypes";
 import { LinkTypes } from "../Link/LinkTypes";
-import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import { ButtonTypes } from "../Button/ButtonTypes";
 
 export default {
     title: "Card",

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -69,7 +69,7 @@ export default function Icon(props: React.PropsWithChildren<IconProps>) {
         className,
         desc,
         iconRotation,
-        modifiers,
+        modifiers = [],
         name,
         role,
         title,

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -23,11 +23,13 @@ export const pagination = () => (
             <Button
                 buttonType={ButtonTypes.Secondary}
                 onClick={action("Previous clicked")}
-                iconDecorative={true}
-                iconName={IconNames.arrow}
-                iconPosition={ButtonIconPositions.Left}
-                iconRotation={IconRotationTypes.rotate90}
             >
+                <Icon
+                    name={IconNames.arrow}
+                    decorative={true}
+                    iconRotation={IconRotationTypes.rotate90}
+                    modifiers={["small", "icon-left"]}
+                />
                 {text("Previous Button Label", "Previous")}
             </Button>
         }
@@ -35,12 +37,14 @@ export const pagination = () => (
             <Button
                 buttonType={ButtonTypes.Secondary}
                 onClick={action("Next clicked")}
-                iconDecorative={true}
-                iconName={IconNames.arrow}
-                iconPosition={ButtonIconPositions.Right}
-                iconRotation={IconRotationTypes.rotate270}
             >
                 {text("Next Button Label", "Next")}
+                <Icon
+                    name={IconNames.arrow}
+                    decorative={true}
+                    iconRotation={IconRotationTypes.rotate270}
+                    modifiers={["small", "icon-right"]}
+                />
             </Button>
         }
     >

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -4,7 +4,7 @@ import { withDesign } from "storybook-addon-designs";
 import { text } from "@storybook/addon-knobs";
 
 import Button from "../Button/Button";
-import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import { ButtonTypes } from "../Button/ButtonTypes";
 import Icon from "../Icons/Icon";
 import { IconNames, IconRotationTypes } from "../Icons/IconTypes";
 import Label from "../Label/Label";

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -4,7 +4,7 @@ import * as Enzyme from "enzyme";
 import * as React from "react";
 
 import Button from "../Button/Button";
-import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import { ButtonTypes } from "../Button/ButtonTypes";
 import Icon from "../Icons/Icon";
 import { IconNames, IconRotationTypes } from "../Icons/IconTypes";
 import Label from "../Label/Label";

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -32,11 +32,12 @@ describe("Pagination Test", () => {
                     <Button
                         buttonType={ButtonTypes.Secondary}
                         onClick={previousCallback()}
-                        iconDecorative={true}
-                        iconName={IconNames.arrow}
-                        iconPosition={ButtonIconPositions.Left}
-                        iconRotation={IconRotationTypes.rotate90}
                     >
+                        <Icon
+                            name={IconNames.arrow}
+                            decorative={true}
+                            iconRotation={IconRotationTypes.rotate90}
+                        />
                         Previous
                     </Button>
                 }
@@ -44,12 +45,13 @@ describe("Pagination Test", () => {
                     <Button
                         buttonType={ButtonTypes.Secondary}
                         onClick={nextCallback()}
-                        iconDecorative={true}
-                        iconName={IconNames.arrow}
-                        iconPosition={ButtonIconPositions.Right}
-                        iconRotation={IconRotationTypes.rotate270}
                     >
                         Next
+                        <Icon
+                            name={IconNames.arrow}
+                            decorative={true}
+                            iconRotation={IconRotationTypes.rotate270}
+                        />
                     </Button>
                 }
             >

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -3,9 +3,10 @@ import * as React from "react";
 import SearchBar from "./SearchBar";
 import Select from "../Select/Select";
 import HelperErrorText from "../HelperErrorText/HelperErrorText";
-import { IconRotationTypes, IconNames } from "../Icons/IconTypes";
 import Button from "../Button/Button";
 import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import Icon from "../Icons/Icon";
+import { IconRotationTypes, IconNames } from "../Icons/IconTypes";
 import Input from "../Input/Input";
 import List from "../List/List";
 import { ListTypes } from "../List/ListTypes";
@@ -126,14 +127,12 @@ export const searchBar = () => (
             ></Input>
             <Button
                 buttonType={ButtonTypes.Primary}
-                iconDecorative={true}
-                iconName={IconNames.search_small}
-                iconPosition={ButtonIconPositions.Left}
                 id="button"
                 onClick={action("clicked")}
                 type="submit"
                 disabled={formErrored || formDisabled ? true : false}
             >
+                <Icon name={IconNames.search_small} decorative={true} />
                 Search
             </Button>
         </SearchBar>

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -4,7 +4,7 @@ import SearchBar from "./SearchBar";
 import Select from "../Select/Select";
 import HelperErrorText from "../HelperErrorText/HelperErrorText";
 import Button from "../Button/Button";
-import { ButtonTypes, ButtonIconPositions } from "../Button/ButtonTypes";
+import { ButtonTypes } from "../Button/ButtonTypes";
 import Icon from "../Icons/Icon";
 import { IconRotationTypes, IconNames } from "../Icons/IconTypes";
 import Input from "../Input/Input";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,7 @@ import "./styles.scss";
 export { default as Accordion } from "./components/Accordion/Accordion";
 export { default as Breadcrumbs } from "./components/Breadcrumbs/Breadcrumbs";
 export { default as Button } from "./components/Button/Button";
-export {
-    ButtonIconPositions,
-    ButtonTypes,
-} from "./components/Button/ButtonTypes";
+export { ButtonTypes } from "./components/Button/ButtonTypes";
 export { default as Card } from "./components/Card/Card";
 export { default as Checkbox } from "./components/Checkbox/Checkbox";
 export { default as Heading } from "./components/Heading/Heading";


### PR DESCRIPTION
Issue number: #328 | #337

## **This PR does the following:**
- Makes `Button`'s `onClick` property options
- Removes all icon props from `Button`. Button now uses `Icon` as a child

### Front End Review:
- [ ] View [the example in Storybook](https://deploy-preview-371--stoic-murdock-c7f044.netlify.app/?path=/story/button--button)
