### PR TITLE
DSD-617, DSD-618 & DSD-621: corrected latest version numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the organization of SCSS files by deleting some files and combining others.
 - Updates `@chakra-ui/react` to version 1.7.1 and `@chakra-ui/system` to version 1.8.1.
 - Updates the `TextInput` component to now have `defaultValue` and `step` props.
+- Updates `Latest Version` number for `Image`, `Notification` and `Pagination` components.
 
 ### Fixes
 

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -37,7 +37,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.6`    |
-| Latest            | `0.25.2`   |
+| Latest            | `0.25.3`   |
 
 <Description of={Image} />
 

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -39,7 +39,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.23.2`   |
-| Latest            | `0.25.2`   |
+| Latest            | `0.25.3`   |
 
 <Description of={Notification} />
 

--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -35,7 +35,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `0.25.2`   |
+| Latest            | `0.25.3`   |
 
 <Description of={Pagination} />
 


### PR DESCRIPTION
Fixes JIRA tickets [DSD-617](https://jira.nypl.org/browse/DSD-617), [DSD-618](https://jira.nypl.org/browse/DSD-618) and [DSD-621](https://jira.nypl.org/browse/DSD-621)

## This PR does the following:
- Updates the `Latest Version` number for `Image`, `Notification` and `Pagination` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of DS

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [x] View [the example in Storybook](https://pr786-nhxkpsbof0wqjqq3e6znhcr3csesdw21.tugboat.qa/)
