### PR TITLE
DSD-716: Updating the Heading component to better map the HeadingLevels enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Fixes
 
 - Fixes the styling of custom anchor elements when passed as a child in the `Link` component.
+- Fixes the Storybook `level` prop value for the `Heading` component so it updates the component.
 
 ## 0.25.8 (January 6, 2022)
 

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -78,7 +78,9 @@ semantic elements can be overwritten using the `displaySize` prop.
     {(args) => (
       <Heading
         {...args}
-        displaySize={sizesEnumValues.getValue(args.displaySize)}
+        displaySize={
+          args.displaySize && sizesEnumValues.getValue(args.displaySize)
+        }
         level={levelsEnumValues.getValue(args.level)}
       />
     )}

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -32,6 +32,11 @@ describe("Heading", () => {
     expect(screen.getByText("Heading 2")).toBeInTheDocument();
   });
 
+  it("renders the default level two if no `level` prop is passed", () => {
+    render(<Heading id="h2">Heading 2</Heading>);
+    expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();
+  });
+
   // TODO: check that header children are links
   // it("Throws error when invalid heading is passed as child", () => {
   //   expect(() => render(<Heading id="h1" level={HeadingLevels.Three}><span>oh no</span></Heading>))
@@ -86,15 +91,9 @@ describe("Heading", () => {
     );
   });
 
-  it("throws an error when an invalid heading number passed", () => {
-    expect(() =>
-      render(<Heading id="h1" level={9} text="Heading 9" />)
-    ).toThrow("Heading only supports levels 1-6");
-  });
-
   it("throws error when neither child nor text is passed", () => {
-    expect(() => render(<Heading id="h1" level={9} />)).toThrow(
-      "Heading only supports levels 1-6"
+    expect(() => render(<Heading id="h1" level={HeadingLevels.One} />)).toThrow(
+      "Heading has no children, please pass prop: text"
     );
   });
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -3,6 +3,7 @@ import * as React from "react";
 
 import { HeadingDisplaySizes, HeadingLevels } from "./HeadingTypes";
 import Link from "../Link/Link";
+import { getVariant } from "../../utils/utils";
 import generateUUID from "../../helpers/generateUUID";
 
 export interface HeadingProps {
@@ -10,32 +11,36 @@ export interface HeadingProps {
   additionalStyles?: { [key: string]: any };
   /** Optional className that appears in addition to `heading` */
   className?: string;
-  /** Optional size used to override the default styles of the semantic HTML `<h>` elements */
+  /** Optional size used to override the default styles of the semantic HTM
+   * `<h>` elements */
   displaySize?: HeadingDisplaySizes;
   /** Optional ID that other components can cross reference for accessibility purposes */
   id?: string;
-  /** Optional number 1-6 used to create the `<h*>` tag; if prop is not passed, `Heading` will default to `<h2>` */
+  /** Optional number 1-6 used to create the `<h*>` tag; if prop is not passed,
+   * `Heading` will default to `<h2>` */
   level?: HeadingLevels;
   /** Inner text of the `<h*>` element */
   text?: string;
-  /** Optional URL that header points to; when `url` prop is passed to `Heading`, a child `<a>` element is created and the heading text becomes an active link */
+  /** Optional URL that header points to; when `url` prop is passed to
+   * `Heading`, a child `<a>` element is created and the heading text becomes
+   * an active link */
   url?: string;
   /** Optional className for the URL when the `url` prop is passed */
   urlClass?: string;
 }
 
-// Used to map between ButtonTypes enum values and Chakra variant options.
-const variantMap = {};
-for (const type in HeadingDisplaySizes) {
-  variantMap[HeadingDisplaySizes[type]] = HeadingDisplaySizes[type];
-}
-
-/**
- * Map the HeadingDisplaySizes to the Heading Chakra theme variant object. If a wrong
- * value is passed (typically in non-Typescript scenarios), then the default
- * is "null" and displaySize is not envoked.
- */
-const getVariant = (displaySize) => variantMap[displaySize] || null;
+/** Map the word heading level to the number heading level. The default is 2. */
+const getMappedLevel = (level = HeadingLevels.Two) => {
+  const levelMap = {
+    one: 1,
+    two: 2,
+    three: 3,
+    four: 4,
+    five: 5,
+    six: 6,
+  };
+  return levelMap[level] || 2;
+};
 
 function Heading(props: React.PropsWithChildren<HeadingProps>) {
   const {
@@ -48,16 +53,15 @@ function Heading(props: React.PropsWithChildren<HeadingProps>) {
     url,
     urlClass,
   } = props;
-  const variant = displaySize ? getVariant(displaySize) : `h${level}`;
+  const finalLevel = getMappedLevel(level);
+  const variant = displaySize
+    ? getVariant(displaySize, HeadingDisplaySizes)
+    : `h${finalLevel}`;
   const styles = useStyleConfig("Heading", { variant });
   // Combine native base styles with any additional styles.
   // This is used in the `Hero` and `Notification` components.
   const finalStyles = { ...styles, ...additionalStyles };
-  const asHeading: any = `h${level}`;
-
-  if (level < 1 || level > 6) {
-    throw new Error("Heading only supports levels 1-6");
-  }
+  const asHeading: any = `h${finalLevel}`;
 
   if (!props.children && !text) {
     throw new Error("Heading has no children, please pass prop: text");

--- a/src/components/Heading/HeadingTypes.tsx
+++ b/src/components/Heading/HeadingTypes.tsx
@@ -6,10 +6,10 @@ export enum HeadingDisplaySizes {
 }
 
 export enum HeadingLevels {
-  One = 1,
-  Two = 2,
-  Three = 3,
-  Four = 4,
-  Five = 5,
-  Six = 6,
+  One = "one",
+  Two = "two",
+  Three = "three",
+  Four = "four",
+  Five = "five",
+  Six = "six",
 }


### PR DESCRIPTION
Fixes JIRA ticket [DSD-716](https://jira.nypl.org/browse/DSD-716)

## This PR does the following:

- Updates the `HeadingLevels` enum to follow the name value pattern and updates the `Heading` component so that it renders correctly in Storybook.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
