### PR TITLE
Fixing issue where the Heading styles did not get imported

### DIFF
--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -9,6 +9,7 @@ import Checkbox from "./components/checkbox";
 import Radio from "./components/radio";
 import CustomRadioGroup from "./components/customRadioGroup";
 import Tabs from "./components/tabs";
+import Heading from "./components/heading";
 
 /**
  * See Chakra default theme for shape of theme object:
@@ -41,6 +42,7 @@ const theme = extendTheme({
   components: {
     Button,
     Checkbox,
+    Heading,
     Radio,
     CustomRadioGroup,
     Tabs,


### PR DESCRIPTION
## This PR does the following:
- Bug fix for the `Heading` component not picking up its correct styles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
