### PR TITLE
DSD-797: Adding 'aboveHeader' prop and 'TemplateAboveHeader' component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Exports Chakra's `Flex` and `Spacer` components.
+- Adds `TemplateAboveHeader` component in the set of "template" components.
+- Adds the `aboveHeader` prop to the `TemplateAppContainer` component to render a `TemplateAboveHeader` component immediately before the `TemplateHeader` component.
 
 ### Breaking Changes
 

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -50,7 +50,7 @@ import { getCategory } from "../../utils/componentCategories";
   parameters={{
     design: {
       type: "figma",
-      url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=11982%3A47778",
+      url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=36835%3A26688",
     },
   }}
 />
@@ -70,9 +70,15 @@ If you have a custom `Header` component that _already_ renders an HTML `<header>
 element, set `renderHeaderElement` to false so only one `<header>` element is
 rendered.
 
-Likewise, f you have a custom `Footer` component that _already_ renders an HTML
+Likewise, if you have a custom `Footer` component that _already_ renders an HTML
 `<footer>` element, set `renderFooterElement` to false so only one `<footer>`
 element is rendered.
+
+If you need to render an alert or notification at the top of the page with an
+`aside` HTML element or HTML element with the `role="complementary"` attribute,
+then pass that alert or notification component to the `aboveHeader` prop. These
+elements should _not_ be rendered in the `header` HTML section since that's an
+accessibility violation.
 
 <b>This is the recommended way to render an app page template.</b>
 

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -29,6 +29,7 @@ import Notification, {
 import Placeholder from "../Placeholder/Placeholder";
 import {
   Template,
+  TemplateAboveHeader,
   TemplateHeader,
   TemplateBreakout,
   TemplateContent,
@@ -79,6 +80,7 @@ element is rendered.
 import { TemplateAppContainer } from "@nypl/design-system-react-components";
 
 <TemplateAppContainer
+  aboveHeader={<Placeholder variant="short">Above Header</Placeholder>}
   header={<Placeholder variant="short">NYPL Header</Placeholder>}
   breakout={
     <>
@@ -103,6 +105,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
   <Story
     name="TemplateAppContainer Component"
     args={{
+      aboveHeader: <Placeholder variant="short">Above Header</Placeholder>,
       breakout: (
         <>
           <Placeholder variant="short">Breadcrumbs</Placeholder>
@@ -124,6 +127,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
       renderHeaderElement: true,
     }}
     argTypes={{
+      aboveHeader: { control: false },
       breakout: { control: false },
       contentPrimary: { control: false },
       contentSidebar: { control: false },
@@ -155,6 +159,7 @@ Basic "template" components structure:
 ```
 import {
   Template,
+  TemplateAboveHeader,
   TemplateHeader,
   TemplateBreakout,
   TemplateContent,
@@ -166,6 +171,9 @@ import {
 
 
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>
     // ...
     <TemplateBreakout>
@@ -196,6 +204,7 @@ import {
       sidebar: "left",
     }}
     argTypes={{
+      aboveHeader: { table: { disable: true } },
       breakout: { table: { disable: true } },
       contentPrimary: { table: { disable: true } },
       contentSidebar: { table: { disable: true } },
@@ -207,6 +216,9 @@ import {
   >
     {(args) => (
       <Template>
+        <TemplateAboveHeader>
+          <Placeholder variant="short">Above Header</Placeholder>
+        </TemplateAboveHeader>
         <TemplateHeader>
           <Placeholder variant="short">NYPL Header</Placeholder>
           <TemplateBreakout>
@@ -248,6 +260,7 @@ import {
 The components consist of:
 
 - `Template`
+- `TemplateAboveHeader`
 - `TemplateHeader`
 - `TemplateBreakout`
 - `TemplateContent`
@@ -266,10 +279,25 @@ The components consist of:
 
 <Description of={Template} />
 
+#### TemplateAboveHeader
+
+```
+<Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
+<Template>
+```
+
+<Description of={TemplateAboveHeader} />
+
 #### TemplateHeader
 
 ```
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>
     // ...
   </TemplateHeader>
@@ -282,6 +310,9 @@ The components consist of:
 
 ```
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>
     <TemplateBreakout>
       // ...
@@ -309,6 +340,9 @@ The components consist of:
 
 ```
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>...</TemplateHeader>
   <TemplateContent>
     <TemplateContentTop>
@@ -324,6 +358,9 @@ The components consist of:
 
 ```
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>...</TemplateHeader>
   <TemplateContent>
     <TemplateContentPrimary>
@@ -339,6 +376,9 @@ The components consist of:
 
 ```
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>...</TemplateHeader>
   <TemplateContent sidebar="right">
     <TemplateContentPrimary>
@@ -351,6 +391,9 @@ The components consist of:
 <Template>
 
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>...</TemplateHeader>
   <TemplateContent sidebar="left">
     <TemplateContentSidebar>
@@ -369,6 +412,9 @@ The components consist of:
 
 ```
 <Template>
+  <TemplateAboveHeader>
+    // ...
+  </TemplateAboveHeader>
   <TemplateHeader>
     // ...
   </TemplateHeader>
@@ -431,6 +477,23 @@ This is best viewed in the Storybook "Canvas" and not "Docs" section.
 <Canvas>
   <Story name="Full Example with Template Children Components">
     <Template>
+      <TemplateAboveHeader>
+        <Notification
+          notificationType={NotificationTypes.Standard}
+          notificationHeading="Standard Notification"
+          notificationContent={
+            <>
+              This is an "announcement" Notification with a heading. Cras mattis
+              consectetur purus sit amet fermentum. Maecenas faucibus mollis
+              interdum. Morbi leo risus, porta ac consectetur ac, vestibulum at
+              eros. Cum sociis natoque penatibus et magnis dis parturient
+              montes, nascetur ridiculus mus. Vivamus sagittis lacus vel augue
+              laoreet rutrum faucibus dolor auctor.
+            </>
+          }
+          showIcon={false}
+        />
+      </TemplateAboveHeader>
       <TemplateHeader>
         <TemplateBreakout>
           <Breadcrumbs

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -5,6 +5,7 @@ import renderer from "react-test-renderer";
 
 import {
   Template,
+  TemplateAboveHeader,
   TemplateHeader,
   TemplateBreakout,
   TemplateContent,
@@ -16,6 +17,7 @@ import {
 } from "./Template";
 import Placeholder from "../Placeholder/Placeholder";
 
+const aboveHeader = <Placeholder variant="short">Above Header</Placeholder>;
 const header = <Placeholder variant="short">NYPL Header</Placeholder>;
 const breakout = (
   <>
@@ -38,6 +40,7 @@ describe("TemplateAppContainer accessibility", () => {
   it("passes axe accessibility test", async () => {
     const { container } = render(
       <TemplateAppContainer
+        aboveHeader={aboveHeader}
         header={header}
         breakout={breakout}
         sidebar={sidebar}
@@ -55,6 +58,7 @@ describe("Template components accessibility", () => {
   it("passes axe accessibility test", async () => {
     const { container } = render(
       <Template>
+        <TemplateAboveHeader>{aboveHeader}</TemplateAboveHeader>
         <TemplateHeader>
           {header}
           <TemplateBreakout>{breakout}</TemplateBreakout>
@@ -75,6 +79,7 @@ describe("TemplateAppContainer component", () => {
   it("renders each section", () => {
     render(
       <TemplateAppContainer
+        aboveHeader={aboveHeader}
         header={header}
         breakout={breakout}
         sidebar={sidebar}
@@ -84,7 +89,7 @@ describe("TemplateAppContainer component", () => {
         footer={footer}
       />
     );
-
+    expect(screen.getByText("Above Header")).toBeInTheDocument();
     expect(screen.getByText("NYPL Header")).toBeInTheDocument();
     expect(screen.getByText("Breadcrumbs")).toBeInTheDocument();
     expect(screen.getByText("Hero")).toBeInTheDocument();
@@ -177,6 +182,7 @@ describe("Template components", () => {
   it("renders each section", () => {
     render(
       <Template>
+        <TemplateAboveHeader>{aboveHeader}</TemplateAboveHeader>
         <TemplateHeader>
           {header}
           <TemplateBreakout>{breakout}</TemplateBreakout>
@@ -190,6 +196,7 @@ describe("Template components", () => {
       </Template>
     );
 
+    expect(screen.getByText("Above Header")).toBeInTheDocument();
     expect(screen.getByText("NYPL Header")).toBeInTheDocument();
     expect(screen.getByText("Breadcrumbs")).toBeInTheDocument();
     expect(screen.getByText("Hero")).toBeInTheDocument();
@@ -201,9 +208,10 @@ describe("Template components", () => {
   });
 
   it("Renders the UI snapshot correctly", () => {
-    const basic = renderer
+    const templateComponents = renderer
       .create(
         <Template>
+          <TemplateAboveHeader>{aboveHeader}</TemplateAboveHeader>
           <TemplateHeader>
             {header}
             <TemplateBreakout>{breakout}</TemplateBreakout>
@@ -217,7 +225,22 @@ describe("Template components", () => {
         </Template>
       )
       .toJSON();
+    const singleComponent = renderer
+      .create(
+        <TemplateAppContainer
+          aboveHeader={aboveHeader}
+          header={header}
+          breakout={breakout}
+          sidebar={sidebar}
+          contentTop={contentTop}
+          contentSidebar={contentSidebar}
+          contentPrimary={contentPrimary}
+          footer={footer}
+        />
+      )
+      .toJSON();
 
-    expect(basic).toMatchSnapshot();
+    expect(templateComponents).toMatchSnapshot();
+    expect(singleComponent).toMatchSnapshot();
   });
 });

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -53,7 +53,10 @@ const Template = (props: React.PropsWithChildren<TemplateProps>) => {
 /**
  * This optional component renders its children from edge-to-edge and should
  * be used for alerts or notifications that are typically site-wide. This must
- * be rendered immediately before the `TemplateHeader` component.
+ * be rendered immediately before the `TemplateHeader` component. This is meant
+ * for components that render an `aside` HTML element or HTML element with the
+ * `role="complementary"` attribute. These elements should *not* be rendered
+ * in the `header` HTML section since that's an accessibility violation.
  */
 const TemplateAboveHeader = (props: React.PropsWithChildren<TemplateProps>) => {
   const styles = useStyleConfig("TemplateBreakout", {});

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -20,6 +20,9 @@ export interface TemplateAppContainerProps
   extends TemplateFooterProps,
     TemplateHeaderProps,
     TemplateSidebarProps {
+  /** DOM that will be rendered before the rest of the components in
+   * `TemplateAppContainer` and immediately before the `TemplateHeader` component. */
+  aboveHeader?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateBreakout` component section. */
   breakout?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateContentPrimary` component section. */
@@ -45,6 +48,16 @@ const Template = (props: React.PropsWithChildren<TemplateProps>) => {
       {props.children}
     </Box>
   );
+};
+
+/**
+ * This optional component renders its children from edge-to-edge and should
+ * be used for alerts or notifications that are typically site-wide. This must
+ * be rendered immediately before the `TemplateHeader` component.
+ */
+const TemplateAboveHeader = (props: React.PropsWithChildren<TemplateProps>) => {
+  const styles = useStyleConfig("TemplateBreakout", {});
+  return <Box __css={styles}>{props.children}</Box>;
 };
 
 /**
@@ -221,6 +234,7 @@ const TemplateAppContainer = (
   props: React.PropsWithChildren<TemplateAppContainerProps>
 ) => {
   const {
+    aboveHeader,
     breakout,
     contentPrimary,
     contentSidebar,
@@ -231,6 +245,9 @@ const TemplateAppContainer = (
     renderFooterElement = true,
     renderHeaderElement = true,
   } = props;
+  const aboveHeaderElem = aboveHeader && (
+    <TemplateAboveHeader>{aboveHeader}</TemplateAboveHeader>
+  );
   const breakoutElem = breakout && (
     <TemplateBreakout>{breakout}</TemplateBreakout>
   );
@@ -245,6 +262,7 @@ const TemplateAppContainer = (
   );
   return (
     <Template>
+      {aboveHeaderElem}
       {(header || breakoutElem) && (
         <TemplateHeader renderHeaderElement={renderHeaderElement}>
           {header}
@@ -274,6 +292,7 @@ const TemplateAppContainer = (
 export {
   TemplateAppContainer,
   Template,
+  TemplateAboveHeader,
   TemplateHeader,
   TemplateBreakout,
   TemplateContent,

--- a/src/components/Template/__snapshots__/Template.test.tsx.snap
+++ b/src/components/Template/__snapshots__/Template.test.tsx.snap
@@ -4,6 +4,99 @@ exports[`Template components Renders the UI snapshot correctly 1`] = `
 <div
   className="nypl-ds css-0"
 >
+  <div
+    className="css-0"
+  >
+    <div
+      className="placeholder placeholder-short"
+    >
+      Above Header
+    </div>
+  </div>
+  <header
+    className="css-0"
+  >
+    <div
+      className="placeholder placeholder-short"
+    >
+      NYPL Header
+    </div>
+    <div
+      className="css-0"
+    >
+      <div
+        className="placeholder placeholder-short"
+      >
+        Breadcrumbs
+      </div>
+      <div
+        className="placeholder placeholder-short"
+      >
+        Hero
+      </div>
+    </div>
+  </header>
+  <main
+    className="css-0"
+  >
+    <div
+      className="css-0"
+    >
+      <div
+        className="placeholder placeholder-undefined"
+      >
+        Content Top
+      </div>
+    </div>
+    <div
+      className="css-0"
+    >
+      <div
+        className="placeholder placeholder-undefined"
+      >
+        Left Sidebar
+      </div>
+    </div>
+    <div
+      className="css-0"
+    >
+      <div
+        className="placeholder placeholder-undefined"
+      >
+        Main Content
+      </div>
+      <div
+        className="placeholder placeholder-short"
+      >
+        More Content
+      </div>
+    </div>
+  </main>
+  <footer
+    className="css-0"
+  >
+    <div
+      className="placeholder placeholder-short"
+    >
+      Footer
+    </div>
+  </footer>
+</div>
+`;
+
+exports[`Template components Renders the UI snapshot correctly 2`] = `
+<div
+  className="nypl-ds css-0"
+>
+  <div
+    className="css-0"
+  >
+    <div
+      className="placeholder placeholder-short"
+    >
+      Above Header
+    </div>
+  </div>
   <header
     className="css-0"
   >

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,6 +107,7 @@ export {
 export {
   TemplateAppContainer,
   Template,
+  TemplateAboveHeader,
   TemplateHeader,
   TemplateBreakout,
   TemplateContent,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-797](https://jira.nypl.org/browse/DSD-797)

## This PR does the following:

- Adds an `aboveHeader` prop to `TemplateAppContainer` to render content immediately before the header region.
- Adds the `TemplateAboveHeader` individual component which is used internally in the `TemplateAppContainer`. This gets rendered from edge-to-edge.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
