### PR TITLE
DSD-263: Updating the warning for number of children for the Select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the README to include information on the production, development, and "preview" Storybook documentation instances.
 - Removes a custom SCSS breakpoint in `_Breadcrumbs.scss` in favor of mobile-first style rules.
+- Updated warnings for too few or too many option children for the `Select` component.
 
 ### Adds
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -358,7 +358,7 @@ describe("Select", () => {
     expect(container.find("select").instance()).to.equal(ref.current);
   });
 
-  it("should throw warning when fewer than 2 options", () => {
+  it("should throw warning when fewer than 4 options", () => {
     wrapper = Enzyme.mount(
       <Select
         labelText="Select Label"
@@ -373,12 +373,12 @@ describe("Select", () => {
     expect(wrapper.find("select").prop("name")).to.equal("test1");
     expect(
       warn.calledWith(
-        "NYPL DS recommends <select> not be used for 1 or fewer options"
+        "NYPL DS recommends that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
       )
     );
   });
 
-  it("should throw warning when there are more than 7 options", () => {
+  it("should throw warning when there are more than 10 options", () => {
     wrapper = Enzyme.mount(
       <Select
         labelText="Select Label"
@@ -400,7 +400,7 @@ describe("Select", () => {
     expect(wrapper.find("select").prop("name")).to.equal("test1");
     expect(
       warn.calledWith(
-        "NYPL DS recommends that your <select>s have fewer than 8 options"
+        "NYPL DS recommends that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
       )
     );
   });

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -104,15 +104,15 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       ariaLabelledBy = labelId + " " + helperTextId;
     }
 
-    if (React.Children.count(children) > 7) {
+    if (React.Children.count(children) > 10) {
       console.warn(
-        "NYPL DS recommends that your <select>s have fewer than 8 options"
+        "NYPL DS recommends that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
       );
     }
 
-    if (React.Children.count(children) < 2) {
+    if (React.Children.count(children) < 4) {
       console.warn(
-        "NYPL DS recomments <select> not be used with 1 or fewer options"
+        "NYPL DS recommends that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
       );
     }
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-263](https://jira.nypl.org/browse/DSD-263)

## This PR does the following:
- Updates the warnings that are logged to the console when too few or too many children are used in the `Select` component.

## How has this been tested?

Locally.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
