### PR TITLE
DSD-777: TemplateAppContainer header element fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds snapshot tests for the `Tabs` component and better checks to warn the user that the `Tabs` is missing data if data wasn't passed as props or children.
 - Updates the `Form` component to warn developers when a child component in the `FormRow` component _is not_ a `FormField`.
 - Adds an `onSubmit` prop to the `Form` component.
+- Adds the `renderHeaderElement` prop to the `TemplateAppContainer` component. This prop is used to control whether the `TemplateAppContainer` component should render its own `<header>` HTML element through its `header` prop, or let the user pass in their own component that renders the `<header>` HTML element.
 
 ### Fixes
 

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -59,14 +59,19 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.3.6`    |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 ## TemplateAppContainer Component
 
 <Description of={TemplateAppContainer} />
 
-If you have a custom `Footer` component that _already_ renders an HTML `<footer>`
-element, set `renderFooterElement` to false so only one `<footer>` element is rendered.
+If you have a custom `Header` component that _already_ renders an HTML `<header>`
+element, set `renderHeaderElement` to false so only one `<header>` element is
+rendered.
+
+Likewise, f you have a custom `Footer` component that _already_ renders an HTML
+`<footer>` element, set `renderFooterElement` to false so only one `<footer>`
+element is rendered.
 
 <b>This is the recommended way to render an app page template.</b>
 
@@ -116,6 +121,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
       header: <Placeholder variant="short">NYPL Header</Placeholder>,
       sidebar: "left",
       renderFooterElement: true,
+      renderHeaderElement: true,
     }}
     argTypes={{
       breakout: { control: false },

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -95,6 +95,45 @@ describe("TemplateAppContainer component", () => {
     expect(screen.getByText("Footer")).toBeInTheDocument();
   });
 
+  it("renders only one header in a custom header component", () => {
+    const customHeader = <header>Custom header</header>;
+    render(
+      <TemplateAppContainer
+        header={customHeader}
+        renderHeaderElement={false}
+        breakout={breakout}
+        sidebar={sidebar}
+        contentTop={contentTop}
+        contentSidebar={contentSidebar}
+        contentPrimary={contentPrimary}
+        footer={footer}
+      />
+    );
+
+    // The `<header>` HTML element has the same meaning as `role="banner"`.
+    expect(screen.getAllByRole("banner")).toHaveLength(1);
+  });
+
+  it("consoles a warning when a header element was passed without setting `renderHeaderElement` to false", () => {
+    const warn = jest.spyOn(console, "warn");
+    const customHeader = <header>Custom header</header>;
+    render(
+      <TemplateAppContainer
+        header={customHeader}
+        breakout={breakout}
+        sidebar={sidebar}
+        contentTop={contentTop}
+        contentSidebar={contentSidebar}
+        contentPrimary={contentPrimary}
+        footer={footer}
+      />
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "`TemplateHeader`: An HTML `header` element was passed in. Set " +
+        "`renderHeaderElement` to `false` to avoid nested HTML `header` elements."
+    );
+  });
+
   it("renders only one footer in a custom footer component", () => {
     const customFooter = <footer>Custom Footer</footer>;
     render(

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -50,7 +50,7 @@ const Template = (props: React.PropsWithChildren<TemplateProps>) => {
 /**
  * This optional component should be the first child of the `Template`
  * component. This is rendered as an HTML `<header>` element. If an HTML
- * `<header>` element is already passed in a custom component as the childre,
+ * `<header>` element is already passed in a custom component as the children,
  * set `renderFooterElement` to `false`. Otherwise, the parent wrapper will
  * render an HTML `<header>` element.
  */


### PR DESCRIPTION
Fixes JIRA ticket [DSD-777](https://jira.nypl.org/browse/DSD-777)

## This PR does the following:

- Adds a `renderHeaderElement` prop to the `TemplateAppContainer` and `TemplateHeader` components to allow it to _not_ render a `<header>` HTML element as its wrapper. This is needed for consuming applications that pass in their own custom component that itself renders a `<header>` element. This fixes and nested header elements.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Fixes any nested `header` HTML element issues as well as custom components that need to render an `<aside>` and a `<header>`. Such use-case came up in the DS Test App where passing a `Notification` component (which renders an `aside` element) causes an accessibility issue because the `TemplateAppContainer` component renders the `Notification` inside a `<header>` element. This causes a "cannot render a landmark element inside another landmark element" accessibility error.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
