### PR TITLE
DSD-734: white BG color for Select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Renames `additionalStyles` prop to `additionalWrapperStyles` in the `Image` Component.
 - Updates the label text style in the disabled state of the `Toggle` component.
 - Updates the `Card` component so it gives a bottom margin to the `Image` component when the `imageAspectRatio` prop is set to `ImageRatios.Original`.
+- Updates `Select` component to use a white background for `static`, `error` and `focus` states.
 
 ### Fixes
 

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -1,6 +1,7 @@
 import { activeFocus, helperTextMargin } from "./global";
 
 const select = {
+  backgroundColor: "ui.white",
   borderRadius: "sm",
   borderColor: "ui.gray.medium",
   paddingTop: "xs",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-734](https://jira.nypl.org/browse/DSD-734)

## This PR does the following:

- Updates `Select` component to use white background color for `static`, `focus` and `error` states.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of DS

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [n/a] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [x] View [the example in Storybook](https://pr852-lurwfrlfib9qdxl4h7qmfbm3qnj2mv64.tugboat.qa/)
