### PR TITLE
Stylelint

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "@nypl/design-system-react-components",
-    "version": "0.18.4",
+    "version": "0.18.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -3512,6 +3512,14 @@
                 "lodash": "^4.17.15",
                 "prettier": "~2.0.5",
                 "regenerator-runtime": "^0.13.3"
+            },
+            "dependencies": {
+                "prettier": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
+                    "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+                    "dev": true
+                }
             }
         },
         "@storybook/theming": {
@@ -14399,9 +14407,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "2.0.5",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.5.tgz",
-            "integrity": "sha512-7PtVymN48hGcO4fGjybyBSIWDsLU4H4XlvOHfq91pz9kkGlonzwTfYkaIEwiRg/dAJF9YlbsduBAgtYLi+8cFg==",
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.2.1.tgz",
+            "integrity": "sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==",
             "dev": true
         },
         "prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -16,13 +16,14 @@
     "scripts": {
         "start": "node node_modules/@storybook/react/bin/index -p 9001 -c .storybook",
         "build-storybook": "node node_modules/.bin/build-storybook -c .storybook -o ./storybook-static",
-        "test": "npm run lint && npm run test:ci",
+        "test": "npm run lint && npm run stylelint && npm run test:ci",
         "test:ci": "npm run build-ts && cp src/styles.scss lib && mocha --require lib/__tests__/setupEnzyme.js --recursive lib/**/*.test.js",
         "format": "prettier --write 'src/**/*.{ts, tsx, js,jsx,json}'",
         "pretty-quick": "pretty-quick",
         "prepare": "npm run dist",
         "build-ts": "rm -rf lib && tsc",
         "dist": "rm -rf dist && webpack --mode production --progress --display-modules --config webpack.config.js",
+        "stylelint": "npx stylelint '**/*.scss'",
         "lint": "tslint -c tslint.json src/__tests__/components/*.tsx src/components/**/**/*.tsx src/components/**/**/**/*.tsx src/utils/*.tsx",
         "watch-webpack": "webpack --mode development --watch --progress --display-modules --config webpack.config.js"
     },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "prepare": "npm run dist",
         "build-ts": "rm -rf lib && tsc",
         "dist": "rm -rf dist && webpack --mode production --progress --display-modules --config webpack.config.js",
-        "stylelint": "npx stylelint '**/*.scss'",
+        "stylelint": "stylelint '**/*.scss'",
         "lint": "tslint -c tslint.json src/__tests__/components/*.tsx src/components/**/**/*.tsx src/components/**/**/**/*.tsx src/utils/*.tsx",
         "watch-webpack": "webpack --mode development --watch --progress --display-modules --config webpack.config.js"
     },
@@ -76,7 +76,7 @@
         "node-sass": "^4.14.1",
         "node-sass-glob-importer": "^5.3.2",
         "normalize.css": "^8.0.1",
-        "prettier": "2.0.5",
+        "prettier": "2.2.1",
         "pretty-quick": "^2.0.1",
         "prop-types": "^15.7.2",
         "react-autosuggest": "^10.0.2",

--- a/src/components/Hero/_Hero.scss
+++ b/src/components/Hero/_Hero.scss
@@ -2,6 +2,32 @@
     background-color: var(--ui-gray-warm-xlight);
 }
 
+.hero--50-50 {
+    .hero__content {
+        @include wrapper;
+
+        align-items: center;
+        display: flex;
+        flex-flow: column nowrap;
+        padding: 0 var(--space) var(--space) var(--space);
+
+        @include breakpoint($breakpoint-large) {
+            flex-flow: row nowrap;
+            padding: unset;
+        }
+    }
+
+    .hero__image {
+        margin-bottom: var(--space-s);
+
+        @include breakpoint($breakpoint-large) {
+            margin-bottom: unset;
+            margin-right: var(--space-s);
+            max-width: 50%;
+        }
+    }
+}
+
 .hero--primary {
     align-items: center;
     display: flex;
@@ -104,32 +130,6 @@
                 flex: 0 0 250px;
                 order: 3;
             }
-        }
-    }
-}
-
-.hero--50-50 {
-    .hero__content {
-        @include wrapper;
-
-        align-items: center;
-        display: flex;
-        flex-flow: column nowrap;
-        padding: 0 var(--space) var(--space) var(--space);
-
-        @include breakpoint($breakpoint-large) {
-            flex-flow: row nowrap;
-            padding: unset;
-        }
-    }
-
-    .hero__image {
-        margin-bottom: var(--space-s);
-
-        @include breakpoint($breakpoint-large) {
-            margin-bottom: unset;
-            margin-right: var(--space-s);
-            max-width: 50%;
         }
     }
 }

--- a/src/components/Label/_Label.scss
+++ b/src/components/Label/_Label.scss
@@ -7,7 +7,7 @@
     justify-content: space-between;
 
     &__required-helper {
-        font-size: var(--type-size--1);
+        font-size: var(--font-size--1);
         font-weight: 300;
     }
 }

--- a/src/components/Modal/_Modal.scss
+++ b/src/components/Modal/_Modal.scss
@@ -1,7 +1,7 @@
 .no-scroll {
+    overflow: hidden;
     position: fixed;
     top: -100vh;
-    overflow: hidden;
 }
 
 .modal {

--- a/src/components/SkeletonLoader/_SkeletonLoader.scss
+++ b/src/components/SkeletonLoader/_SkeletonLoader.scss
@@ -1,8 +1,5 @@
 .skeleton-loader:empty {
-    margin: auto;
-    width: 100%;
-    height: 485px; /* change height to see repeat-y behavior */
-
+    animation: shine 1s infinite;
     background-image: linear-gradient(
             100deg,
             rgba(255, 255, 255, 0),
@@ -16,16 +13,14 @@
         linear-gradient(var(--ui-gray-warm-light) 20px, transparent 0),
         linear-gradient(var(--ui-gray-warm-light) 20px, transparent 0),
         linear-gradient(var(--ui-gray-warm-light) 20px, transparent 0);
-
-    background-repeat: repeat-y;
-
-    background-size: 50px 230px, /* highlight */ 300px 230px, 250px 230px,
-        250px 230px, 250px 230px, 200px 230px, 200px 230px, 200px 230px;
-
     background-position: 0 0, /* highlight */ 0px 0, 0px 40px, 0px 67px,
         0px 94px, 0px 121px, 0px 148px, 0px 175px;
-
-    animation: shine 1s infinite;
+    background-repeat: repeat-y;
+    background-size: 50px 230px, /* highlight */ 300px 230px, 250px 230px,
+        250px 230px, 250px 230px, 200px 230px, 200px 230px, 200px 230px;
+    height: 485px; /* change height to see repeat-y behavior */
+    margin: auto;
+    width: 100%;
 }
 
 @keyframes shine {

--- a/src/components/Template/_Template.scss
+++ b/src/components/Template/_Template.scss
@@ -1,5 +1,5 @@
 $sidebar-width: 25%;
-$sidebar-width-s: calc(25% - calc(4 * #{var(--space-s)}));
+$sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
 
 .main {
     @include wrapper;

--- a/src/styles/base/_card-grid.scss
+++ b/src/styles/base/_card-grid.scss
@@ -22,11 +22,11 @@
 
     &--full {
         @include breakpoint($breakpoint-large) {
-            > *:not(:last-child):not(:nth-last-child(2)):not(:nth-last-child(3)) {
+            > *:nth-child(3n) {
                 @include space-stack-xxl;
             }
 
-            > *:nth-child(3n) {
+            > *:not(:last-child):not(:nth-last-child(2)):not(:nth-last-child(3)) {
                 @include space-stack-xxl;
             }
 


### PR DESCRIPTION
Fixes #450 

## **This PR does the following:**
- Adds `stylelint` to the `npm test` script workflow.

The original issues fixed in this PR:
<img width="1319" alt="Screen Shot 2020-12-02 at 12 14 02 PM" src="https://user-images.githubusercontent.com/1280564/100907349-368fd000-3498-11eb-86ce-43060e65ab42.png">

The one that took the most time is this one because it's not a helpful message at all!
<img width="313" alt="Screen Shot 2020-12-02 at 12 11 25 PM" src="https://user-images.githubusercontent.com/1280564/100907379-427b9200-3498-11eb-8930-518663f8f71d.png">

It turns out the error was in the `_Template.scss` file. A css variable was being interpolated but it doesn't need to be. (Another useless message because it's not that specific line that is the issue but the next line).
<img width="520" alt="Screen Shot 2020-12-02 at 12 11 31 PM" src="https://user-images.githubusercontent.com/1280564/100907467-5cb57000-3498-11eb-80ba-575f3c715f19.png">


On a related not but maybe not for this PR, the Github Actions flow runs `npm lint` and then `npm test`. The test command, `npm test`, internally runs `npm lint` so it's running twice. Not sure if that's intended. I added the `stylelint` command into the `npm run test` command but it can be added into the `lint` command instead. Thoughts?

### Front End Review:
- [ ] View [the example in Storybook](https://deploy-preview-458--stoic-murdock-c7f044.netlify.app/)
