### PR TITLE
Bugfix: Removing storybook-static from gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ public
 .DS_Store
 lib
 dist
-storybook-static

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+## 0.23.3
+
+### Fixes
+
+- Removes the `storybook-static` directory from `.gitignore` so that the Github Actions deploy job can work properly.
+
 ## 0.23.2
 
 ### Adds

--- a/README.md
+++ b/README.md
@@ -180,4 +180,4 @@ There should be no need to run the static Storybook instance while actively deve
 $ npm run build-storybook
 ```
 
-You can then view `/storybook-static/index.html` in your browser.
+You can then view `/storybook-static/index.html` in your browser. _Make sure not to commit this directory_.


### PR DESCRIPTION
## This PR does the following:
- Removes "storybook-static" from gitignore so that the github pages deployment can work properly.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
