### PR TITLE
DSD-519: Changelog reminder update

### DIFF
--- a/.github/workflows/rebase.yml
+++ b/.github/workflows/rebase.yml
@@ -9,7 +9,7 @@ jobs:
       - name: Changelog Reminder
         uses: peterjgrainger/action-changelog-reminder@v1.3.0
         with:
-          changelog_regex: "/CHANGELOG.md"
+          changelog_regex: "/CHANGELOG.md/"
           customPrMessage: "Your pull request is missing a changelog—was that intentional?"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Changes
+
+- Updates the Github Action for the changelog reminder.
+
 ## 0.25.2 (October 28, 2021)
 
 ### Adds


### PR DESCRIPTION
Fixes JIRA ticket [DSD-519](https://jira.nypl.org/browse/DSD-519)

## This PR does the following:
- Updates the regex for the changelog reminder Github action. _I think_ this will fix it. Checking the code inside the Github action, it creates a `new Regex(...)` with the value we passed. It's missing a forward slash at the end for the regex to work. We'll just have to text it in other PRs to make sure it works.

## How has this been tested?

With new PRs for the Github Action to trigger (or not in this case).

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
