### PR TITLE
Adding a hidden type and updating the mobile styles for the  class.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.18.1
+
+### Breaking Changes
+
+-   For `Input` components that use the `.input-group` class, on mobile those input elements are now stacked on top of each other rather than side-to-side.
+
+### Updates
+
+-   Updates the `Input` component to allow it to render a "hidden" input type.
+
 ## 0.18.0
 
 ### Breaking Changes

--- a/src/components/Input/Input.test.tsx
+++ b/src/components/Input/Input.test.tsx
@@ -241,3 +241,21 @@ describe("Radio buttons", () => {
         expect(onChange.callCount).to.equal(1);
     });
 });
+
+describe("Hidden input", () => {
+    it("Renders a hidden type input", () => {
+        const container = Enzyme.mount(
+            <Input
+                id="inputID-hidden"
+                ariaLabel="Hidden Input Label"
+                type={InputTypes.hidden}
+                value="hidden"
+            />
+        );
+
+        const input = container.find("input");
+
+        expect(input.prop("aria-hidden")).to.equal(true);
+        expect(input.prop("value")).to.equal("hidden");
+    });
+});

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -66,6 +66,10 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref?) => {
         inputProps["aria-required"] = true;
     }
 
+    if (type === InputTypes.hidden) {
+        inputProps["aria-hidden"] = true;
+    }
+
     let transformedInput = (
         <input
             id={`input-${id}`}

--- a/src/components/Input/InputTypes.tsx
+++ b/src/components/Input/InputTypes.tsx
@@ -4,4 +4,5 @@ export enum InputTypes {
     password = "password",
     text = "text",
     radio = "radio",
+    hidden = "hidden",
 }

--- a/src/components/Input/_Input.scss
+++ b/src/components/Input/_Input.scss
@@ -1,3 +1,5 @@
+$break-input-mobile: 400px;
+
 .input {
     @include space-inset-xs;
     @include space-stack-xs;
@@ -55,10 +57,12 @@
 }
 
 .input-group {
-    display: flex;
-    justify-content: space-between;
+    @include breakpoint($break-input-mobile) {
+        display: flex;
+        justify-content: space-between;
 
-    > *:not(:last-child) {
-        @include space-inline-m;
+        > *:not(:last-child) {
+            @include space-inline-m;
+        }
     }
 }


### PR DESCRIPTION
Fixes #415 and #416 

## **This PR does the following:**
- This adds a `"hidden"` InputType and renders a hidden `input` element from it with `aria-hidden` set to true.
- This also updates the mobile design for the `.input-group` class so that input fields are stacked rather than side-to-side.

Note: the fields bleed into the right edge but that's storybook styling.
current:
<img width="419" alt="Screen Shot 2020-10-07 at 2 55 41 PM" src="https://user-images.githubusercontent.com/1280564/95375308-70d05d00-08ad-11eb-9635-d2303ff9a466.png">

update:
<img width="427" alt="Screen Shot 2020-10-07 at 2 55 20 PM" src="https://user-images.githubusercontent.com/1280564/95375314-7332b700-08ad-11eb-8e53-4d7735e4ca25.png">


### Front End Review:
- [ ] View [the example in Storybook]()
