### PR TITLE
DSD-759: Fixing Breadcrumbs issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixing `Breadcrumbs` related logging issue with a CSS pseudo-selector and setting the `aria-label` to "Breadcrumbs". Adding an accessibility test that should fail when more than one `Breadcrumbs` component is rendered on a page since that landmark should only be rendered once on a web page.
+
 ## 0.25.9 (February 3, 2022)
 
 ### Adds

--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@nypl/design-system-react-components",
-      "version": "0.25.8",
+      "version": "0.25.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/react": "1.7.1",

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -53,7 +53,9 @@ export const enumValues = getStorybookEnumValues(
 
 <Description of={Breadcrumbs} />
 
-The `Breadcrumbs` component is a navigation element that provides a breadcrumb path that reflects the site structure and allows a user to navigate to any page available in the breadcrumb hierarchy.
+The `Breadcrumbs` component is a navigation element that provides a breadcrumb
+path that reflects the site structure and allows a user to navigate to any page
+available in the breadcrumb hierarchy.
 
 <Canvas withToolbar>
   <Story
@@ -80,6 +82,15 @@ The `Breadcrumbs` component is a navigation element that provides a breadcrumb p
 </Canvas>
 
 <ArgsTable story="Breadcrumbs with Controls" />
+
+### Accessibility
+
+Only one `Breadcrumbs` component should be rendered on a page. This is because
+only one HTML `<nav>` element with `aria-label` attribute of "Breadcrumbs"
+should be rendered. The DS `Breadcrumbs` component renders this HTML landmark
+so only one component must be rendered on a page.
+
+- [W3 Breadcrumbs Practice](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html)
 
 ### Long Titles
 

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -11,11 +11,26 @@ describe("Breadcrumbs Accessibility", () => {
     { url: "#string1", text: "string1" },
     { url: "#string2", text: "string2" },
   ];
+
   it("passes axe accessibility test", async () => {
     const { container } = render(
       <Breadcrumbs breadcrumbsData={breadcrumbsData} />
     );
     expect(await axe(container)).toHaveNoViolations();
+  });
+
+  // This fails because there MUST only be one "breadcrumb" landmark item
+  // on a page. This specifically means there should be one `<nav>` element
+  // with `aria-label="Breadcrumb"`.
+  // https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html
+  it("does not pass axe accessibility test", async () => {
+    const { container } = render(
+      <>
+        <Breadcrumbs breadcrumbsData={breadcrumbsData} />
+        <Breadcrumbs breadcrumbsData={breadcrumbsData} />
+      </>
+    );
+    expect(await axe(container)).not.toHaveNoViolations();
   });
 });
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -6,8 +6,6 @@ import {
   useStyleConfig,
 } from "@chakra-ui/react";
 
-import generateUUID from "../../helpers/generateUUID";
-import { ColorVariants } from "./BreadcrumbsTypes";
 import Icon from "../Icons/Icon";
 import {
   IconNames,
@@ -15,6 +13,8 @@ import {
   IconSizes,
   IconTypes,
 } from "../Icons/IconTypes";
+import generateUUID from "../../helpers/generateUUID";
+import { ColorVariants } from "./BreadcrumbsTypes";
 import { getVariant } from "../../utils/utils";
 
 export interface BreadcrumbsDataProps {
@@ -83,9 +83,15 @@ function Breadcrumbs(props: React.PropsWithChildren<BreadcrumbProps>) {
   const styles = useStyleConfig("Breadcrumb", { variant });
   const finalStyles = { ...styles, ...additionalStyles };
   const breadcrumbItems = getElementsFromData(breadcrumbsData, id);
+  const ariaAttrs = { "aria-label": "Breadcrumb" };
 
   return (
-    <ChakraBreadcrumb className={className} __css={finalStyles} id={id}>
+    <ChakraBreadcrumb
+      className={className}
+      id={id}
+      {...ariaAttrs}
+      __css={finalStyles}
+    >
       {breadcrumbItems}
     </ChakraBreadcrumb>
   );

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 1`] = `
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="chakra-breadcrumb css-0"
   id="breadcrumbs-test"
 >
@@ -101,7 +101,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 1`] = `
 
 exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 2`] = `
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="chakra-breadcrumb css-0"
   id="breadcrumbs-test"
 >
@@ -200,7 +200,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 2`] = `
 
 exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 3`] = `
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="chakra-breadcrumb css-0"
   id="breadcrumbs-test"
 >
@@ -299,7 +299,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 3`] = `
 
 exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 4`] = `
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="chakra-breadcrumb css-0"
   id="breadcrumbs-test"
 >
@@ -398,7 +398,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 4`] = `
 
 exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 5`] = `
 <nav
-  aria-label="breadcrumb"
+  aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1f2fw9u"
   id="breadcrumbs-test"
 >

--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -4,7 +4,7 @@ import {
   Canvas,
   ArgsTable,
   Description,
-} from "@storybook/addon-docs/blocks";
+} from "@storybook/addon-docs";
 import { withDesign } from "storybook-addon-designs";
 
 import Table from "./Table";
@@ -22,20 +22,18 @@ The `Table` component is used to organize and display tabular data in rows and c
   parameters={{
     design: {
       type: "figma",
-      url:
-        "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=46780%3A27675",
+      url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=46780%3A27675",
     },
     jest: ["Table.test.tsx"],
   }}
   argTypes={{
     columnHeaders: [],
     columnHeadersBackgroundColor: { control: { type: "color" } },
-    columnHeadersTextColor: {control: {type: "color"}},
-    id: {control: false},
+    columnHeadersTextColor: { control: { type: "color" } },
+    id: { control: false },
     tableData: { control: false },
   }}
 />
-
 
 # Table
 
@@ -50,16 +48,42 @@ The `Table` component is used to organize and display tabular data in rows and c
   <Story
     name="Table"
     args={{
-      columnHeaders: ["First Name", "Last Name", "Nick Name", "Address1", "City", "Zipcode", "State"],
-      tableData: [ ["Tom", "Nook", "Tanukichi", "Main Street", "New York", "23458", "NY" ], [ "Isabelle", "-", "Shizue", "Walnut Street", "New York", "23458", "NY"], [ "K.K.", "Slider", "Totakeke", "Niper Place", "New York", "98765", "NY"], [ "Sonny", "Resetti", "Risetto san", "Village Road", "New York", "09873", "NY" ], ],
+      columnHeaders: [
+        "First Name",
+        "Last Name",
+        "Nick Name",
+        "Address1",
+        "City",
+        "Zipcode",
+        "State",
+      ],
+      tableData: [
+        ["Tom", "Nook", "Tanukichi", "Main Street", "New York", "23458", "NY"],
+        ["Isabelle", "-", "Shizue", "Walnut Street", "New York", "23458", "NY"],
+        [
+          "K.K.",
+          "Slider",
+          "Totakeke",
+          "Niper Place",
+          "New York",
+          "98765",
+          "NY",
+        ],
+        [
+          "Sonny",
+          "Resetti",
+          "Risetto san",
+          "Village Road",
+          "New York",
+          "09873",
+          "NY",
+        ],
+      ],
       useRowHeaders: false,
       showRowDividers: false,
     }}
   >
-    {(args) => (
-      <Table {...args}>
-      </Table>
-    )}
+    {(args) => <Table {...args}></Table>}
   </Story>
 </Canvas>
 

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -67,7 +67,7 @@ const Breadcrumb = {
         marginInlineStart: "xxs",
       },
     },
-    "li:nth-last-child(2)": {
+    "li:nth-last-of-type(2)": {
       display: "inline-block",
       span: {
         display: { base: "none", md: "inline" },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-759](https://jira.nypl.org/browse/DSD-759)

## This PR does the following:

- Updates the `Breadcrumbs` aria-label to "Breadcrumbs". This should not be modified and having more than one `<nav>` element with the same aria-label is not correct. We can't prevent this from the DS but can only give the pattern for using it. https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html
- Updated a CSS pseudo-class that fails because of the `Emotion` package and how styled components are rendered on the server and client side.
- Note, there server/client id not matching issue is not related to the component but just the app passing in ids to the correct components.

## How has this been tested?

Locally and Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- There should only be one `<nav>` HTML element with aria-label set to "Breadcrumbs". Since the DS `Breadcrumbs` component renders this landmark, only one should be rendered on the page.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
