### PR TITLE
DSD-572 & DSD-573: CheckboxGroup and RadioGroup element width update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Checkbox` component with an "indeterminate" state through the `isIndeterminate` prop.
 - Updates the `CheckboxGroup` component story with an "indeterminate" state example.
 - Updates the `CheckboxGroup` and `RadioGroup` components to use the `Fieldset` component.
-- Updates the `CheckboxGroup` and `RadioGroup` components to use "fit-content" for their form input elements' width value.
 - Updates the `HelperErrorText` and `TextInput` components with added `additionalStyles` prop.
 - Updates the `Button` Style Guide documentation.
 - Updates the `Iconography` Style Guide story documentation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Checkbox` component with an "indeterminate" state through the `isIndeterminate` prop.
 - Updates the `CheckboxGroup` component story with an "indeterminate" state example.
 - Updates the `CheckboxGroup` and `RadioGroup` components to use the `Fieldset` component.
+- Updates the `CheckboxGroup` and `RadioGroup` components to use "fit-content" for their form input elements' width value.
 - Updates the `HelperErrorText` and `TextInput` components with added `additionalStyles` prop.
 - Updates the `Button` Style Guide documentation.
 - Updates the `Iconography` Style Guide story documentation.

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -1,9 +1,9 @@
 import * as React from "react";
 import {
   Box,
-  Stack,
   CheckboxGroup as ChakraCheckboxGroup,
-  useStyleConfig,
+  Stack,
+  useMultiStyleConfig,
 } from "@chakra-ui/react";
 
 import HelperErrorText from "../HelperErrorText/HelperErrorText";
@@ -114,8 +114,8 @@ const CheckboxGroup = React.forwardRef<HTMLInputElement, CheckboxGroupProps>(
       }
     });
 
-    // Get the Chakra-based styles for all the custom elements in this component.
-    const styles = useStyleConfig("CustomCheckboxGroup", {});
+    // Get the Chakra-based styles for the custom elements in this component.
+    const styles = useMultiStyleConfig("CheckboxGroup", {});
 
     return (
       <Fieldset
@@ -132,12 +132,13 @@ const CheckboxGroup = React.forwardRef<HTMLInputElement, CheckboxGroupProps>(
             spacing={spacingProp}
             ref={ref}
             aria-label={!showLabel ? labelText : null}
+            sx={styles.stack}
           >
             {newChildren}
           </Stack>
         </ChakraCheckboxGroup>
         {footnote && showHelperInvalidText && (
-          <Box __css={styles}>
+          <Box __css={styles.helper}>
             <HelperErrorText isInvalid={isInvalid} id={`${id}-helperErrorText`}>
               {footnote}
             </HelperErrorText>

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -20,12 +20,12 @@ export interface RadioGroupProps {
   className?: string;
   /** Populates the initial value of the input */
   defaultValue?: string;
-  /** Optional string to populate the HelperErrorText for error state */
-  invalidText?: string;
   /** Optional string to populate the HelperErrorText for standard state */
   helperText?: string;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
+  /** Optional string to populate the HelperErrorText for error state */
+  invalidText?: string;
   /** Adds the 'disabled' prop to the input when true. */
   isDisabled?: boolean;
   /** Adds the 'aria-invalid' attribute to the input and
@@ -118,8 +118,8 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
       }
     });
 
-    // Get the Chakra-based styles for all the custom elements in this component.
-    const styles = useMultiStyleConfig("CustomRadioGroup", {});
+    // Get the Chakra-based styles for the custom elements in this component.
+    const styles = useMultiStyleConfig("RadioGroup", {});
 
     return (
       <Fieldset
@@ -135,11 +135,12 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
           ref={ref}
           aria-label={!showLabel ? labelText : null}
           {...radioGroupProps}
+          sx={styles.stack}
         >
           {newChildren}
         </Stack>
         {footnote && showHelperInvalidText && (
-          <Box __css={styles}>
+          <Box __css={styles.helper}>
             <HelperErrorText isInvalid={isInvalid} id={`${id}-helperErrorText`}>
               {footnote}
             </HelperErrorText>

--- a/src/theme/components/checkboxGroup.ts
+++ b/src/theme/components/checkboxGroup.ts
@@ -1,0 +1,8 @@
+import { checkboxRadioGroupStyles } from "./global";
+
+const CheckboxGroup = {
+  parts: ["helper", "stack"],
+  baseStyle: checkboxRadioGroupStyles,
+};
+
+export default CheckboxGroup;

--- a/src/theme/components/customCheckboxGroup.ts
+++ b/src/theme/components/customCheckboxGroup.ts
@@ -1,7 +1,0 @@
-const CustomCheckboxGroup = {
-  baseStyle: {
-    marginTop: "s",
-  },
-};
-
-export default CustomCheckboxGroup;

--- a/src/theme/components/customRadioGroup.ts
+++ b/src/theme/components/customRadioGroup.ts
@@ -1,7 +1,0 @@
-const CustomRadioGroup = {
-  baseStyle: {
-    marginTop: "s",
-  },
-};
-
-export default CustomRadioGroup;

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -47,7 +47,7 @@ const checkboxRadioHelperStyle = {
     fontStyle: "italic",
   },
 };
-// Used in `Label` and `Fieldset`:
+// Used in `Label` and `Fieldset`.
 const labelLegendText = {
   alignItems: "baseline",
   width: "100%",
@@ -62,12 +62,21 @@ const labelLegendText = {
     fontSize: "-1",
   },
 };
+const checkboxRadioGroupStyles = {
+  helper: {
+    marginTop: "s",
+  },
+  stack: {
+    width: "fit-content",
+  },
+};
 
 export {
   activeFocus,
-  checkboxRadioLabelStyles,
   checkboxRadioControlSize,
+  checkboxRadioGroupStyles,
   checkboxRadioHelperStyle,
+  checkboxRadioLabelStyles,
   helperTextMargin,
   labelLegendText,
 };

--- a/src/theme/components/radioGroup.ts
+++ b/src/theme/components/radioGroup.ts
@@ -1,0 +1,8 @@
+import { checkboxRadioGroupStyles } from "./global";
+
+const RadioGroup = {
+  parts: ["helper", "stack"],
+  baseStyle: checkboxRadioGroupStyles,
+};
+
+export default RadioGroup;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -14,9 +14,8 @@ import Button from "./components/button";
 import Card from "./components/card";
 import Checkbox from "./components/checkbox";
 import ComponentWrapper from "./components/componentWrapper";
-import CustomCheckboxGroup from "./components/customCheckboxGroup";
+import CheckboxGroup from "./components/checkboxGroup";
 import { CustomImage, CustomImageWrapper } from "./components/image";
-import CustomRadioGroup from "./components/customRadioGroup";
 import CustomSelect from "./components/select";
 import DatePicker from "./components/datePicker";
 import Fieldset from "./components/fieldset";
@@ -31,6 +30,7 @@ import List from "./components/list";
 import NotificationStyles from "./components/notification";
 import Pagination from "./components/pagination";
 import Radio from "./components/radio";
+import RadioGroup from "./components/radioGroup";
 import SearchBar from "./components/searchBar";
 import { Skeleton, SkeletonLoader } from "./components/skeletonLoader";
 import StatusBadge from "./components/statusBadge";
@@ -76,11 +76,10 @@ const theme = extendTheme({
     Button,
     ...Card,
     Checkbox,
+    CheckboxGroup,
     ComponentWrapper,
-    CustomCheckboxGroup,
     CustomImage,
     CustomImageWrapper,
-    CustomRadioGroup,
     CustomSelect,
     DatePicker,
     Fieldset,
@@ -95,6 +94,7 @@ const theme = extendTheme({
     ...NotificationStyles,
     Pagination,
     Radio,
+    RadioGroup,
     SearchBar,
     Skeleton,
     SkeletonLoader,


### PR DESCRIPTION
Fixes JIRA tickets [DSD-572](https://jira.nypl.org/browse/DSD-572) and [DSD-573](https://jira.nypl.org/browse/DSD-573).

## This PR does the following:
- The main update is to update the width of the form input elements in the `CheckboxGroup` and `RadioGroup` components to "fit-width".
  - This updates the width of individual checkbox or radio elements to their content area rather than their parent's width.
- Removes "custom" from the name in the JS theme object files for these two components.
- Both these components share a lot and we can refactor them in the future but I made a minor attempt at doing so.

## How has this been tested?

Storybook.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
