### PR TITLE
DSD-827: Removing border and padding from fieldset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Removes border and padding from the `fieldset` HTML element.
+
 ## 0.25.11 (March 3, 2022)
 
 ### Updates

--- a/src/components/Fieldset/Fieldset.stories.mdx
+++ b/src/components/Fieldset/Fieldset.stories.mdx
@@ -39,7 +39,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.3`   |
-| Latest            | `0.25.11`  |
+| Latest            | `0.25.12`  |
 
 <Description of={Fieldset} />
 

--- a/src/components/Fieldset/Fieldset.stories.mdx
+++ b/src/components/Fieldset/Fieldset.stories.mdx
@@ -39,7 +39,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.3`   |
-| Latest            | `0.25.10`  |
+| Latest            | `0.25.11`  |
 
 <Description of={Fieldset} />
 

--- a/src/theme/components/fieldset.ts
+++ b/src/theme/components/fieldset.ts
@@ -6,6 +6,8 @@ const Fieldset = {
   baseStyle: ({ isLegendHidden }) => {
     const screenreaderStyles = isLegendHidden ? screenreaderOnly : {};
     return {
+      border: 0,
+      padding: 0,
       legend: {
         ...labelLegendText,
         ...screenreaderStyles,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-827](https://jira.nypl.org/browse/DSD-827)

## This PR does the following:

- Removes the border and padding from the `Fieldset` component.

## How has this been tested?

Storybook. Note, there are some other fieldset rules coming in from the NYPL Header and Footer but once those are updated/removed, those rules won't come in.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
