### PR TITLE
Footer within template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.17.4
+
+### Changes
+
+-   Moves footer outside of `.nypl-ds` namespace on Template story
+
 ## 0.17.3
 
 ### Adds

--- a/README.md
+++ b/README.md
@@ -65,6 +65,8 @@ function NewComponent(props) {
 
 Some things in the Design System, such as the universal focus styling and the box-model the DS uses, are namespaced to the `.nypl-ds` class. To include those in your app, add `.nypl-ds` to whichever wrapper tag makes sense in your application (e.g., `<div class="app">` or `<div class="container">`).
 
+#### NYPL DS, NYPL Header, and NYPL Footer
+
 Please note that the NYPL Header and Footer should be _outside_ of the `.nypl-ds` wrapper class.
 
 ### CDN

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -80,11 +80,10 @@ export const Template = ({ showSidebar, sidebarSide, ...args }) => (
                     </div>
                 )}
             </main>
-
-            <footer className={bem("footer")}>
-                <Placeholder>Footer</Placeholder>
-            </footer>
         </div>
+        <footer className={bem("footer")}>
+            <Placeholder>Footer</Placeholder>
+        </footer>
     </>
 );
 


### PR DESCRIPTION
Fixes #402 

## **This PR does the following:**
- Fixes template story in which footer was appearing inside `.nypl-ds` namespace, conflicting with information provided within the [README](https://github.com/NYPL/nypl-design-system#using-the-design-system-in-your-product)

### Front End Review:
- [ ] View [the Template stories in Storybook](https://deploy-preview-404--stoic-murdock-c7f044.netlify.app/?path=/story/template--template)
