### PR TITLE
Add `attributes` to `SearchBar` form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## 0.20.3
+
+### Changes
+
+- Add the `attributes` property to the `SearchBar` `<form>`
+
 ## 0.20.2
 
 ### Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Changes
 
+- Add `method` and `action` to `SearchBar` `<form>`
+
+### Bugfixes
+
 - Add the `attributes` property to the `SearchBar` `<form>`
 
 ## 0.20.2

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -14,11 +14,14 @@ export interface SearchBarProps {
   ariaLabelledBy?: string;
   /** Additional attributes passed to the form */
   attributes?: { [key: string]: any };
-
   /** BlockName for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
   blockName?: string;
   /** ClassName that appears in addition to "search-bar" */
   className?: string;
+  /** Adds 'method' property to the form */
+  method?: string;
+  /** Adds 'action' property to the form */
+  action?: string;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
@@ -40,6 +43,8 @@ export default function SearchBar(
     modifiers = [],
     onSubmit,
     attributes,
+    method,
+    action,
   } = props;
 
   const baseClass = "search-bar";
@@ -52,6 +57,8 @@ export default function SearchBar(
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       onSubmit={onSubmit}
+      method={method}
+      action={action}
       {...attributes}
     >
       {children}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -39,6 +39,7 @@ export default function SearchBar(
     id,
     modifiers = [],
     onSubmit,
+    attributes,
   } = props;
 
   const baseClass = "search-bar";
@@ -51,6 +52,7 @@ export default function SearchBar(
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       onSubmit={onSubmit}
+      {...attributes}
     >
       {children}
     </form>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-112](https://jira.nypl.org/browse/DSD-112)

## **This PR does the following:**
- The `SearchBar` accepts an `attributes` prop, but it is currently not being implemented. Seems like a small oversight. I need to use it for SCC to add `method` and `action` attributes, which are on existing SCC search bar.

### Front End Review:
- [ ] View [the example in Storybook]()
