### PR TITLE
DSD-476: Card padding bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `FormSpacing` enum to DS exports.
 
+### Fixes
+
+- Fixes left padding on `Card` when `imageAtEnd` and `border` are both `true`.
+
 ## 0.24.0
 
 ### Breaking Changes

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -58,7 +58,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `0.24.0`   |
+| Latest            | `0.24.1`   |
 
 <Description of={Card} />
 

--- a/src/components/Card/_Card.scss
+++ b/src/components/Card/_Card.scss
@@ -233,6 +233,16 @@
             padding: var(--space-s) var(--space-s) var(--space-s) 0;
           }
         }
+
+        &.card--at-end {
+          .card__body {
+            padding: var(--space-s) var(--space-s) 0;
+
+            @include breakpoint($breakpoint-medium) {
+              padding: var(--space-s) 0 var(--space-s) var(--space-s);
+            }
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
Fixes JIRA ticket [DSD-476](https://jira.nypl.org/browse/DSD-476)

## This PR does the following:
- Fixes left padding on `Card` when `imageAtEnd` and `border` are both `true`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- Storybook in local build of DS

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [x] View [the example in Storybook](https://pr674-i918voh5bkuj76iyjpg4thvela1bn0eb.tugboat.qa/)
