### PR TITLE
Release v0.25.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Changes
 
 - Adds "(Required)" text to the placeholder in the `SearchBar` component when `isRequired` is true.
+- Removes `<=12.22` from node engine in `package.json` to reduce installation issues.
 
 ## 0.25.5 (December 9, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Removes `<=12.22` from node engine in `package.json` to reduce installation issues.
+
 ## 0.25.6 (December 16, 2021)
 
 ### Adds
@@ -18,7 +22,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Changes
 
 - Adds "(Required)" text to the placeholder in the `SearchBar` component when `isRequired` is true.
-- Removes `<=12.22` from node engine in `package.json` to reduce installation issues.
 
 ## 0.25.5 (December 9, 2021)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+## 0.25.7 (December 20, 2021)
+
 ### Fixes
 
 - Removes `<=12.22` from node engine in `package.json` to reduce installation issues.

--- a/package-lock.json
+++ b/package-lock.json
@@ -88,7 +88,7 @@
         "tslib": "2.3.0"
       },
       "engines": {
-        "node": ">10 <=12.22"
+        "node": ">10"
       },
       "peerDependencies": {
         "react": ">=16.13.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "src"
   ],
   "engines": {
-    "node": ">10 <=12.22"
+    "node": ">10"
   },
   "author": "NYPL",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "0.25.6",
+  "version": "0.25.7",
   "description": "Design System React Components",
   "repository": {
     "type": "git",


### PR DESCRIPTION
## This PR does the following:

### Fixes

- Removes `<=12.22` from node engine in `package.json` to reduce installation issues.