### PR TITLE
DSD-303: Minor Story documentation update for the List component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Changes
+
+- Updates stories for `List` component to use MDX format.
+
 ## 0.23.1
 
 ### Adds

--- a/package-lock.json
+++ b/package-lock.json
@@ -12469,6 +12469,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"
@@ -25844,6 +25845,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -8,7 +8,8 @@ import {
 import Accordion from "./Accordion";
 import { withDesign } from "storybook-addon-designs";
 import * as stories from "./Accordion.stories.tsx";
-import { list as ListStory } from "../List/List.stories.tsx";
+import { listRenderer as ListStory } from "../List/List.stories.tsx";
+import { ListTypes } from "../List/ListTypes";
 import { Source } from "@storybook/addon-docs/blocks";
 import dedent from "ts-dedent";
 import ReactDOMServer from "react-dom/server";
@@ -44,7 +45,7 @@ sure that each `inputId` is unique.
     name="Basic"
     args={{
       accordionLabel: "Click to expand",
-      children: <ListStory {...ListStory.args} />,
+      children: <ListStory type={ListTypes.Unordered} />,
       inputId: "accordionBtn",
     }}
   >

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -5,7 +5,7 @@ import Accordion from "./Accordion";
 import List from "../List/List";
 import { ListTypes } from "../List/ListTypes";
 import Link from "../Link/Link";
-import { list as ListStory } from "../List/List.stories";
+import { listRenderer as ListStory } from "../List/List.stories";
 
 // Set up the reusable template to create a list of Accordion components.
 const AccordionListTemplate = ({ count, children, ...args }) => (
@@ -56,7 +56,7 @@ export const AccordionScroll = _props => (
         modifiers={["fixed-height"]}
         defaultOpen={true}
       >
-        <ListStory {...ListStory.args}></ListStory>
+        <ListStory type={ListTypes.Unordered} />
       </Accordion>
     </div>
     <div>Example content underneath</div>

--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -1,0 +1,168 @@
+import {
+  Meta,
+  Story,
+  Canvas,
+  ArgsTable,
+  Preview,
+  Description,
+} from "@storybook/addon-docs/blocks";
+import { withDesign } from "storybook-addon-designs";
+import Card from "../Card/Card";
+import Heading from "../Heading/Heading";
+import Icon from "../Icons/Icon";
+import { IconNames, IconRotationTypes } from "../Icons/IconTypes";
+import Image from "../Image/Image";
+import Link from "../Link/Link";
+import { LinkTypes } from "../Link/LinkTypes";
+import List from "./List";
+import { ListTypes } from "./ListTypes";
+import { listRenderer, cardsList } from "./List.stories.tsx";
+
+<Meta
+  title="List"
+  component={List}
+  decorators={[withDesign]}
+  parameters={{
+    design: {
+      type: "figma",
+      url:
+        "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=16115%3A304",
+    },
+  }}
+  argTypes={{
+    blockName: { table: { disable: true } },
+    modifiers: { table: { disable: true } },
+    children: { table: { disable: true } },
+    definitions: { table: { disable: true } },
+    itemGroups: { table: { disable: true } },
+    type: {
+      control: {
+        type: "radio",
+      },
+    },
+  }}
+/>
+
+# List
+
+<Description of={List} />
+
+<Preview withToolbar>
+  <Story
+    name="List"
+    args={{
+      id: "nypl-list",
+      type: ListTypes.Unordered,
+      title: "",
+    }}
+  >
+    {args => listRenderer(args)}}
+  </Story>
+</Preview>
+
+<ArgsTable story="List" />
+
+## Definition List
+
+<Preview withToolbar>
+  <Story
+    name="Definition List"
+    args={{
+      id: "nypl-list2",
+      type: ListTypes.Definition,
+      title: "Middle-Earth Peoples",
+    }}
+    argTypes={{
+      type: { table: { disable: true } },
+    }}
+    parameters={{
+      design: {
+        type: "figma",
+        url:
+          "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=10734%3A5178",
+      },
+    }}
+  >
+    {args => listRenderer(args)}}
+  </Story>
+</Preview>
+
+## Ordered Card List
+
+<Preview withToolbar>
+  <Story
+    name="Ordered Card List"
+    args={{
+      id: "nypl-list3",
+    }}
+    argTypes={{
+      type: { table: { disable: true } },
+      title: { table: { disable: true } },
+    }}
+  >
+    {args => <List type={ListTypes.Ordered}>{cardsList}</List>}
+  </Story>
+</Preview>
+
+## Definition List of Links
+
+<Preview withToolbar>
+  <Story
+    name="Definition List of Links"
+    args={{
+      type: ListTypes.Definition,
+      title: "Details",
+    }}
+    argTypes={{
+      type: { table: { disable: true } },
+      title: { table: { disable: true } },
+    }}
+    parameters={{
+      design: {
+        type: "figma",
+        url:
+          "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=10734%3A5178",
+      },
+    }}
+  >
+    {args => (
+      <List title="Details" type={ListTypes.Definition}>
+        <dt>Authors</dt>
+        <dd>
+          <a href="#">Chirwa, Ephraim Wadonda, author</a>
+          <br />
+          <a href="#">Dorward, Andrew, author</a>
+        </dd>
+        <dt>Subjects</dt>
+        <dd>
+          <a href="#">Ackerbau</a>
+          <br />
+          <a href="#">Ackerbau.</a>
+          <br />
+          <a href="#">Africa.</a>
+          <br />
+          <a href="#">Afrika.</a>
+          <br />
+          <a href="#">Agrarsubvention</a>
+          <br />
+          <a href="#">Agrarsubvention.</a>
+          <br />
+          <a href="#">Agricultura -- Subvencions -- Malawi.</a>
+          <br />
+          <a href="#">Agricultural economics New.</a>
+          <br />
+          <a href="#">Agricultural subsidies</a>
+          <br />
+          <a href="#">Agricultural subsidies -- Developing countries.</a>
+          <br />
+          <a href="#">Agricultural subsidies -- Malawi.</a>
+          <br />
+          <a href="#">Agricultural subsidies.</a>
+          <br />
+          <a href="#">BUSINESS &amp; ECONOMICS -- Industries</a>
+          <br />
+        </dd>
+      </List>
+    )}
+  </Story>
+</Preview>

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import Card from "../Card/Card";
 import Heading from "../Heading/Heading";
 import Icon from "../Icons/Icon";
-import { IconNames, IconRotationTypes } from "../Icons/IconTypes";
+import { IconNames } from "../Icons/IconTypes";
 import Image from "../Image/Image";
 import Link from "../Link/Link";
 import { LinkTypes } from "../Link/LinkTypes";
@@ -94,7 +94,6 @@ const exampleCard = (
           name={IconNames.headset}
           decorative={true}
           modifiers={["left", "small"]}
-          iconRotation={IconRotationTypes.rotate0}
         ></Icon>
         Audiobook
       </div>

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import { boolean, select } from "@storybook/addon-knobs";
 
 import Card from "../Card/Card";
 import Heading from "../Heading/Heading";
@@ -10,11 +9,6 @@ import Link from "../Link/Link";
 import { LinkTypes } from "../Link/LinkTypes";
 import List from "./List";
 import { ListTypes } from "./ListTypes";
-
-export default {
-  title: "List",
-  component: List,
-};
 
 const itemGroups = [
   "Art",
@@ -60,9 +54,9 @@ const definitions = [
   },
 ];
 
-const ListTemplate = ({ type, ...args }) => (
-  <List type={type} {...args}>
-    {type !== ListTypes.Definition
+export const listRenderer = args => (
+  <List {...args}>
+    {args.type !== ListTypes.Definition
       ? itemGroups.map((item, i) => <li key={i}>{item}</li>)
       : definitions.map((item, i) => [
           <dt key={`dt_${i}`}>{item.term}</dt>,
@@ -70,52 +64,6 @@ const ListTemplate = ({ type, ...args }) => (
         ])}
   </List>
 );
-
-export const list = ListTemplate.bind({});
-
-list.args = {
-  type: ListTypes.Unordered,
-  itemGroups: itemGroups,
-  definitions: definitions,
-};
-
-list.parameters = {
-  design: {
-    type: "figma",
-    url:
-      "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=16115%3A304",
-  },
-};
-
-const DefinitionListTemplate = ({ items, ...args }) => (
-  <List type={ListTypes.Definition} {...args}>
-    {items.map((item, i) => [
-      <dt key={`dt_${i}`}>{...item.term}</dt>,
-      <dd key={`dd_${i}`}>{...item.definition}</dd>,
-    ])}
-  </List>
-);
-
-export const definitionList = DefinitionListTemplate.bind({});
-definitionList.args = {
-  items: definitions,
-  title: "Middle-Earth Peoples",
-};
-
-definitionList.argTypes = {
-  type: {
-    table: { disable: true },
-  },
-};
-
-definitionList.storyName = "Definition List";
-definitionList.parameters = {
-  design: {
-    type: "figma",
-    url:
-      "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=10734%3A5178",
-  },
-};
 
 const exampleCard = (
   <Card
@@ -159,69 +107,7 @@ const exampleCard = (
   </Card>
 );
 
-const cards = [];
-
+export const cardsList = [];
 for (let i = 0; i < 3; i++) {
-  cards.push(<li key={i}>{exampleCard}</li>);
+  cardsList.push(<li key={i}>{exampleCard}</li>);
 }
-
-export const cardList = () => (
-  <>
-    <List
-      type={select("List Type", ListTypes, ListTypes.Unordered)}
-      modifiers={boolean("List Styling", false) ? null : ["no-list-styling"]}
-    >
-      {cards}
-    </List>
-  </>
-);
-/* eslint-disable jsx-a11y/anchor-is-valid */
-export const listOfLinks = () => (
-  <List title="Details" type={ListTypes.Definition}>
-    <dt>Authors</dt>
-    <dd>
-      <a href="#">Chirwa, Ephraim Wadonda, author</a>
-      <br />
-      <a href="#">Dorward, Andrew, author</a>
-    </dd>
-    <dt>Subjects</dt>
-    <dd>
-      <a href="#">Ackerbau</a>
-      <br />
-      <a href="#">Ackerbau.</a>
-      <br />
-      <a href="#">Africa.</a>
-      <br />
-      <a href="#">Afrika.</a>
-      <br />
-      <a href="#">Agrarsubvention</a>
-      <br />
-      <a href="#">Agrarsubvention.</a>
-      <br />
-      <a href="#">Agricultura -- Subvencions -- Malawi.</a>
-      <br />
-      <a href="#">Agricultural economics New.</a>
-      <br />
-      <a href="#">Agricultural subsidies</a>
-      <br />
-      <a href="#">Agricultural subsidies -- Developing countries.</a>
-      <br />
-      <a href="#">Agricultural subsidies -- Malawi.</a>
-      <br />
-      <a href="#">Agricultural subsidies.</a>
-      <br />
-      <a href="#">BUSINESS &amp; ECONOMICS -- Industries</a>
-      <br />
-    </dd>
-  </List>
-);
-/* eslint-enable jsx-a11y/anchor-is-valid */
-
-listOfLinks.storyName = "Definition List of Links";
-listOfLinks.parameters = {
-  docs: {
-    source: {
-      type: "dynamic",
-    },
-  },
-};

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -12,12 +12,14 @@ export interface ListProps {
   id?: string;
   /** Modifiers array for use with BEM. See how to work with modifiers and BEM here: http://getbem.com/introduction/ */
   modifiers?: any[];
-  /** Ordered, Unordered, or Definition */
-  type: ListTypes;
   /** An optional title that will appear over the list (only applies to Definition Lists) */
   title?: string;
+  /** Ordered, Unordered, or Definition */
+  type: ListTypes;
 }
 
+/** A component that renders list item `li` elements or definition item `dt`
+ * and `dd` elements based on the `listType` prop. */
 export default function List(props: React.PropsWithChildren<ListProps>) {
   const {
     blockName,
@@ -38,7 +40,7 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
     case ListTypes.Ordered:
       errorText = "Direct children of `List` (ordered) should be `<li>`s";
       React.Children.map(children, function (child: React.ReactElement) {
-        if (child.type !== "li") {
+        if (child.type !== "li" && child.props.mdxType !== "li") {
           throw new Error(errorText);
         }
       });
@@ -54,7 +56,7 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
     case ListTypes.Unordered:
       errorText = "Direct children of `List` (unordered) should be `<li>`s";
       React.Children.map(children, function (child: React.ReactElement) {
-        if (child.type !== "li") {
+        if (child.type !== "li" && child.props.mdxType !== "li") {
           throw new Error(errorText);
         }
       });
@@ -74,7 +76,10 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
         if (
           child.type !== "dt" &&
           child.type !== "dd" &&
-          child.type !== React.Fragment
+          child.type !== React.Fragment &&
+          child.props.mdxType !== "dt" &&
+          child.props.mdxType !== "dd" &&
+          child.props.mdxType !== React.Fragment
         ) {
           throw new Error(errorText);
         }


### PR DESCRIPTION
Fixes [DSD-303](https://jira.nypl.org/browse/DSD-303)

## **This PR does the following:**
- This removes the `itemGroups` and `definitions` props from the Controls section in the `List` component.
- This adds an `.mdx` file for the `List` component documentation and updates references.
- There's another round of updates for this component but that will be covered in a different PR for [DSD-361](https://jira.nypl.org/browse/DSD-361).

### Front End Review:
- [ ] View [the example in Storybook]()
