### PR TITLE
Styling the wrappers for the Autosuggest stories

### DIFF
--- a/src/components/Autosuggest/Autosuggest.stories.tsx
+++ b/src/components/Autosuggest/Autosuggest.stories.tsx
@@ -106,15 +106,17 @@ export const autosuggestLibrary = () => {
     };
 
     return (
-        <Autosuggest
-            suggestions={suggestions}
-            onSuggestionsFetchRequested={onSuggestionsFetchRequested}
-            onSuggestionsClearRequested={onSuggestionsClearRequested}
-            getSuggestionValue={getSuggestionValue}
-            renderSuggestion={renderSuggestion}
-            inputProps={inputProps}
-            renderInputComponent={renderInputComponent}
-        />
+        <div style={{ padding: "5px", minHeight: "400px" }}>
+            <Autosuggest
+                suggestions={suggestions}
+                onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+                onSuggestionsClearRequested={onSuggestionsClearRequested}
+                getSuggestionValue={getSuggestionValue}
+                renderSuggestion={renderSuggestion}
+                inputProps={inputProps}
+                renderInputComponent={renderInputComponent}
+            />
+        </div>
     );
 };
 
@@ -183,8 +185,8 @@ export const autosuggestFish = () => {
     };
 
     return (
-        <>
-            <Label htmlFor="fish-autosuggest" id="fish-autosuggest-label">
+        <div style={{ padding: "5px", minHeight: "400px" }}>
+            <Label htmlFor="input-fish-autosuggest" id="fish-autosuggest-label">
                 Fish in Animal Crossing
             </Label>
             <Autosuggest
@@ -198,6 +200,6 @@ export const autosuggestFish = () => {
                 renderInputComponent={renderInputComponent}
                 highlightFirstSuggestion={true}
             />
-        </>
+        </div>
     );
 };

--- a/src/components/Autosuggest/Autosuggest.stories.tsx
+++ b/src/components/Autosuggest/Autosuggest.stories.tsx
@@ -14,12 +14,21 @@ export default {
 };
 
 /**
- * autosuggestLibrary
+ * StoryWrapper
+ * Wrapper component just to give the Autosuggest examples more space for the
+ * suggestions dropdown to display.
+ */
+const StoryWrapper = ({ children }) => (
+    <div style={{ padding: "5px", minHeight: "400px" }}>{children}</div>
+);
+
+/**
+ * LibraryExample
  * An example component that internally uses the `react-autosuggest` library.
  * The list is made up of objects with `label` key. It adds a Label, Input, and
  * HelperErrorText as elements for the autosuggest component to render.
  */
-export const autosuggestLibrary = () => {
+const LibraryExample = () => {
     const [value, setValue] = useState("");
     const [suggestions, setSuggestions] = useState([]);
     const libraryList = [
@@ -55,7 +64,7 @@ export const autosuggestLibrary = () => {
                 </Label>
                 <HelperErrorText id="id-helperText" isError={false}>
                     Select your home library. Start by typing the name of the
-                    library.
+                    library. Try "ba".
                 </HelperErrorText>
                 <Input
                     type={InputTypes.text}
@@ -106,27 +115,31 @@ export const autosuggestLibrary = () => {
     };
 
     return (
-        <div style={{ padding: "5px", minHeight: "400px" }}>
-            <Autosuggest
-                suggestions={suggestions}
-                onSuggestionsFetchRequested={onSuggestionsFetchRequested}
-                onSuggestionsClearRequested={onSuggestionsClearRequested}
-                getSuggestionValue={getSuggestionValue}
-                renderSuggestion={renderSuggestion}
-                inputProps={inputProps}
-                renderInputComponent={renderInputComponent}
-            />
-        </div>
+        <Autosuggest
+            suggestions={suggestions}
+            onSuggestionsFetchRequested={onSuggestionsFetchRequested}
+            onSuggestionsClearRequested={onSuggestionsClearRequested}
+            getSuggestionValue={getSuggestionValue}
+            renderSuggestion={renderSuggestion}
+            inputProps={inputProps}
+            renderInputComponent={renderInputComponent}
+        />
     );
 };
 
+export const AutosuggestLibrary = () => (
+    <StoryWrapper>
+        <LibraryExample />
+    </StoryWrapper>
+);
+
 /**
- * autosuggestFish
+ * FishExample
  * An example component that internally uses the `react-autosuggest` library.
  * The list is made up of strings. It adds an Input element for the autosuggest
  * component to render and renders the Label separately.
  */
-export const autosuggestFish = () => {
+const FishExample = () => {
     const [value, setValue] = useState("");
     const [suggestions, setSuggestions] = useState([]);
     const fishList = [
@@ -185,7 +198,7 @@ export const autosuggestFish = () => {
     };
 
     return (
-        <div style={{ padding: "5px", minHeight: "400px" }}>
+        <>
             <Label htmlFor="input-fish-autosuggest" id="fish-autosuggest-label">
                 Fish in Animal Crossing
             </Label>
@@ -200,6 +213,12 @@ export const autosuggestFish = () => {
                 renderInputComponent={renderInputComponent}
                 highlightFirstSuggestion={true}
             />
-        </div>
+        </>
     );
 };
+
+export const AutosuggestFish = () => (
+    <StoryWrapper>
+        <FishExample />
+    </StoryWrapper>
+);

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -66,14 +66,12 @@ export const link = () => (
     </>
 );
 
-link.story = {
-    name: "Link",
-    parameters: {
-        design: {
-            type: "figma",
-            url:
-                "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=16115%3A407",
-        },
+link.storyName = "Link";
+link.parameters = {
+    design: {
+        type: "figma",
+        url:
+            "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=16115%3A407",
     },
 };
 
@@ -127,13 +125,11 @@ export const linkWithOtherRouters = () => (
     </>
 );
 
-linkWithOtherRouters.story = {
-    name: "Link With Other Routers",
-    parameters: {
-        design: {
-            type: "figma",
-            url:
-                "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=16115%3A407",
-        },
+linkWithOtherRouters.storyName = "Link With Other Routers";
+linkWithOtherRouters.parameters = {
+    design: {
+        type: "figma",
+        url:
+            "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=16115%3A407",
     },
 };

--- a/src/components/SkeletonLoader/SkeletonLoader.stories.tsx
+++ b/src/components/SkeletonLoader/SkeletonLoader.stories.tsx
@@ -11,13 +11,11 @@ export default {
 
 export const skeletonLoader = () => <SkeletonLoader />;
 
-skeletonLoader.story = {
-    name: "Skeleton Loader",
-    parameters: {
-        design: {
-            type: "figma",
-            url:
-                "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=17219%3A7",
-        },
+skeletonLoader.storyName = "Skeleton Loader";
+skeletonLoader.parameters = {
+    design: {
+        type: "figma",
+        url:
+            "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=17219%3A7",
     },
 };


### PR DESCRIPTION
Fixes #429 

## **This PR does the following:**
- Adds padding and a min-height to the wrappers of the Autosuggest component so that the suggestions show up in the Storybook stories.
- Also a minor update to two different stories and how they are configured.

### Front End Review:
- [ ] View [the Autosuggest example in Storybook](https://deploy-preview-432--stoic-murdock-c7f044.netlify.app/?path=/story/autosuggest--autosuggest-fish)
