### PR TITLE
DSD-199: RadioGroup component - part 2

### DIFF
--- a/src/components/Radio/Radio.stories.mdx
+++ b/src/components/Radio/Radio.stories.mdx
@@ -36,8 +36,10 @@ import Radio from "./Radio";
 
 <Description of={Radio} />
 
-This component renders a radio button form element. See below for configuration information. Note that the `id` property, while optional, will
-cause an accessibility violation if none is present.
+This component renders a radio button form element. Note that all these examples
+show the `Radio` button in isolation. We recommend to always use the `Radio`
+component inside the Design System `RadioGroup` component. The `RadioGroup`
+component will handle all the states and data management.
 
 <Canvas withToolbar>
   <Story

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -19,7 +19,8 @@ export interface RadioProps {
   isChecked?: boolean;
   /** Adds the 'disabled' attribute to the input when true. */
   isDisabled?: boolean;
-  /** Adds the 'aria-invalid' attribute to the input when true. */
+  /** Adds the 'aria-invalid' attribute to the input and
+   * sets the error state when true. */
   isInvalid?: boolean;
   /** Adds the 'required' attribute to the input when true. */
   isRequired?: boolean;

--- a/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -7,11 +7,12 @@ import {
   Description,
 } from "@storybook/addon-docs/blocks";
 import { withDesign } from "storybook-addon-designs";
-import Radio from "../Radio/Radio";
 
 import { getCategory } from "../../utils/componentCategories";
-import RadioGroup, { RadioGroupLayouts } from "./RadioGroup";
-import { onChangeDefault } from "./RadioGroup";
+import DSProvider from "../../theme/provider";
+import RadioGroup, { onChangeDefault } from "./RadioGroup";
+import { RadioGroupLayoutTypes } from "./RadioGroupLayoutTypes";
+import Radio from "../Radio/Radio";
 
 <Meta
   title={getCategory("RadioGroup")}
@@ -27,6 +28,7 @@ import { onChangeDefault } from "./RadioGroup";
   }}
   argTypes={{
     children: { table: { disable: true } },
+    className: { table: { disable: true } },
     onChange: { table: { disable: true } },
     id: { table: { disable: true } },
   }}
@@ -40,27 +42,201 @@ import { onChangeDefault } from "./RadioGroup";
   <Story
     name="RadioGroup"
     args={{
-      name: "radio-story",
       defaultValue: "4",
-      layout: RadioGroupLayouts.Vertical,
-      labelText: "radio group label",
-      helperText: "this is the helper text",
       errorText: "error!",
+      helperText: "This is the helper text for the full group.",
+      isDisabled: false,
+      isInvalid: false,
+      isRequired: false,
+      labelText: "Standar Radio Group",
+      layout: RadioGroupLayoutTypes.Column,
+      name: "radio-story",
+      optReqFlag: true,
       showLabel: true,
-      errored: false,
-      required: false,
-      disabled: false,
     }}
   >
     {(args) => (
       <RadioGroup {...args}>
-        <Radio value="2" labelText="Radio 2" showLabel />
-        <Radio value="3" labelText="Radio 3" showLabel />
-        <Radio value="4" labelText="Radio 4" showLabel />
-        <Radio value="5" labelText="Radio 5" showLabel />
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+        <Radio value="5" labelText="Radio 5" />
       </RadioGroup>
     )}
   </Story>
 </Preview>
 
 <ArgsTable story="RadioGroup" />
+
+## Layout Patterns
+
+Use the `layout` prop to set the `Radio` buttons to display in a column or in
+a row.
+
+<Canvas>
+  <DSProvider>
+    <RadioGroup
+      labelText="Column (default)"
+      name="column-example"
+      optReqFlag={false}
+    >
+      <Radio value="2" labelText="Radio 2" />
+      <Radio value="3" labelText="Radio 3" />
+      <Radio value="4" labelText="Radio 4" />
+      <Radio value="5" labelText="Radio 5" />
+    </RadioGroup>
+    <br />
+    <RadioGroup
+      labelText="Row"
+      name="row-example"
+      layout={RadioGroupLayoutTypes.Row}
+      optReqFlag={false}
+    >
+      <Radio value="2" labelText="Radio 2" />
+      <Radio value="3" labelText="Radio 3" />
+      <Radio value="4" labelText="Radio 4" />
+      <Radio value="5" labelText="Radio 5" />
+    </RadioGroup>
+  </DSProvider>
+</Canvas>
+
+## Errored
+
+<Canvas>
+  <DSProvider>
+    <RadioGroup
+      labelText="Errored Radio Group"
+      name="errored-example"
+      optReqFlag={false}
+      errorText="Error message for the full group."
+      isInvalid
+    >
+      <Radio value="2" labelText="Radio 2" />
+      <Radio value="3" labelText="Radio 3" />
+      <Radio value="4" labelText="Radio 4" />
+      <Radio value="5" labelText="Radio 5" />
+    </RadioGroup>
+  </DSProvider>
+</Canvas>
+
+## Disabled
+
+<Canvas>
+  <DSProvider>
+    <RadioGroup
+      labelText="Disabled Radio Group"
+      name="disabled-example"
+      optReqFlag={false}
+      helperText="The reason for being disabled."
+      isDisabled
+    >
+      <Radio value="2" labelText="Radio 2" />
+      <Radio value="3" labelText="Radio 3" />
+      <Radio value="4" labelText="Radio 4" />
+      <Radio value="5" labelText="Radio 5" />
+    </RadioGroup>
+  </DSProvider>
+</Canvas>
+
+## Getting Radio Data Values
+
+### Controlled Component using `name` and `onChange` props
+
+If your application uses controlled React components and the DS RadioGroup must
+be controlled, you can extract the data through the `name` and `onChange` props.
+This will be called every time a new `Radio` value is selected.
+
+```jsx
+const onChange = (data) => {
+  // This will return the value selected as a string.
+  console.log(data);
+};
+// ...
+
+// Example of the DS RadioGroup instance with the function above:
+<RadioGroup
+  id="controlled-example"
+  labelText="Radio Group"
+  name="radioExample"
+  defaultValue="3"
+  onChange={onChange}
+>
+  <Radio value="2" labelText="Radio 2" />
+  <Radio value="3" labelText="Radio 3" />
+  <Radio value="4" labelText="Radio 4" />
+</RadioGroup>;
+```
+
+### Uncontrolled Component using `ref`s
+
+If your application uses uncontrolled components, you can pass React `ref` props
+to the DS RadioGroup component to get the selected value from the DOM.
+
+The following example is using the `register` React `ref` from the
+`react-hook-form` package.
+
+```jsx
+import { useFormContext, Controller } from "react-hook-form";
+// ...
+const { register, handleSubmit, control } = useFormContext();
+// ...
+const submitForm = (formData) => {
+  // This will return an object with all the DOM element values that were
+  // registered with a `name` attribute.
+  // {
+  //   radioExample: "3"
+  // }
+  console.log(formData);
+  // ...
+};
+
+<form
+  onSubmit={handleSubmit(submitForm)}
+  method="post"
+  action="/some/api/endpoint"
+>
+  <Controller
+    as={
+      <RadioGroup
+        id="uncontrolled-example"
+        labelText="Radio Group"
+        name="radioExample"
+        defaultValue="3"
+        ref={register()}
+      >
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    }
+    name="radioExample"
+    control={control}
+  />
+</form>;
+```
+
+The above is specific to `react-hook-form` but a similar pattern can be used
+with normal React `ref` values.
+
+```jsx
+const radioGroupRef = React.createRef<HTMLInputElement>();
+// ...
+<RadioGroup
+  id="uncontrolled-example"
+  labelText="Radio Group"
+  name="radioExample"
+  defaultValue="3"
+  ref={radioGroupRef}
+>
+  <Radio value="2" labelText="Radio 2" />
+  <Radio value="3" labelText="Radio 3" />
+  <Radio value="4" labelText="Radio 4" />
+</RadioGroup>
+
+// ...
+// Get the value through:
+const onSubmit = () => {
+  // ...
+  const radioGroupValue = radioGroupRef.current.value;
+};
+```

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -312,4 +312,16 @@ describe("Radio Button", () => {
     expect(isInvalid).toMatchSnapshot();
     expect(isDisabled).toMatchSnapshot();
   });
+
+  it("should throw warning when a non-Radio component is used as a child", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      <RadioGroup labelText="wrong child!" name="wrong" id="wrong-child">
+        <p>This is wrong!</p>
+      </RadioGroup>
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "Only `Radio` components are allowed inside the `RadioGroup` component."
+    );
+  });
 });

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -1,0 +1,315 @@
+import * as React from "react";
+import { render, screen } from "@testing-library/react";
+import { axe } from "jest-axe";
+import renderer from "react-test-renderer";
+
+import * as generateUUID from "../../helpers/generateUUID";
+import RadioGroup from "./RadioGroup";
+import Radio from "../Radio/Radio";
+import { RadioGroupLayoutTypes } from "./RadioGroupLayoutTypes";
+import userEvent from "@testing-library/user-event";
+
+describe("Radio Accessibility", () => {
+  it("passes axe accessibility", async () => {
+    const { container } = render(
+      <RadioGroup labelText="RadioGroup example" name="a11y-test">
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+        <Radio value="5" labelText="Radio 5" />
+      </RadioGroup>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("Radio Button", () => {
+  it("renders with radio inputs and a label", () => {
+    render(
+      <RadioGroup labelText="Test Label" name="test1">
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    expect(screen.getByText(/Test Label/i)).toBeInTheDocument();
+    expect(screen.getAllByRole("radio")).toHaveLength(3);
+    expect(screen.getByText("Radio 2")).toBeInTheDocument();
+    expect(screen.getByText("Radio 3")).toBeInTheDocument();
+    expect(screen.getByText("Radio 4")).toBeInTheDocument();
+  });
+
+  it("renders with appropriate 'aria-label' attribute and value when 'showLabel' prop is set to false", () => {
+    render(
+      <RadioGroup labelText="Test Label" name="test2" showLabel={false}>
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    expect(screen.getByRole("radiogroup")).toHaveAttribute(
+      "aria-label",
+      "Test Label"
+    );
+  });
+
+  it("renders visible helper or error text", () => {
+    const { rerender } = render(
+      <RadioGroup
+        labelText="Test Label"
+        name="test3"
+        helperText="This is the helper text for the full group."
+        errorText="This is the error text :("
+      >
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    expect(
+      screen.getByText("This is the helper text for the full group.")
+    ).toBeVisible();
+    expect(
+      screen.queryByText("This is the error text :(")
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <RadioGroup
+        labelText="Test Label"
+        name="test4"
+        helperText="This is the helper text for the full group."
+        errorText="This is the error text :("
+        isInvalid
+      >
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    expect(screen.getByText("This is the error text :(")).toBeVisible();
+    expect(
+      screen.queryByText("This is the helper text for the full group.")
+    ).not.toBeInTheDocument();
+  });
+
+  it("sets the RadioGroup's ID", () => {
+    render(
+      <RadioGroup labelText="Test Label" name="test5" id="some-id">
+        <Radio value="2" labelText="Radio 2" />
+      </RadioGroup>
+    );
+
+    // The "group" role here is for the `fieldset` element.
+    expect(screen.getByRole("group")).toHaveAttribute(
+      "id",
+      "radio-group-some-id"
+    );
+  });
+
+  it("sets the next value through the onChange function", () => {
+    let newValue = "";
+    const onChange = (value) => {
+      newValue = value;
+    };
+    render(
+      <RadioGroup
+        labelText="Test Label"
+        name="getValue"
+        defaultValue="4"
+        onChange={onChange}
+      >
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+
+    expect(newValue).toEqual("");
+    userEvent.click(screen.getByText("Radio 3"));
+    expect(newValue).toEqual("3");
+    userEvent.click(screen.getByText("Radio 2"));
+    expect(newValue).toEqual("2");
+  });
+
+  it("calls the UUID generation function if no id prop value is passed", () => {
+    const generateUUIDSpy = jest.spyOn(generateUUID, "default");
+    expect(generateUUIDSpy).toHaveBeenCalledTimes(0);
+    render(
+      <RadioGroup labelText="Test Label" name="test6">
+        <Radio value="2" labelText="Radio 2" id="radio2" />
+      </RadioGroup>
+    );
+    expect(generateUUIDSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("sets the 'disabled' attribute for all its Radio children", () => {
+    render(
+      <RadioGroup labelText="Test Label" name="test7" isDisabled>
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    const radios = screen.getAllByRole("radio");
+
+    expect(radios).toHaveLength(3);
+    expect(radios[0]).toHaveAttribute("disabled");
+    expect(radios[1]).toHaveAttribute("disabled");
+    expect(radios[2]).toHaveAttribute("disabled");
+  });
+
+  it("sets the 'required' attribute for all its Radio children", () => {
+    render(
+      <RadioGroup labelText="Test Label" name="test8" isRequired>
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    const radios = screen.getAllByRole("radio");
+
+    expect(radios).toHaveLength(3);
+    expect(radios[0]).toHaveAttribute("required");
+    expect(radios[0]).toHaveAttribute("aria-required");
+    expect(radios[1]).toHaveAttribute("required");
+    expect(radios[1]).toHaveAttribute("aria-required");
+    expect(radios[2]).toHaveAttribute("required");
+    expect(radios[2]).toHaveAttribute("aria-required");
+  });
+
+  it("sets the error state for all its Radio children", () => {
+    render(
+      <RadioGroup labelText="Test Label" name="test9" isInvalid>
+        <Radio value="2" labelText="Radio 2" />
+        <Radio value="3" labelText="Radio 3" />
+        <Radio value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    const radios = screen.getAllByRole("radio");
+
+    expect(radios).toHaveLength(3);
+    expect(radios[0]).toHaveAttribute("aria-invalid");
+    expect(radios[1]).toHaveAttribute("aria-invalid");
+    expect(radios[2]).toHaveAttribute("aria-invalid");
+  });
+
+  it("renders the UI snapshot correctly", () => {
+    const column = renderer
+      .create(
+        <RadioGroup labelText="column" name="column" id="column">
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const row = renderer
+      .create(
+        <RadioGroup
+          labelText="row"
+          name="row"
+          id="row"
+          layout={RadioGroupLayoutTypes.Row}
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const noLabel = renderer
+      .create(
+        <RadioGroup
+          labelText="no label"
+          name="noLabel"
+          id="noLabel"
+          showLabel={false}
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const helperText = renderer
+      .create(
+        <RadioGroup
+          labelText="helperText"
+          name="helperText"
+          id="helperText"
+          helperText="helper text"
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const errorText = renderer
+      .create(
+        <RadioGroup
+          labelText="errorText"
+          name="errorText"
+          id="errorText"
+          errorText="error text"
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const noOptReqLabel = renderer
+      .create(
+        <RadioGroup
+          labelText="no optional or required label"
+          name="optReq"
+          id="optReq"
+          optReqFlag={false}
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const isRequired = renderer
+      .create(
+        <RadioGroup
+          labelText="required"
+          name="required"
+          id="required"
+          isRequired
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const isInvalid = renderer
+      .create(
+        <RadioGroup labelText="invalid" name="invalid" id="invalid" isInvalid>
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+    const isDisabled = renderer
+      .create(
+        <RadioGroup
+          labelText="disabled"
+          name="disabled"
+          id="disabled"
+          isDisabled
+        >
+          <Radio value="2" labelText="Radio 2" id="radio-2" />
+          <Radio value="3" labelText="Radio 3" id="radio-3" />
+        </RadioGroup>
+      )
+      .toJSON();
+
+    expect(column).toMatchSnapshot();
+    expect(row).toMatchSnapshot();
+    expect(noLabel).toMatchSnapshot();
+    expect(helperText).toMatchSnapshot();
+    expect(errorText).toMatchSnapshot();
+    expect(noOptReqLabel).toMatchSnapshot();
+    expect(isRequired).toMatchSnapshot();
+    expect(isInvalid).toMatchSnapshot();
+    expect(isDisabled).toMatchSnapshot();
+  });
+});

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,114 +1,148 @@
 import * as React from "react";
-import { RadioGroup as ChakraRadioGroup, Stack } from "@chakra-ui/react";
+import {
+  Box,
+  Stack,
+  useMultiStyleConfig,
+  useRadioGroup,
+} from "@chakra-ui/react";
 
 import HelperErrorText from "../HelperErrorText/HelperErrorText";
 import generateUUID from "../../helpers/generateUUID";
 import { spacing } from "../../theme/foundations/spacing";
-
-export enum RadioGroupLayouts {
-  Vertical = "vertical",
-  Horizontal = "horizontal",
-}
-
-type DirectionMap = { [key: string]: "column" | "row" };
-
+import { RadioGroupLayoutTypes } from "./RadioGroupLayoutTypes";
 export interface RadioGroupProps {
-  /** The radio group label. */
-  labelText: string;
-  /** className you can add in addition to 'input' */
+  /** Any child node passed to the component. */
+  children: React.ReactNode;
+  /** Additional class name. */
   className?: string;
-  /** Adds the 'disabled' prop to the input when true */
-  disabled?: boolean;
-  /** Helper for modifiers array; adds 'errored' styling */
-  errored?: boolean;
-  required?: boolean;
-  optReqFlag?: boolean;
+  /** Populates the initial value of the input */
+  defaultValue?: string;
   /** Optional string to populate the HelperErrorText for error state */
   errorText?: string;
   /** Optional string to populate the HelperErrorText for standard state */
   helperText?: string;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
-  /** The name prop indicates into which group of radios this radio belongs.  If none is specified, 'default' will be used */
-  name?: string;
+  /** Adds the 'disabled' prop to the input when true. */
+  isDisabled?: boolean;
+  /** Adds the 'aria-invalid' attribute to the input and
+   * sets the error state when true. */
+  isInvalid?: boolean;
+  /** Adds the 'required' attribute to the input when true. */
+  isRequired?: boolean;
+  /** The radio group label displayed in a `legend` element if `showlabel` is
+   * true, or an "aria-label" if `showLabel` is false. */
+  labelText: string;
+  /** Renders the Radio buttons in a row or column (default). */
+  layout?: RadioGroupLayoutTypes;
+  /** The `name` prop indicates the form group for all the Radio children. */
+  name: string;
   /** The action to perform on the `<input>`'s onChange function  */
-  onChange?: (value: string) => string;
-  /** Offers the ability to show the radio's label onscreen or hide it. Refer to the `labelText` property for more information. */
-  showLabel: boolean;
-  /** Populates the value of the input */
-  defaultValue?: string;
-  layout?: RadioGroupLayouts;
+  onChange?: (value: string) => void;
+  /** Whether or not to display "Required"/"Optional" in the label text. */
+  optReqFlag?: boolean;
+  /** Offers the ability to show the group's legend onscreen or hide it. Refer
+   * to the `labelText` property for more information. */
+  showLabel?: boolean;
 }
 
 export const onChangeDefault = () => {
   return;
 };
 
-const directionMap: DirectionMap = {
-  [RadioGroupLayouts.Vertical]: "column",
-  [RadioGroupLayouts.Horizontal]: "row",
-};
+const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
+  (props, ref?) => {
+    const {
+      children,
+      className = "",
+      defaultValue,
+      errorText,
+      helperText,
+      id = generateUUID(),
+      isDisabled = false,
+      isInvalid = false,
+      isRequired = false,
+      labelText,
+      layout = RadioGroupLayoutTypes.Column,
+      name,
+      onChange = onChangeDefault,
+      optReqFlag = true,
+      showLabel = true,
+    } = props;
+    const footnote = isInvalid ? errorText : helperText;
+    const direction = layout;
+    const newChildren = [];
 
-function RadioGroup(props: React.PropsWithChildren<RadioGroupProps>) {
-  const {
-    className,
-    id = generateUUID(),
-    children,
-    name,
-    defaultValue,
-    onChange = onChangeDefault,
-    layout = RadioGroupLayouts.Vertical,
-    labelText,
-    helperText,
-    errorText,
-    showLabel,
-    errored = false,
-    required,
-    disabled,
-  } = props;
-  const baseName = "RadioGroup";
-  const footnote = errored ? errorText : helperText;
-  const direction = directionMap[layout];
-  const newChildren = [];
+    // Use Chakra's RadioGroup hook to set and get the proper props
+    // or the custom components.
+    const { getRootProps, getRadioProps } = useRadioGroup({
+      name,
+      defaultValue,
+      onChange,
+    });
+    const radioGroupProps = getRootProps();
 
-  React.Children.map(children, (child: React.ReactElement, i) => {
-    const attributes = { key: i };
-    if (child !== undefined && child !== null) {
-      attributes["name"] = name;
-      if (disabled) {
-        attributes["disabled"] = true;
-        attributes["aria-disabled"] = true;
-      }
-      if (errored) {
-        attributes["errored"] = true;
-      }
-      if (child.props.value === defaultValue) {
-        attributes["checked"] = true;
-      }
-      newChildren.push(React.cloneElement(child, { ...attributes }));
-    }
-  });
+    // Go through the Radio children and update them as needed.
+    React.Children.map(children, (child: React.ReactElement, i) => {
+      const chakraRadioProps = getRadioProps({
+        value: child.props.value,
+      } as any);
+      const newProps = { key: i };
 
-  return (
-    <fieldset id={`radio-group-${id}`} className={`${baseName} ${className}`}>
-      <legend className={showLabel ? "" : "sr-only"}>
-        <span>{labelText}</span>
-        <span>{required ? "required" : "optional"}</span>
-      </legend>
-      <ChakraRadioGroup
-        name={name}
-        defaultValue={defaultValue}
-        onChange={onChange}
+      if (child !== undefined && child !== null) {
+        if (isDisabled) {
+          newProps["isDisabled"] = true;
+        }
+        if (isInvalid) {
+          newProps["isInvalid"] = true;
+        }
+        if (isRequired) {
+          newProps["isRequired"] = true;
+        }
+        if (child.props.value === defaultValue) {
+          newProps["checked"] = true;
+        }
+        newChildren.push(
+          React.cloneElement(child, { ...newProps, ...chakraRadioProps })
+        );
+      }
+    });
+
+    // Get the Chakra-based styles for all the custom elements in this component.
+    const styles = useMultiStyleConfig("CustomRadioGroup", {});
+
+    return (
+      <Box
+        as="fieldset"
+        id={`radio-group-${id}`}
+        className={className}
+        __css={styles}
       >
-        <Stack direction={[direction]} spacing={spacing.s}>
+        <legend className={showLabel ? "" : "sr-only"}>
+          <span>{labelText}</span>
+          {optReqFlag && (
+            <Box as="span" __css={styles.required}>
+              {isRequired ? "Required" : "Optional"}
+            </Box>
+          )}
+        </legend>
+        <Stack
+          direction={[direction]}
+          spacing={spacing.s}
+          ref={ref}
+          aria-label={!showLabel ? labelText : null}
+          {...radioGroupProps}
+        >
           {newChildren}
         </Stack>
-      </ChakraRadioGroup>
-      {footnote && (
-        <HelperErrorText isError={errored}>{footnote}</HelperErrorText>
-      )}
-    </fieldset>
-  );
-}
+        {footnote && (
+          <Box __css={styles.helper}>
+            <HelperErrorText isError={isInvalid}>{footnote}</HelperErrorText>
+          </Box>
+        )}
+      </Box>
+    );
+  }
+);
 
 export default RadioGroup;

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -10,6 +10,7 @@ import HelperErrorText from "../HelperErrorText/HelperErrorText";
 import generateUUID from "../../helpers/generateUUID";
 import { spacing } from "../../theme/foundations/spacing";
 import { RadioGroupLayoutTypes } from "./RadioGroupLayoutTypes";
+import Radio from "../Radio/Radio";
 export interface RadioGroupProps {
   /** Any child node passed to the component. */
   children: React.ReactNode;
@@ -70,7 +71,8 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
       showLabel = true,
     } = props;
     const footnote = isInvalid ? errorText : helperText;
-    const direction = layout;
+    const spacingProp =
+      layout === RadioGroupLayoutTypes.Column ? spacing.s : spacing.l;
     const newChildren = [];
 
     // Use Chakra's RadioGroup hook to set and get the proper props
@@ -84,6 +86,13 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
 
     // Go through the Radio children and update them as needed.
     React.Children.map(children, (child: React.ReactElement, i) => {
+      if (child.type !== Radio) {
+        if (child.props.mdxType && child.props.mdxType === "Radio") return;
+        console.warn(
+          "Only `Radio` components are allowed inside the `RadioGroup` component."
+        );
+      }
+
       const chakraRadioProps = getRadioProps({
         value: child.props.value,
       } as any);
@@ -127,8 +136,8 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
           )}
         </legend>
         <Stack
-          direction={[direction]}
-          spacing={spacing.s}
+          direction={[layout]}
+          spacing={spacingProp}
           ref={ref}
           aria-label={!showLabel ? labelText : null}
           {...radioGroupProps}

--- a/src/components/RadioGroup/RadioGroupLayoutTypes.tsx
+++ b/src/components/RadioGroup/RadioGroupLayoutTypes.tsx
@@ -1,0 +1,4 @@
+export enum RadioGroupLayoutTypes {
+  Column = "column",
+  Row = "row",
+}

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -139,7 +139,7 @@ exports[`Radio Button renders the UI snapshot correctly 2`] = `
   </legend>
   <div
     aria-label={null}
-    className="chakra-stack css-dpw0d4"
+    className="chakra-stack css-1objuxj"
     role="radiogroup"
   >
     <label

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,0 +1,1101 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Radio Button renders the UI snapshot correctly 1`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-column"
+>
+  <legend
+    className=""
+  >
+    <span>
+      column
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="column"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="column"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 2`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-row"
+>
+  <legend
+    className=""
+  >
+    <span>
+      row
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-dpw0d4"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="row"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="row"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 3`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-noLabel"
+>
+  <legend
+    className="sr-only"
+  >
+    <span>
+      no label
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label="no label"
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="noLabel"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="noLabel"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 4`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-helperText"
+>
+  <legend
+    className=""
+  >
+    <span>
+      helperText
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="helperText"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="helperText"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+  <div
+    className="css-0"
+  >
+    <div
+      aria-atomic={true}
+      aria-live="off"
+      className="helper-text"
+    >
+      helper text
+    </div>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 5`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-errorText"
+>
+  <legend
+    className=""
+  >
+    <span>
+      errorText
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="errorText"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="errorText"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 6`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-optReq"
+>
+  <legend
+    className=""
+  >
+    <span>
+      no optional or required label
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="optReq"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="optReq"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 7`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-required"
+>
+  <legend
+    className=""
+  >
+    <span>
+      required
+    </span>
+    <span
+      className="css-0"
+    >
+      Required
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        aria-required={true}
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="required"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={true}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        aria-required={true}
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="required"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={true}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 8`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-invalid"
+>
+  <legend
+    className=""
+  >
+    <span>
+      invalid
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-2"
+        name="invalid"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        data-invalid=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        data-invalid=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        aria-invalid={true}
+        checked={false}
+        className="chakra-radio__input"
+        disabled={false}
+        id="radio-3"
+        name="invalid"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        data-invalid=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        data-invalid=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;
+
+exports[`Radio Button renders the UI snapshot correctly 9`] = `
+<fieldset
+  className=" css-0"
+  id="radio-group-disabled"
+>
+  <legend
+    className=""
+  >
+    <span>
+      disabled
+    </span>
+    <span
+      className="css-0"
+    >
+      Optional
+    </span>
+  </legend>
+  <div
+    aria-label={null}
+    className="chakra-stack css-1wdv1uh"
+    role="radiogroup"
+  >
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        aria-disabled={true}
+        checked={false}
+        className="chakra-radio__input"
+        disabled={true}
+        id="radio-2"
+        name="disabled"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="2"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 2
+      </span>
+    </label>
+    <label
+      className="chakra-radio css-78joka"
+    >
+      <input
+        aria-disabled={true}
+        checked={false}
+        className="chakra-radio__input"
+        disabled={true}
+        id="radio-3"
+        name="disabled"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
+        }
+        type="radio"
+        value="3"
+      />
+      <span
+        aria-hidden={true}
+        className="css-ssalds"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      />
+      <span
+        className="chakra-radio__label css-1y8kf23"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Radio 3
+      </span>
+    </label>
+  </div>
+</fieldset>
+`;

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ export {
 export { NotificationTypes } from "./components/Notification/NotificationTypes";
 export { default as Pagination } from "./components/Pagination/Pagination";
 export { default as Radio } from "./components/Radio/Radio";
+export { default as RadioGroup } from "./components/RadioGroup/RadioGroup";
+export { RadioGroupLayoutTypes } from "./components/RadioGroup/RadioGroupLayoutTypes";
 export { default as SearchBar } from "./components/SearchBar/SearchBar";
 export { default as SkeletonLoader } from "./components/SkeletonLoader/SkeletonLoader";
 export {

--- a/src/theme/components/customRadioGroup.ts
+++ b/src/theme/components/customRadioGroup.ts
@@ -1,0 +1,18 @@
+const CustomRadioGroup = {
+  parts: ["required", "helper"],
+  baseStyle: {
+    legend: {
+      marginBottom: 4,
+    },
+    required: {
+      marginLeft: 6,
+    },
+    helper: {
+      marginTop: 4,
+    },
+  },
+  sizes: {},
+  defaultProps: {},
+};
+
+export default CustomRadioGroup;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -6,6 +6,7 @@ import { spacing } from "./foundations/spacing";
 import breakpoints from "./foundations/breakpoints";
 import Button from "./components/button";
 import Radio from "./components/radio";
+import CustomRadioGroup from "./components/customRadioGroup";
 
 /**
  * See Chakra default theme for shape of theme object:
@@ -38,6 +39,7 @@ const theme = extendTheme({
   components: {
     Button,
     Radio,
+    CustomRadioGroup,
   },
   // Chakra prefixes its own CSS variables with `--chakra` by default but this
   // can be updated to be anything we want. This can be "nypl" to have the


### PR DESCRIPTION
Fixes JIRA ticket [DSD-199](https://jira.nypl.org/browse/DSD-199)

## This PR does the following:
- Continues off from PR #661 
- This covers some concerns from the first PR and continues working through the Chakra refactor.
- Instead of using Chakra's own `RadioGroup` component, this uses other Chakra components and the style object to divide and appropriately set styles.
- Configures the `RadioGroup` component so it works with the DS `Radio` component.

## How has this been tested?

Locally in Storybook and linked in the Library Card app for uncontrolled and controlled forms states.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
