### PR TITLE
DSD-326: heading display sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `HorizontalRule` component
 - Adds new `short` class for `Placeholder`
+- Adds `displaySize` prop to `Heading`
 
 ### Changes
 

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -32,7 +32,7 @@ import Heading from "./Heading";
 
 <Description of={Heading} />
 
-A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's text can be passed in through a `text` prop or as a child. Default styles for semantic elements can be overwriten using the `displaySize` prop.
+A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's text can be passed in through a `text` prop or as a child. Default styles for semantic elements can be overwritten using the `displaySize` prop.
 
 <Preview withToolbar>
   <Story

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -9,6 +9,7 @@ import {
 import { withDesign } from "storybook-addon-designs";
 
 import Heading from "./Heading";
+import { DisplaySizes } from "./HeadingDisplaySizes";
 
 <Meta
   title="Heading"
@@ -36,7 +37,7 @@ A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's
 
 <Preview withToolbar>
   <Story
-    name="Basic"
+    name="Heading Props"
     args={{
       id: "heading1",
       level: 1,
@@ -47,9 +48,11 @@ A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's
   </Story>
 </Preview>
 
-<ArgsTable story="Basic" />
+<ArgsTable story="Heading Props" />
 
 ## Default Heading Styles
+
+<Story name="Default Heading Styles" />
 
 <Preview>
   <div>
@@ -59,6 +62,39 @@ A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's
     <Heading id="heading4" level={4} text="<h4> Heading 4" />
     <Heading id="heading5" level={5} text="<h5> Heading 5" />
     <Heading id="heading6" level={6} text="<h6> Heading 6" />
+  </div>
+</Preview>
+
+## DisplaySize Styles
+
+<Story name="DisplaySize Styles" />
+
+<Preview>
+  <div>
+    <Heading
+      id="heading1"
+      level={1}
+      displaySize={DisplaySizes.Primary}
+      text="<h1> DisplaySizes.Primary"
+    />
+    <Heading
+      id="heading1"
+      level={1}
+      displaySize={DisplaySizes.Secondary}
+      text="<h1> DisplaySizes.Secondary"
+    />
+    <Heading
+      id="heading1"
+      level={1}
+      displaySize={DisplaySizes.Tertiary}
+      text="<h1> DisplaySizes.Tertiary"
+    />
+    <Heading
+      id="heading1"
+      level={1}
+      displaySize={DisplaySizes.Callout}
+      text="<h1> DisplaySizes.Callout"
+    />
   </div>
 </Preview>
 
@@ -75,6 +111,8 @@ A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's
 </Preview>
 
 ## Headings with Links
+
+When the `url` prop is passed to `Heading`, a child `<a>` element is created and the heading text becomes an active link.
 
 <Preview>
   <Story name="Headings with Links">

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -52,50 +52,50 @@ A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's
 
 ## Default Heading Styles
 
-<Story name="Default Heading Styles" />
-
 <Preview>
-  <div>
-    <Heading id="heading1" level={1} text="<h1> Heading 1" />
-    <Heading id="heading2" level={2} text="<h2> Heading 2" />
-    <Heading id="heading3" level={3} text="<h3> Heading 3" />
-    <Heading id="heading4" level={4} text="<h4> Heading 4" />
-    <Heading id="heading5" level={5} text="<h5> Heading 5" />
-    <Heading id="heading6" level={6} text="<h6> Heading 6" />
-  </div>
+  <Story name="Default Heading Styles">
+    <div>
+      <Heading id="heading1" level={1} text="<h1> Heading 1" />
+      <Heading id="heading2" level={2} text="<h2> Heading 2" />
+      <Heading id="heading3" level={3} text="<h3> Heading 3" />
+      <Heading id="heading4" level={4} text="<h4> Heading 4" />
+      <Heading id="heading5" level={5} text="<h5> Heading 5" />
+      <Heading id="heading6" level={6} text="<h6> Heading 6" />
+    </div>
+  </Story>
 </Preview>
 
 ## DisplaySize Styles
 
-<Story name="DisplaySize Styles" />
-
 <Preview>
-  <div>
-    <Heading
-      id="heading1"
-      level={1}
-      displaySize={DisplaySizes.Primary}
-      text="<h1> DisplaySizes.Primary"
-    />
-    <Heading
-      id="heading1"
-      level={1}
-      displaySize={DisplaySizes.Secondary}
-      text="<h1> DisplaySizes.Secondary"
-    />
-    <Heading
-      id="heading1"
-      level={1}
-      displaySize={DisplaySizes.Tertiary}
-      text="<h1> DisplaySizes.Tertiary"
-    />
-    <Heading
-      id="heading1"
-      level={1}
-      displaySize={DisplaySizes.Callout}
-      text="<h1> DisplaySizes.Callout"
-    />
-  </div>
+  <Story name="DisplaySize Styles">
+    <div>
+      <Heading
+        id="heading1"
+        level={1}
+        displaySize={DisplaySizes.Primary}
+        text="<h1> DisplaySizes.Primary"
+      />
+      <Heading
+        id="heading1"
+        level={1}
+        displaySize={DisplaySizes.Secondary}
+        text="<h1> DisplaySizes.Secondary"
+      />
+      <Heading
+        id="heading1"
+        level={1}
+        displaySize={DisplaySizes.Tertiary}
+        text="<h1> DisplaySizes.Tertiary"
+      />
+      <Heading
+        id="heading1"
+        level={1}
+        displaySize={DisplaySizes.Callout}
+        text="<h1> DisplaySizes.Callout"
+      />
+    </div>
+  </Story>
 </Preview>
 
 ## Heading with Bold

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -32,7 +32,7 @@ import Heading from "./Heading";
 
 <Description of={Heading} />
 
-A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's text can be passed in through a `text` prop or as a child.
+A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's text can be passed in through a `text` prop or as a child. Default styles for semantic elements can be overwriten using the `displaySize` prop.
 
 <Preview withToolbar>
   <Story
@@ -49,16 +49,16 @@ A `Heading` component will render a standard HTML `<h>` tag (1-6). The heading's
 
 <ArgsTable story="Basic" />
 
-## All Heading Sizes
+## Default Heading Styles
 
 <Preview>
   <div>
-    <Heading id="heading1" level={1} text="Heading 1" />
-    <Heading id="heading2" level={2} text="Heading 2" />
-    <Heading id="heading3" level={3} text="Heading 3" />
-    <Heading id="heading4" level={4} text="Heading 4" />
-    <Heading id="heading5" level={5} text="Heading 5" />
-    <Heading id="heading6" level={6} text="Heading 6" />
+    <Heading id="heading1" level={1} text="<h1> Heading 1" />
+    <Heading id="heading2" level={2} text="<h2> Heading 2" />
+    <Heading id="heading3" level={3} text="<h3> Heading 3" />
+    <Heading id="heading4" level={4} text="<h4> Heading 4" />
+    <Heading id="heading5" level={5} text="<h5> Heading 5" />
+    <Heading id="heading6" level={6} text="<h6> Heading 6" />
   </div>
 </Preview>
 

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -3,6 +3,7 @@ import * as Enzyme from "enzyme";
 import * as React from "react";
 
 import Heading from "./Heading";
+import { DisplaySizes } from "./HeadingDisplaySizes";
 
 describe("Section Headings", () => {
   let wrapper: Enzyme.ShallowWrapper<any, any>;
@@ -85,5 +86,17 @@ describe("Section Headings", () => {
         </Heading>
       )
     ).to.throw("Please only pass one child into Heading, got span, span");
+  });
+  it("Uses custom display size", () => {
+    wrapper = Enzyme.shallow(
+      <Heading
+        id="h1"
+        level={1}
+        text={"Heading with Secondary displaySize"}
+        displaySize={DisplaySizes.Secondary}
+      />
+    );
+    expect(wrapper.find("h1")).to.have.lengthOf(1);
+    expect(wrapper.find("h1").hasClass("heading--secondary")).to.equal(true);
   });
 });

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,23 +1,26 @@
 // MT-82, MT 225, etc
 import * as React from "react";
 import bem from "../../utils/bem";
+import { DisplaySizes } from "./HeadingDisplaySizes";
 
 export interface HeadingProps {
   /** BlockName for use with BEM. See how to work with blockNames and BEM here: http://getbem.com/introduction/ */
   blockName?: string;
-  /** ClassName that appears in addition to "heading" */
+  /** Optional className that appears in addition to `heading` */
   className?: string;
-  /** ID that other components can cross reference for accessibility purposes */
+  /** Optional size used to override the default styles of the semantic HTML `<h>` elements */
+  displaySize?: DisplaySizes;
+  /** Optional ID that other components can cross reference for accessibility purposes */
   id?: string;
-  /** Number 1-6, creating the <h*> tag */
+  /** Number 1-6; used to create the `<h*>` tag */
   level: number;
   /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
   modifiers?: string[];
-  /** Inner text of the <h*> element */
+  /** Inner text of the `<h*>` element */
   text?: string;
-  /** URL that header points to */
+  /** Optional URL that header points to */
   url?: string;
-  /** className for the URL when the url prop is passed */
+  /** Optional className for the URL when the `url` prop is passed */
   urlClass?: string;
 }
 
@@ -25,6 +28,7 @@ export default function Heading(props: React.PropsWithChildren<HeadingProps>) {
   const {
     blockName,
     className,
+    displaySize,
     id,
     level,
     modifiers = [],
@@ -34,6 +38,10 @@ export default function Heading(props: React.PropsWithChildren<HeadingProps>) {
   } = props;
 
   const baseClass = "heading";
+
+  if (displaySize) {
+    modifiers.push(displaySize);
+  }
 
   if (level < 1 || level > 6) {
     throw new Error("Heading only supports levels 1-6");

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -18,7 +18,7 @@ export interface HeadingProps {
   modifiers?: string[];
   /** Inner text of the `<h*>` element */
   text?: string;
-  /** Optional URL that header points to */
+  /** Optional URL that header points to; when `url` prop is passed to `Heading`, a child `<a>` element is created and the heading text becomes an active link */
   url?: string;
   /** Optional className for the URL when the `url` prop is passed */
   urlClass?: string;

--- a/src/components/Heading/HeadingDisplaySizes.tsx
+++ b/src/components/Heading/HeadingDisplaySizes.tsx
@@ -1,0 +1,6 @@
+export enum DisplaySizes {
+  Primary = "primary",
+  Secondary = "secondary",
+  Tertiary = "tertiary",
+  Callout = "callout",
+}

--- a/src/components/Heading/_Heading.scss
+++ b/src/components/Heading/_Heading.scss
@@ -110,6 +110,24 @@
   h6 {
     @include heading-xs;
   }
+
+  .heading {
+    &--primary {
+      @include heading-xl;
+    }
+
+    &--secondary {
+      @include heading-large;
+    }
+
+    &--tertiary {
+      @include heading-medium;
+    }
+
+    &--callout {
+      @include heading-xs;
+    }
+  }
 }
 
 .heading__link {


### PR DESCRIPTION
Fixes [DSD-326](https://jira.nypl.org/browse/DSD-326)

## **This PR does the following:**
- Adds `displaySize` prop to `Heading` for overriding default heading styles

### Front End Review:
- [ ] View [the example in Storybook]()
