### PR TITLE
Optionally adding an id attribute to the Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.18.4
+
+### Updates
+
+-   Updates the `Input` component to conditionally render an `id` attribute if an `id` prop value is passed to it.
+
 ## 0.18.3
 
 ### Changes

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -54,6 +54,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref?) => {
     }
 
     let inputProps = {
+        id: id ? `input-${id}` : null,
         className: bem("input", modifiers, blockName, [className]),
         type: type,
         value: value,
@@ -72,7 +73,6 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>((props, ref?) => {
 
     let transformedInput = (
         <input
-            id={`input-${id}`}
             {...inputProps}
             placeholder={placeholder}
             ref={ref}


### PR DESCRIPTION
Fixes #433 

## **This PR does the following:**
- Conditionally renders an `id` for the `Input` component. The `id` is an optional prop but if one isn't added, the `Input` component still renders an `id` as `id="input-undefined"`.

Does this update require a changelog update? It's not changing the API but it is updating what gets rendered.

Another approach I was thinking of doing was making the `id` required so it always renders an id. What do you think?

### Front End Review:
- [ ] View [the example in Storybook]()
