### PR TITLE
Minor bug fixes to Accordion and SearchBar components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.20.3
+
+### Bugfixes
+
+- Adds focus outline to the `Accordion` component so it appears when it is tabbed.
+
 ## 0.20.2
 
 ### Changes

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -39,9 +39,7 @@
 
     &:focus {
       + .accordion__label {
-        box-shadow: 0;
-        outline: 2px solid var(--ui-focus);
-        outline-offset: -1px;
+        @include focus-outline;
       }
     }
 

--- a/src/components/Accordion/_Accordion.scss
+++ b/src/components/Accordion/_Accordion.scss
@@ -37,6 +37,14 @@
     position: absolute;
     z-index: -1;
 
+    &:focus {
+      + .accordion__label {
+        box-shadow: 0;
+        outline: 2px solid var(--ui-focus);
+        outline-offset: -1px;
+      }
+    }
+
     &:checked {
       + .accordion__label .icon--minus {
         display: inline;

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -130,7 +130,11 @@ export const searchBar = () => (
         type="submit"
         disabled={formErrored || formDisabled ? true : false}
       >
-        <Icon name={IconNames.search} decorative={true} />
+        <Icon
+          name={IconNames.search}
+          decorative={true}
+          modifiers={["small", "icon-left"]}
+        />
         Search
       </Button>
     </SearchBar>


### PR DESCRIPTION
Fixes [DQ-49](https://jira.nypl.org/browse/DSD-49) and [DQ-90](https://jira.nypl.org/browse/DSD-90)

## **This PR does the following:**
- Adds a focus outline style to the `label` element in the `Accordion` component when the `input` element is focused. This makes it easier to see where users are when they tab on the component.
- Fixes a minor issue where the search icon looks off in the `SearchBar` component story.

### Front End Review:
- [ ] View [the Accordion example in Storybook](https://deploy-preview-520--stoic-murdock-c7f044.netlify.app/?path=/story/accordion--accordion-as-faq-set) and tab through 
- [ ] View [the SearchBar example in Storybook](https://deploy-preview-520--stoic-murdock-c7f044.netlify.app/?path=/story/searchbar--search-bar)
