### PR TITLE
DSD-697: Toggle disabled state styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `SearchBar` component to now be implemented with the `ComponentWrapper` component.
 - Removes the `ButtonTypes.SearchBar` variant style for the `Button` component. The style object is now set and passed directly to the `Button` component in the `SearchBar` component through the `additionalStyles` prop.
 - Renames `additionalStyles` prop to `additionalWrapperStyles` in the `Image` Component.
+- Updates the label text style in the disabled state of the `Toggle` component.
 
 ### Fixes
 

--- a/src/theme/components/toggle.ts
+++ b/src/theme/components/toggle.ts
@@ -12,24 +12,24 @@ const Switch = {
   baseStyle: {
     opacity: 0.4,
     track: {
-      p: "4px",
       border: "1px solid",
       borderColor: "ui.gray.medium",
+      p: "4px",
       _checked: {
-        borderColor: "ui.link.primary",
         bg: "ui.link.primary",
+        borderColor: "ui.link.primary",
         opacity: 1,
       },
       _invalid: {
-        borderColor: "ui.error.primary",
         bg: "inherit",
+        borderColor: "ui.error.primary",
         "> span": {
           bg: "ui.error.primary",
         },
       },
       _disabled: {
-        borderColor: "ui.gray.medium",
         bg: "ui.gray.medium",
+        borderColor: "ui.gray.medium",
         _checked: {
           opacity: 0.4,
         },
@@ -41,7 +41,11 @@ const Switch = {
         zIndex: "9999",
       },
     },
-    label: { fontSize: -1, marginLeft: "xs" },
+    label: {
+      fontSize: "label.default",
+      marginLeft: "xs",
+      _disabled: { fontStyle: "italic" },
+    },
     thumb: {
       _disabled: {
         bg: "ui.error.primary",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-697](https://jira.nypl.org/browse/DSD-697)

## This PR does the following:

- Updates the label text style in the disabled state of the `Toggle` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Local build of DS Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a (This is purely a style change.)

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [x] View [the example in Storybook](https://pr844-fnhznvmpkobo3nj8nnrgsqy80jdukyxw.tugboat.qa/)
