### PR TITLE
Fixes bug identified by LibCal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.17.0
+
+### Breaking Changes
+
+-   Sets up the default `font-size` value in the `.nypl-ds` namespace.
+
 ## 0.16.1
 
 ### Adds

--- a/src/styles/base/_04-base.scss
+++ b/src/styles/base/_04-base.scss
@@ -1,5 +1,7 @@
 .nypl-ds {
     box-sizing: border-box;
+    // Sets up the base font-size, 1rem, for the system
+    font-size: 16px;
     // Users with non-overlay scrollbars have a small horiznotal scrollbar from our breakout mixin. Fix identified here: https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/#one-big-dumb-caveat
     overflow-x: hidden;
 


### PR DESCRIPTION
No associated bug number

## **This PR does the following:**
- The DS exported a typescale based on `rem`s, but did not set up what `1rem`'s value should be. Apps that did not have `font-size: 16px;` (the value set [here](https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=10975%3A52), [here](https://github.com/NYPL/nypl-d8/blob/development/web/themes/custom/nypl_emulsify/components/_patterns/00-base/02-typography/02-type-scale/_type-scale.scss#L4)) could have different values setting up the font-sizing.
