### PR TITLE
Make overflow hidden on `<body>` for modal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.18.3
+
+### Changes
+
+-   Add `overflow: hidden` to `.no-scroll` styling on `<body>` for modal to prevent scroll element for content behind modal being displayed
+
 ## 0.18.2
 
 ### Changes

--- a/src/components/Modal/_Modal.scss
+++ b/src/components/Modal/_Modal.scss
@@ -1,6 +1,7 @@
 .no-scroll {
     position: fixed;
     top: -100vh;
+    overflow: hidden;
 }
 
 .modal {


### PR DESCRIPTION
Related to discussion in #419

## **This PR does the following:**
- Add `overflow: hidden;` to the `<body>` to prevent the vertical scroll from displaying for the content behind the modal.

### Front End Review:
- [ ] View [the example in Storybook](https://nypl.github.io/nypl-design-system/storybook-static/?path=/story/modal--modal)

^ this story does not show the modal over content that extends past the bottom edge of the container. Any thoughts on adding another modal story?