### PR TITLE
DSD-828: Notification bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `Notification`'s icons to be decorative by default.
+
+### Fixes
+
+- Updates the alignment of the `Notifications`'s dismissible icon.
+
 ## 0.25.11 (March 3, 2022)
 
 ### Updates

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -59,7 +59,7 @@ export const enumValues = getStorybookEnumValues(
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.23.2`   |
-| Latest            | `0.25.11`  |
+| Latest            | `0.25.12`  |
 
 <Description of={Notification} />
 
@@ -117,6 +117,11 @@ This is an HTML landmark element that is similar to adding an attribute of
 be rendered inside other landmark elements such as the `header` and `footer`
 landmark elements. Adding a `Notification` component inside an HTML `main` landmark
 element is acceptable.
+
+Icons rendered in the `Notification` component are decorative by default which
+means that they are hidden to screen readers. Since the "X" close icon inside the
+dismissible button is decorative and because there is no discernible text inside
+the button, an `aria-label` attribute is added to the button.
 
 ## Variants
 

--- a/src/components/Notification/Notification.test.tsx
+++ b/src/components/Notification/Notification.test.tsx
@@ -77,8 +77,12 @@ describe("Notification", () => {
   });
 
   it("renders with an Icon", () => {
-    // The Icon's role is "img".
-    expect(screen.queryByRole("img")).toBeInTheDocument();
+    // Since the icon has aria-hidden set to true, we can't get it
+    // by its "img" role.
+    const icon = utils.container.querySelector(
+      "#notificationID-notification-icon"
+    );
+    expect(icon).toBeInTheDocument();
   });
 
   it("does not render an Icon", () => {
@@ -90,8 +94,10 @@ describe("Notification", () => {
         showIcon={false}
       />
     );
-    // The Icon's role is "img".
-    expect(screen.queryByRole("img")).not.toBeInTheDocument();
+    const icon = utils.container.querySelector(
+      "#notificationID-notification-icon"
+    );
+    expect(icon).not.toBeInTheDocument();
   });
 
   it("renders a custom Icon component", () => {
@@ -111,7 +117,11 @@ describe("Notification", () => {
         notificationHeading="Notification Heading"
       />
     );
-    expect(utils.container.querySelector(".custom-icon")).toBeInTheDocument();
+
+    const customIcon = utils.container.querySelector(
+      "#notificationID-custom-notification-icon"
+    );
+    expect(customIcon).toBeInTheDocument();
   });
 
   it("renders the announcement Notification type", () => {
@@ -163,14 +173,15 @@ describe("Notification", () => {
         notificationType={NotificationTypes.Standard}
       />
     );
-    const icons = screen.queryAllByRole("img");
 
-    expect(icons).toHaveLength(2);
-    expect(screen.getByTitle("Notification standard icon")).toBeInTheDocument();
+    const dismissibleIcon = utils.container.querySelector(
+      "#notificationID-dismissible-notification-icon"
+    );
+    expect(dismissibleIcon).toBeInTheDocument();
     expect(screen.getByTitle("Notification close icon")).toBeInTheDocument();
   });
 
-  it.skip("renders the UI snapshot correctly", () => {
+  it("renders the UI snapshot correctly", () => {
     const standard = renderer
       .create(
         <Notification

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -124,7 +124,6 @@ export default function Notification(props: NotificationProps) {
   const iconElement = () => {
     const baseIconProps = {
       additionalStyles: styles.icon,
-      decorative: false,
       size: IconSizes.Large,
     };
     // If the icon should not display, return null.
@@ -164,13 +163,16 @@ export default function Notification(props: NotificationProps) {
   };
   const dismissibleButton = dismissible && (
     <Button
-      buttonType={ButtonTypes.Link}
-      onClick={handleClose}
       additionalStyles={styles.dismissibleButton}
+      attributes={{
+        "aria-label": "Close the notification",
+      }}
+      buttonType={ButtonTypes.Link}
+      id={`${id}-notification-dismissible-button`}
+      onClick={handleClose}
     >
       <Icon
-        decorative={false}
-        id={`${id}-notification-dismissible-icon`}
+        id={`${id}-dismissible-notification-icon`}
         name={IconNames.Close}
         size={IconSizes.Large}
         title="Notification close icon"

--- a/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -13,12 +13,12 @@ exports[`Notification renders the UI snapshot correctly 1`] = `
       className="css-0"
     >
       <svg
-        aria-hidden={false}
+        aria-hidden={true}
         className="chakra-icon css-onkibi"
         focusable={false}
         id="notificationID1-notification-icon"
         role="img"
-        title="alert_notification_important icon"
+        title="Notification standard icon"
         viewBox="0 0 24 24"
       >
         <g
@@ -77,12 +77,12 @@ exports[`Notification renders the UI snapshot correctly 2`] = `
       className="css-0"
     >
       <svg
-        aria-hidden={false}
+        aria-hidden={true}
         className="chakra-icon css-onkibi"
         focusable={false}
         id="notificationID2-notification-icon"
         role="img"
-        title="speaker_notes icon"
+        title="Notification announcement icon"
         viewBox="0 0 24 24"
       >
         <g
@@ -141,12 +141,12 @@ exports[`Notification renders the UI snapshot correctly 3`] = `
       className="css-0"
     >
       <svg
-        aria-hidden={false}
+        aria-hidden={true}
         className="chakra-icon css-onkibi"
         focusable={false}
         id="notificationID3-notification-icon"
         role="img"
-        title="error_filled icon"
+        title="Notification warning icon"
         viewBox="0 0 24 24"
       >
         <g
@@ -205,12 +205,12 @@ exports[`Notification renders the UI snapshot correctly 4`] = `
       className="css-0"
     >
       <svg
-        aria-hidden={false}
+        aria-hidden={true}
         className="chakra-icon css-onkibi"
         focusable={false}
         id="notificationID4-notification-icon"
         role="img"
-        title="alert_notification_important icon"
+        title="Notification standard icon"
         viewBox="0 0 24 24"
       >
         <g
@@ -297,5 +297,100 @@ exports[`Notification renders the UI snapshot correctly 6`] = `
       </div>
     </div>
   </div>
+</aside>
+`;
+
+exports[`Notification renders the UI snapshot correctly 7`] = `
+<aside
+  className="css-0"
+  data-type="standard"
+  id="notificationID7"
+>
+  <div
+    className="css-0"
+  >
+    <div
+      className="css-0"
+    >
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-onkibi"
+        focusable={false}
+        id="notificationID7-notification-icon"
+        role="img"
+        title="Notification standard icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
+      <div
+        className="css-0"
+      >
+        Notification content.
+      </div>
+    </div>
+  </div>
+  <button
+    aria-label="Close the notification"
+    className="chakra-button css-0"
+    data-testid="button"
+    id="notificationID7-notification-dismissible-button"
+    onClick={[Function]}
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-onkibi"
+      focusable={false}
+      id="notificationID7-dismissible-notification-icon"
+      role="img"
+      title="Notification close icon"
+      viewBox="0 0 24 24"
+    >
+      <g
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path
+          d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+          fill="none"
+          strokeLinecap="round"
+        />
+        <path
+          d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+          fill="currentColor"
+          strokeLinecap="round"
+        />
+        <circle
+          cx="12"
+          cy="12"
+          fill="none"
+          r="11.25"
+          strokeMiterlimit="10"
+        />
+      </g>
+    </svg>
+  </button>
 </aside>
 `;

--- a/src/theme/components/notification.ts
+++ b/src/theme/components/notification.ts
@@ -38,6 +38,9 @@ const Notification = {
         position: "absolute",
         right: "0",
         top: "0",
+        svg: {
+          marginTop: "0",
+        },
         _hover: {
           bg: "inherit",
         },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-828](https://jira.nypl.org/browse/DSD-828)

## This PR does the following:

- Sets icons in the `Notification` component to be decorative by default.
- Updates the alignment of the icon inside the dismissible button.
- Uncomments the snapshot test for the `Notification` component.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Icons in the `Notification` component are decorative so hidden to screenreaders.
- The icon in the dismissible button is now decorative so the button needs an `aria-label` for screenreaders to pick it up.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
