### PR TITLE
DSD-608: Deprecates the Input component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the breakpoint CSS variable names by adding the `--nypl` prefix and the SCSS variables by adding the `$nypl` prefix. Updates references throughout the codebase.
 - Changes the `Button`'s `disabled` prop to `isDisabled`.
 
+### Deprecates
+
+- Deprecates the `Input` component. The `Input` component will be removed from the NYPL Design System React Library in the first release of January 2022.
+
 ## 0.25.3 (November 18, 2021)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Deprecates
 
 - Deprecates the `Input` component. The `Input` component will be removed from the NYPL Design System React Library in the first release of January 2022.
+- Deprecates the `CardEdition` component. The `CardEdition` component will be removed from the NYPL Design System React Library in the first release of January 2022.
 
 ## 0.25.3 (November 18, 2021)
 

--- a/src/utils/componentCategories.ts
+++ b/src/utils/componentCategories.ts
@@ -19,7 +19,7 @@ const categories = {
   },
   deprecated: {
     title: "Components/Deprecated",
-    components: [],
+    components: ["Input"],
   },
   feedback: {
     title: "Components/Feedback",
@@ -43,7 +43,6 @@ const categories = {
       "Fieldset",
       "FileUploader",
       "Form",
-      "Input",
       "Label",
       "NumberInput",
       "Radio",

--- a/src/utils/componentCategories.ts
+++ b/src/utils/componentCategories.ts
@@ -3,7 +3,7 @@
 const categories = {
   basicContent: {
     title: "Components/Basic Elements",
-    components: ["Card", "CardEdition", "Hero", "Promo", "Sponsor", "Table"],
+    components: ["Card", "Hero", "Promo", "Sponsor", "Table"],
   },
   contentDisplay: {
     title: "Components/Content Display",
@@ -19,7 +19,7 @@ const categories = {
   },
   deprecated: {
     title: "Components/Deprecated",
-    components: ["Input"],
+    components: ["CardEdition", "Input"],
   },
   feedback: {
     title: "Components/Feedback",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-608](https://jira.nypl.org/browse/DSD-608)

## This PR does the following:
- Deprecates the `Input` component by moving it to the "Components/Deprecated" category in Storybook.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
