### PR TITLE
DSD-736: Allowing HTML in the HelperErrorText component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Completely removes the `CardEdition` and `Input` components and related files and references.
 - Removes all references of the `BEM` CSS pattern.
 - Removes all references to logos from the `Icon` component.
+- Removes passing in text to the `HelperErrorText` component as children. Now, the `text` prop is used to render its text.
 
 ### Changes
 
@@ -33,6 +34,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Renames `additionalStyles` prop to `additionalWrapperStyles` in the `Image` Component.
 - Updates the label text style in the disabled state of the `Toggle` component.
 - Updates the `Card` component so it gives a bottom margin to the `Image` component when the `imageAspectRatio` prop is set to `ImageRatios.Original`.
+- Updates the `HelperErrorText` component to allow HTML to be passed in as a string or HTML.
+- Updates how the `HelperErrorText` component renders text in the following components: `Checkbox`, `CheckboxGroup`, `ComponentWrapper`, `DatePicker`, `Radio`, `RadioGroup`, `SearchBar`, `Select`, `Slider`, `TextInput`, `Toggle`, `VideoPlayer`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Removes all references of the `BEM` CSS pattern.
 - Removes all references to logos from the `Icon` component.
 - Removes passing in text to the `HelperErrorText` component as children. Now, the `text` prop is used to render its text.
+- Renames the `SearchBar`'s `helperErrorText` prop to `helperText` to be consistent with other components.
 
 ### Changes
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -1,23 +1,26 @@
-import * as React from "react";
 import {
   Box,
   Checkbox as ChakraCheckbox,
   Icon,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
+import * as React from "react";
+
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import generateUUID from "../../helpers/generateUUID";
 
 export interface CheckboxProps {
   /** className you can add in addition to 'input' */
   className?: string;
   /** Optional string to populate the HelperErrorText for standard state */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the HelperErrorText for the error state
    * when `isInvalid` is true. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** When using the Checkbox as a "controlled" form element, you can specify
    * the Checkbox's checked state using this prop.
    * Learn more about controlled and uncontrolled form fields:
@@ -89,7 +92,7 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
       value,
     } = props;
     const styles = useMultiStyleConfig("Checkbox", {});
-    const footnote = isInvalid ? invalidText : helperText;
+    const footnote: HelperErrorTextType = isInvalid ? invalidText : helperText;
     const ariaAttributes = {};
     const onChange = props.onChange || onChangeDefault;
     // Use Chakra's default indeterminate icon.
@@ -130,9 +133,11 @@ const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(
         </ChakraCheckbox>
         {footnote && showHelperInvalidText && (
           <Box __css={styles.helper}>
-            <HelperErrorText isInvalid={isInvalid} id={`${id}-helperText`}>
-              {footnote}
-            </HelperErrorText>
+            <HelperErrorText
+              id={`${id}-helperText`}
+              isInvalid={isInvalid}
+              text={footnote}
+            />
           </Box>
         )}
       </>

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -6,12 +6,14 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
-import generateUUID from "../../helpers/generateUUID";
-import { spacing } from "../../theme/foundations/spacing";
-import { CheckboxGroupLayoutTypes } from "./CheckboxGroupLayoutTypes";
 import Checkbox from "../Checkbox/Checkbox";
+import { CheckboxGroupLayoutTypes } from "./CheckboxGroupLayoutTypes";
 import Fieldset from "../Fieldset/Fieldset";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
+import { spacing } from "../../theme/foundations/spacing";
+import generateUUID from "../../helpers/generateUUID";
 
 export interface CheckboxGroupProps {
   /** Any child node passed to the component. */
@@ -19,11 +21,11 @@ export interface CheckboxGroupProps {
   /** Populates the initial value of the input */
   defaultValue?: string[];
   /** Optional string to populate the HelperErrorText for standard state */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the HelperErrorText for error state */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Adds the 'disabled' prop to the input when true. */
   isDisabled?: boolean;
   /** A`dds the 'aria-invalid' attribute to the input and
@@ -76,7 +78,7 @@ const CheckboxGroup = React.forwardRef<HTMLInputElement, CheckboxGroupProps>(
       showHelperInvalidText = true,
       showLabel = true,
     } = props;
-    const footnote = isInvalid ? invalidText : helperText;
+    const footnote: HelperErrorTextType = isInvalid ? invalidText : helperText;
     const spacingProp =
       layout === CheckboxGroupLayoutTypes.Column ? spacing.s : spacing.l;
     const newChildren = [];
@@ -139,9 +141,11 @@ const CheckboxGroup = React.forwardRef<HTMLInputElement, CheckboxGroupProps>(
         </ChakraCheckboxGroup>
         {footnote && showHelperInvalidText && (
           <Box __css={styles.helper}>
-            <HelperErrorText isInvalid={isInvalid} id={`${id}-helperErrorText`}>
-              {footnote}
-            </HelperErrorText>
+            <HelperErrorText
+              id={`${id}-helperErrorText`}
+              isInvalid={isInvalid}
+              text={footnote}
+            />
           </Box>
         )}
       </Fieldset>

--- a/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -584,11 +584,14 @@ exports[`Checkbox renders the UI snapshot correctly 4`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "helper text",
+        }
+      }
       data-isinvalid={false}
       id="helperText-helperErrorText"
-    >
-      helper text
-    </div>
+    />
   </div>
 </fieldset>
 `;

--- a/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -1,10 +1,13 @@
-import * as React from "react";
 import { Box, useMultiStyleConfig } from "@chakra-ui/react";
-import generateUUID from "../../helpers/generateUUID";
+import * as React from "react";
+
 import Heading from "../Heading/Heading";
 import { HeadingLevels } from "../Heading/HeadingTypes";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import Text from "../Text/Text";
+import generateUUID from "../../helpers/generateUUID";
 
 export interface ComponentWrapperProps {
   /** The UI elements that will be wrapped by this component */
@@ -14,12 +17,12 @@ export interface ComponentWrapperProps {
   /** Optional string to set the text for a `Heading` component */
   headingText?: string;
   /** Optional string to set the text for a `HelperErrorText` component */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the `HelperErrorText` for the error state
    * when `isInvalid` is true. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Sets invalid text in the error state. */
   isInvalid?: boolean;
 }
@@ -38,7 +41,7 @@ function ComponentWrapper(
   } = props;
   const hasChildren = !!children;
   const styles = useMultiStyleConfig("ComponentWrapper", { hasChildren });
-  const footNote = isInvalid ? invalidText : helperText;
+  const footnote: HelperErrorTextType = isInvalid ? invalidText : helperText;
 
   // Note: Typescript warns when there are no children passed and
   // doesn't compile. This is meant to log in non-Typescript apps.
@@ -57,11 +60,13 @@ function ComponentWrapper(
       )}
       {descriptionText && <Text>{descriptionText}</Text>}
       {children}
-      {footNote && (
+      {footnote && (
         <Box __css={styles.helperText}>
-          <HelperErrorText id={`${id}-helperText`} isInvalid={isInvalid}>
-            {footNote}
-          </HelperErrorText>
+          <HelperErrorText
+            id={`${id}-helperText`}
+            isInvalid={isInvalid}
+            text={footnote}
+          />
         </Box>
       )}
     </Box>

--- a/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
+++ b/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
@@ -25,11 +25,14 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 1`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "helper text",
+        }
+      }
       data-isinvalid={false}
       id="id-helperText"
-    >
-      helper text
-    </div>
+    />
   </div>
 </div>
 `;
@@ -69,11 +72,14 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 3`] = `
       aria-atomic={true}
       aria-live="polite"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "invalid text",
+        }
+      }
       data-isinvalid={true}
       id="id-helperText"
-    >
-      invalid text
-    </div>
+    />
   </div>
 </div>
 `;

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -5,7 +5,9 @@ import { DatePickerTypes } from "./DatePickerTypes";
 import Fieldset from "../Fieldset/Fieldset";
 import { FormRow, FormField } from "../Form/Form";
 import { FormSpacing } from "../Form/FormTypes";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import TextInput, {
   InputProps,
   TextInputRefType,
@@ -74,7 +76,7 @@ export interface DatePickerProps extends DatePickerWrapperProps {
   /** DatePicker date types that can be rendered. */
   dateType?: DatePickerTypes;
   /** Populates the `HelperErrorText` component in this component. */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** Populates the `HelperErrorText` component in the "From" `TextInput` component. */
   helperTextFrom?: string;
   /** Populates the `HelperErrorText` component in the "To" `TextInput` component. */
@@ -86,7 +88,7 @@ export interface DatePickerProps extends DatePickerWrapperProps {
   initialDateTo?: string;
   /** Populates the `HelperErrorText` error state for both "From"
    * and "To" input components. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Adds the 'disabled' property to the input element(s). */
   isDisabled?: boolean;
   /** Adds 'isInvalid' styling. */
@@ -415,9 +417,11 @@ const DatePicker = React.forwardRef<TextInputRefType, DatePickerProps>(
           )}
         </DateRangeRow>
         {helperText && isDateRange && showHelperInvalidText && (
-          <HelperErrorText id={`${id}-helper-text`} isInvalid={false}>
-            {helperText}
-          </HelperErrorText>
+          <HelperErrorText
+            id={`${id}-helper-text`}
+            isInvalid={false}
+            text={helperText}
+          />
         )}
       </DatePickerWrapper>
     );

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -363,11 +363,14 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                   aria-atomic={true}
                   aria-live="polite"
                   className=" css-0"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Please select a valid date.",
+                    }
+                  }
                   data-isinvalid={true}
                   id="invalid-start-helperText"
-                >
-                  Please select a valid date.
-                </div>
+                />
               </div>
             </div>
           </div>
@@ -415,11 +418,14 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                   aria-atomic={true}
                   aria-live="polite"
                   className=" css-0"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "Please select a valid date.",
+                    }
+                  }
                   data-isinvalid={true}
                   id="invalid-end-helperText"
-                >
-                  Please select a valid date.
-                </div>
+                />
               </div>
             </div>
           </div>
@@ -430,11 +436,14 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Note that the Library may be closed on Sundays.",
+        }
+      }
       data-isinvalid={false}
       id="invalid-helper-text"
-    >
-      Note that the Library may be closed on Sundays.
-    </div>
+    />
   </fieldset>
 </div>
 `;
@@ -539,11 +548,14 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Note that the Library may be closed on Sundays.",
+        }
+      }
       data-isinvalid={false}
       id="disabled-helper-text"
-    >
-      Note that the Library may be closed on Sundays.
-    </div>
+    />
   </fieldset>
 </div>
 `;
@@ -740,11 +752,14 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
               aria-atomic={true}
               aria-live="polite"
               className=" css-0"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "Please select a valid date.",
+                }
+              }
               data-isinvalid={true}
               id="invalid-start-helperText"
-            >
-              Please select a valid date.
-            </div>
+            />
           </div>
         </div>
       </div>
@@ -805,11 +820,14 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
               aria-atomic={true}
               aria-live="off"
               className=" css-0"
+              dangerouslySetInnerHTML={
+                Object {
+                  "__html": "Note that the Library may be closed on Sundays.",
+                }
+              }
               data-isinvalid={false}
               id="disabled-start-helperText"
-            >
-              Note that the Library may be closed on Sundays.
-            </div>
+            />
           </div>
         </div>
       </div>

--- a/src/components/HelperErrorText/HelperErrorText.stories.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.mdx
@@ -8,6 +8,8 @@ import {
 import { withDesign } from "storybook-addon-designs";
 
 import HelperErrorText from "./HelperErrorText";
+import Link from "../Link/Link";
+import Text from "../Text/Text";
 import { getCategory } from "../../utils/componentCategories";
 import DSProvider from "../../theme/provider";
 
@@ -59,14 +61,14 @@ import DSProvider from "../../theme/provider";
       className: undefined,
       id: "helperErrorText-id",
       isInvalid: false,
+      text: "This is the helper text!",
     }}
   >
     {(args) => (
-      <HelperErrorText {...args}>
-        {args.isInvalid
-          ? "This is the error text :("
-          : "This is the helper text!"}
-      </HelperErrorText>
+      <HelperErrorText
+        {...args}
+        text={args.isInvalid ? "This is the error text :(" : args.text}
+      />
     )}
   </Story>
 </Canvas>
@@ -75,15 +77,27 @@ import DSProvider from "../../theme/provider";
 
 ## With HTML Children
 
-The `HelperErrorText` component can take any React component or HTML element as
-its children.
+The `HelperErrorText` component can render any React component or HTML element
+through the `text` prop.
 
 <Canvas>
   <Story name="With HTML Children">
-    <HelperErrorText>
-      If you're unsure of your size, please view the{" "}
-      <a href="#sizing-chart">Sizing Chart</a>.
-    </HelperErrorText>
+    <HelperErrorText
+      text={
+        <>
+          This first example uses an HTML anchor element for{" "}
+          <a href="#">a link</a>.
+        </>
+      }
+    />
+    <HelperErrorText
+      text={
+        <Text>
+          This second example uses DS components, such as the{" "}
+          <Link href="#">`Link`</Link> component, and the `Text` component.
+        </Text>
+      }
+    />
   </Story>
 </Canvas>
 
@@ -94,7 +108,7 @@ NYPL "invalid" styling.
 
 <Canvas>
   <Story name="Invalid State">
-    <HelperErrorText isInvalid>This is the error text :(</HelperErrorText>
+    <HelperErrorText isInvalid text="This is the error text :(" />
   </Story>
 </Canvas>
 
@@ -129,10 +143,10 @@ announced immediately.
     }}
   >
     {(args) => (
-      <HelperErrorText {...args}>
-        Only invalid text can be read to screen readers with the appropriate
-        aria-atomic and aria-live props.
-      </HelperErrorText>
+      <HelperErrorText
+        {...args}
+        text="Only invalid text can be read to screen readers with the appropriate aria-atomic and aria-live props."
+      />
     )}
   </Story>
 </Canvas>

--- a/src/components/HelperErrorText/HelperErrorText.test.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.test.tsx
@@ -7,45 +7,51 @@ import HelperErrorText from "./HelperErrorText";
 
 describe("HelperErrorText Accessibility", () => {
   it("passes axe accessibility test", async () => {
-    const { container } = render(<HelperErrorText>Text</HelperErrorText>);
+    const { container } = render(<HelperErrorText text="Text" />);
     expect(await axe(container)).toHaveNoViolations();
   });
 });
 
 describe("HelperErrorText", () => {
   it("renders the text passed", () => {
-    render(<HelperErrorText>Text</HelperErrorText>);
+    render(<HelperErrorText text="Text" />);
     expect(screen.getByText("Text")).toBeInTheDocument();
   });
 
+  it("renders the text passed as an HTML string", () => {
+    render(<HelperErrorText text="<b>This text is bold</b>" />);
+    expect(screen.getByText("This text is bold")).toBeInTheDocument();
+  });
+
+  it("renders the text passed as HTML", () => {
+    render(<HelperErrorText text={<b>This text is bold</b>} />);
+    expect(screen.getByText("This text is bold")).toBeInTheDocument();
+  });
+
   it("renders the invalid state", () => {
-    const utils = render(<HelperErrorText>Text</HelperErrorText>);
+    const utils = render(<HelperErrorText text="Text" />);
 
     // False by default. Note, this is a custom `data-*` attribute only used
     // for testing the invalid state.
     expect(screen.getByText("Text")).toHaveAttribute("data-isinvalid", "false");
 
-    utils.rerender(<HelperErrorText isInvalid>Text</HelperErrorText>);
+    utils.rerender(<HelperErrorText isInvalid text="Text" />);
     expect(screen.getByText("Text")).toHaveAttribute("data-isinvalid", "true");
   });
 
   it("has aria-live and aria-atomic attributes when errored", () => {
-    render(<HelperErrorText isInvalid>Text</HelperErrorText>);
+    render(<HelperErrorText isInvalid text="Text" />);
     expect(screen.getByText("Text")).toHaveAttribute("aria-live", "polite");
     expect(screen.getByText("Text")).toHaveAttribute("aria-atomic");
   });
 
   it("accepts an aria-atomic value of false", () => {
-    const utils = render(
-      <HelperErrorText isInvalid>Static Text</HelperErrorText>
-    );
+    const utils = render(<HelperErrorText isInvalid text="Static Text" />);
     // The default is "true".
     expect(screen.getByText("Static Text")).toHaveAttribute("aria-atomic");
 
     utils.rerender(
-      <HelperErrorText ariaAtomic={false} isInvalid>
-        Static Text
-      </HelperErrorText>
+      <HelperErrorText ariaAtomic={false} isInvalid text="Static Text" />
     );
     // But the prop accepts false in case only part of the helper text
     // should only be read instead of the whole region.
@@ -57,16 +63,37 @@ describe("HelperErrorText", () => {
 
   it("Renders the UI snapshot correctly", () => {
     const basic = renderer
-      .create(<HelperErrorText id="basic">Text</HelperErrorText>)
+      .create(<HelperErrorText id="basic" text="Text" />)
       .toJSON();
     const invalid = renderer
+      .create(<HelperErrorText id="invalid" isInvalid text="Text" />)
+      .toJSON();
+    const withHTMLString = renderer
       .create(
-        <HelperErrorText id="invalid" isInvalid>
-          Text
-        </HelperErrorText>
+        <HelperErrorText
+          id="invalid"
+          isInvalid
+          text="This helper text <b>contains HTML in the string</b>."
+        />
       )
       .toJSON();
+    const withHTMLElement = renderer
+      .create(
+        <HelperErrorText
+          id="invalid"
+          isInvalid
+          text={
+            <>
+              This helper text <b>contains HTML</b>.
+            </>
+          }
+        />
+      )
+      .toJSON();
+
     expect(basic).toMatchSnapshot();
     expect(invalid).toMatchSnapshot();
+    expect(withHTMLString).toMatchSnapshot();
+    expect(withHTMLElement).toMatchSnapshot();
   });
 });

--- a/src/components/HelperErrorText/HelperErrorText.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.tsx
@@ -4,6 +4,7 @@ import { Box, useStyleConfig } from "@chakra-ui/react";
 import generateUUID from "../../helpers/generateUUID";
 
 export type AriaLiveValues = "assertive" | "off" | "polite";
+export type HelperErrorTextType = string | JSX.Element;
 
 interface HelperErrorTextProps {
   /** Optionally pass in additional Chakra-based styles. */
@@ -24,38 +25,37 @@ interface HelperErrorTextProps {
   id?: string;
   /** Toggles between helper and invalid styling. */
   isInvalid?: boolean;
+  /** The text to display. */
+  text: HelperErrorTextType;
 }
 
 /**
  * Helper or Error text for forms
  */
-export default function HelperErrorText(
-  props: React.PropsWithChildren<HelperErrorTextProps>
-) {
-  const {
-    additionalStyles = {},
-    ariaAtomic = true,
-    ariaLive = "polite",
-    children,
-    className = "",
-    id = generateUUID(),
-    isInvalid = false,
-  } = props;
+export default function HelperErrorText({
+  additionalStyles = {},
+  ariaAtomic = true,
+  ariaLive = "polite",
+  className = "",
+  id = generateUUID(),
+  isInvalid = false,
+  text,
+}: HelperErrorTextProps) {
   // Only announce the text in the invalid state.
   const announceAriaLive = isInvalid;
   const styles = useStyleConfig("HelperErrorText", { isInvalid });
   const finalStyles = { ...styles, ...additionalStyles };
-
-  return (
-    <Box
-      id={id}
-      className={className}
-      aria-atomic={ariaAtomic}
-      data-isinvalid={isInvalid}
-      aria-live={announceAriaLive ? ariaLive : "off"}
-      __css={finalStyles}
-    >
-      {children}
-    </Box>
+  const props = {
+    "aria-atomic": ariaAtomic,
+    "aria-live": announceAriaLive ? ariaLive : "off",
+    className,
+    "data-isinvalid": isInvalid,
+    id,
+    __css: finalStyles,
+  };
+  return typeof text === "string" ? (
+    <Box {...props} dangerouslySetInnerHTML={{ __html: text }} />
+  ) : (
+    <Box {...props}>{text}</Box>
   );
 }

--- a/src/components/HelperErrorText/__snapshots__/HelperErrorText.test.tsx.snap
+++ b/src/components/HelperErrorText/__snapshots__/HelperErrorText.test.tsx.snap
@@ -5,11 +5,14 @@ exports[`HelperErrorText Renders the UI snapshot correctly 1`] = `
   aria-atomic={true}
   aria-live="off"
   className=" css-0"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "Text",
+    }
+  }
   data-isinvalid={false}
   id="basic"
->
-  Text
-</div>
+/>
 `;
 
 exports[`HelperErrorText Renders the UI snapshot correctly 2`] = `
@@ -17,9 +20,43 @@ exports[`HelperErrorText Renders the UI snapshot correctly 2`] = `
   aria-atomic={true}
   aria-live="polite"
   className=" css-0"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "Text",
+    }
+  }
+  data-isinvalid={true}
+  id="invalid"
+/>
+`;
+
+exports[`HelperErrorText Renders the UI snapshot correctly 3`] = `
+<div
+  aria-atomic={true}
+  aria-live="polite"
+  className=" css-0"
+  dangerouslySetInnerHTML={
+    Object {
+      "__html": "This helper text <b>contains HTML in the string</b>.",
+    }
+  }
+  data-isinvalid={true}
+  id="invalid"
+/>
+`;
+
+exports[`HelperErrorText Renders the UI snapshot correctly 4`] = `
+<div
+  aria-atomic={true}
+  aria-live="polite"
+  className=" css-0"
   data-isinvalid={true}
   id="invalid"
 >
-  Text
+  This helper text 
+  <b>
+    contains HTML
+  </b>
+  .
 </div>
 `;

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -5,20 +5,22 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import generateUUID from "../../helpers/generateUUID";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
 
 export interface RadioProps {
   /** Additional class name. */
   className?: string;
   /** Optional string to populate the HelperErrorText for the standard state. */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the HelperErrorText for the error state
    * when `isInvalid` is true.
    */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** When using the Radio as a "controlled" form element, you can specify the
    * `Radio`'s checked state using this prop. You must also pass an onChange prop.
    * Learn more about controlled and uncontrolled form fields: https://goshakkk.name/controlled-vs-uncontrolled-inputs-react/ */
@@ -100,9 +102,11 @@ const Radio = React.forwardRef<HTMLInputElement, RadioProps>((props, ref?) => {
       </ChakraRadio>
       {footnote && showHelperInvalidText && (
         <Box __css={styles.helper} aria-disabled={isDisabled}>
-          <HelperErrorText isInvalid={isInvalid} id={`${id}-helperText`}>
-            {footnote}
-          </HelperErrorText>
+          <HelperErrorText
+            id={`${id}-helperText`}
+            isInvalid={isInvalid}
+            text={footnote}
+          />
         </Box>
       )}
     </>

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,17 +1,19 @@
-import * as React from "react";
 import {
   Box,
   Stack,
   useMultiStyleConfig,
   useRadioGroup,
 } from "@chakra-ui/react";
+import * as React from "react";
 
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
-import generateUUID from "../../helpers/generateUUID";
-import { spacing } from "../../theme/foundations/spacing";
-import { RadioGroupLayoutTypes } from "./RadioGroupLayoutTypes";
-import Radio from "../Radio/Radio";
 import Fieldset from "../Fieldset/Fieldset";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
+import { spacing } from "../../theme/foundations/spacing";
+import Radio from "../Radio/Radio";
+import { RadioGroupLayoutTypes } from "./RadioGroupLayoutTypes";
+import generateUUID from "../../helpers/generateUUID";
 
 export interface RadioGroupProps {
   /** Any child node passed to the component. */
@@ -21,11 +23,11 @@ export interface RadioGroupProps {
   /** Populates the initial value of the input */
   defaultValue?: string;
   /** Optional string to populate the HelperErrorText for standard state */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the HelperErrorText for error state */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Adds the 'disabled' prop to the input when true. */
   isDisabled?: boolean;
   /** Adds the 'aria-invalid' attribute to the input and
@@ -76,7 +78,7 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
       showHelperInvalidText = true,
       showLabel = true,
     } = props;
-    const footnote = isInvalid ? invalidText : helperText;
+    const footnote: HelperErrorTextType = isInvalid ? invalidText : helperText;
     const spacingProp =
       layout === RadioGroupLayoutTypes.Column ? spacing.s : spacing.l;
     const newChildren = [];
@@ -141,9 +143,11 @@ const RadioGroup = React.forwardRef<HTMLInputElement, RadioGroupProps>(
         </Stack>
         {footnote && showHelperInvalidText && (
           <Box __css={styles.helper}>
-            <HelperErrorText isInvalid={isInvalid} id={`${id}-helperErrorText`}>
-              {footnote}
-            </HelperErrorText>
+            <HelperErrorText
+              id={`${id}-helperErrorText`}
+              isInvalid={isInvalid}
+              text={footnote}
+            />
           </Box>
         )}
       </Fieldset>

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -468,11 +468,14 @@ exports[`Radio Button renders the UI snapshot correctly 4`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "helper text",
+        }
+      }
       data-isinvalid={false}
       id="helperText-helperErrorText"
-    >
-      helper text
-    </div>
+    />
   </div>
 </fieldset>
 `;

--- a/src/components/SearchBar/SearchBar.Test.tsx
+++ b/src/components/SearchBar/SearchBar.Test.tsx
@@ -28,14 +28,14 @@ const textInputProps = {
   name: "textInputName",
   placeholder: "Item Search",
 };
-const helperErrorText = "Search for items in Animal Crossing New Horizons";
+const helperText = "Search for items in Animal Crossing New Horizons";
 const invalidText = "Could not find the item :(";
 
 describe("SearchBar Accessibility", () => {
   it("passes axe accessibility test", async () => {
     const { container } = render(
       <SearchBar
-        helperErrorText={helperErrorText}
+        helperText={helperText}
         id="id"
         invalidText={invalidText}
         labelText="Searchbar"
@@ -55,7 +55,7 @@ describe("SearchBar", () => {
   it("renders the basic form", () => {
     render(
       <SearchBar
-        helperErrorText={helperErrorText}
+        helperText={helperText}
         id="id"
         labelText="searchbar"
         onSubmit={searchBarSubmit}
@@ -74,7 +74,7 @@ describe("SearchBar", () => {
   it("renders an optional Select component", () => {
     render(
       <SearchBar
-        helperErrorText={helperErrorText}
+        helperText={helperText}
         id="id"
         labelText="searchbar"
         onSubmit={searchBarSubmit}
@@ -89,7 +89,7 @@ describe("SearchBar", () => {
   it("renders the invalid text in the invalid state", () => {
     render(
       <SearchBar
-        helperErrorText={helperErrorText}
+        helperText={helperText}
         id="id"
         invalidText={invalidText}
         isInvalid
@@ -100,13 +100,13 @@ describe("SearchBar", () => {
       />
     );
     expect(screen.getByText(invalidText)).toBeInTheDocument();
-    expect(screen.queryByText(helperErrorText)).not.toBeInTheDocument();
+    expect(screen.queryByText(helperText)).not.toBeInTheDocument();
   });
 
   it("does not render the default invalid text from the Select or TextInput components", () => {
     render(
       <SearchBar
-        helperErrorText={helperErrorText}
+        helperText={helperText}
         id="id"
         invalidText={invalidText}
         isInvalid
@@ -124,7 +124,7 @@ describe("SearchBar", () => {
   it("calls the callback function on submit ", () => {
     render(
       <SearchBar
-        helperErrorText={helperErrorText}
+        helperText={helperText}
         id="id"
         labelText="searchBar"
         onSubmit={searchBarSubmit}
@@ -174,7 +174,7 @@ describe("SearchBar", () => {
     const basic = renderer
       .create(
         <SearchBar
-          helperErrorText={helperErrorText}
+          helperText={helperText}
           id="basic"
           labelText="searchbar"
           onSubmit={jest.fn()}
@@ -185,7 +185,7 @@ describe("SearchBar", () => {
     const withSelect = renderer
       .create(
         <SearchBar
-          helperErrorText={helperErrorText}
+          helperText={helperText}
           id="withSelect"
           labelText="searchbar"
           onSubmit={jest.fn()}

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -96,7 +96,7 @@ export const optionsGroup = [
       action: undefined,
       buttonOnClick: undefined,
       className: undefined,
-      helperErrorText: "Search for items in Animal Crossing New Horizons",
+      helperText: "Search for items in Animal Crossing New Horizons",
       id: "searchBar-id",
       invalidText: "Could not find the item :(",
       isDisabled: false,
@@ -128,7 +128,7 @@ export const optionsGroup = [
           name: "textInputName",
           placeholder: "Item Search",
         }}
-        helperErrorText={args.showHelperText && args.helperErrorText}
+        helperText={args.showHelperText && args.helperText}
       />
     )}
   </Story>
@@ -215,20 +215,47 @@ style is used by default.
 
 ### HelperErrorText Component
 
-To render the `HelperErrorText` component, pass a string value to the
-`helperErrorText` prop. For the invalid state when `isInvalid` is true, pass the
-error string in the `invalidText` prop.
+To render the `HelperErrorText` component, pass a string or HTML to the
+`helperText` prop. For the invalid state when `isInvalid` is true, pass the
+error string or HTML in the `invalidText` prop.
 
 ```
-const helperErrorText = "";
+const helperText = "";
 
 // ...
 <SearchBar
   onSubmit={() => {}}
-  helperErrorText="Search for items in Animal Crossing New Horizons"
+  helperText="Search for items in <b>Animal Crossing New Horizons</b>."
   // ...
 />
 ```
+
+<Canvas>
+  <DSProvider>
+    <SearchBar
+      descriptionText="The helper text below contains HTML in a string."
+      helperText="Search for items in <b>Animal Crossing New Horizons</b>."
+      onSubmit={() => {}}
+      textInputProps={{
+        labelText: "Item Search",
+        name: "textInputName",
+        placeholder: "Item Search",
+      }}
+    />
+    <br />
+    <SearchBar
+      descriptionText="The invalid text below contains HTML in a string."
+      isInvalid
+      invalidText="Could <b>not</b> find the item <b>:(</b>"
+      onSubmit={() => {}}
+      textInputProps={{
+        labelText: "Item Search",
+        name: "textInputName",
+        placeholder: "Item Search",
+      }}
+    />
+  </DSProvider>
+</Canvas>
 
 ## Search Autocomplete
 
@@ -257,7 +284,7 @@ precedence.
         <SearchBar
           onSubmit={() => {}}
           textInputElement={stories.SearchBarExample()}
-          helperErrorText="Select your home library. Start by typing the name of the library. Try 'ba'."
+          helperText="Select your home library. Start by typing the name of the library. Try 'ba'."
           {...args}
         />
       </div>
@@ -285,7 +312,7 @@ handle the error state yourself.
         name: "textInputName",
         placeholder: "Item Search",
       }}
-      helperErrorText="This is the helper text!"
+      helperText="This is the helper text!"
       invalidText="Could not find the item :("
       isInvalid
     />
@@ -307,7 +334,7 @@ handle the disabled state yourself.
         name: "textInputName",
         placeholder: "Item Search",
       }}
-      helperErrorText="Reason for disabled state."
+      helperText="Reason for disabled state."
       isDisabled
     />
   </DSProvider>
@@ -380,7 +407,7 @@ function SearchBarValueExample() {
         onChange: textInputOnChange,
         placeholder: "Item Search",
       }}
-      helperErrorText="Search for an item"
+      helperText="Search for an item"
       invalidText="Could not find the item :("
     />
   );
@@ -410,7 +437,7 @@ export function SearchBarValueExample() {
         onChange: textInputOnChange,
         placeholder: "Item Search",
       }}
-      helperErrorText="Search for an item"
+      helperText="Search for an item"
       invalidText="Could not find the item :("
     />
   );

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -1,9 +1,10 @@
-import * as React from "react";
 import { Box, useMultiStyleConfig } from "@chakra-ui/react";
+import * as React from "react";
 
 import Button from "../Button/Button";
 import { ButtonTypes } from "../Button/ButtonTypes";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
 import Icon from "../Icons/Icon";
 import { IconAlign, IconNames, IconSizes } from "../Icons/IconTypes";
 import Select from "../Select/Select";
@@ -42,12 +43,12 @@ export interface SearchBarProps {
   /** Optional string for the SearchBar's heading text above the component. */
   headingText?: string;
   /** The text to display below the form in a `HelperErrorText` component. */
-  helperErrorText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the `HelperErrorText` for the error state
    * when `isInvalid` is true. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Sets children form components in the disabled state. */
   isDisabled?: boolean;
   /** Sets children form components in the error state. */
@@ -82,7 +83,7 @@ export default function SearchBar(props: SearchBarProps) {
     className,
     descriptionText,
     headingText,
-    helperErrorText,
+    helperText,
     id = generateUUID(),
     invalidText,
     isDisabled = false,
@@ -107,7 +108,7 @@ export default function SearchBar(props: SearchBarProps) {
   };
   const helperErrorTextID = generateUUID();
   const ariaDescribedby = helperErrorTextID;
-  const footnote = isInvalid ? invalidText : helperErrorText;
+  const footnote = isInvalid ? invalidText : helperText;
   const finalAriaLabel = footnote ? `${labelText} - ${footnote}` : labelText;
   const textInputPlaceholder = `${textInputProps?.placeholder} ${
     isRequired ? "(Required)" : ""
@@ -181,7 +182,7 @@ export default function SearchBar(props: SearchBarProps) {
     <ComponentWrapper
       descriptionText={descriptionText}
       headingText={headingText}
-      helperText={helperErrorText}
+      helperText={helperText}
       id={id}
       invalidText={invalidText}
       isInvalid={isInvalid}

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -5,23 +5,25 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 
-import Label from "../Label/Label";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
-import generateUUID from "../../helpers/generateUUID";
-import { IconNames, IconSizes } from "../Icons/IconTypes";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import Icon from "../Icons/Icon";
+import { IconNames, IconSizes } from "../Icons/IconTypes";
+import Label from "../Label/Label";
 import { SelectTypes } from "./SelectTypes";
+import generateUUID from "../../helpers/generateUUID";
 
 export interface SelectProps {
   /** A class name for the `div` parent element. */
   className?: string;
   /** Optional string to populate the `HelperErrorText` for the standard state. */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the `HelperErrorText` for the error state
    * when `isInvalid` is true. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Adds the `disabled` and `aria-disabled` attributes to the select when true */
   isDisabled?: boolean;
   /** Adds the `aria-invalid` attribute to the select when true. This also makes
@@ -87,7 +89,9 @@ const Select = React.forwardRef<
   const finalInvalidText = invalidText
     ? invalidText
     : "There is an error related to this field.";
-  const footnote = isInvalid ? finalInvalidText : helperText;
+  const footnote: HelperErrorTextType = isInvalid
+    ? finalInvalidText
+    : helperText;
   // To control the `Select` component, both `onChange` and `value`
   // must be passed.
   const controlledProps = onChange ? { onChange, value } : {};
@@ -140,9 +144,11 @@ const Select = React.forwardRef<
       </ChakraSelect>
       {footnote && showHelperInvalidText && (
         <Box __css={styles.helper} aria-disabled={isDisabled}>
-          <HelperErrorText isInvalid={isInvalid} id={id + `-helperText`}>
-            {footnote}
-          </HelperErrorText>
+          <HelperErrorText
+            id={`${id}-helperText`}
+            isInvalid={isInvalid}
+            text={footnote}
+          />
         </Box>
       )}
     </Box>

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -14,7 +14,9 @@ import {
 
 import generateUUID from "../../helpers/generateUUID";
 import Label from "../Label/Label";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import TextInput from "../TextInput/TextInput";
 import { TextInputTypes } from "../TextInput/TextInputTypes";
 
@@ -26,12 +28,12 @@ export interface SliderProps {
    */
   defaultValue?: number | number[];
   /** Optional string to populate the HelperErrorText for standard state */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes. */
   id?: string;
   /** Optional string to populate the `HelperErrorText` for the error state
    * when `isInvalid` is true. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Adds the 'disabled' state to the slider and text input(s) when true. */
   isDisabled?: boolean;
   /** Adds the 'invalid' state to the slider and text input(s) when true. */
@@ -112,7 +114,9 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
     finalIsInvalid = true;
   }
   const optReqText = isRequired ? "Required" : "Optional";
-  const footnote = finalIsInvalid ? invalidText : helperText;
+  const footnote: HelperErrorTextType = finalIsInvalid
+    ? invalidText
+    : helperText;
   const styles = useMultiStyleConfig("CustomSlider", {
     isDisabled,
     isInvalid: finalIsInvalid,
@@ -298,9 +302,11 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
 
       {footnote && showHelperInvalidText && (
         <Box __css={styles.helper}>
-          <HelperErrorText id={`${id}-helperText`} isInvalid={finalIsInvalid}>
-            {footnote}
-          </HelperErrorText>
+          <HelperErrorText
+            id={`${id}-helperText`}
+            isInvalid={finalIsInvalid}
+            text={footnote}
+          />
         </Box>
       )}
     </Box>

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -168,11 +168,14 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="defaultRangeSlider-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -347,11 +350,14 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
       aria-atomic={true}
       aria-live="polite"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component error text :(",
+        }
+      }
       data-isinvalid={true}
       id="errored-helperText"
-    >
-      Component error text :(
-    </div>
+    />
   </div>
 </div>
 `;
@@ -526,11 +532,14 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="required-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -705,11 +714,14 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="disabled-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -986,11 +998,14 @@ exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="noVisibleValues-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -1226,11 +1241,14 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="defaultSlider-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -1363,11 +1381,14 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
       aria-atomic={true}
       aria-live="polite"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component error text :(",
+        }
+      }
       data-isinvalid={true}
       id="errored-helperText"
-    >
-      Component error text :(
-    </div>
+    />
   </div>
 </div>
 `;
@@ -1500,11 +1521,14 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="required-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -1638,11 +1662,14 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="disabled-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;
@@ -1855,11 +1882,14 @@ exports[`Slider Single Slider renders the UI snapshot correctly 6`] = `
       aria-atomic={true}
       aria-live="off"
       className=" css-0"
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "Component helper text.",
+        }
+      }
       data-isinvalid={false}
       id="noVisibleValues-helperText"
-    >
-      Component helper text.
-    </div>
+    />
   </div>
 </div>
 `;

--- a/src/components/StyleGuide/Bidirectionality.stories.mdx
+++ b/src/components/StyleGuide/Bidirectionality.stories.mdx
@@ -118,7 +118,7 @@ won't hurt.
   <DSProvider>
     <div style={{ width: "400px" }}>
       <SearchBar
-        helperErrorText="Use a keyword or phrase to search!"
+        helperText="Use a keyword or phrase to search!"
         id="example1"
         isRequired
         textInputProps={{
@@ -139,7 +139,7 @@ block to see its code implementation.
     <div dir="rtl">
       <div style={{ width: "400px" }}>
         <SearchBar
-          helperErrorText="استخدم كلمة رئيسية أو عبارة للبحث!"
+          helperText="استخدم كلمة رئيسية أو عبارة للبحث!"
           id="example2"
           isRequired
           textInputProps={{
@@ -161,7 +161,7 @@ block to see its code implementation.
     <div style={{ direction: "rtl" }}>
       <div style={{ width: "400px" }}>
         <SearchBar
-          helperErrorText="استخدم كلمة رئيسية أو عبارة للبحث!"
+          helperText="استخدم كلمة رئيسية أو عبارة للبحث!"
           id="example3"
           isRequired
           textInputProps={{

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -173,6 +173,36 @@ text within the `label` element.
   </DSProvider>
 </Canvas>
 
+## HTML in Helper Text
+
+HTML can be passed into the `helperText` prop as a string or HTML.
+
+```jsx
+helperText="Choose <b>wisely!</b>"
+// or
+helperText={<>Choose <b>wisely!</b></>}
+```
+
+<Canvas>
+  <DSProvider>
+    <TextInput
+      labelText="What is your favorite color?"
+      placeholder="i.e. blue, green, etc."
+      helperText="Choose <b>wisely!</b>"
+    />
+    <br />
+    <TextInput
+      labelText="What is your favorite color?"
+      placeholder="i.e. blue, green, etc."
+      helperText={
+        <>
+          Choose <b>wisely!</b>
+        </>
+      }
+    />
+  </DSProvider>
+</Canvas>
+
 ## Textarea
 
 The TextInput component includes a multiline `textarea` form field. To render a

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -12,7 +12,9 @@ import {
   TextInputVariants,
 } from "./TextInputTypes";
 import Label from "../Label/Label";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import generateUUID from "../../helpers/generateUUID";
 
 export interface InputProps {
@@ -25,11 +27,11 @@ export interface InputProps {
   /** The starting value of the input field. */
   defaultValue?: string;
   /** Populates the HelperErrorText for the standard state */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Populates the HelperErrorText for the error state */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** Adds the `disabled` and `aria-disabled` prop to the input when true */
   isDisabled?: boolean;
   /** Adds errored styling to the input/textarea and helper text elements */
@@ -111,7 +113,7 @@ const TextInput = React.forwardRef<TextInputRefType, InputProps>(
     const finalInvalidText = invalidText
       ? invalidText
       : "There is an error related to this field.";
-    let footnote: string | React.ReactNode = isInvalid
+    let footnote: HelperErrorTextType = isInvalid
       ? finalInvalidText
       : helperText;
     let fieldOutput;
@@ -184,9 +186,11 @@ const TextInput = React.forwardRef<TextInputRefType, InputProps>(
         {fieldOutput}
         {footnote && showHelperInvalidText && !isHidden && (
           <Box __css={finalStyles.helper} aria-disabled={isDisabled}>
-            <HelperErrorText isInvalid={isInvalid} id={`${id}-helperText`}>
-              {footnote}
-            </HelperErrorText>
+            <HelperErrorText
+              id={`${id}-helperText`}
+              isInvalid={isInvalid}
+              text={footnote}
+            />
           </Box>
         )}
       </Box>

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -1,13 +1,16 @@
-import * as React from "react";
 import {
   Box,
   Switch,
   useMultiStyleConfig,
   useStyleConfig,
 } from "@chakra-ui/react";
-import generateUUID from "../../helpers/generateUUID";
+import * as React from "react";
+
+import HelperErrorText, {
+  HelperErrorTextType,
+} from "../HelperErrorText/HelperErrorText";
 import { ToggleSizes } from "./ToggleSizes";
-import HelperErrorText from "../HelperErrorText/HelperErrorText";
+import generateUUID from "../../helpers/generateUUID";
 
 export interface ToggleProps {
   /** Optionally pass in additional Chakra-based styles. */
@@ -16,12 +19,12 @@ export interface ToggleProps {
    *   If true, the toggle will be initially set to the "on" position. */
   defaultChecked?: boolean;
   /** Optional string to populate the HelperErrorText for standard state */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the HelperErrorText for the error state
    * when `isInvalid` is true. */
-  invalidText?: string;
+  invalidText?: HelperErrorTextType;
   /** When using the Toggle as a "controlled" form element, you can specify
    * the Toggle's checked state using this prop.
    * Learn more about controlled and uncontrolled form fields:
@@ -71,7 +74,7 @@ const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
       onChange = onChangeDefault,
       size = ToggleSizes.Large,
     } = props;
-    const footnote = isInvalid ? invalidText : helperText;
+    const footnote: HelperErrorTextType = isInvalid ? invalidText : helperText;
     const ariaAttributes = {};
     const styles = useMultiStyleConfig("Toggle", {});
     const switchStyles = useStyleConfig("Switch");
@@ -105,9 +108,11 @@ const Toggle = React.forwardRef<HTMLInputElement, ToggleProps>(
         </Box>
         {footnote && (
           <Box __css={styles.helper}>
-            <HelperErrorText isInvalid={isInvalid} id={`${id}-helperText`}>
-              {footnote}
-            </HelperErrorText>
+            <HelperErrorText
+              id={`${id}-helperText`}
+              isInvalid={isInvalid}
+              text={footnote}
+            />
           </Box>
         )}
       </>

--- a/src/components/VideoPlayer/VideoPlayer.stories.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.stories.mdx
@@ -163,3 +163,17 @@ If the necessary props are not passed to the `VideoPlayer` component, the compon
     />
   </DSProvider>
 </Canvas>
+
+## HTML in Helper Text
+
+It's possible to include HTML in the `helperText` prop.
+
+<Canvas>
+  <DSProvider>
+    <VideoPlayer
+      helperText="This helper text <b>contains HTML</b>."
+      videoId="474719268"
+      videoType={VideoPlayerTypes.Vimeo}
+    />
+  </DSProvider>
+</Canvas>

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -1,30 +1,40 @@
-import * as React from "react";
 import { Box, useMultiStyleConfig } from "@chakra-ui/react";
+import * as React from "react";
+
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
+import { VideoPlayerAspectRatios, VideoPlayerTypes } from "./VideoPlayerTypes";
 import generateUUID from "../../helpers/generateUUID";
 import { getVariant } from "../../utils/utils";
-import { VideoPlayerAspectRatios, VideoPlayerTypes } from "./VideoPlayerTypes";
 
 export interface VideoPlayerProps {
-  /** Optional aspect ratio prop to control the sizing of the video player; if omitted, the video player defaults to `sixteen-by-nine` */
+  /** Optional aspect ratio prop to control the sizing of the video player; if
+   * omitted, the video player defaults to `sixteen-by-nine` */
   aspectRatio?: VideoPlayerAspectRatios;
   /** Optional className you can add in addition to `video-player` */
   className?: string;
   /** Optional string to set the text for a video description */
   descriptionText?: string;
-  /** Optional string to set a code snippet provided by YouTube or Vimeo; the `videoPlayer` component will accept the `embedCode` prop or the `videoId` and `videoType` props */
+  /** Optional string to set a code snippet provided by YouTube or Vimeo; the
+   * `videoPlayer` component will accept the `embedCode` prop or the `videoId`
+   * and `videoType` props */
   embedCode?: string;
   /** Optional string to set the text for a `Heading` component */
   headingText?: string;
   /** Optional string to set the text for a `HelperErrorText` component */
-  helperText?: string;
+  helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
-  /** Optional title to be added to the `<iframe>` element for improved accessibility; this title should describe in a few words the content of the video; if omitted, a generic title will be added; if a `title` attribute is already present in the `embedCode` prop, this prop will be ignored */
+  /** Optional title to be added to the `<iframe>` element for improved
+   * accessibility; this title should describe in a few words the content of
+   * the video; if omitted, a generic title will be added; if a `title`
+   * attribute is already present in the `embedCode` prop, this prop will be
+   * ignored */
   iframeTitle?: string;
   /** Offers the ability to hide the helper/invalid text. */
   showHelperInvalidText?: boolean;
-  /** Required YouTube or Vimeo video ID. This value can be pulled from a video's YouTube or Vimeo URL. */
+  /** Required YouTube or Vimeo video ID. This value can be pulled from a
+   * video's YouTube or Vimeo URL. */
   videoId?: string;
   /** Required. Used to specify which video service is being used. */
   videoType?: VideoPlayerTypes;

--- a/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
+++ b/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
@@ -64,11 +64,14 @@ exports[`VideoPlayer renders the UI snapshot correctly 2`] = `
         aria-atomic={true}
         aria-live="off"
         className=" css-0"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "VideoPlayer helper test.",
+          }
+        }
         data-isinvalid={false}
         id="video-player-with-text-componentWrapper-helperText"
-      >
-        VideoPlayer helper test.
-      </div>
+      />
     </div>
   </div>
 </div>
@@ -112,11 +115,14 @@ exports[`VideoPlayer renders the UI snapshot correctly 3`] = `
         aria-atomic={true}
         aria-live="off"
         className=" css-0"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "VideoPlayer helper test.",
+          }
+        }
         data-isinvalid={false}
         id="video-player-with-text-componentWrapper-helperText"
-      >
-        VideoPlayer helper test.
-      </div>
+      />
     </div>
   </div>
 </div>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-736](https://jira.nypl.org/browse/DSD-736)

## This PR does the following:

- Allows HTML to be passed in the `HelperErrorText` component as a string or as HTML DOM elements.
- Updates passing in text as a child to passing it through a `text` prop in the `HelperErrorText` component.
- Updates how the `HelperErrorText` component is used in the `Checkbox`, `CheckboxGroup`, `ComponentWrapper`, `DatePicker`, `Radio`, `RadioGroup`, `SearchBar`, `Select`, `Slider`, `TextInput`, `Toggle`, and `VideoPlayer` components.
- Adds some examples in Storybook.
- Renames the `SearchBar`'s `helperErrorText` prop to `helperText` to be consistent with other components.

## How has this been tested?

Storybook and updated tests.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A but if bad HTML is passed we won't have much control. Eventually, we can set guidelines on what _not_ to pass.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
