### PR TITLE
DSD-806: font styles for input components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Fieldset` and `RadioGroup` so the `children` prop is declared through `React.PropsWithChildren` rather than in their respective prop interfaces.
 - Passes an `id` to the `Icon` in the `Select` component.
 - Adds snapshot tests for the `Select` componnet.
+- Updates font size to "12px" and top margin to "4px" for `HelperErrorText` component.
+- Updates font size to "14px" for `TextInput` component.
 
 ### Fixes
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29625,6 +29625,11 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       },
+      "bin": {
+        "sshpk-conv": "bin/sshpk-conv",
+        "sshpk-sign": "bin/sshpk-sign",
+        "sshpk-verify": "bin/sshpk-verify"
+      },
       "engines": {
         "node": ">=0.10.0"
       }

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -57,7 +57,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.1.0`    |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={Checkbox} />
 

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -69,7 +69,7 @@ export const enumValues = getStorybookEnumValues(
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.1`   |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={CheckboxGroup} />
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -8,12 +8,13 @@ import { FormGaps } from "../Form/FormTypes";
 import HelperErrorText, {
   HelperErrorTextType,
 } from "../HelperErrorText/HelperErrorText";
+import { helperTextMargin } from "../../theme/components/global";
 import TextInput, {
   InputProps,
   TextInputRefType,
 } from "../TextInput/TextInput";
 import generateUUID from "../../helpers/generateUUID";
-import { useMultiStyleConfig } from "@chakra-ui/system";
+import { Box, useMultiStyleConfig } from "@chakra-ui/react";
 
 // The object shape for the DatePicker's start and end date state values.
 export interface FullDateType {
@@ -416,11 +417,13 @@ const DatePicker = React.forwardRef<TextInputRefType, DatePickerProps>(
           )}
         </DateRangeRow>
         {helperText && isDateRange && showHelperInvalidText && (
-          <HelperErrorText
-            id={`${id}-helper-text`}
-            isInvalid={false}
-            text={helperText}
-          />
+          <Box __css={helperTextMargin}>
+            <HelperErrorText
+              id={`${id}-helper-text`}
+              isInvalid={false}
+              text={helperText}
+            />
+          </Box>
         )}
       </DatePickerWrapper>
     );

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -433,17 +433,21 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
       </div>
     </div>
     <div
-      aria-atomic={true}
-      aria-live="off"
-      className=" css-0"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Note that the Library may be closed on Sundays.",
+      className="css-fjhuh4"
+    >
+      <div
+        aria-atomic={true}
+        aria-live="off"
+        className=" css-0"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Note that the Library may be closed on Sundays.",
+          }
         }
-      }
-      data-isinvalid={false}
-      id="invalid-helper-text"
-    />
+        data-isinvalid={false}
+        id="invalid-helper-text"
+      />
+    </div>
   </fieldset>
 </div>
 `;
@@ -545,17 +549,21 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
       </div>
     </div>
     <div
-      aria-atomic={true}
-      aria-live="off"
-      className=" css-0"
-      dangerouslySetInnerHTML={
-        Object {
-          "__html": "Note that the Library may be closed on Sundays.",
+      className="css-fjhuh4"
+    >
+      <div
+        aria-atomic={true}
+        aria-live="off"
+        className=" css-0"
+        dangerouslySetInnerHTML={
+          Object {
+            "__html": "Note that the Library may be closed on Sundays.",
+          }
         }
-      }
-      data-isinvalid={false}
-      id="disabled-helper-text"
-    />
+        data-isinvalid={false}
+        id="disabled-helper-text"
+      />
+    </div>
   </fieldset>
 </div>
 `;

--- a/src/components/HelperErrorText/HelperErrorText.stories.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.mdx
@@ -47,7 +47,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={HelperErrorText} />
 

--- a/src/components/Radio/Radio.stories.mdx
+++ b/src/components/Radio/Radio.stories.mdx
@@ -53,7 +53,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.22.0`   |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={Radio} />
 

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -67,7 +67,7 @@ export const enumValues = getStorybookEnumValues(SelectTypes, "SelectTypes");
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={Select} />
 

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -76,7 +76,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.4`   |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={Slider} />
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -61,7 +61,7 @@ export const enumValues = getStorybookEnumValues(
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.22.0`   |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={TextInput} />
 

--- a/src/components/Toggle/Toggle.stories.mdx
+++ b/src/components/Toggle/Toggle.stories.mdx
@@ -55,7 +55,7 @@ export const sizeEnumValues = getStorybookEnumValues(
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.8`   |
-| Latest            | `0.25.9`   |
+| Latest            | `0.25.10`  |
 
 <Description of={Toggle} />
 

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -13,7 +13,7 @@ const activeFocus = {
 };
 // Used in `Select` and `TextInput`.
 const helperTextMargin = {
-  marginTop: "xs",
+  marginTop: "xxs",
   marginBottom: "0",
 };
 // Used in `Checkbox` and `Radio`.

--- a/src/theme/components/textInput.ts
+++ b/src/theme/components/textInput.ts
@@ -5,6 +5,7 @@ const input = {
   border: "1px solid",
   borderColor: "ui.gray.medium",
   borderRadius: "sm",
+  fontSize: "text.caption",
   py: "xs",
   px: "s",
   _hover: {

--- a/src/theme/components/toggle.ts
+++ b/src/theme/components/toggle.ts
@@ -4,7 +4,7 @@ const baseStyle = {
   label: { display: "flex", alignItems: "center", width: "fit-content" },
   helper: {
     ...helperTextMargin,
-    marginLeft: "xs",
+    marginLeft: "xxs",
   },
 };
 

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -55,7 +55,7 @@ const typography: Typography = {
       callout: fontSizeValues["1"],
     },
     helper: {
-      default: fontSizeValues["-1"],
+      default: fontSizeValues["-2"],
     },
     label: {
       default: fontSizeValues["-1"],


### PR DESCRIPTION
Fixes JIRA ticket xxx

## This PR does the following:

- Updates font size to "12px" and top margin to "4px" for `HelperErrorText` component.
- Updates font size to "14px" for `TextInput` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. —>
- local build of DS storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
