### PR TITLE
DSD-825: Updating margins for List ul and ol

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Changes
+
+- Removes the margin from the global `.nypl p` CSS rule.
+
+### Fixes
+
+- Updates the top and bottom margin of the `List`'s `Unordered` and `Ordered` types.
+
 ## 0.25.11 (March 3, 2022)
 
 ### Updates

--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -51,7 +51,7 @@ export const enumValues = getStorybookEnumValues(ListTypes, "ListTypes");
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `0.25.11`  |
+| Latest            | `0.25.12`  |
 
 <Description of={List} />
 

--- a/src/styles/base/_03-base.scss
+++ b/src/styles/base/_03-base.scss
@@ -13,10 +13,6 @@
   // our breakout mixin. Fix identified here: https://cloudfour.com/thinks/breaking-out-with-viewport-units-and-calc/#one-big-dumb-caveat
   overflow-x: hidden;
 
-  p {
-    margin: 0 0 var(--nypl-space-s);
-  }
-
   *,
   *::after,
   *::before {

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -47,6 +47,14 @@ const checkboxRadioHelperStyle = {
     fontStyle: "italic",
   },
 };
+const checkboxRadioGroupStyles = {
+  helper: {
+    marginTop: "s",
+  },
+  stack: {
+    width: "fit-content",
+  },
+};
 // Used in `Label` and `Fieldset`.
 const labelLegendText = {
   alignItems: "baseline",
@@ -62,13 +70,10 @@ const labelLegendText = {
     fontWeight: "helper.default",
   },
 };
-const checkboxRadioGroupStyles = {
-  helper: {
-    marginTop: "s",
-  },
-  stack: {
-    width: "fit-content",
-  },
+// Used for p, ul, and ol
+const textMargin = {
+  margin: "0",
+  marginBottom: "s",
 };
 
 export {
@@ -79,4 +84,5 @@ export {
   checkboxRadioLabelStyles,
   helperTextMargin,
   labelLegendText,
+  textMargin,
 };

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -1,7 +1,5 @@
-const topBottomMargin = {
-  marginTop: "s",
-  marginBottom: "s",
-};
+import { textMargin } from "./global";
+
 const List = {
   baseStyle: ({ inline, noStyling }) => ({
     // Browser automatically applies margin, so by default we unset it.
@@ -21,7 +19,7 @@ const List = {
   }),
   variants: {
     ul: ({ noStyling }) => ({
-      ...topBottomMargin,
+      ...textMargin,
       listStyle: "none",
       li: {
         _before: {
@@ -38,7 +36,7 @@ const List = {
         },
       },
     }),
-    ol: topBottomMargin,
+    ol: textMargin,
     dl: {
       borderBottom: "1px solid",
       borderColor: "ui.gray.light-cool",

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -1,3 +1,7 @@
+const topBottomMargin = {
+  marginTop: "s",
+  marginBottom: "s",
+};
 const List = {
   baseStyle: ({ inline, noStyling }) => ({
     // Browser automatically applies margin, so by default we unset it.
@@ -17,6 +21,7 @@ const List = {
   }),
   variants: {
     ul: ({ noStyling }) => ({
+      ...topBottomMargin,
       listStyle: "none",
       li: {
         _before: {
@@ -33,6 +38,7 @@ const List = {
         },
       },
     }),
+    ol: topBottomMargin,
     dl: {
       borderBottom: "1px solid",
       borderColor: "ui.gray.light-cool",

--- a/src/theme/foundations/global.ts
+++ b/src/theme/foundations/global.ts
@@ -1,3 +1,5 @@
+import { textMargin } from "../components/global";
+
 /**
  * These rules affect all the global elements on the `body` element of the
  * page when the `DSProvider` component is used. This means that even if the
@@ -23,10 +25,9 @@ const global = {
   svg: {
     display: "inline",
   },
-  p: {
-    margin: "0",
-    marginBottom: "s",
-  },
+  p: textMargin,
+  ul: textMargin,
+  ol: textMargin,
 };
 
 export default global;

--- a/src/theme/foundations/global.ts
+++ b/src/theme/foundations/global.ts
@@ -24,7 +24,8 @@ const global = {
     display: "inline",
   },
   p: {
-    margin: "0 0 var(--nypl-space-s",
+    margin: "0",
+    marginBottom: "s",
   },
 };
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-825](https://jira.nypl.org/browse/DSD-825)

## This PR does the following:

- Adds top and bottom margin to the `Unordered` and `Ordered` `List` types.
- Removes the `.nypl p` bottom margin rule and moves it to the Chakra global file.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
