### PR TITLE
DSD-387: SkeletonLoader enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds `SkeletonLoaderLayouts` and `SkeletonLoaderImageRatios` enums to DS exports
+
 ## 0.23.3
 
 ### Fixes

--- a/src/components/SkeletonLoader/SkeletonLoader.stories.mdx
+++ b/src/components/SkeletonLoader/SkeletonLoader.stories.mdx
@@ -62,7 +62,7 @@ import { action } from "@storybook/addon-actions";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.17.3`   |
-| Latest            | `0.23.2`   |
+| Latest            | `0.23.4`   |
 
 <Description of={SkeletonLoader} />
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,10 @@ export { default as Pagination } from "./components/Pagination/Pagination";
 export { default as Radio } from "./components/Radio/Radio";
 export { default as SearchBar } from "./components/SearchBar/SearchBar";
 export { default as SkeletonLoader } from "./components/SkeletonLoader/SkeletonLoader";
+export {
+  SkeletonLoaderImageRatios,
+  SkeletonLoaderLayouts,
+} from "./components/SkeletonLoader/SkeletonLoaderTypes";
 export { default as Select } from "./components/Select/Select";
 export { default as StatusBadge } from "./components/StatusBadge/StatusBadge";
 export { default as TextInput } from "./components/TextInput/TextInput";


### PR DESCRIPTION
Fixes JIRA ticket [DSD-387](https://jira.nypl.org/browse/DSD-387)

## This PR does the following:
- Adds `SkeletonLoaderLayouts` and `SkeletonLoaderImageRatios` enums to DS exports

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of DS Storybook
- import working branch into DS test app

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] All new and existing tests passed.

## Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [x] View [the example in Storybook](https://deploy-preview-614--nypl-design-system-dev.netlify.app)
