### PR TITLE
DSD-451: Adding Callout variant for the Button component

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -192,16 +192,7 @@ must include an up arrow icon on the right side.
 <Canvas>
   <Story name="Patterns">
     <ButtonGroup>
-      <Button
-        buttonType={ButtonTypes.Primary}
-        attributes={{
-          style: {
-            backgroundColor: getCSSVariable("--section-books-and-more-primary"),
-          },
-        }}
-      >
-        Donate to this library
-      </Button>
+      <Button buttonType={ButtonTypes.Callout}>Donate to this library</Button>
       <Button buttonType={ButtonTypes.Secondary}>
         Back to Top
         <Icon
@@ -224,6 +215,7 @@ The different `ButtonTypes` modified by the `buttonType` prop:
     <ButtonGroup>
       <Button buttonType={ButtonTypes.Primary}>Primary</Button>
       <Button buttonType={ButtonTypes.Secondary}>Secondary</Button>
+      <Button buttonType={ButtonTypes.Callout}>Callout</Button>
       <Button buttonType={ButtonTypes.Pill}>Pill</Button>
       <Button buttonType={ButtonTypes.Link}>Link</Button>
     </ButtonGroup>

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -80,7 +80,7 @@ describe("rendering content from its children prop", () => {
   it("should render element children", () => {
     const { container } = render(
       <Button id="button3" onClick={onClick}>
-        <em>I'm a em element</em>
+        <em>I'm an em element</em>
       </Button>
     );
     expect(screen.getByText(/a em element/i)).toBeInTheDocument();
@@ -124,6 +124,17 @@ describe("Button Snapshot", () => {
         </Button>
       )
       .toJSON();
+    const callout = renderer
+      .create(
+        <Button
+          id="button"
+          onClick={jest.fn()}
+          buttonType={ButtonTypes.Callout}
+        >
+          Callout
+        </Button>
+      )
+      .toJSON();
     const pill = renderer
       .create(
         <Button id="button" onClick={jest.fn()} buttonType={ButtonTypes.Pill}>
@@ -141,6 +152,7 @@ describe("Button Snapshot", () => {
 
     expect(primary).toMatchSnapshot();
     expect(secondary).toMatchSnapshot();
+    expect(callout).toMatchSnapshot();
     expect(pill).toMatchSnapshot();
     expect(link).toMatchSnapshot();
   });

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -83,7 +83,7 @@ describe("rendering content from its children prop", () => {
         <em>I'm an em element</em>
       </Button>
     );
-    expect(screen.getByText(/a em element/i)).toBeInTheDocument();
+    expect(screen.getByText(/an em element/i)).toBeInTheDocument();
     expect(container.querySelector("em")).toBeInTheDocument();
   });
 });

--- a/src/components/Button/ButtonTypes.tsx
+++ b/src/components/Button/ButtonTypes.tsx
@@ -1,6 +1,7 @@
 export enum ButtonTypes {
   Primary = "primary",
   Secondary = "secondary",
+  Callout = "callout",
   Pill = "pill",
   Link = "link",
 }

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -29,11 +29,22 @@ exports[`Button Snapshot Renders the UI snapshot correctly 3`] = `
   onClick={[MockFunction]}
   type="button"
 >
-  Pill
+  Callout
 </button>
 `;
 
 exports[`Button Snapshot Renders the UI snapshot correctly 4`] = `
+<button
+  className="chakra-button button  css-0"
+  id="button"
+  onClick={[MockFunction]}
+  type="button"
+>
+  Pill
+</button>
+`;
+
+exports[`Button Snapshot Renders the UI snapshot correctly 5`] = `
 <button
   className="chakra-button button  css-0"
   id="button"

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -36,8 +36,6 @@ const variants = {
     bg: "ui.link.primary",
     minWidth: "none",
     height: "none",
-    hoverBg: "blue.600",
-    activeBg: "blue.700",
   },
   secondary: {
     bg: "ui.white",
@@ -84,6 +82,15 @@ const variants = {
     },
     paddingInlineStart: 1, // var(--space-xs)
     paddingInlineEnd: 1, //var(--space-xs)
+  },
+  callout: {
+    bg: "brand.primary",
+    _hover: {
+      bg: "brand.secondary",
+    },
+    _active: {
+      bg: "brand.secondary",
+    },
   },
 };
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-451](https://jira.nypl.org/browse/DSD-451)

## This PR does the following:
- Adds the `Callout` variant to the `Button` component so users don't need to update the background color through the `attributes` prop.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Netlify creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
