### PR TITLE
DSD-745: default width for HorizontalRule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Template` component to use `s` (16px) spacing on the left and right sides of the main content area.
 - Updates the `HelperErrorText` component to allow HTML to be passed in as a string or HTML.
 - Updates how the `HelperErrorText` component renders text in the following components: `Checkbox`, `CheckboxGroup`, `ComponentWrapper`, `DatePicker`, `Radio`, `RadioGroup`, `SearchBar`, `Select`, `Slider`, `TextInput`, `Toggle`, `VideoPlayer`.
+- Updates the `HorizontalRule` component to use "100%" as the default value for the `width` prop.
 
 ### Fixes
 

--- a/src/components/HorizontalRule/HorizontalRule.stories.mdx
+++ b/src/components/HorizontalRule/HorizontalRule.stories.mdx
@@ -9,6 +9,7 @@ import {
 import { withDesign } from "storybook-addon-designs";
 
 import HorizontalRule from "./HorizontalRule";
+import SimpleGrid from "../Grid/SimpleGrid";
 import { getCategory } from "../../utils/componentCategories";
 
 <Meta
@@ -25,7 +26,7 @@ import { getCategory } from "../../utils/componentCategories";
   argTypes={{
     className: { control: false },
     height: { table: { defaultValue: { summary: "2px" } } },
-    width: { table: { defaultValue: { summary: "auto" } } },
+    width: { table: { defaultValue: { summary: "100%" } } },
   }}
 />
 
@@ -34,7 +35,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.23.0`   |
-| Latest            | `0.25.3`   |
+| Latest            | `0.25.10`  |
 
 <Description of={HorizontalRule} />
 

--- a/src/components/HorizontalRule/HorizontalRule.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.tsx
@@ -16,12 +16,12 @@ export interface HorizontalRuleProps {
   height?: string;
   /** Optional width value. This value should be entered with the same
    * formatting as a CSS width attribute (ex. `50%`, `640px`, `20rem`). If
-   * omitted, the horizontal rule will have a default width of "auto". */
+   * omitted, the horizontal rule will have a default width of "100%". */
   width?: string;
 }
 
 export default function HorizontalRule(props: HorizontalRuleProps) {
-  const { align, className, height = "2px", width = "auto" } = props;
+  const { align, className, height = "2px", width = "100%" } = props;
   const styles = useStyleConfig("HorizontalRule", { align });
   let finalHeight = height;
 

--- a/src/components/HorizontalRule/__snapshots__/HorizontalRule.test.tsx.snap
+++ b/src/components/HorizontalRule/__snapshots__/HorizontalRule.test.tsx.snap
@@ -2,13 +2,13 @@
 
 exports[`HorizontalRule renders the UI snapshot correctly 1`] = `
 <hr
-  className="css-ili6fu"
+  className="css-1bhbd2a"
 />
 `;
 
 exports[`HorizontalRule renders the UI snapshot correctly 2`] = `
 <hr
-  className="css-1pwp4fu"
+  className="css-154goob"
 />
 `;
 
@@ -20,12 +20,12 @@ exports[`HorizontalRule renders the UI snapshot correctly 3`] = `
 
 exports[`HorizontalRule renders the UI snapshot correctly 4`] = `
 <hr
-  className="css-ili6fu"
+  className="css-1bhbd2a"
 />
 `;
 
 exports[`HorizontalRule renders the UI snapshot correctly 5`] = `
 <hr
-  className="css-ili6fu"
+  className="css-1bhbd2a"
 />
 `;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-745](https://jira.nypl.org/browse/DSD-745)

## This PR does the following:

- Updates the `HorizontalRule` component to use "100%" as the default value for the `width` prop.  This is necessary for use cases where the `HorizontalRule` component is a child of the `SimpleGrid` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. —>
- local build of DS Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
