### PR TITLE
DSD-439: Adding the 'showOptReqLabel' prop in the Select 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Exports `VideoPlayerAspectRatios`
 - Adds Tugboat QA configuration for PR preview deployments to replace Netlify.
-- Updates the `DatePicker`, `TextInput`, and `Label` components to pass an optional `showOptReqLabel` prop to conditionally render "Required"/"Optional" in the label text.
+- Updates the `DatePicker`, `TextInput`, `Select`, and `Label` components to pass an optional `showOptReqLabel` prop to conditionally render "Required"/"Optional" in the label text.
 
 ## 0.23.4
 

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -36,6 +36,11 @@ import { getCategory } from "../../utils/componentCategories";
 
 # Select
 
+| Component Version | DS Version |
+| ----------------- | ---------- |
+| Added             | `0.7.0`    |
+| Latest            | `0.24.0`   |
+
 <Description of={Select} />
 
 The `Select` component renders a `select` element along with its `option` children. For optimal accessibility, the `labelText` property is a required prop, regardless of the label visibility. Additionally, while the `id` prop is optional, a unique `id` attribute is necessary for accessibility. If the prop is left blank, a value will be generated for you.
@@ -47,6 +52,7 @@ The `Select` component renders a `select` element along with its `option` childr
       id: "mySelect",
       labelText: "What is your favorite color?",
       showLabel: true,
+      showOptReqLabel: true,
       helperText: "Choose wisely.",
       errorText: "Waaaaaaaa!",
       errored: false,
@@ -95,6 +101,7 @@ A Select can be rendered with or without visible labels. When `showLabel` is set
     args={{
       labelText: "What is your favorite color?",
       showLabel: false,
+      showOptReqLabel: false,
     }}
   >
     {(args) => (

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -119,11 +119,12 @@ describe("Select", () => {
     );
   });
 
-  it("Renders required and aria-required attributes", () => {
-    render(
+  it("Renders required or optional text in the label", () => {
+    const utils = render(
       <Select
         id="custom-select-id"
         labelText="Select Label"
+        showLabel={true}
         onChange={changeCallback}
         onBlur={blurCallback}
         name="test4"
@@ -133,10 +134,69 @@ describe("Select", () => {
         <option aria-selected={false}>test2</option>
       </Select>
     );
+    expect(screen.getByLabelText(/Select Label/i)).toBeInTheDocument();
+    expect(screen.getByText(/Required/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Optional/i)).not.toBeInTheDocument();
+
+    utils.rerender(
+      <Select
+        id="custom-select-id"
+        labelText="Select Label"
+        showLabel={true}
+        onChange={changeCallback}
+        onBlur={blurCallback}
+        name="test4"
+        required={false}
+      >
+        <option aria-selected={true}>test1</option>
+        <option aria-selected={false}>test2</option>
+      </Select>
+    );
+
+    expect(screen.getByLabelText(/Select Label/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Required/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/Optional/i)).toBeInTheDocument();
+  });
+
+  it("Renders required and aria-required attributes when 'showLabel' is false", () => {
+    render(
+      <Select
+        id="custom-select-id"
+        labelText="Select Label"
+        showLabel={false}
+        onChange={changeCallback}
+        onBlur={blurCallback}
+        name="test4"
+        required
+      >
+        <option aria-selected={true}>test1</option>
+        <option aria-selected={false}>test2</option>
+      </Select>
+    );
+    expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
     expect(screen.getByLabelText("Select Label")).toHaveAttribute(
       "aria-required"
     );
     expect(screen.getByLabelText("Select Label")).toHaveAttribute("required");
+  });
+
+  it("Should not render a required label if 'showOptReqLabel' flag is false, but still render the label", () => {
+    render(
+      <Select
+        id="custom-select-id"
+        labelText="Select Label"
+        onChange={changeCallback}
+        onBlur={blurCallback}
+        name="test4"
+        required
+        showOptReqLabel={false}
+      >
+        <option aria-selected={true}>test1</option>
+        <option aria-selected={false}>test2</option>
+      </Select>
+    );
+    expect(screen.queryByText(/required/i)).not.toBeInTheDocument();
+    expect(screen.getByLabelText("Select Label")).toBeInTheDocument();
   });
 
   it("Renders required and aria-required attributes using deprecated prop", () => {

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -46,6 +46,8 @@ export interface SelectProps {
   selectedOption?: string;
   /** Offers the ability to show the label onscreen or hide it. Refer to the `labelText` property for more information. */
   showLabel?: boolean;
+  /** Whether or not to display the "Required"/"Optional" text in the label text. */
+  showOptReqLabel?: boolean;
 }
 
 const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
@@ -70,6 +72,7 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
       disabled = false,
       selectedOption,
       showLabel,
+      showOptReqLabel = true,
     } = props;
 
     const modifiers = props.modifiers ? props.modifiers : [];
@@ -143,7 +146,11 @@ const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
     return (
       <div className="select">
         {labelText && showLabel && (
-          <Label htmlFor={id} optReqFlag={optReqFlag} id={id + `-label`}>
+          <Label
+            htmlFor={id}
+            optReqFlag={showOptReqLabel && optReqFlag}
+            id={id + `-label`}
+          >
             {labelText}
           </Label>
         )}


### PR DESCRIPTION
… optionally render Required/Optional in its label

Fixes JIRA ticket [DSD-439](https://jira.nypl.org/browse/DSD-439)

## This PR does the following:
- Adds `showOptReqLabel` prop in the `Select` component to optionally render "Required" or "Optional" in its `Label` component.

## How has this been tested?

Locally and through Storybook.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
