### PR TITLE
DSD-281: space css vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Changes
+
+- Removes `color-classes` and `css-vars` mixins from `_03-mixins.scss`
+- Adds `color-classes` and `css-vars` mixins to `styles.scss`
+- Changes order of CSS `@import` rules on `styles.scss`
+
 ## 0.22.0
 
 ### Breaking Changes

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -8,8 +8,12 @@
 @import "~system-font-css/_system-font.scss";
 // End libs
 
-// Order important
-//generates a series of color classes that can be used anywhere
+/*
+ * The `color-classes` and `css-vars` mixins have been included here 
+ * because they are utilized in the colors SCSS files.
+ */
+
+// generates a series of color classes that can be used anywhere
 @mixin color-classes($map) {
   @each $name, $color in $map {
     .cl-#{$name} {
@@ -18,6 +22,7 @@
   }
 }
 
+// generates a collection of CSS vars
 @mixin css-vars($map, $prefix) {
   $prefix: str-insert($prefix, "-", str-length($prefix) + 1);
 
@@ -26,6 +31,7 @@
   }
 }
 
+// Order important
 @import "./styles/01-colors/_colors-brand";
 @import "./styles/01-colors/_colors-utility";
 @import "./styles/02-typography/_type-scale";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,7 +9,23 @@
 // End libs
 
 // Order important
-@import "./styles/base/03-mixins";
+//generates a series of color classes that can be used anywhere
+@mixin color-classes($map) {
+  @each $name, $color in $map {
+    .cl-#{$name} {
+      color: $color;
+    }
+  }
+}
+
+@mixin css-vars($map, $prefix) {
+  $prefix: str-insert($prefix, "-", str-length($prefix) + 1);
+
+  @each $name, $color in $map {
+    --#{$prefix}#{$name}: #{$color};
+  }
+}
+
 @import "./styles/01-colors/_colors-brand";
 @import "./styles/01-colors/_colors-utility";
 @import "./styles/02-typography/_type-scale";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,23 +9,7 @@
 // End libs
 
 // Order important
-//generates a series of color classes that can be used anywhere
-@mixin color-classes($map) {
-  @each $name, $color in $map {
-    .cl-#{$name} {
-      color: $color;
-    }
-  }
-}
-
-@mixin css-vars($map, $prefix) {
-  $prefix: str-insert($prefix, "-", str-length($prefix) + 1);
-
-  @each $name, $color in $map {
-    --#{$prefix}#{$name}: #{$color};
-  }
-}
-
+@import "./styles/base/03-mixins";
 @import "./styles/01-colors/_colors-brand";
 @import "./styles/01-colors/_colors-utility";
 @import "./styles/02-typography/_type-scale";

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -9,12 +9,28 @@
 // End libs
 
 // Order important
-@import "./styles/03-space/*.*";
-@import "./styles/base/03-mixins";
+//generates a series of color classes that can be used anywhere
+@mixin color-classes($map) {
+  @each $name, $color in $map {
+    .cl-#{$name} {
+      color: $color;
+    }
+  }
+}
+
+@mixin css-vars($map, $prefix) {
+  $prefix: str-insert($prefix, "-", str-length($prefix) + 1);
+
+  @each $name, $color in $map {
+    --#{$prefix}#{$name}: #{$color};
+  }
+}
+
 @import "./styles/01-colors/_colors-brand";
 @import "./styles/01-colors/_colors-utility";
 @import "./styles/02-typography/_type-scale";
 @import "./styles/02-typography/_typefaces";
+@import "./styles/03-space/_space";
 @import "./styles/**/*.scss";
 @import "./components/Icons/_Icons.scss";
 @import "./components/Button/_Button.scss";

--- a/src/styles/base/_03-mixins.scss
+++ b/src/styles/base/_03-mixins.scss
@@ -71,24 +71,6 @@
   @return "%23" + str-slice("#{$colour}", 2, -1);
 }
 
-//generates a series of color classes that can be used anywhere
-@mixin color-classes($map) {
-  @each $name, $color in $map {
-    .cl-#{$name} {
-      color: $color;
-    }
-  }
-}
-
-//generates a collection of CSS vars
-@mixin css-vars($map, $prefix) {
-  $prefix: str-insert($prefix, "-", str-length($prefix) + 1);
-
-  @each $name, $color in $map {
-    --#{$prefix}#{$name}: #{$color};
-  }
-}
-
 @mixin placeholder {
   &::-webkit-input-placeholder {
     @content;


### PR DESCRIPTION
Fixes DSD-281

## **This PR does the following:**
- Removes `color-classes` and `css-vars` mixins from `_03-mixins.scss`
- Adds `color-classes` and `css-vars` mixins to `styles.scss`
- Changes order of CSS `@import` rules on `styles.scss`

### Front End Review:
- [ ] View [the example in Storybook]()
