### PR TITLE
Accordion input styles only apply to direct child

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## [ Unreleased ]
+
+### Changes
+
+-   Accordion: Accordion input styling affects only direct children
+
 ## 0.18.7
 
 ### Changes

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -37,7 +37,11 @@ export default function Accordion(
             id={id}
             className={bem("accordion", modifiers, blockName, [className])}
         >
-            <input id={`accordion-${inputId}`} type="checkbox" />
+            <input
+                id={`accordion-${inputId}`}
+                className={bem("input", modifiers, "accordion")}
+                type="checkbox"
+            />
             <label
                 htmlFor={`accordion-${inputId}`}
                 className={bem("label", modifiers, "accordion")}

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -33,7 +33,7 @@
         }
     }
 
-    input {
+    &__input {
         opacity: 0;
         position: absolute;
         z-index: -1;


### PR DESCRIPTION
Fixes NO-REF

## **This PR does the following:**
- Accordion input styles used to apply to all inputs under accordion. This made it impossible to put, for example, a list of checkboxes inside an accordion element.  The style is now correctly scoped.  

### Front End Review:
- [ ] View [the example in Storybook]() <-- There is no Storybook example, but I'm happy to put one in if it is helpful! 
