### PR TITLE
DSD-775: Passing in an onSubmit prop to the Form component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds snapshot tests for the `Tabs` component and better checks to warn the user that the `Tabs` is missing data if data wasn't passed as props or children.
 - Updates the `Form` component to warn developers when a child component in the `FormRow` component _is not_ a `FormField`.
 - Adds an `onSubmit` prop to the `Form` component.
+- Adds the `renderHeaderElement` prop to the `TemplateAppContainer` component. This prop is used to control whether the `TemplateAppContainer` component should render its own `<header>` HTML element through its `header` prop, or let the user pass in their own component that renders the `<header>` HTML element.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Passes an `onChange` prop to the `Select` component inside the `SearchBar` through its `selectProps` prop.
 - Adds snapshot tests for the `Tabs` component and better checks to warn the user that the `Tabs` is missing data if data wasn't passed as props or children.
 - Updates the `Form` component to warn developers when a child component in the `FormRow` component _is not_ a `FormField`.
+- Adds an `onSubmit` prop to the `Form` component.
 
 ### Fixes
 

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import renderer from "react-test-renderer";
 
@@ -171,6 +171,23 @@ describe("Form", () => {
     expect(warn).toHaveBeenCalledWith(
       "FormRow children must be `FormField` components."
     );
+  });
+
+  it("calls the onSubmit function", () => {
+    const onSubmit = jest.fn();
+    render(
+      <Form onSubmit={onSubmit}>
+        <FormRow>
+          <FormField>
+            <TextInput labelText="Input Field" />
+          </FormField>
+        </FormRow>
+      </Form>
+    );
+    const form = screen.getByRole("form");
+    expect(onSubmit).toHaveBeenCalledTimes(0);
+    fireEvent.submit(form);
+    expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
   // TO DO: There's somethign weird about checking for the "grid-gap" style.

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,4 +1,3 @@
-import { Box } from "@chakra-ui/react";
 import * as React from "react";
 
 import { FormGaps } from "./FormTypes";
@@ -23,6 +22,8 @@ export interface FormProps extends FormBaseProps {
   action?: string;
   /** Optional form `method` attribute */
   method?: "get" | "post";
+  /** Function to call for the `onSubmit` form event. */
+  onSubmit?: (e: React.FormEvent<HTMLFormElement>) => void;
 }
 
 /** FormRow child-component */
@@ -63,9 +64,10 @@ export default function Form(props: React.PropsWithChildren<FormProps>) {
     action,
     children,
     className,
+    gap = FormGaps.Large,
     id = generateUUID(),
     method,
-    gap = FormGaps.Large,
+    onSubmit,
   } = props;
 
   let attributes = {};
@@ -83,16 +85,16 @@ export default function Form(props: React.PropsWithChildren<FormProps>) {
   );
 
   return (
-    <Box
-      as="form"
+    <form
       aria-label="form"
-      id={id}
-      {...attributes}
       className={className}
+      id={id}
+      onSubmit={onSubmit}
+      {...attributes}
     >
       <SimpleGrid columns={1} gap={gap} id={`${id}-parent`}>
         {alteredChildren}
       </SimpleGrid>
-    </Box>
+    </form>
   );
 }

--- a/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`Form Snapshot Renders the UI snapshot correctly 1`] = `
 <form
   aria-label="form"
-  className="css-0"
   id="snapshot-form"
 >
   <div

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -59,14 +59,19 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.3.6`    |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 ## TemplateAppContainer Component
 
 <Description of={TemplateAppContainer} />
 
-If you have a custom `Footer` component that _already_ renders an HTML `<footer>`
-element, set `renderFooterElement` to false so only one `<footer>` element is rendered.
+If you have a custom `Header` component that _already_ renders an HTML `<header>`
+element, set `renderHeaderElement` to false so only one `<header>` element is
+rendered.
+
+Likewise, f you have a custom `Footer` component that _already_ renders an HTML
+`<footer>` element, set `renderFooterElement` to false so only one `<footer>`
+element is rendered.
 
 <b>This is the recommended way to render an app page template.</b>
 
@@ -116,6 +121,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
       header: <Placeholder variant="short">NYPL Header</Placeholder>,
       sidebar: "left",
       renderFooterElement: true,
+      renderHeaderElement: true,
     }}
     argTypes={{
       breakout: { control: false },

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -95,6 +95,45 @@ describe("TemplateAppContainer component", () => {
     expect(screen.getByText("Footer")).toBeInTheDocument();
   });
 
+  it("renders only one header in a custom header component", () => {
+    const customHeader = <header>Custom header</header>;
+    render(
+      <TemplateAppContainer
+        header={customHeader}
+        renderHeaderElement={false}
+        breakout={breakout}
+        sidebar={sidebar}
+        contentTop={contentTop}
+        contentSidebar={contentSidebar}
+        contentPrimary={contentPrimary}
+        footer={footer}
+      />
+    );
+
+    // The `<header>` HTML element has the same meaning as `role="banner"`.
+    expect(screen.getAllByRole("banner")).toHaveLength(1);
+  });
+
+  it("consoles a warning when a header element was passed without setting `renderHeaderElement` to false", () => {
+    const warn = jest.spyOn(console, "warn");
+    const customHeader = <header>Custom header</header>;
+    render(
+      <TemplateAppContainer
+        header={customHeader}
+        breakout={breakout}
+        sidebar={sidebar}
+        contentTop={contentTop}
+        contentSidebar={contentSidebar}
+        contentPrimary={contentPrimary}
+        footer={footer}
+      />
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "`TemplateHeader`: An HTML `header` element was passed in. Set " +
+        "`renderHeaderElement` to `false` to avoid nested HTML `header` elements."
+    );
+  });
+
   it("renders only one footer in a custom footer component", () => {
     const customFooter = <footer>Custom Footer</footer>;
     render(

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -50,7 +50,7 @@ const Template = (props: React.PropsWithChildren<TemplateProps>) => {
 /**
  * This optional component should be the first child of the `Template`
  * component. This is rendered as an HTML `<header>` element. If an HTML
- * `<header>` element is already passed in a custom component as the childre,
+ * `<header>` element is already passed in a custom component as the children,
  * set `renderFooterElement` to `false`. Otherwise, the parent wrapper will
  * render an HTML `<header>` element.
  */


### PR DESCRIPTION
Fixes JIRA ticket [DSD-775](https://jira.nypl.org/browse/DSD-775)

## This PR does the following:

- Adds an `onSubmit` prop to the main `Form` component. This is needed for submitting forms on the serverside or when pressing "enter" on a keyboard.
- The previous `Box` wrapper was updated to a regular HTML `form` element because the type for the event argument didn't match up correctly. Chakra's `Box` wanted a `React.FormEvent<HTMLDivElement>` but the right type is `React.FormEvent<HTMLFormElement>`.

## How has this been tested?

Locally, unit tests, and in the DS test app example form submission page.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- This update allows the "enter" button to submit a form when there is no `type="submit"` button or input element or an "onClick" function for the button or input element.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
