### PR TITLE
DSD-646: Label bottom margin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Changes
 
-- Updates the bottom margin on labels and legends for form components.
+- Reduces the bottom margin on labels and legends for form components from "16px" to "8px", or "s" to "sx" in Chakra-theme variables.
 
 ## 0.25.5 (December 9, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Changes category for `Table` component from `Basic Elements` to `Page Layout`.
 - Updates the background color for the `Locations` variant in the `Breadcrumbs` component from `section.locations.secondary` to `section.locations.primary`.
+- Reduces the bottom margin on labels and legends for form components from "16px" to "8px", or "s" to "sx" in Chakra-theme variables.
 
 ## 0.25.7 (December 20, 2021)
 
@@ -32,7 +33,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Changes
 
-- Reduces the bottom margin on labels and legends for form components from "16px" to "8px", or "s" to "sx" in Chakra-theme variables.
 - Adds "(Required)" text to the placeholder in the `SearchBar` component when `isRequired` is true.
 
 ## 0.25.5 (December 9, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Changes
+
+- Updates the bottom margin on labels and legends for form components.
+
 ## 0.25.5 (December 9, 2021)
 
 ### Fixes

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -51,7 +51,7 @@ const checkboxRadioHelperStyle = {
 const labelLegendText = {
   alignItems: "baseline",
   width: "100%",
-  marginBottom: "s",
+  marginBottom: "xs",
   fontSize: "14px",
   fontWeight: "medium",
   display: "flex",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-646](https://jira.nypl.org/browse/DSD-646)

## This PR does the following:

- Updates the bottom margin for labels and legends in form components from "s" to "xs". The components affected include: `CheckboxGroup`, `DatePicker`, `Fieldset`, `RadioGroup`, `Select`, `Slider`, and `TextInput`.

## How has this been tested?

In Storybook. `Select` and `TextInput` are missing snapshot tests but I'll create a separate ticket for that.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None, it's just appearance.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
