### PR TITLE
DSD-252 Hides pagination when there are 0 or 1 pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Changes `Radio` styles to use SASS vars in place of CSS vars
 - Adds `TextInput` component to handle email, hidden, number, password, text, textarea, tel and url input types
 - Adds default width and padding to `StatusBadge` component.
+- Hides pagination when there are 0 or 1 pages.
 
 ### BugFixes
 

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -159,20 +159,19 @@ describe("Pagination with changeCallback", () => {
     expect(changeCallback.callCount).to.equal(1);
   });
 
-  it("When pagination has 1 element, one element is shown with both buttons disabled", () => {
-    wrapper = Enzyme.mount(
+  it("When pagination has 1 element, pagination is not shown", () => {
+    const shallow = Enzyme.shallow(
       <Pagination pageCount={1} currentPage={1} onPageChange={changeCallback} />
     );
 
-    // Previous/Next buttons + list = 3 total items
-    expect(wrapper.find("li")).to.have.lengthOf(3);
-    expect(wrapper.find("a").first().hasClass("disabled")).to.equal(true);
-    expect(
-      wrapper.find("a").first().find("[aria-disabled='true']")
-    ).to.have.lengthOf(1);
-    expect(wrapper.find("a").last().hasClass("disabled")).to.equal(true);
-    expect(
-      wrapper.find("a").last().find("[aria-disabled='true']")
-    ).to.have.lengthOf(1);
+    expect(shallow.isEmptyRender()).to.equal(true);
+  });
+
+  it("When pagination has 0 elements, pagination is not shown", () => {
+    const shallow = Enzyme.shallow(
+      <Pagination pageCount={0} currentPage={1} onPageChange={changeCallback} />
+    );
+
+    expect(shallow.isEmptyRender()).to.equal(true);
   });
 });

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -68,7 +68,7 @@ describe("Pagination with getPageHref", () => {
     expect(wrapper.find("a").at(5).hasClass("selected")).to.equal(true);
   });
 
-  it("When pagination has 1 element, one element is shown with both buttons disabled", () => {
+  it("When pagination has 1 element, pagination is not shown", () => {
     const shallow = Enzyme.shallow(
       <Pagination pageCount={1} currentPage={1} getPageHref={getPageHref} />
     );

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -69,20 +69,18 @@ describe("Pagination with getPageHref", () => {
   });
 
   it("When pagination has 1 element, one element is shown with both buttons disabled", () => {
-    wrapper = Enzyme.mount(
+    const shallow = Enzyme.shallow(
       <Pagination pageCount={1} currentPage={1} getPageHref={getPageHref} />
     );
+    expect(shallow.isEmptyRender()).to.equal(true);
+  });
 
-    // Previous/Next buttons + list = 3 total items
-    expect(wrapper.find("li")).to.have.lengthOf(3);
-    expect(wrapper.find("a").first().hasClass("disabled")).to.equal(true);
-    expect(
-      wrapper.find("a").first().find("[aria-disabled='true']")
-    ).to.have.lengthOf(1);
-    expect(wrapper.find("a").last().hasClass("disabled")).to.equal(true);
-    expect(
-      wrapper.find("a").last().find("[aria-disabled='true']")
-    ).to.have.lengthOf(1);
+  it("When pagination has 0 elements, pagination is not shown", () => {
+    const shallow = Enzyme.shallow(
+      <Pagination pageCount={0} currentPage={1} getPageHref={getPageHref} />
+    );
+
+    expect(shallow.isEmptyRender()).to.equal(true);
   });
 });
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -31,6 +31,12 @@ const Pagination: React.FC<PaginationProps> = (props: PaginationProps) => {
     getPageHref,
     onPageChange,
   } = props;
+
+  //If there are 0 or 1 pages, the pagination should not show
+  if (pageCount <= 1) {
+    return null;
+  }
+
   if (getPageHref && onPageChange) {
     console.warn(
       "Both onPageHref and onPageChange are passed. Will default to using onPageHref"


### PR DESCRIPTION
Fixes #DSD-252

## **This PR does the following:**
- Hides the pagination when there are 0 or 1 pages

### Front End Review:
- [ ] View [the example in Storybook]()
