### PR TITLE
DSD-156 Template Flex-wrap and Reflow match

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### BugFixes
 
 - Breadcrumbs now show up in light colours
+- Template reflow and breakpoints now happen at the same time
 
 ## 0.21.0
 

--- a/src/components/Template/_Template.scss
+++ b/src/components/Template/_Template.scss
@@ -1,6 +1,10 @@
 $sidebar-width: 25%;
 $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
 
+// Adding an extra margin to the breakpoints allows
+//the breakpoints to be hit and the elements to be flexed at the same time
+$breakpoint-margin: 35px;
+
 .main {
   @include wrapper;
 
@@ -10,7 +14,7 @@ $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
     display: flex;
     flex-flow: column nowrap;
 
-    @include breakpoint($breakpoint-medium) {
+    @include breakpoint($breakpoint-medium + $breakpoint-margin) {
       flex-flow: row wrap;
     }
   }
@@ -31,7 +35,7 @@ $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
 
   &--with-sidebar-right,
   &--with-sidebar-left {
-    @include breakpoint($breakpoint-medium) {
+    @include breakpoint($breakpoint-medium + $breakpoint-margin) {
       flex: 1 1 60%;
       min-width: 0;
     }
@@ -42,14 +46,14 @@ $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
     flex-flow: column nowrap;
     order: 1;
 
-    @include breakpoint($breakpoint-medium) {
+    @include breakpoint($breakpoint-medium + $breakpoint-margin) {
       @include space-inline-none;
     }
   }
 }
 
 .content-secondary {
-  @include breakpoint($breakpoint-medium) {
+  @include breakpoint($breakpoint-medium + $breakpoint-margin) {
     flex: 0 1 $sidebar-width;
     order: 1;
 

--- a/src/components/Template/_Template.scss
+++ b/src/components/Template/_Template.scss
@@ -27,8 +27,8 @@ $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
 }
 
 .content-primary {
-  width: 100%;
   flex: 1 1;
+  width: 100%;
 
   &--with-sidebar-right,
   &--with-sidebar-left {
@@ -52,7 +52,6 @@ $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
   flex: 0 0 $sidebar-width;
 
   @include breakpoint($breakpoint-medium) {
-    flex: 0 0 $sidebar-width;
     order: 1;
 
     &--with-sidebar-left {

--- a/src/components/Template/_Template.scss
+++ b/src/components/Template/_Template.scss
@@ -1,10 +1,6 @@
 $sidebar-width: 25%;
 $sidebar-width-s: calc(25% - calc(4 * var(--space-s)));
 
-// Adding an extra margin to the breakpoints allows
-//the breakpoints to be hit and the elements to be flexed at the same time
-$breakpoint-margin: 35px;
-
 .main {
   @include wrapper;
 
@@ -14,7 +10,7 @@ $breakpoint-margin: 35px;
     display: flex;
     flex-flow: column nowrap;
 
-    @include breakpoint($breakpoint-medium + $breakpoint-margin) {
+    @include breakpoint($breakpoint-medium) {
       flex-flow: row wrap;
     }
   }
@@ -32,11 +28,11 @@ $breakpoint-margin: 35px;
 
 .content-primary {
   width: 100%;
+  flex: 1 1;
 
   &--with-sidebar-right,
   &--with-sidebar-left {
-    @include breakpoint($breakpoint-medium + $breakpoint-margin) {
-      flex: 1 1 60%;
+    @include breakpoint($breakpoint-medium) {
       min-width: 0;
     }
   }
@@ -46,15 +42,17 @@ $breakpoint-margin: 35px;
     flex-flow: column nowrap;
     order: 1;
 
-    @include breakpoint($breakpoint-medium + $breakpoint-margin) {
+    @include breakpoint($breakpoint-medium) {
       @include space-inline-none;
     }
   }
 }
 
 .content-secondary {
-  @include breakpoint($breakpoint-medium + $breakpoint-margin) {
-    flex: 0 1 $sidebar-width;
+  flex: 0 0 $sidebar-width;
+
+  @include breakpoint($breakpoint-medium) {
+    flex: 0 0 $sidebar-width;
     order: 1;
 
     &--with-sidebar-left {


### PR DESCRIPTION
Fixes #DSD-156

## **This PR does the following:**
- Template used to have an awkward part where the components flexed downward but the wide-width styles were not applying.  This has been fixed. 
- A lot of the math in the Template component seems to come from the fact that we are using Flexbox when we really should be using Grid. 

### Front End Review:
- [ ] View [the example in Storybook]()
