### PR TITLE
DSD-304: breadcrumbs width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Breaking Changes
+
+- Removes `breakout` CSS from `Breadcrumbs`
+
 ### Changes
 
 - Changes `Breadcrumbs` story from `.tsx` to `.mdx`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Breaking Changes
 
-- Removes `breakout` CSS from `Breadcrumbs`
+- Removes `breakout` CSS from `Breadcrumbs`. To retain previous behavior, `Breadcrumbs` component should be a child of a `.content-header` element.
 
 ### Changes
 

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -1,8 +1,6 @@
 $break-breadcrumbs-mobile: max-width 599px;
 
 .breadcrumbs {
-  @include breakout;
-
   background-color: var(--ui-black);
   padding-bottom: var(--space-xs);
   padding-top: var(--space-xs);


### PR DESCRIPTION
Fixes [DSD-304](https://jira.nypl.org/browse/DSD-304)

## **This PR does the following:**
- Removes default breakout CSS from `Breadcrumbs` component

### Front End Review:
- [ ] View [the example in Storybook]()
