### PR TITLE
DSD-670: Fixing margin styles for the Slider component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes the styles for the `Slider` to better accomodate the slider thumbs and the width of the container.
+
 ## 0.25.11 (March 3, 2022)
 
 ### Updates

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -76,7 +76,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.4`   |
-| Latest            | `0.25.10`  |
+| Latest            | `0.25.12`  |
 
 <Description of={Slider} />
 

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -120,8 +120,8 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
   const styles = useMultiStyleConfig("CustomSlider", {
     isDisabled,
     isInvalid: finalIsInvalid,
-    isRangeSlider,
     showBoxes,
+    showValues,
   });
   // Props that the `Slider` and `RangeSlider` Chakra
   // components both use.
@@ -138,6 +138,9 @@ export default function Slider(props: React.PropsWithChildren<SliderProps>) {
     // *final* value once a user stops dragging the slider.
     onChangeEnd: (val) => onChange && onChange(val),
     step,
+    // Additional margins so slider thumbs don't overflow past the
+    // edge when the value boxes or min/max values are hidden.
+    sx: styles.sliderContainer,
   };
   // Props that the two `TextInput` components use.
   const textInputSharedProps = {

--- a/src/theme/components/slider.ts
+++ b/src/theme/components/slider.ts
@@ -3,7 +3,7 @@ const staticValues = {
   marginTop: "xs",
   marginBottom: "xs",
   marginRight: "s",
-  marginLeft: "s",
+  marginLeft: "0",
 };
 const CustomSlider = {
   parts: [
@@ -12,11 +12,12 @@ const CustomSlider = {
     "leftValue",
     "rightValue",
     "textInput",
+    "sliderContainer",
     "filledTrack",
     "track",
     "thumb",
   ],
-  baseStyle: ({ isDisabled, isInvalid, isRangeSlider, showBoxes }) => {
+  baseStyle: ({ isDisabled, isInvalid, showBoxes, showValues }) => {
     let baseColor = "ui.link.primary";
     if (isInvalid) {
       baseColor = "ui.error.primary";
@@ -32,15 +33,10 @@ const CustomSlider = {
       helper: {
         marginTop: "xs",
       },
-      leftValue: {
-        ...staticValues,
-        // If the text input boxes are shown, then there already is a
-        // margin, so we can set this static value to "0". But for the
-        // single Slider, we *do* need the margin set.
-        marginLeft: showBoxes && isRangeSlider ? "0" : "s",
-      },
+      leftValue: staticValues,
       rightValue: {
         ...staticValues,
+        marginLeft: "s",
         // If the text input boxes are shown, then there already is
         // a margin, so we can set this static value to "0".
         marginRight: showBoxes ? "0" : "s",
@@ -50,6 +46,13 @@ const CustomSlider = {
         // min or max value text input.
         minWidth: "65px",
         color: isInvalid ? "ui.error.primary" : "ui.black",
+      },
+      // This is added to the container so that the slider thumbs don't
+      // overflow past the container when the value boxes or min/max values
+      // are not shown.
+      sliderContainer: {
+        marginLeft: !showValues ? "xs" : null,
+        marginRight: !showBoxes && !showValues ? "xs" : null,
       },
       // Filled track doesn't have a _disabled or _invalid state...
       // so we manually do it through the props.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-670](https://jira.nypl.org/browse/DSD-670)

## This PR does the following:

- Updates the internal margin styles for the `Slider` component.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
