### PR TITLE
DSD-497: Global JS styling objects

### DIFF
--- a/src/theme/components/accordion.ts
+++ b/src/theme/components/accordion.ts
@@ -12,10 +12,10 @@ const buttonStyles = {
   },
 };
 const panelStyles = {
-  paddingTop: 2, // --space-xs
-  paddingRight: 24, // --space-xxxl
-  paddingLeft: 4, // --space-s
-  paddingBottom: 2, // --space-xs
+  paddingTop: "xs",
+  paddingRight: "xxxl",
+  paddingLeft: "s",
+  paddingBottom: "xs",
 };
 
 const Accordion = {

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,4 +1,4 @@
-// style object for base or default style
+// Style object for base or default style
 const baseStyle = {
   borderRadius: "2px",
   lineHeight: "1.5",
@@ -6,8 +6,8 @@ const baseStyle = {
   cursor: "pointer",
   color: "ui.white",
   justifyContent: "center",
-  py: 2, // var(--space-xs)
-  px: 4, // var(--space-s)
+  py: "xs",
+  px: "s",
   textDecoration: "none",
   wordWrap: "normal",
   _hover: {
@@ -23,74 +23,72 @@ const baseStyle = {
     opacity: "1",
   },
 };
-// styles for different sizes ("sm", "md", "lg")
+// Styles for different "lg" size
 const sizes = {
   lg: {
     width: "150px",
   },
 };
-// styles for different visual variants:
-// primary, secondary, link, pill, icon-only
-const variants = {
-  primary: {
-    bg: "ui.link.primary",
-    minWidth: "none",
-    height: "none",
+// Styles for different visual variants:
+// primary, secondary, link, pill, icon-only, callout
+const primary = {
+  bg: "ui.link.primary",
+  minWidth: "none",
+  height: "none",
+};
+const secondary = {
+  bg: "ui.white",
+  border: "1px solid",
+  borderColor: "ui.gray.light-cool",
+  color: "inherit",
+  _hover: {
+    bg: "ui.gray.xx-light-cool",
   },
-  secondary: {
-    bg: "ui.white",
-    border: "1px solid",
-    borderColor: "ui.gray.light-cool",
-    color: "inherit",
-    _hover: {
-      bg: "ui.gray.xx-light-cool",
-    },
-  },
-  link: {
+};
+const link = {
+  bg: "transparent",
+  lineHeight: "2.5",
+  color: "ui.link.primary",
+  textDecoration: "underline",
+  _disabled: {
     bg: "transparent",
-    lineHeight: "2.5",
-    color: "ui.link.primary",
-    textDecoration: "underline",
-    _disabled: {
-      bg: "transparent",
-    },
-    _hover: {
-      bg: "transparent",
-      color: "ui.link.secondary",
-    },
   },
-  pill: {
-    bg: "ui.white",
-    border: "1px solid",
-    borderColor: "ui.gray.light-cool",
-    color: "inherit",
-    borderRadius: "20px",
-    py: 2, // var(--space-xs)
-    paddingInlineStart: 6, // var(--space-m)
-    paddingInlineEnd: 6, // var(--space-m)
-    _hover: {
-      bg: "ui.gray.xx-light-cool",
-    },
+  _hover: {
+    bg: "transparent",
+    color: "ui.link.secondary",
   },
-  "icon-only": {
-    bg: "ui.white",
-    border: "1px solid",
-    borderColor: "ui.gray.light-cool",
-    color: "inherit",
-    _hover: {
-      bg: "ui.gray.xx-light-cool",
-    },
-    paddingInlineStart: 1, // var(--space-xs)
-    paddingInlineEnd: 1, //var(--space-xs)
+};
+const pill = {
+  bg: "ui.white",
+  border: "1px solid",
+  borderColor: "ui.gray.light-cool",
+  color: "inherit",
+  borderRadius: "20px",
+  py: "xs",
+  paddingInlineStart: "m",
+  paddingInlineEnd: "m",
+  _hover: {
+    bg: "ui.gray.xx-light-cool",
   },
-  callout: {
-    bg: "brand.primary",
-    _hover: {
-      bg: "brand.secondary",
-    },
-    _active: {
-      bg: "brand.secondary",
-    },
+};
+const iconOnly = {
+  bg: "ui.white",
+  border: "1px solid",
+  borderColor: "ui.gray.light-cool",
+  color: "inherit",
+  _hover: {
+    bg: "ui.gray.xx-light-cool",
+  },
+  paddingInlineStart: "xs",
+  paddingInlineEnd: "xs",
+};
+const callout = {
+  bg: "brand.primary",
+  _hover: {
+    bg: "brand.secondary",
+  },
+  _active: {
+    bg: "brand.secondary",
   },
 };
 
@@ -98,8 +96,15 @@ const Button = {
   baseStyle,
   sizes,
   // Available variants:
-  //   primary, secondary, link, pill, icon-only
-  variants,
+  // primary, secondary, link, pill, icon-only
+  variants: {
+    primary,
+    secondary,
+    link,
+    pill,
+    ["icon-only"]: iconOnly,
+    callout,
+  },
   // Default values
   defaultProps: {
     size: "md",

--- a/src/theme/components/checkbox.ts
+++ b/src/theme/components/checkbox.ts
@@ -1,5 +1,11 @@
 // @see https://github.com/chakra-ui/chakra-ui/blob/main/packages/theme/src/components/checkbox.ts
-// For avail theme override options.
+// for available theme override options.
+
+import {
+  checkboxRadioLabelStyles,
+  checkboxRadioControlSize,
+  checkboxRadioHelperStyle,
+} from "./global";
 
 // Style object for the Checkbox's visual icon.
 const baseStyleIcon = {
@@ -52,40 +58,19 @@ const baseStyleControl = {
   },
 
   _invalid: {
-    borderColor: "ui.error",
-    color: "ui.error",
+    borderColor: "ui.error.primary",
+    color: "ui.error.primary",
   },
 };
 
 // Style object for the Checkbox's label
 const baseStyleLabel = {
-  userSelect: "none",
-  fontSize: 0,
-  fontWeight: "light",
-  marginBottom: 0,
-  marginLeft: 2,
-  verticalAlign: "middle",
-
-  _disabled: {
-    color: "ui.gray.dark",
-    opacity: 1,
-    fontStyle: "italic",
-  },
-
-  _invalid: {
-    color: "ui.error",
-  },
+  ...checkboxRadioLabelStyles,
 };
 
 // Style object for the Checkbox's helper text
 const baseStyleHelper = {
-  marginTop: 2, // var(--space-xs)
-  marginBottom: 0,
-  marginLeft: "30px", // calc(22px + var(--space-xs))
-
-  _disabled: {
-    fontStyle: "italic",
-  },
+  ...checkboxRadioHelperStyle,
 };
 
 const baseStyle = {
@@ -99,7 +84,10 @@ const baseStyle = {
 const sizes = {
   lg: {
     // Controls the width/height of the checkbox itself.
-    control: { w: "1.375rem", h: "1.375rem", borderRadius: "3px" },
+    control: {
+      ...checkboxRadioControlSize,
+      borderRadius: "3px",
+    },
     // Controls the font-size of the label only.
     label: { fontSize: "md" },
   },

--- a/src/theme/components/customCheckboxGroup.ts
+++ b/src/theme/components/customCheckboxGroup.ts
@@ -1,15 +1,9 @@
+import { checkboxRadioGroupLayout } from "./global";
+
 const CustomCheckboxGroup = {
-  parts: ["required", "helper"],
+  parts: ["legend", "required", "helper"],
   baseStyle: {
-    legend: {
-      marginBottom: 4,
-    },
-    required: {
-      marginLeft: 6,
-    },
-    helper: {
-      marginTop: 4,
-    },
+    ...checkboxRadioGroupLayout,
   },
   sizes: {},
   defaultProps: {},

--- a/src/theme/components/customRadioGroup.ts
+++ b/src/theme/components/customRadioGroup.ts
@@ -1,15 +1,9 @@
+import { checkboxRadioGroupLayout } from "./global";
+
 const CustomRadioGroup = {
-  parts: ["required", "helper"],
+  parts: ["legend", "required", "helper"],
   baseStyle: {
-    legend: {
-      marginBottom: 4,
-    },
-    required: {
-      marginLeft: 6,
-    },
-    helper: {
-      marginTop: 4,
-    },
+    ...checkboxRadioGroupLayout,
   },
   sizes: {},
   defaultProps: {},

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -1,0 +1,70 @@
+/** Export "mixin" styles. */
+export { wrapperStyles } from "./globalMixins";
+
+/** Reusable component styles. */
+
+// Used in `Select` and `TextInput`.
+const activeFocus = {
+  border: "1px solid",
+  borderColor: "ui.focus",
+  zIndex: "9999",
+  outline: "1px solid",
+  outlineColor: "ui.focus",
+};
+// Used in `Select` and `TextInput`.
+const helperTextMargin = {
+  marginTop: "xs",
+  marginBottom: "0",
+};
+// Used in `Checkbox` and `Radio`.
+const checkboxRadioLabelStyles = {
+  userSelect: "none",
+  fontSize: "0",
+  fontWeight: "light",
+  marginBottom: "0",
+  marginLeft: "xs",
+  verticalAlign: "middle",
+  _disabled: {
+    color: "ui.gray.dark",
+    opacity: 1,
+    fontStyle: "italic",
+  },
+  _invalid: {
+    color: "ui.error.primary",
+  },
+};
+// Custom values not in the spacing theme.
+// Used in `Checkbox` and `Radio`.
+const checkboxRadioControlSize = {
+  h: "1.375rem",
+  w: "1.375rem",
+};
+// Used in `CheckboxGroup` and `RadioGroup`.
+const checkboxRadioGroupLayout = {
+  legend: {
+    marginBottom: "s",
+  },
+  required: {
+    marginLeft: "m",
+  },
+  helper: {
+    marginTop: "s",
+  },
+};
+// Used in `Checkbox` and `Radio`.
+const checkboxRadioHelperStyle = {
+  ...helperTextMargin,
+  marginLeft: "30px", // calc(22px + var(--space-xs))
+  _disabled: {
+    fontStyle: "italic",
+  },
+};
+
+export {
+  activeFocus,
+  checkboxRadioLabelStyles,
+  checkboxRadioControlSize,
+  checkboxRadioGroupLayout,
+  checkboxRadioHelperStyle,
+  helperTextMargin,
+};

--- a/src/theme/components/globalMixins.ts
+++ b/src/theme/components/globalMixins.ts
@@ -1,0 +1,16 @@
+/**
+ * These objects are also SCSS mixins but are now JS objects in the
+ * context of css-in-js and the custom NYPL-theme.
+ */
+const wrapperStyles = {
+  marginY: "0",
+  marginX: "auto",
+  maxWidth: "1280px",
+  paddingTop: "0",
+  paddingBottom: "0",
+  paddingRight: "0",
+  paddingLeft: "0",
+  width: "100%",
+};
+
+export { wrapperStyles };

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -1,8 +1,8 @@
 const margins = {
-  marginTop: 0,
-  marginLeft: 0,
-  marginRight: 0,
-  marginBottom: 4, // var(--space-s)
+  marginTop: "0",
+  marginLeft: "0",
+  marginRight: "0",
+  marginBottom: "s",
 };
 
 // Heading Styles
@@ -45,8 +45,7 @@ const headings = {
   },
 };
 
-// styles for different visual variants:
-// primary, secondary, tertiary, callout
+// Styles for different visual variants
 const variants = {
   h1: headings.h1,
   h2: headings.h2,
@@ -62,7 +61,8 @@ const variants = {
 
 const Heading = {
   // Available variants:
-  //   primary, secondary, tertiary, callout
+  // h1, h2, h3, h4, h5, h6,
+  // primary, secondary, tertiary, callout
   variants,
   defaultProps: {
     variant: "secondary",

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -1,16 +1,5 @@
-// From the `wrapper` SCSS mixin.
-// TODO: Eventually we may be able to put shared JS style objects
-// into a utils file for other mixins that are shared.
-const wrapperStyles = {
-  marginY: 0,
-  marginX: "auto",
-  maxWidth: "1280px",
-  paddingTop: 0,
-  paddingBottom: 0,
-  paddingRight: 0,
-  paddingLeft: 0,
-  width: "100%",
-};
+import { wrapperStyles } from "./global";
+
 // Used for all "secondary" variants.
 const secondaryBase = {
   overflowX: "hidden",
@@ -44,14 +33,14 @@ const secondaryBase = {
 };
 // Used for all "secondary" variants' heading component.
 const secondaryHeadingBase = {
-  marginBottom: 0,
+  marginBottom: "0",
   bg: "ui.black",
   color: "ui.white",
   flex: "1 1 100%",
-  marginTop: 0,
+  marginTop: "0",
   paddingBottom: "xxs",
   position: "relative",
-  zIndex: 0,
+  zIndex: "0",
   order: { md: "1" },
   _before: {
     bg: "ui.black",
@@ -76,156 +65,156 @@ const getSecondaryVariantStyles = (bgColor: string) => ({
     },
   },
 });
-
-const variants = {
-  primary: {
+// Variant styling
+const primary = {
+  alignItems: "center",
+  display: "flex",
+  flexFlow: {
+    base: "column nowrap",
+    md: "row nowrap",
+  },
+  justifyContent: "center",
+  minHeight: "350px",
+  content: {
+    bg: "ui.black",
+    color: "ui.white",
+    flex: {
+      base: "0 0 100%",
+      md: "0 0 60%",
+    },
+    maxWidth: { md: "960px" },
+    paddingTop: "xxl",
+    paddingBottom: "xxl",
+    paddingRight: "l",
+    paddingLeft: "l",
+    a: {
+      color: "inherit",
+      display: "inline-block",
+    },
+    heading: {
+      marginBottom: "0",
+    },
+    bodyText: {
+      marginBottom: "0",
+    },
+  },
+};
+const secondary = {
+  ...secondaryBase,
+  heading: {
+    ...secondaryHeadingBase,
+  },
+};
+const secondaryBooksAndMore = getSecondaryVariantStyles(
+  "section.books-and-more.primary"
+);
+const secondaryLocations = getSecondaryVariantStyles(
+  "section.locations.primary"
+);
+const secondaryResearch = getSecondaryVariantStyles("section.research.primary");
+const secondaryWhatsOn = getSecondaryVariantStyles("section.whats-on.primary");
+const tertiary = {
+  bg: "ui.gray.xdark",
+  content: {
+    ...wrapperStyles,
+    color: "ui.white",
+    display: "flex",
+    flexFlow: "column nowrap",
+    paddingTop: "l",
+    paddingBottom: "l",
+    paddingRight: "s",
+    paddingLeft: "s",
+    p: {
+      marginBottom: "0",
+    },
+  },
+  heading: {
+    marginBottom: "s",
+    _lastChild: {
+      marginBottom: "0",
+    },
+  },
+  p: {
+    marginBottom: "0",
+  },
+};
+const campaign = {
+  alignItems: "center",
+  display: "flex",
+  justifyContent: "center",
+  marginBottom: "xxl",
+  minHeight: "300px",
+  overflow: "visible",
+  padding: {
+    base: "l",
+    md: "0",
+  },
+  position: "relative",
+  content: {
     alignItems: "center",
+    bg: "ui.black",
+    color: "ui.white",
     display: "flex",
     flexFlow: {
       base: "column nowrap",
       md: "row nowrap",
     },
-    justifyContent: "center",
-    minHeight: "350px",
-    content: {
-      bg: "ui.black",
-      color: "ui.white",
-      flex: {
-        base: "0 0 100%",
-        md: "0 0 60%",
-      },
-      maxWidth: { md: "960px" },
-      paddingTop: "xxl",
-      paddingBottom: "xxl",
-      paddingRight: "l",
-      paddingLeft: "l",
-      a: {
-        color: "inherit",
-        display: "inline-block",
-      },
-      heading: {
-        marginBottom: 0,
-      },
-      bodyText: {
-        marginBottom: 0,
-      },
-    },
+    minHeight: "320px",
+    flex: { md: "0 0 90%" },
+    maxWidth: { md: "1280px" },
+    position: { md: "relative" },
+    top: { md: "xxl" },
   },
-  secondary: {
-    ...secondaryBase,
-    heading: {
-      ...secondaryHeadingBase,
-    },
+  a: {
+    color: "inherit",
+    display: "inline-block",
   },
-  secondaryBooksAndMore: getSecondaryVariantStyles(
-    "section.books-and-more.primary"
-  ),
-  secondaryLocations: getSecondaryVariantStyles("section.locations.primary"),
-  secondaryResearch: getSecondaryVariantStyles("section.research.primary"),
-  secondaryWhatsOn: getSecondaryVariantStyles("section.whats-on.primary"),
-  tertiary: {
-    bg: "ui.gray.xdark",
-    content: {
-      ...wrapperStyles,
-      color: "ui.white",
-      display: "flex",
-      flexFlow: "column nowrap",
-      paddingTop: "l",
-      paddingBottom: "l",
-      paddingRight: "s",
-      paddingLeft: "s",
-      p: {
-        marginBottom: "0",
-      },
+  img: {
+    flex: {
+      base: "1 1 100%",
+      md: "0 0 50%",
     },
-    heading: {
-      marginBottom: "s",
-      _lastChild: {
-        marginBottom: "0",
-      },
-    },
-    p: {
-      marginBottom: "0",
-    },
+    minWidth: "0", // https://github.com/philipwalton/flexbugs/issues/41
+    objectFit: "cover",
+    width: "100%",
+    height: { md: "320px" },
   },
-  campaign: {
+  interior: {
+    flex: {
+      base: "0 0 100%",
+      md: "0 0 50%",
+    },
+    padding: "l",
+    maxWidth: { md: "960px" },
+  },
+};
+const fiftyfifty = {
+  content: {
+    ...wrapperStyles,
     alignItems: "center",
     display: "flex",
-    justifyContent: "center",
-    marginBottom: "xxl",
-    minHeight: "300px",
-    overflow: "visible",
+    flexFlow: {
+      base: "column nowrap",
+      lg: "row nowrap",
+    },
+    paddingBottom: "s",
+    paddingRight: "s",
+    paddingLeft: "s",
     padding: {
-      base: "l",
-      md: 0,
-    },
-    position: "relative",
-    content: {
-      alignItems: "center",
-      bg: "ui.black",
-      color: "ui.white",
-      display: "flex",
-      flexFlow: {
-        base: "column nowrap",
-        md: "row nowrap",
-      },
-      minHeight: "320px",
-      flex: { md: "0 0 90%" },
-      maxWidth: { md: "1280px" },
-      position: { md: "relative" },
-      top: { md: "xxl" },
-    },
-    a: {
-      color: "inherit",
-      display: "inline-block",
-    },
-    img: {
-      flex: {
-        base: "1 1 100%",
-        md: "0 0 50%",
-      },
-      minWidth: "0", // https://github.com/philipwalton/flexbugs/issues/41
-      objectFit: "cover",
-      width: "100%",
-      height: { md: "320px" },
-    },
-    interior: {
-      flex: {
-        base: "0 0 100%",
-        md: "0 0 50%",
-      },
-      padding: "l",
-      maxWidth: { md: "960px" },
+      lg: "unset",
     },
   },
-  fiftyfifty: {
-    content: {
-      ...wrapperStyles,
-      alignItems: "center",
-      display: "flex",
-      flexFlow: {
-        base: "column nowrap",
-        lg: "row nowrap",
-      },
-      paddingBottom: "s",
-      paddingRight: "s",
-      paddingLeft: "s",
-      padding: {
-        lg: "unset",
-      },
+  img: {
+    marginBottom: {
+      base: "s",
+      lg: "unset",
     },
-    img: {
-      marginBottom: {
-        base: "s",
-        lg: "unset",
-      },
-      marginRight: {
-        lg: "s",
-      },
-      maxWidth: {
-        base: "fit-content",
-        lg: "50%",
-      },
+    marginRight: {
+      lg: "s",
+    },
+    maxWidth: {
+      base: "fit-content",
+      lg: "50%",
     },
   },
 };
@@ -234,9 +223,17 @@ const Hero = {
     bg: "ui.gray.x-light-warm",
   },
   // Available variants:
-  // primary, secondary, secondaryBooksAndMore, secondaryLocations,
-  // secondaryResearch, secondaryWhatsOn, tertiary, campaign, fiftyfifty
-  variants,
+  variants: {
+    primary,
+    secondary,
+    secondaryBooksAndMore,
+    secondaryLocations,
+    secondaryResearch,
+    secondaryWhatsOn,
+    tertiary,
+    campaign,
+    fiftyfifty,
+  },
 };
 
 export default Hero;

--- a/src/theme/components/radio.ts
+++ b/src/theme/components/radio.ts
@@ -1,3 +1,9 @@
+import {
+  checkboxRadioLabelStyles,
+  checkboxRadioControlSize,
+  checkboxRadioHelperStyle,
+} from "./global";
+
 // Style object for the Radio's "control" or visual icon.
 const baseStyleControl = {
   verticalAlign: "middle",
@@ -23,11 +29,11 @@ const baseStyleControl = {
     },
     _invalid: {
       _hover: {
-        borderColor: "ui.error",
+        borderColor: "ui.error.primary",
       },
       _before: {
-        borderColor: "ui.error",
-        bg: "ui.error",
+        borderColor: "ui.error.primary",
+        bg: "ui.error.primary",
       },
     },
     _hover: {
@@ -36,8 +42,8 @@ const baseStyleControl = {
     _before: {
       content: `""`,
       display: "block",
-      w: 3,
-      h: 3,
+      w: "3",
+      h: "3",
       borderRadius: "100%",
       bg: "ui.focus",
     },
@@ -51,7 +57,7 @@ const baseStyleControl = {
     borderColor: "ui.focus",
   },
   _invalid: {
-    borderColor: "ui.error",
+    borderColor: "ui.error.primary",
   },
   // TODO:
   // _indeterminate: {
@@ -62,21 +68,12 @@ const baseStyleControl = {
 
 // Style object for the Radio's label
 const baseStyleLabel = {
-  userSelect: "none",
-  fontSize: 0,
-  fontWeight: "light",
-  marginBottom: 0,
-  marginLeft: 2,
-  verticalAlign: "middle",
+  ...checkboxRadioLabelStyles,
+};
 
-  _disabled: {
-    color: "ui.gray.dark",
-    opacity: 1,
-    fontStyle: "italic",
-  },
-  _invalid: {
-    color: "ui.error",
-  },
+// Style object for the Radio's helper text
+const baseStyleHelper = {
+  ...checkboxRadioHelperStyle,
 };
 
 const baseStyle = {
@@ -84,28 +81,20 @@ const baseStyle = {
   control: baseStyleControl,
   label: baseStyleLabel,
   // Custom element in the DS Radio component.
-  helper: {
-    marginTop: 2, // var(--space-xs)
-    marginBottom: 0,
-    marginLeft: "30px", // calc(22px + var(--space-xs))
-    _disabled: {
-      fontStyle: "italic",
-    },
-  },
+  helper: baseStyleHelper,
 };
 
 // Sticking to "md" for the default size.
 const sizes = {
   md: {
     control: {
-      // Custom values not in the spacing theme.
-      h: "1.375rem",
-      w: "1.375rem",
+      ...checkboxRadioControlSize,
     },
   },
 };
 
 const Radio = {
+  parts: ["control", "label", "helper"],
   baseStyle,
   sizes,
   // Default values

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -1,41 +1,36 @@
-const activeFocus = {
-  border: "1px solid",
-  borderColor: "ui.focus",
-  zIndex: "9999",
-  outline: "1px solid",
-  outlineColor: "ui.focus",
+import { activeFocus, helperTextMargin } from "./global";
+
+const select = {
+  borderRadius: "2px",
+  borderColor: "ui.gray.medium",
+  paddingTop: "xs",
+  paddingRight: "xl",
+  paddingBottom: "xs",
+  paddingLeft: "s",
+  _hover: {
+    borderColor: "ui.gray.medium",
+  },
+  _active: activeFocus,
+  _focus: activeFocus,
+  _disabled: {
+    color: "ui.gray.xdark",
+    bg: "ui.gray.xx-light-cool",
+    opacity: "1",
+  },
+  _invalid: {
+    border: "1px solid",
+    borderColor: "ui.error.primary",
+    boxShadow: "none",
+  },
 };
 
 const Select = {
   parts: ["select", "helper"],
   baseStyle: {
-    select: {
-      borderRadius: "2px",
-      borderColor: "ui.gray.medium",
-      paddingTop: 2, // --space-xs
-      paddingRight: 12, // --space-xl
-      paddingBottom: 2, // --space-xs
-      paddingLeft: 4, // --space-s
-      _hover: {
-        borderColor: "ui.gray.medium",
-      },
-      _active: activeFocus,
-      _focus: activeFocus,
-      _disabled: {
-        color: "ui.gray.xdark",
-        bg: "ui.gray.xx-light-cool",
-        opacity: "1",
-      },
-      _invalid: {
-        border: "1px solid",
-        borderColor: "ui.error.primary",
-        boxShadow: "none",
-      },
-    },
     helper: {
-      marginTop: 2, // --space-xs
-      marginBottom: 0,
+      ...helperTextMargin,
     },
+    select,
   },
   defaultProps: {
     size: "md",

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -1,74 +1,77 @@
+const tab = {
+  color: "black !important",
+  paddingInlineStart: "4",
+  paddingLeft: "4",
+  background: "transparent",
+  border: "0",
+  borderBottom: "1px solid",
+  borderColor: "red",
+  marginRight: {
+    base: "0",
+    md: "1px",
+  },
+  paddingRight: {
+    base: "4",
+    md: "8",
+    lg: "12",
+  },
+  whiteSpace: "nowrap",
+  _hover: {
+    bg: "ui.gray.x-light-warm",
+    borderTopRadius: "2",
+    borderBottom: "1px solid",
+    borderBottomColor: "ui.black",
+  },
+  _selected: {
+    fontWeight: "bold",
+    bg: "ui.gray.light-warm",
+    border: "0",
+    borderTopRadius: "2",
+    borderBottom: "3px solid",
+    borderBottomColor: "ui.black",
+    paddingBottom: "5px",
+  },
+  _focus: {
+    boxShadow: "0",
+  },
+};
+// Only display the previous/next arrow buttons on mobile.
+const buttonArrows = {
+  border: "0",
+  display: {
+    // "inline-block" - hiding until the full "arrow" functionality is built out
+    base: "none",
+    // After 38em/600px, don't display the arrow button anymore.
+    md: "none",
+  },
+  height: "44px",
+  width: "44px !important",
+};
+// Styles to better align the mobile arrow buttons with the tablist.
+const tablistWrapper = {
+  display: "flex",
+  alignItems: "center",
+  borderBottom: {
+    base: "0",
+    md: "1px solid black",
+  },
+  margin: {
+    base: "-4px",
+    md: "0",
+  },
+  overflowX: { base: "auto", md: "visible" },
+  paddingBottom: { base: "5px", md: "0" },
+  paddingLeft: { base: "xxs", md: "0" },
+  paddingRight: { base: "xxs", md: "0" },
+  paddingTop: { base: "xxs", md: "0" },
+};
+
 const CustomTabs = {
+  parts: ["tab", "buttonArrows", "tablistWrapper"],
   baseStyle: {
-    tablist: {
-      // no custom styles
-    },
-    tab: {
-      color: "black !important",
-      paddingInlineStart: 4,
-      paddingLeft: 4,
-      background: "transparent",
-      border: "0",
-      borderBottom: "1px solid",
-      borderColor: "red",
-      marginRight: {
-        base: "0",
-        md: "1px",
-      },
-      paddingRight: {
-        base: 4,
-        md: 8,
-        lg: 12,
-      },
-      whiteSpace: "nowrap",
-      _hover: {
-        bg: "ui.gray.x-light-warm",
-        borderTopRadius: 2,
-        borderBottom: "1px solid",
-        borderBottomColor: "ui.black",
-      },
-      _selected: {
-        fontWeight: "bold",
-        bg: "ui.gray.light-warm",
-        border: "0",
-        borderTopRadius: 2,
-        borderBottom: "3px solid",
-        borderBottomColor: "ui.black",
-        paddingBottom: "5px",
-      },
-      _focus: {
-        boxShadow: 0,
-      },
-    },
-    // Only display the previous/next arrow buttons on mobile.
-    buttonArrows: {
-      border: "0",
-      display: {
-        base: "none", // "inline-block" - hiding until the full "arrow" functionality is built out
-        // After 38em/600px, don't display the arrow button anymore.
-        md: "none",
-      },
-      height: "44px",
-      width: "44px !important",
-    },
-    // Just to better align the mobile arrow buttons with the tablist.
-    tablistWrapper: {
-      display: "flex",
-      alignItems: "center",
-      borderBottom: {
-        base: "0",
-        md: "1px solid black",
-      },
-      margin: {
-        base: "-4px",
-        md: "0",
-      },
-      overflowX: { base: "auto", md: "visible" },
-      paddingBottom: { base: "5px", md: "0" },
-      paddingLeft: { base: "4px", md: "0" },
-      paddingRight: { base: "4px", md: "0" },
-      paddingTop: { base: "4px", md: "0" },
-    },
+    tab,
+    buttonArrows,
+    tablistWrapper,
   },
   defaultProps: {},
 };

--- a/src/theme/components/textInput.ts
+++ b/src/theme/components/textInput.ts
@@ -1,17 +1,11 @@
-const activeFocus = {
-  border: "1px solid",
-  borderColor: "ui.focus",
-  zIndex: "9999",
-  outline: "1px solid",
-  outlineColor: "ui.focus",
-};
+import { activeFocus, helperTextMargin } from "./global";
+
 const input = {
   border: "1px solid",
   borderColor: "ui.gray.medium",
   borderRadius: "2px",
-  py: 2, // --space-xs
-  px: 4, // --space-s
-
+  py: "xs",
+  px: "s",
   _hover: {
     borderColor: "ui.gray.dark",
   },
@@ -29,23 +23,22 @@ const input = {
   },
   _invalid: {
     border: "1px solid",
-    borderColor: "ui.error",
+    borderColor: "ui.error.primary",
     boxShadow: "none",
   },
 };
 
 const TextInput = {
-  parts: ["helper", "input", "text"],
+  parts: ["helper", "input", "textarea"],
   baseStyle: {
+    helper: {
+      ...helperTextMargin,
+    },
     input,
     textarea: {
       ...input,
-      lineheight: 1.5,
-      minHeight: 16, // --space-xxl
-    },
-    helper: {
-      marginTop: 2, // --space-xs
-      marginBottom: 0,
+      lineheight: "1.5",
+      minHeight: "xxl",
     },
   },
 };

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -1,9 +1,11 @@
 import { extendTheme } from "@chakra-ui/react";
-import colors from "./foundations/colors";
+/** Global theme styles */
 import global from "./foundations/global";
-import typography from "./foundations/typography";
-import { spacing } from "./foundations/spacing";
 import breakpoints from "./foundations/breakpoints";
+import colors from "./foundations/colors";
+import { spacing } from "./foundations/spacing";
+import typography from "./foundations/typography";
+/** Component styles */
 import Accordion from "./components/accordion";
 import Button from "./components/button";
 import Checkbox from "./components/checkbox";
@@ -38,8 +40,8 @@ const theme = extendTheme({
   styles: { global },
   breakpoints,
   colors,
-  ...typography,
   space: spacing,
+  ...typography,
   /**
    * Chakra documentation on component styles:
    * https://chakra-ui.com/docs/theming/component-style
@@ -49,12 +51,12 @@ const theme = extendTheme({
     Button,
     Checkbox,
     CustomCheckboxGroup,
-    Heading,
-    Radio,
     CustomRadioGroup,
     CustomSelect,
-    Tabs,
+    Heading,
     Hero,
+    Radio,
+    Tabs,
     TextInput,
   },
   // Chakra prefixes its own CSS variables with `--chakra` by default but this


### PR DESCRIPTION
Fixes JIRA ticket [DSD-497](https://jira.nypl.org/browse/DSD-497)

## This PR does the following:
- Cleans up all the css-in-js styling JS objects to use name variables rather than numeric values, such as using `"xs"` instead of `2`.
- Creates a `globalMixins.ts` file for "converting" SCSS mixings to JS objects.
- Creates a `global.ts` object for reusable JS styling objects. This file imports and exports `globalMixins`. This is to make it easier to just use `global.ts` when importing objects instead of having to remember to import either `global` or `globalMixins`. Maybe it makes more sense to just import both directly if they are needed.
- SCSS Mixins should not be deleted since they _might_ still be used in consuming apps through the compiled scss file.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
