### PR TITLE
CSS Accordion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.18.5
+
+### Updates
+
+-   Converts the Accordion component to open and close through CSS rather than through Javascript.
+
 ## 0.18.4
 
 ### Updates

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@nypl/design-system-react-components",
-    "version": "0.18.3",
+    "version": "0.18.5",
     "description": "Design System React Components",
     "repository": {
         "type": "git",
@@ -96,7 +96,7 @@
         "svg-sprite": "^1.5.0",
         "ts-loader": "^6.2.0",
         "tslint": "^5.0.0",
-        "tslint-react-a11y": "^1.0.0",
+        "tslint-react-a11y": "^1.1.0",
         "twig": "^1.13.3",
         "twig-loader": "^0.5.1",
         "twigjs-loader": "^1.0.0",

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,8 +1,7 @@
 import * as React from "react";
-import { Meta, Story } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import range from "lodash/range";
-import Accordion, { AccordionProps } from "./Accordion";
-import { action } from "@storybook/addon-actions";
+import Accordion from "./Accordion";
 import { withDesign } from "storybook-addon-designs";
 
 import List from "../List/List";
@@ -22,7 +21,9 @@ const AccordionListTemplate = ({ count, children, ...args }) => (
     <List type={ListTypes.Unordered} modifiers={["no-list-styling"]}>
         {range(count).map((i) => (
             <li key={i}>
-                <Accordion {...args}>{children}</Accordion>
+                <Accordion {...args} inputId={`${args.inputId}-${i}`}>
+                    {children}
+                </Accordion>
             </li>
         ))}
     </List>
@@ -35,7 +36,7 @@ export const AccordionWithList = AccordionListTemplate.bind({});
 // "Controls" tab.
 AccordionWithList.args = {
     accordionLabel: "Click to expand",
-    labelId: "accordionBtn",
+    inputId: "accordionBtn",
     children: <ListStory {...ListStory.args} />,
     count: 1,
 };
@@ -78,7 +79,7 @@ export const AccordionAsFAQSet = AccordionListTemplate.bind({});
 AccordionAsFAQSet.args = {
     accordionLabel: "FAQ Question Lorem Ipsum",
     modifiers: ["faq"],
-    labelId: "accordionBtn",
+    inputId: "accordionBtn",
     children: faqContent,
     count: 3,
 };

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -4,7 +4,7 @@ import * as React from "react";
 
 import Accordion from "./Accordion";
 
-describe("Renders Input (closed state)", () => {
+describe("Accordion", () => {
     let container;
     before(() => {
         container = Enzyme.mount(
@@ -13,42 +13,17 @@ describe("Renders Input (closed state)", () => {
                 inputId="accordionBtn"
                 accordionLabel="Click to expand"
             >
-                <div className="accordion-content">
+                <p className="accordion-content">
                     this is the accordion content
-                </div>
+                </p>
             </Accordion>
         );
     });
 
-    it("Renders an input", () => {
+    it("Renders an input checkbox and label", () => {
         expect(container.find("input").exists()).to.equal(true);
-    });
-    // TODO:
-    // it("renders content but is hidden", () => {});
-});
-
-describe("Renders Input (open state)", () => {
-    let container: Enzyme.ReactWrapper<
-        any,
-        Readonly<{}>,
-        React.Component<{}, {}, any>
-    >;
-    before(() => {
-        container = Enzyme.mount(
-            <Accordion
-                id="accordion"
-                inputId="accordionBtn2"
-                accordionLabel="Click to expand"
-            >
-                <div className="accordion-content">content content</div>
-            </Accordion>
+        expect(container.find(".accordion__label").text()).to.contain(
+            "Click to expand"
         );
-        container.find("input").simulate("click");
     });
-
-    it("Renders an input", () => {
-        expect(container.find("input").exists()).to.equal(true);
-    });
-    // TODO:
-    // it("Renders content and is visible", () => {});
 });

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -5,30 +5,26 @@ import * as React from "react";
 import Accordion from "./Accordion";
 
 describe("Renders Input (closed state)", () => {
-    let container: Enzyme.ReactWrapper<
-        any,
-        Readonly<{}>,
-        React.Component<{}, {}, any>
-    >;
+    let container;
     before(() => {
         container = Enzyme.mount(
             <Accordion
                 id="accordion"
-                labelId="accordionBtn"
+                inputId="accordionBtn"
                 accordionLabel="Click to expand"
             >
-                {" "}
-                <div className="accordion-content">content content</div>{" "}
+                <div className="accordion-content">
+                    this is the accordion content
+                </div>
             </Accordion>
         );
     });
 
-    it("Renders a button", () => {
-        expect(container.find("Button").exists()).to.equal(true);
+    it("Renders an input", () => {
+        expect(container.find("input").exists()).to.equal(true);
     });
-    it("does not render content", () => {
-        expect(container.find(".accordion-content").exists()).to.equal(false);
-    });
+    // TODO:
+    // it("renders content but is hidden", () => {});
 });
 
 describe("Renders Input (open state)", () => {
@@ -41,20 +37,18 @@ describe("Renders Input (open state)", () => {
         container = Enzyme.mount(
             <Accordion
                 id="accordion"
-                labelId="accordionBtn2"
+                inputId="accordionBtn2"
                 accordionLabel="Click to expand"
             >
-                {" "}
-                <div className="accordion-content">content content</div>{" "}
+                <div className="accordion-content">content content</div>
             </Accordion>
         );
-        container.find("button").simulate("click");
+        container.find("input").simulate("click");
     });
 
-    it("Renders a button", () => {
-        expect(container.find("Button").exists()).to.equal(true);
+    it("Renders an input", () => {
+        expect(container.find("input").exists()).to.equal(true);
     });
-    it("Renders content", () => {
-        expect(container.find(".accordion-content").exists()).to.equal(true);
-    });
+    // TODO:
+    // it("Renders content and is visible", () => {});
 });

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -34,31 +34,27 @@ export default function Accordion(
 
     return (
         <div
-            className={bem("accordion", modifiers, blockName, [className])}
             id={id}
+            className={bem("accordion", modifiers, blockName, [className])}
         >
-            <input
-                id={`accordion-${inputId}`}
-                type="checkbox"
-                value="empty checkbox"
-                aria-checked={false}
-            />
+            <input id={`accordion-${inputId}`} type="checkbox" />
             <label
-                className={bem("label", modifiers, "accordion")}
                 htmlFor={`accordion-${inputId}`}
+                className={bem("label", modifiers, "accordion")}
             >
                 {accordionLabel}
                 <Icon
-                    name={IconNames.minus}
                     decorative={true}
+                    name={IconNames.minus}
                     modifiers={["small", `${IconNames.minus}`]}
                 />
                 <Icon
-                    name={IconNames.plus}
                     decorative={true}
+                    name={IconNames.plus}
                     modifiers={["small", `${IconNames.plus}`]}
                 />
             </label>
+
             <div className={bem("content", modifiers, "accordion")}>
                 {children}
             </div>

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -52,28 +52,23 @@ export default class Accordion extends React.Component<
                 className={bem("accordion", modifiers, blockName, [className])}
                 id={id}
             >
-                <Button
-                    onClick={this.toggleContentShow}
-                    id={labelId}
-                    type="button"
-                    blockName="accordion"
-                    buttonType={ButtonTypes.Secondary}
-                    modifiers={modifiers}
-                >
+                <input type="checkbox" id="chck1" />
+                <label className="tab-label" htmlFor="chck1">
                     {accordionLabel}
                     <Icon
-                        name={
-                            this.state.isOpen ? IconNames.minus : IconNames.plus
-                        }
+                        name={IconNames.minus}
                         decorative={true}
-                        modifiers={["small"]}
+                        modifiers={["small", `${IconNames.minus}`]}
                     />
-                </Button>
-                {this.state.isOpen && (
-                    <div className={bem("content", modifiers, "accordion")}>
-                        {this.props.children}
-                    </div>
-                )}
+                    <Icon
+                        name={IconNames.plus}
+                        decorative={true}
+                        modifiers={["small", `${IconNames.plus}`]}
+                    />
+                </label>
+                <div className={bem("content", modifiers, "accordion")}>
+                    {this.props.children}
+                </div>
             </div>
         );
     }

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -1,7 +1,5 @@
 import * as React from "react";
-import Button from "../Button/Button";
 import bem from "../../utils/bem";
-import { ButtonTypes } from "../Button/ButtonTypes";
 import Icon from "../Icons/Icon";
 import { IconNames } from "../Icons/IconTypes";
 
@@ -14,62 +12,56 @@ export interface AccordionProps {
     className?: string;
     /** ID that other components can cross reference for accessibility purposes */
     id?: string;
-    /** accordionLabel's ID */
-    labelId?: string;
+    /** accordionLabel's input ID */
+    inputId?: string;
     /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
     modifiers?: string[];
 }
 
 /** Accordion component that shows content on toggle */
-export default class Accordion extends React.Component<
-    AccordionProps,
-    { isOpen: boolean }
-> {
-    constructor(props: AccordionProps) {
-        super(props);
-        this.state = {
-            isOpen: false,
-        };
-        this.toggleContentShow = this.toggleContentShow.bind(this);
-    }
+export default function Accordion(
+    props: React.PropsWithChildren<AccordionProps>
+) {
+    const {
+        modifiers,
+        blockName,
+        id,
+        className,
+        inputId,
+        accordionLabel,
+        children,
+    } = props;
 
-    toggleContentShow() {
-        this.setState((prevState) => ({ isOpen: !prevState.isOpen }));
-    }
-
-    render() {
-        const {
-            modifiers,
-            blockName,
-            id,
-            className,
-            labelId,
-            accordionLabel,
-        } = this.props;
-
-        return (
-            <div
-                className={bem("accordion", modifiers, blockName, [className])}
-                id={id}
+    return (
+        <div
+            className={bem("accordion", modifiers, blockName, [className])}
+            id={id}
+        >
+            <input
+                id={`accordion-${inputId}`}
+                type="checkbox"
+                value="empty checkbox"
+                aria-checked={false}
+            />
+            <label
+                className={bem("label", modifiers, "accordion")}
+                htmlFor={`accordion-${inputId}`}
             >
-                <input type="checkbox" id="chck1" />
-                <label className="tab-label" htmlFor="chck1">
-                    {accordionLabel}
-                    <Icon
-                        name={IconNames.minus}
-                        decorative={true}
-                        modifiers={["small", `${IconNames.minus}`]}
-                    />
-                    <Icon
-                        name={IconNames.plus}
-                        decorative={true}
-                        modifiers={["small", `${IconNames.plus}`]}
-                    />
-                </label>
-                <div className={bem("content", modifiers, "accordion")}>
-                    {this.props.children}
-                </div>
+                {accordionLabel}
+                <Icon
+                    name={IconNames.minus}
+                    decorative={true}
+                    modifiers={["small", `${IconNames.minus}`]}
+                />
+                <Icon
+                    name={IconNames.plus}
+                    decorative={true}
+                    modifiers={["small", `${IconNames.plus}`]}
+                />
+            </label>
+            <div className={bem("content", modifiers, "accordion")}>
+                {children}
             </div>
-        );
-    }
+        </div>
+    );
 }

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -3,32 +3,21 @@
     color: inherit;
     width: 100%;
 
-    input {
-        position: absolute;
-        opacity: 0;
-        z-index: -1;
-
-        &:checked {
-            + .accordion__label .icon--minus {
-                display: inline;
-            }
-            + .accordion__label .icon--plus {
-                display: none;
-            }
-            ~ .accordion__content {
-                display: inline-block;
-            }
-        }
+    &__content {
+        display: none;
+        padding: var(--space-xxs) var(--space-xxxl) var(--space-xs)
+            var(--space-s);
+        transition: all 0.35s;
     }
 
     &__label {
         @include button--outline;
 
-        border: none;
-        justify-content: space-between;
-        font-weight: 500;
-        cursor: pointer;
         align-items: center;
+        border: none;
+        cursor: pointer;
+        font-weight: 500;
+        justify-content: space-between;
 
         .icon--minus {
             display: none;
@@ -44,11 +33,24 @@
         }
     }
 
-    &__content {
-        padding: var(--space-xxs) var(--space-xxxl) var(--space-xs)
-            var(--space-s);
-        display: none;
-        transition: all 0.35s;
+    input {
+        opacity: 0;
+        position: absolute;
+        z-index: -1;
+
+        &:checked {
+            + .accordion__label .icon--minus {
+                display: inline;
+            }
+
+            + .accordion__label .icon--plus {
+                display: none;
+            }
+
+            ~ .accordion__content {
+                display: inline-block;
+            }
+        }
     }
 
     // Eliminates the double border on accordion sets in ul-lis

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -1,48 +1,37 @@
-.tab {
-    &-label {
-        display: flex;
-        justify-content: space-between;
-        padding: 1em;
-        font-weight: bold;
-        cursor: pointer;
-    }
-}
-
-input {
-    position: absolute;
-    opacity: 0;
-    z-index: -1;
-}
-.tab-label .icon--minus {
-    display: none;
-}
-
-input:checked {
-    + .tab-label .icon--minus {
-        display: inline;
-    }
-    + .tab-label .icon--plus {
-        display: none;
-    }
-    ~ .accordion__content {
-        max-height: 100vh;
-    }
-}
-
 .accordion {
     border: 1px solid var(--ui-gray-medium);
     color: inherit;
     width: 100%;
 
-    &__button {
+    input {
+        position: absolute;
+        opacity: 0;
+        z-index: -1;
+
+        &:checked {
+            + .accordion__label .icon--minus {
+                display: inline;
+            }
+            + .accordion__label .icon--plus {
+                display: none;
+            }
+            ~ .accordion__content {
+                display: inline-block;
+            }
+        }
+    }
+
+    &__label {
         @include button--outline;
 
-        align-items: center;
         border: none;
-        display: inline-flex;
-        font-weight: 500;
         justify-content: space-between;
-        width: 100%;
+        font-weight: 500;
+        cursor: pointer;
+
+        .icon--minus {
+            display: none;
+        }
 
         &:hover {
             background-color: var(--ui-gray-light);
@@ -55,7 +44,9 @@ input:checked {
     }
 
     &__content {
-        max-height: 0;
+        padding: var(--space-xxs) var(--space-xxxl) var(--space-xs)
+            var(--space-s);
+        display: none;
         transition: all 0.35s;
     }
 

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -1,3 +1,34 @@
+.tab {
+    &-label {
+        display: flex;
+        justify-content: space-between;
+        padding: 1em;
+        font-weight: bold;
+        cursor: pointer;
+    }
+}
+
+input {
+    position: absolute;
+    opacity: 0;
+    z-index: -1;
+}
+.tab-label .icon--minus {
+    display: none;
+}
+
+input:checked {
+    + .tab-label .icon--minus {
+        display: inline;
+    }
+    + .tab-label .icon--plus {
+        display: none;
+    }
+    ~ .accordion__content {
+        max-height: 100vh;
+    }
+}
+
 .accordion {
     border: 1px solid var(--ui-gray-medium);
     color: inherit;
@@ -24,8 +55,8 @@
     }
 
     &__content {
-        padding: var(--space-xxs) var(--space-xxxl) var(--space-xs)
-            var(--space-s);
+        max-height: 0;
+        transition: all 0.35s;
     }
 
     // Eliminates the double border on accordion sets in ul-lis

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -28,6 +28,7 @@
         justify-content: space-between;
         font-weight: 500;
         cursor: pointer;
+        align-items: center;
 
         .icon--minus {
             display: none;

--- a/tslint.json
+++ b/tslint.json
@@ -31,6 +31,8 @@
             "check-operator",
             "check-separator",
             "check-type"
-        ]
+        ],
+        "react-a11y-input-elements": false,
+        "react-a11y-role-has-required-aria-props": false
     }
 }


### PR DESCRIPTION
Fixes #403 

## **This PR does the following:**
- Updates the `Accordion` component to open and close just with CSS. Instead of using local state and a button, there is now an input element and a label element that apply CSS rules to open/close the content area with display `none` or `inline-block`.

One reason why I wanted this change was that closing the modal unmounted the content area and that caused form values to disappear. So now the content gets rendered all the time.

Some problems with this approach:
* The a11y linter complained that the checkbox did not have the right default value so I had to add `value="empty checkbox"`. This seems unnecessary but the linter complained and now I'm wondering if there'll be any consequences to this. I tried a placeholder which seems less risky but that did not work.
* The a11y linter also complained that it needed the right `aria-*` props and I had to add `aria-checked={false}`. This doesn't seem so bad except that there's no way to update this when the checkbox component _is_ checked since the point of this was trying _not_ to use javascript.
* Lastly, I'm having a hard time testing this with enzyme. It's much easier with jest using something like "check to see if this text string is visible to the user" but that's not available through enzyme. Also, it seems you can't check for CSS rules or DOM element styles like "check if `display` is `none`", etc.

So now, would this be worth continuing and merging?

### Front End Review:
- [ ] View [the example in Storybook]()
