### PR TITLE
Link with class button has white text color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## [Prerelease]
+
+### Bugfixes
+
+- `Link` with class `button` has white text color
+
 ## 0.20.1
 
 ### Bugfixes

--- a/src/components/Link/_Link.scss
+++ b/src/components/Link/_Link.scss
@@ -10,7 +10,7 @@
   }
 
   // .button links have a blue background
-  &.button:hover {
+  &.button {
     color: var(--ui-white);
   }
 


### PR DESCRIPTION
Fixes https://jira.nypl.org/browse/DSD-102

## **This PR does the following:**
- Links with class `button` were showing up with blue text, which made them hard to see on the blue button.  This changes the text color to be white. 

### Front End Review:
- [ ] View [the example in Storybook]()
