### PR TITLE
Updates hero padding on primary type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,15 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.18.6
+
+### Changes
+
+-   Updates `Hero`'s primary option to have a larger top/bottom padding on the inner content via [Reno-1670](https://jira.nypl.org/browse/RENO-1670)
+
 ## 0.18.5
 
-### Updates
+### Changes
 
 -   Converts the Accordion component to open and close through CSS rather than through Javascript.
 
 ## 0.18.4
 
-### Updates
+### Changes
 
 -   Updates the `Input` component to conditionally render an `id` attribute if an `id` prop value is passed to it.
 

--- a/src/components/Hero/_Hero.scss
+++ b/src/components/Hero/_Hero.scss
@@ -43,7 +43,7 @@
         background-color: var(--ui-black);
         color: var(--ui-white);
         flex: 0 0 100%;
-        padding: var(--space-m) var(--space-l);
+        padding: var(--space-xxl) var(--space-l);
 
         a {
             color: inherit;


### PR DESCRIPTION
## **This PR does the following:**
- Updates `Hero`'s primary option to have a larger top/bottom padding on the inner content via [Reno-1670](https://jira.nypl.org/browse/RENO-1670)

### Front End Review:
- [ ] View [the example in Storybook](https://deploy-preview-457--stoic-murdock-c7f044.netlify.app/?path=/story/hero--hero-primary)
