### PR TITLE
DSD-346: Breadcrumbs - removing a custom SCSS breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Changes
 
 - Updates the README to include information on the production, development, and "preview" Storybook documentation instances.
+- Removes a custom SCSS breakpoint in `_Breadcrumbs.scss` in favor of mobile-first style rules.
 
 ### Adds
 

--- a/src/components/Breadcrumbs/_Breadcrumbs.scss
+++ b/src/components/Breadcrumbs/_Breadcrumbs.scss
@@ -1,5 +1,3 @@
-$break-breadcrumbs-mobile: max-width 599px;
-
 .breadcrumbs {
   background-color: var(--ui-black);
   padding-bottom: var(--space-xs);
@@ -21,15 +19,20 @@ $break-breadcrumbs-mobile: max-width 599px;
         padding-left: var(--space-xxs);
       }
 
-      @include breakpoint($break-breadcrumbs-mobile) {
-        display: none;
+      display: none;
+
+      @include breakpoint($breakpoint-medium) {
+        display: inline;
       }
     }
 
     &:last-child {
-      @include breakpoint($break-breadcrumbs-mobile) {
-        display: block;
-        padding-left: var(--space-m);
+      display: block;
+      padding-left: var(--space-m);
+
+      @include breakpoint($breakpoint-medium) {
+        display: inline;
+        padding-left: 0;
       }
     }
   }


### PR DESCRIPTION
Fixes JIRA ticket [DSD-346](https://jira.nypl.org/browse/DSD-346)

## This PR does the following:
- Removes the `$break-breadcrumbs-mobile` custom breakpoint variable. Instead of using a `max-width 599px`, it uses the already configured `$breakpoint-medium` variable and updates the styling rules so it's more mobile-first.

## How has this been tested?

Through storybook with different responsive layouts.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
