### PR TITLE
Hero Secondary now follows site sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - `Select`: selectedOption holds the selected value, instead of just the default.
 - `Hero`: `Hero.Secondary` now changes background color based on NYPL site section
+- `Hero`: All props are now optional
 - `Input`: added onChange prop to explicitly allow it to be used as a controlled component
 - Uses stricter linters and more Prettier configs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Changes
 
-- Input: added onChange prop to explicitly allow it to be used as a controlled component
-- Select: selectedOption holds the selected value, instead of just the default.
+- `Select`: selectedOption holds the selected value, instead of just the default.
+- `Hero`: `Hero.Secondary` now changes background color based on NYPL site section
+- `Input`: added onChange prop to explicitly allow it to be used as a controlled component
 - Uses stricter linters and more Prettier configs.
 
 ### Breaking Changes

--- a/src/components/Colors/Colors.stories.tsx
+++ b/src/components/Colors/Colors.stories.tsx
@@ -9,6 +9,7 @@ import List from "../List/List";
 import Heading from "../Heading/Heading";
 import { ListTypes } from "../List/ListTypes";
 import { CSSVariablesInterface } from "../../interfaces";
+import sections from "../../utils/siteSections";
 
 export default {
   title: "Colors",
@@ -44,13 +45,6 @@ for (const [key, value] of Object.entries(uiVariables)) {
 for (const [key, value] of Object.entries(grayScaleVariables)) {
   makeUIDocCard(key, value, grayscaleDocs);
 }
-
-const sections = [
-  "nypl--books-and-more",
-  "nypl--locations",
-  "nypl--research",
-  "nypl--whats-on",
-];
 
 const sectionDefault = sections[3];
 

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -1,13 +1,12 @@
 import * as React from "react";
-import { Story, Meta } from "@storybook/react/types-6-0";
+import { Meta } from "@storybook/react/types-6-0";
 import { withDesign } from "storybook-addon-designs";
 
 import sections from "../../utils/siteSections";
 import Image from "../Image/Image";
 import Heading from "../Heading/Heading";
 import { HeroTypes } from "./HeroTypes";
-import Hero, { HeroProps } from "./Hero";
-import { string } from "prop-types";
+import Hero from "./Hero";
 
 export default {
   title: "Hero",

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -88,6 +88,12 @@ heroSecondary.argTypes = {
   className: { table: { disable: true } },
   locationDetails: { table: { disable: true } },
   children: { table: { disable: true } },
+  section: {
+    control: {
+      type: "select",
+      options: sections,
+    },
+  },
 };
 
 heroSecondary.parameters = {

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -2,22 +2,23 @@ import * as React from "react";
 import { Story, Meta } from "@storybook/react/types-6-0";
 import { withDesign } from "storybook-addon-designs";
 
+import sections from "../../utils/siteSections";
 import Image from "../Image/Image";
 import Heading from "../Heading/Heading";
 import { HeroTypes } from "./HeroTypes";
 import Hero, { HeroProps } from "./Hero";
-
-const sections = [
-  "nypl--books-and-more",
-  "nypl--locations",
-  "nypl--research",
-  "nypl--whats-on",
-];
+import { string } from "prop-types";
 
 export default {
   title: "Hero",
   component: Hero,
   decorators: [withDesign],
+  argTypes: {
+    section: {
+      type: "select",
+      options: sections,
+    },
+  },
 } as Meta;
 
 const HeroTemplate = ({ section, ...args }) => (

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { Story } from "@storybook/react/types-6-0";
+import { Story, Meta } from "@storybook/react/types-6-0";
 import { withDesign } from "storybook-addon-designs";
 
 import Image from "../Image/Image";
@@ -7,14 +7,21 @@ import Heading from "../Heading/Heading";
 import { HeroTypes } from "./HeroTypes";
 import Hero, { HeroProps } from "./Hero";
 
+const sections = [
+  "nypl--books-and-more",
+  "nypl--locations",
+  "nypl--research",
+  "nypl--whats-on",
+];
+
 export default {
   title: "Hero",
   component: Hero,
   decorators: [withDesign],
-};
+} as Meta;
 
-const HeroTemplate: Story<HeroProps> = args => (
-  <div className={"nypl-ds"}>
+const HeroTemplate = ({ section, ...args }) => (
+  <div className={"nypl-ds " + section}>
     <Hero {...args} />
   </div>
 );
@@ -67,6 +74,7 @@ heroSecondary.args = {
       alt={""}
     />
   ),
+  section: sections[0],
 };
 
 heroSecondary.argTypes = {
@@ -76,6 +84,8 @@ heroSecondary.argTypes = {
   foregroundColor: { table: { disable: true } },
   backgroundColor: { table: { disable: true } },
   image: { table: { disable: true } },
+  blockName: { table: { disable: true } },
+  className: { table: { disable: true } },
   locationDetails: { table: { disable: true } },
   children: { table: { disable: true } },
 };

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -41,6 +41,7 @@ heroPrimary.args = {
 
 heroPrimary.argTypes = {
   heroType: { table: { disable: true } },
+  heading: { table: { disable: true } },
   image: { table: { disable: true } },
   foregroundColor: { control: { type: "color" } },
   backgroundColor: { control: { type: "color" } },
@@ -79,8 +80,8 @@ heroSecondary.args = {
 
 heroSecondary.argTypes = {
   heroType: { table: { disable: true } },
-  backgroundImageSrc: { table: { disable: true } },
   heading: { table: { disable: true } },
+  backgroundImageSrc: { table: { disable: true } },
   subHeaderText: { table: { disable: true } },
   foregroundColor: { table: { disable: true } },
   backgroundColor: { table: { disable: true } },

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -80,6 +80,7 @@ heroSecondary.args = {
 heroSecondary.argTypes = {
   heroType: { table: { disable: true } },
   backgroundImageSrc: { table: { disable: true } },
+  heading: { table: { disable: true } },
   subHeaderText: { table: { disable: true } },
   foregroundColor: { table: { disable: true } },
   backgroundColor: { table: { disable: true } },

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -21,9 +21,9 @@ export interface HeroProps {
    */
   foregroundColor?: string;
   /** Required heading element. */
-  heading: JSX.Element;
+  heading?: JSX.Element;
   /** Can be Primary, secondary, tertiary, or 50/50. */
-  heroType: HeroTypes;
+  heroType?: HeroTypes;
   /** Image used for secondary Hero types. Note, cannot
    * be used in conjunction with backgroundImageSrc.
    */

--- a/src/components/Hero/_Hero.scss
+++ b/src/components/Hero/_Hero.scss
@@ -1,5 +1,9 @@
 .hero {
   background-color: var(--ui-gray-warm-xlight);
+
+  .nypl--whats-on & {
+    background-color: tomato;
+  }
 }
 
 .hero--50-50 {

--- a/src/components/Hero/_Hero.scss
+++ b/src/components/Hero/_Hero.scss
@@ -1,9 +1,5 @@
 .hero {
   background-color: var(--ui-gray-warm-xlight);
-
-  .nypl--whats-on & {
-    background-color: tomato;
-  }
 }
 
 .hero--50-50 {
@@ -109,6 +105,38 @@
 
       @include breakpoint($breakpoint-medium) {
         order: 1;
+      }
+
+      .nypl--books-and-more & {
+        background-color: var(--section-books-and-more-primary);
+
+        &::before {
+          background-color: var(--section-books-and-more-primary);
+        }
+      }
+
+      .nypl--locations & {
+        background-color: var(--section-locations-primary);
+
+        &::before {
+          background-color: var(--section-locations-primary);
+        }
+      }
+
+      .nypl--research & {
+        background-color: var(--section-research-primary);
+
+        &::before {
+          background-color: var(--section-research-primary);
+        }
+      }
+
+      .nypl--whats-on & {
+        background-color: var(--section-whats-on-primary);
+
+        &::before {
+          background-color: var(--section-whats-on-primary);
+        }
       }
     }
 

--- a/src/utils/siteSections.ts
+++ b/src/utils/siteSections.ts
@@ -1,0 +1,10 @@
+// NYPL site sections. See Figma: https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=15454%3A47007
+
+const sections = [
+  "nypl--books-and-more",
+  "nypl--locations",
+  "nypl--research",
+  "nypl--whats-on",
+];
+
+export default sections;


### PR DESCRIPTION
Fixes #454

## **This PR does the following:**
- Updates `Hero.Secondary` to follow site sections
- Makes all `Hero` props optional

### Front End Review:
- [ ] View [the example in Storybook](https://deploy-preview-485--stoic-murdock-c7f044.netlify.app/?path=/story/hero--hero-secondary)
  - [ ] Use controls to change the section the Hero is in