### PR TITLE
Bug fix: Explicitly adding postcss 8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
         "node-sass": "^4.14.1",
         "node-sass-glob-importer": "^5.3.2",
         "normalize.css": "^8.0.1",
+        "postcss": "8.3.6",
         "prettier": "2.1.1",
         "pretty-quick": "^3.1.1",
         "react": "16.14.0",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "node-sass": "^4.14.1",
     "node-sass-glob-importer": "^5.3.2",
     "normalize.css": "^8.0.1",
+    "postcss": "8.3.6",
     "prettier": "2.1.1",
     "pretty-quick": "^3.1.1",
     "react": "16.14.0",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-447](https://jira.nypl.org/browse/DSD-447)

## This PR does the following:
- Adds postcss 8 because the project won't build otherwise (it throws an exception).

## How has this been tested?

In the RENO-2240 #585  PR when @wluisi brought this issue to my attention and then in other PR branches.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
