### PR TITLE
Using env files for the github release action.

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -7,7 +7,7 @@ jobs:
         steps:
             - uses: actions/checkout@master
             - name: Changelog Reminder
-              uses: peterjgrainger/action-changelog-reminder@v1.2.0
+              uses: peterjgrainger/action-changelog-reminder@v1.3.0
               with:
                   changelog_regex: "CHANGELOG.md"
                   customPrMessage: "Your pull request is missing a changelog—was that intentional?"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             # we take the message of the commit to use for tag and release body.
             - name: get commit message
               run: |
-                  echo ::set-env name=commitmsg::$(git log --format=%b -n 1 ${{ github.event.after }})
+                  echo "commitmsg=$(git log --format=%b -n 1 ${{ github.event.after }})" >> $GITHUB_ENV
 
             # the tag will match the package.json version (eg. v1.0.0)
             - name: Tag


### PR DESCRIPTION
Fixes #449 

## **This PR does the following:**
- I think this should fix the `set-env` issue. That's deprecated and environment files is the suggested alternative. I also updated the version of the changelog reminder action.

Not sure if this will work so it needs to be tested in production, unfortunately.

### Front End Review:
- [ ] View [the example in Storybook]()
