### PR TITLE
DSD-733: Updating the SearchBar's placeholder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the default placeholder value for the `SearchBar`'s `TextInput` component.
+- Updates the `SearchBar`'s `textInputProps` prop objetc to not require the `placeholder` property.
+
 ## 0.25.11 (March 3, 2022)
 
 ### Updates

--- a/src/components/SearchBar/SearchBar.Test.tsx
+++ b/src/components/SearchBar/SearchBar.Test.tsx
@@ -217,6 +217,25 @@ describe("SearchBar", () => {
     expect(searchBarSubmit).toHaveBeenCalledTimes(1);
   });
 
+  it("renders a default placeholder", () => {
+    const textInputProps: TextInputProps = {
+      labelText: "Item Search",
+      name: "textInputName",
+    };
+
+    render(
+      <SearchBar
+        id="requiredState"
+        isDisabled
+        labelText={labelText}
+        onSubmit={jest.fn()}
+        textInputProps={textInputProps}
+      />
+    );
+
+    expect(screen.getByPlaceholderText("Search terms")).toBeInTheDocument();
+  });
+
   it("renders 'required' in the placeholder text", () => {
     const { rerender } = render(
       <SearchBar
@@ -247,8 +266,7 @@ describe("SearchBar", () => {
     ).toBeInTheDocument();
   });
 
-  // TODO: Fix the `Select` component before enabling this test
-  it.skip("renders the UI snapshot correctly", () => {
+  it("renders the UI snapshot correctly", () => {
     const basic = renderer
       .create(
         <SearchBar

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -60,7 +60,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `0.25.11`  |
+| Latest            | `0.25.12`  |
 
 <Description of={SearchBar} />
 
@@ -166,9 +166,9 @@ const selectProps = {
 ### TextInput Component
 
 To render the `TextInput` component, an object must be passed to the
-`textInputProps` prop. It _must_ include `labelText`, `name`, and `placeholder`
-properties. The `labelText` value won't be rendered but will be used for its
-`aria-label` attribute. Optional properties to pass include `onChange` and `value`.
+`textInputProps` prop. It _must_ include `labelText` and `name` properties. The
+`labelText` value won't be rendered but will be used for its `aria-label`
+attribute. Optional properties to pass include `onChange`, `placeholder`, and `value`.
 
 ```
 const textInputProps = {

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -27,7 +27,7 @@ export interface SelectProps extends BaseProps {
   optionsData: string[];
 }
 export interface TextInputProps extends BaseProps {
-  placeholder: string;
+  placeholder?: string;
   value?: string;
 }
 
@@ -108,7 +108,8 @@ export default function SearchBar(props: SearchBarProps) {
   };
   const footnote = isInvalid ? invalidText : helperText;
   const finalAriaLabel = footnote ? `${labelText} - ${footnote}` : labelText;
-  const textInputPlaceholder = `${textInputProps?.placeholder} ${
+  const inputPlaceholder = textInputProps?.placeholder || "Search terms";
+  const textInputPlaceholder = `${inputPlaceholder} ${
     isRequired ? "(Required)" : ""
   }`;
   const buttonType = noBrandButtonType


### PR DESCRIPTION
Fixes JIRA ticket [DSD-733](https://jira.nypl.org/browse/DSD-733)

## This PR does the following:

- Makes the `placeholder` property in the `textInputProps` prop for the `SearchBar` component not required anymore.
- Sets the default placeholder value to "Search terms"

## How has this been tested?

Storybook and tests.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
