### PR TITLE
Breadcrumbs show up in light colors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Currently, this repo is in Prerelease. When it is released, this project will adhere to [Semantic Versioning](https://semver.org/spec/v2.0.0.html)
 ========
 
+## [PRERELEASE]
+
+### BugFixes
+
+- Breadcrumbs now show up in light colours
+
 ## 0.21.0
 
 ### Breaking Changes

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -7,7 +7,7 @@ import Heading from "../Heading/Heading";
 import Link from "../Link/Link";
 
 export default {
-  title: "Breadcrumb",
+  title: "Breadcrumbs",
   component: Breadcrumbs,
   decorators: [withDesign],
 };

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -52,7 +52,11 @@ $break-breadcrumbs-mobile: max-width 599px;
   &__link:link,
   &__link:visited,
   &__link:focus {
-    color: inherit;
+    color: var(--ui-white);
+
+    &:hover {
+      color: var(--ui-gray-light);
+    }
     text-decoration: none;
   }
 

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -56,7 +56,7 @@ $break-breadcrumbs-mobile: max-width 599px;
     text-decoration: none;
   }
 
-  &__link:hover {
+  &__item a:hover {
     color: var(--ui-gray-light);
     text-decoration: underline;
   }

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -53,14 +53,11 @@ $break-breadcrumbs-mobile: max-width 599px;
   &__link:visited,
   &__link:focus {
     color: var(--ui-white);
-
-    &:hover {
-      color: var(--ui-gray-light);
-    }
     text-decoration: none;
   }
 
   &__link:hover {
+    color: var(--ui-gray-light);
     text-decoration: underline;
   }
 


### PR DESCRIPTION
Fixes DSD-116

## **This PR does the following:**
- Breadcrumbs now have the dark-background link styling 

### Front End Review:
- [ ] View [the example in Storybook]()
