### PR TITLE
Type styles scoped

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Breaking Changes
 
 - Removed `SectionTitle`
+- Scopes all element selects to the `.nypl-ds` class
 
 ## 0.19.1
 

--- a/src/components/Heading/_Heading.scss
+++ b/src/components/Heading/_Heading.scss
@@ -89,25 +89,27 @@
   }
 }
 
-h1 {
-  @include heading-xl;
-}
+.nypl-ds {
+  h1 {
+    @include heading-xl;
+  }
 
-h2 {
-  @include heading-large;
-}
+  h2 {
+    @include heading-large;
+  }
 
-h3 {
-  @include heading-medium;
-}
+  h3 {
+    @include heading-medium;
+  }
 
-h4 {
-  @include heading-small;
-}
+  h4 {
+    @include heading-small;
+  }
 
-h5,
-h6 {
-  @include heading-xs;
+  h5,
+  h6 {
+    @include heading-xs;
+  }
 }
 
 .heading__link {

--- a/src/components/Image/_Image.scss
+++ b/src/components/Image/_Image.scss
@@ -8,8 +8,10 @@
   }
 }
 
-figure {
-  margin: unset;
+.nypl-ds {
+  figure {
+    margin: unset;
+  }
 }
 
 .figure {

--- a/src/components/Link/_Link.scss
+++ b/src/components/Link/_Link.scss
@@ -61,9 +61,11 @@
   }
 }
 
-a,
-.link {
-  @include link;
+.nypl-ds {
+  a,
+  .link {
+    @include link;
+  }
 }
 
 .more-link {

--- a/src/components/Select/_Select.scss
+++ b/src/components/Select/_Select.scss
@@ -46,9 +46,9 @@
 }
 
 /* Support for rtl text, explicit support for Arabic and Hebrew */
-*[dir="rtl"] .select,
-:root:lang(ar) .select,
-:root:lang(iw) .select {
+*[dir="rtl"] .nypl-ds .select,
+:root:lang(ar) .nypl-ds .select,
+:root:lang(iw) .nypl-ds .select {
   background-position: left 0.7em top 70%;
   padding: var(--space-xs) var(--space-l) var(--space-xs) var(--space-s);
 }

--- a/src/styles/base/_typography.scss
+++ b/src/styles/base/_typography.scss
@@ -4,9 +4,11 @@
   margin: #{$margin};
 }
 
-p,
-.paragraph {
-  @include paragraph;
+.nypl-ds {
+  p,
+  .paragraph {
+    @include paragraph;
+  }
 }
 
 .blockquote {


### PR DESCRIPTION
Fixes #456 

## **This PR does the following:**
- Scopes any element selectors styling to the `.nypl-ds` class

### Front End Review:
- [ ] View [the example in Storybook]()
