### PR TITLE
Adding padding to every story as a decorator to display the focus ring.

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,6 +1,7 @@
 // Typically, this file isn't created for a Storybook service, but we want it
 // to be able to add the custom styles.
 import "!style-loader!css-loader!sass-loader!import-glob-loader!../src/styles.scss";
+import React from "react";
 // We also want to add MDX-style documentation here:
 import { addParameters } from "@storybook/react";
 import { DocsPage, DocsContainer } from "@storybook/addon-docs/blocks";
@@ -11,3 +12,11 @@ addParameters({
     page: DocsPage,
   },
 });
+
+export const decorators = [
+  Story => (
+    <div style={{ margin: "10px" }}>
+      <Story />
+    </div>
+  ),
+];


### PR DESCRIPTION
Fixes [DSD-30](https://jira.nypl.org/browse/DSD-30)

## **This PR does the following:**
- Adds a global decorator to Storybook stories so that the focus ring displays correctly.

### Front End Review:
- [ ] View [first screenshot specified in JIRA ticket in Storybook](https://deploy-preview-519--stoic-murdock-c7f044.netlify.app/?path=/story/link--link) and [second screenshot](https://deploy-preview-519--stoic-murdock-c7f044.netlify.app/?path=/story/checkbox--uncontrolled-checkbox)
