### PR TITLE
DSD-620: Updating the margin for sublabels in DatePicker component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the organization of SCSS files by deleting some files and combining others.
 - Updates `@chakra-ui/react` to version 1.7.1 and `@chakra-ui/system` to version 1.8.1.
 - Updates the `TextInput` component to now have `defaultValue` and `step` props.
+- Updates the margin for labels in the `DatePicker` component when it is in the "date range" state.
 
 ### Fixes
 

--- a/src/theme/components/datePicker.ts
+++ b/src/theme/components/datePicker.ts
@@ -8,7 +8,7 @@ const DatePicker = {
     subLabels: {
       label: {
         fontSize: "12px",
-        marginBottom: "xs",
+        marginBottom: "0",
       },
     },
   },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-620](https://jira.nypl.org/browse/DSD-620)

## This PR does the following:
- Updates the sub-label margins to "0" for the `DatePicker` component in the "date range" state.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
