### PR TITLE
DSD-642: Removing the showLabel prop from SearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Exports components and variables that were initially missed when they were added: `ColorVariants`, `Fieldset`, `IconAlign`, `StatusBadgeTypes`,
 - Fixes `SearchBar` by passing necessary props down to its `TextInput` through the `textInputProps` prop.
 - Fixes `DatePicker` component unit tests.
+- Removes the `showLabel` prop from the `SearchBar` component to prevent confusion. Labels for the `Select` and `TextInput` components are never shown but are added through the `aria-label` attribute.
 
 ### Breaking Changes
 

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -217,8 +217,8 @@ precedence.
     name="Search Autocomplete"
     args={{
       isDisabled: false,
-      isRequired: false,
       isInvalid: false,
+      isRequired: false,
     }}
   >
     {(args) => (

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -56,6 +56,9 @@ based on the required props.
 The `Select` dropdown narrows the search within a specific category, typically
 title or author. Toggle the `Select` through the Controls.
 
+Note: The labels for the `Select` and `TextInput` components are not visible but
+aria-labels are used to make these children components accessible.
+
 export const optionsGroup = [
   "Art",
   "Bushes",
@@ -73,13 +76,13 @@ export const optionsGroup = [
   <Story
     name="Basic"
     args={{
-      showHelperText: true,
-      showSelect: true,
+      helperErrorText: "Search for items in Animal Crossing New Horizons",
       invalidText: "Could not find the item :(",
       isDisabled: false,
       isInvalid: false,
       isRequired: false,
-      helperErrorText: "Search for items in Animal Crossing New Horizons",
+      showHelperText: true,
+      showSelect: true,
     }}
   >
     {(args) => (
@@ -88,8 +91,8 @@ export const optionsGroup = [
         {...args}
         selectProps={
           args.showSelect && {
-            name: "selectName",
             labelText: "Select a category",
+            name: "selectName",
             optionsData: optionsGroup,
           }
         }
@@ -213,9 +216,9 @@ precedence.
   <Story
     name="Search Autocomplete"
     args={{
-      isInvalid: false,
       isDisabled: false,
       isRequired: false,
+      isInvalid: false,
     }}
   >
     {(args) => (
@@ -316,14 +319,14 @@ function SearchBarValueExample() {
     <SearchBar
       onSubmit={onSubmit}
       selectProps={{
-        name: "selectName",
         labelText: "Select a category",
+        name: "selectName",
         optionsData: optionsGroup,
       }}
       textInputProps={{
         labelText: "Item Search",
-        onChange: textInputOnChange,
         name: "textInputName",
+        onChange: textInputOnChange,
         placeholder: "Item Search",
       }}
       helperErrorText="Search for an item"
@@ -346,14 +349,14 @@ export function SearchBarValueExample() {
     <SearchBar
       onSubmit={onSubmit}
       selectProps={{
-        name: "selectName",
         labelText: "Select a category",
+        name: "selectName",
         optionsData: optionsGroup,
       }}
       textInputProps={{
         labelText: "Item Search",
-        onChange: textInputOnChange,
         name: "textInputName",
+        onChange: textInputOnChange,
         placeholder: "Item Search",
       }}
       helperErrorText="Search for an item"

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -58,9 +58,6 @@ export interface SearchBarProps {
   onSubmit: (event: React.FormEvent) => void;
   /** Required props to render a `Select` element. */
   selectProps?: SelectProps | undefined;
-  /** Will be used to visually display the label text for this
-   * `SearchBar` component. False by default. */
-  showLabel?: boolean;
   /** Custom input element to render instead of a `TextInput` element. */
   textInputElement?: JSX.Element;
   /** Required props to render a `TextInput` element. */


### PR DESCRIPTION
Fixes JIRA ticket [DSD-642](https://jira.nypl.org/browse/DSD-642)

## This PR does the following:
- Removes the `showLabel` prop from the `SearchBar` component. This prop was never used in the component so it's confusing seeing that prop and it not visually affecting the component. Internally, the labels for the `Select` and `TextInput` components are never shown, so the high-level `showLabel` is not necessary.

## How has this been tested?

Storybook and tests.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
