### PR TITLE
DSD-639: Better aria labels in the Slider component

### DIFF
--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -22,7 +22,8 @@ import DSProvider from "../../theme/provider";
   parameters={{
     design: {
       type: "figma",
-      url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=36889%3A25871",
+      url:
+        "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=36889%3A25871",
     },
     jest: ["Slider.test.tsx"],
   }}
@@ -78,6 +79,17 @@ For this type of component, the `value` prop must be a single number.
 
 <ArgsTable story="Slider with Props" />
 
+### Accessibility
+
+Chakra's `Slider` component is accessible and, as recommended, we pass in an
+`aria-label` to their `Slider` component. On top of that, the DS `Slider`
+component's `<label>` points to the `<input>` element which shows the current
+value. This `input` element also has its own `aria-label`. When the input box
+is hidden, the `for` attribute in the `label` element is removed.
+
+Note that Chakra handles its single slider thumb aria attributes: `aria-valuemin`,
+`aria-valuemax`, `aria-valuenow`, and `aria-orientation`.
+
 ## Range Slider
 
 Set `isRangeSlider` to `true` to create a range slider. The text input
@@ -116,6 +128,19 @@ numbers. This signifies the starting and ending values of the range slider.
 </Canvas>
 
 <ArgsTable story="Range Slider with Props" />
+
+### Accessibility
+
+Chakra's `RangeSlider` component is accessible and, as recommended, we pass in
+two `aria-label`s to their `RangeSlider` component. The syntax is different than
+the expected standard string; the `RangeSlider` expect `aria-label` to be an array
+of two strings. On top of this, the DS `Slider`'s `<label>` element, when in the
+`isRangeSlider` state, points to the _first_ `<input>` element which shows the
+current _start_ value. These two `input` elements also have their own `aria-label`s.
+When the input boxes are hidden, the `for` attribute in the `label` element is removed.
+
+Note that Chakra handles its two slider thumbs aria attributes: `aria-valuemin`,
+`aria-valuemax`, `aria-valuenow`, and `aria-orientation`.
 
 ### Single Slider States
 

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -487,11 +487,11 @@ describe("Slider", () => {
       expect(screen.queryByText(/Label/i)).not.toBeInTheDocument();
       expect(screen.getAllByRole("slider")[0]).toHaveAttribute(
         "aria-label",
-        "Custom Label minimum value"
+        "Custom Label - start value"
       );
       expect(screen.getAllByRole("slider")[1]).toHaveAttribute(
         "aria-label",
-        "Custom Label maximum value"
+        "Custom Label - end value"
       );
     });
 

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -97,8 +97,9 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
     showValues = true,
     step = 1,
   } = props;
-  const [currentValue, setCurrentValue] =
-    React.useState<typeof defaultValue>(defaultValue);
+  const [currentValue, setCurrentValue] = React.useState<typeof defaultValue>(
+    defaultValue
+  );
   let finalIsInvalid = isInvalid;
   // In the Range Slider, if the first value is bigger than the second value,
   // then set the invalid state.
@@ -195,10 +196,13 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
         ...textInputSharedProps,
       },
     };
+    const updatedLabel = !isRangeSlider
+      ? labelText
+      : `${labelText} - ${type} value`;
     return (
       <TextInput
         id={`${id}-textInput-${type}`}
-        labelText={`Range slider ${type} value`}
+        labelText={updatedLabel}
         additionalStyles={{
           ...styles.textInput,
           // Specific margins for each text input to
@@ -220,7 +224,7 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
         // Both slider thumbs need values and should be in an array.
         aria-label={
           !showLabel
-            ? [`${labelText} minimum value`, `${labelText} maximum value`]
+            ? [`${labelText} - start value`, `${labelText} - end value`]
             : null
         }
         // Both slider thumbs need values and should be in an array,
@@ -262,7 +266,12 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
           // We can't target the slider thumbs since those are divs and we
           // should link the label somewhere. So either target the first
           // input box in a `RangeSlider` or the only input box in a `Slider`.
-          htmlFor={`${id}-textInput-${isRangeSlider ? "start" : "end"}`}
+          // When the input fields are not visible, remove this attribute.
+          htmlFor={
+            showBoxes
+              ? `${id}-textInput-${isRangeSlider ? "start" : "end"}`
+              : null
+          }
           optReqFlag={optReqFlag && optReqText}
         >
           {labelText}

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
       className="css-oihlfv"
     >
       <input
-        aria-label="Range slider start value"
+        aria-label="Label - start value"
         className="chakra-input css-0"
         disabled={false}
         id="defaultRangeSlider-textInput-start"
@@ -145,7 +145,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label - end value"
         className="chakra-input css-0"
         disabled={false}
         id="defaultRangeSlider-textInput-end"
@@ -201,7 +201,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
     >
       <input
         aria-invalid={true}
-        aria-label="Range slider start value - There is an error related to this field."
+        aria-label="Label - start value - There is an error related to this field."
         className="chakra-input css-0"
         disabled={false}
         id="errored-textInput-start"
@@ -324,7 +324,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
     >
       <input
         aria-invalid={true}
-        aria-label="Range slider end value - There is an error related to this field."
+        aria-label="Label - end value - There is an error related to this field."
         className="chakra-input css-0"
         disabled={false}
         id="errored-textInput-end"
@@ -379,7 +379,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
       className="css-oihlfv"
     >
       <input
-        aria-label="Range slider start value"
+        aria-label="Label - start value"
         aria-required={true}
         className="chakra-input css-0"
         disabled={false}
@@ -502,7 +502,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label - end value"
         aria-required={true}
         className="chakra-input css-0"
         disabled={false}
@@ -558,7 +558,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       className="css-oihlfv"
     >
       <input
-        aria-label="Range slider start value"
+        aria-label="Label - start value"
         className="chakra-input css-0"
         disabled={true}
         id="disabled-textInput-start"
@@ -682,7 +682,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label - end value"
         className="chakra-input css-0"
         disabled={true}
         id="disabled-textInput-end"
@@ -725,7 +725,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
       className="css-oihlfv"
     >
       <input
-        aria-label="Range slider start value"
+        aria-label="Label - start value"
         className="chakra-input css-0"
         disabled={false}
         id="noLabels-textInput-start"
@@ -788,7 +788,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
         />
       </div>
       <div
-        aria-label="Label minimum value"
+        aria-label="Label - start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -813,7 +813,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
         tabIndex={0}
       />
       <div
-        aria-label="Label maximum value"
+        aria-label="Label - end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -847,7 +847,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label - end value"
         className="chakra-input css-0"
         disabled={false}
         id="noLabels-textInput-end"
@@ -872,7 +872,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
 >
   <label
     className="css-0"
-    htmlFor="noVisibleValues-textInput-start"
+    htmlFor={null}
     id="noVisibleValues-label"
   >
     Label
@@ -1045,7 +1045,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 7`] = `
         />
       </div>
       <div
-        aria-label="Label minimum value"
+        aria-label="Label - start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -1070,7 +1070,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 7`] = `
         tabIndex={0}
       />
       <div
-        aria-label="Label maximum value"
+        aria-label="Label - end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -1203,7 +1203,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label"
         className="chakra-input css-0"
         disabled={false}
         id="defaultSlider-textInput-end"
@@ -1340,7 +1340,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
     >
       <input
         aria-invalid={true}
-        aria-label="Range slider end value - There is an error related to this field."
+        aria-label="Label - There is an error related to this field."
         className="chakra-input css-0"
         disabled={false}
         id="errored-textInput-end"
@@ -1476,7 +1476,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label"
         aria-required={true}
         className="chakra-input css-0"
         disabled={false}
@@ -1615,7 +1615,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label"
         className="chakra-input css-0"
         disabled={true}
         id="disabled-textInput-end"
@@ -1738,7 +1738,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
       className="css-1g047oq"
     >
       <input
-        aria-label="Range slider end value"
+        aria-label="Label"
         className="chakra-input css-0"
         disabled={false}
         id="noLabels-textInput-end"
@@ -1763,7 +1763,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 6`] = `
 >
   <label
     className="css-0"
-    htmlFor="noVisibleValues-textInput-end"
+    htmlFor={null}
     id="noVisibleValues-label"
   >
     Label


### PR DESCRIPTION
Fixes JIRA ticket [DSD-639](https://jira.nypl.org/browse/DSD-639)

## This PR does the following:
- Adds aria labels to the text input fields in the `Slider` component for the single and range slider.
- Adds accessibility sections in Storybook for each type of slider.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
