### PR TITLE
DSD-706: Removing HTML attribute props in HorizontalRule, Form, and Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Changes
+
+- Updates the `Form`, `HorizontalRule`, `Image` component by removing the native HTML attributes as props. This sets the props allowed to the list of props declared in their own files.
+
 ## 0.25.8 (January 6, 2022)
 
 ### Adds

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,7 +1,8 @@
+import { Box } from "@chakra-ui/react";
 import * as React from "react";
+
 import { FormSpacing } from "./FormTypes";
 import SimpleGrid from "../Grid/SimpleGrid";
-import { Box } from "@chakra-ui/react";
 import generateUUID from "../../helpers/generateUUID";
 
 export interface FormChildProps {
@@ -54,8 +55,8 @@ export function FormField(props: React.PropsWithChildren<FormChildProps>) {
   );
 }
 
-/** main Form component */
-export default function Form(props: React.ComponentProps<"form"> & FormProps) {
+/** Main Form component */
+export default function Form(props: React.PropsWithChildren<FormProps>) {
   const {
     action,
     children,

--- a/src/components/HorizontalRule/HorizontalRule.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.tsx
@@ -1,6 +1,6 @@
 // HorizontalRule
-import * as React from "react";
 import { Box, useStyleConfig } from "@chakra-ui/react";
+import * as React from "react";
 
 export interface HorizontalRuleProps {
   /** Optional alignment value to align the horizontal rule to one side or the
@@ -20,9 +20,7 @@ export interface HorizontalRuleProps {
   width?: string;
 }
 
-export default function HorizontalRule(
-  props: React.ComponentProps<"hr"> & HorizontalRuleProps
-) {
+export default function HorizontalRule(props: HorizontalRuleProps) {
   const { align, className, height = "2px", width = "auto" } = props;
   const styles = useStyleConfig("HorizontalRule", { align });
   let finalHeight = height;

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -1,5 +1,5 @@
-import * as React from "react";
 import { Box, useMultiStyleConfig } from "@chakra-ui/react";
+import * as React from "react";
 
 import { ImageRatios, ImageSizes, ImageTypes } from "./ImageTypes";
 
@@ -55,7 +55,7 @@ function ImageWrapper(props: React.PropsWithChildren<ImageWrapperProps>) {
   );
 }
 
-export default function Image(props: React.ComponentProps<"img"> & ImageProps) {
+export default function Image(props: ImageProps) {
   const {
     additionalStyles = {},
     alt,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-706](https://jira.nypl.org/browse/DSD-706)

## This PR does the following:

- Removes the native HTML attributes that were used as props in the `Form`, `HorizontalRule`, and `Image` components. It previously allowed all native HTML attributes to be passed as props, but these are not needed since we explicitly list down the allowed props. 

## How has this been tested?

In Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
