### PR TITLE
POC of table of contents with a11y section for Slider

### DIFF
--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -40,6 +40,15 @@ import { getCategory } from "../../utils/componentCategories";
 | Added             | `0.1.0`    |
 | Latest            | `0.25.10`  |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [FAQ Example](#faq-example)
+
+## Overview
+
 <Description of={Accordion} />
 
 The `Accordion` component displays a list of high-level options that can
@@ -54,6 +63,38 @@ with `label` and `panel` properties for each accordion item. Note that you can
 pass in a string or DOM elements into the `panel` property in each object. This
 approach is needed because, internally, we deal with the logic to render the
 necessary icon, Chakra components, and styles.
+
+```jsx
+const contentData = [
+  {
+    label: "Tom Nook",
+    panel: (
+      <Card
+        layout={CardLayouts.Row}
+        center
+        imageSrc="https://play.nintendo.com/images/AC_Tom_FRYtwIN.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
+        imageAlt="Alt text"
+        imageAspectRatio={ImageRatios.TwoByOne}
+      >
+        <CardHeading level={HeadingLevels.Four} id="heading1">
+          Tom Nook
+        </CardHeading>
+        <CardContent>
+          Tom Nook, <b>known in Japan as Tanukichi</b>, is a fictional
+          character in the Animal Crossing series who operates the
+          village store.
+        </CardContent>
+      </Card>
+    ),
+  },
+];
+
+...
+
+<Accordion contentData={contentData} />
+```
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -90,39 +131,30 @@ necessary icon, Chakra components, and styles.
   </Story>
 </Canvas>
 
-```jsx
-const contentData = [
-  {
-    label: "Tom Nook",
-    panel: (
-      <Card
-        layout={CardLayouts.Row}
-        center
-        imageSrc="https://play.nintendo.com/images/AC_Tom_FRYtwIN.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
-        imageAlt="Alt text"
-        imageAspectRatio={ImageRatios.TwoByOne}
-      >
-        <CardHeading level={HeadingLevels.Four} id="heading1">
-          Tom Nook
-        </CardHeading>
-        <CardContent>
-          Tom Nook, <b>known in Japan as Tanukichi</b>, is a fictional
-          character in the Animal Crossing series who operates the
-          village store.
-        </CardContent>
-      </Card>
-    ),
-  },
-];
-
-...
-
-<Accordion contentData={contentData} />
-```
-
 <ArgsTable story="Accordion with Controls" />
 
-## FAQ example
+## Accessibility
+
+- Follows US Design System requirements for buttons/accordion panels (including ARIA to make clear what is expanded/collapsed.). Deviates from USDS in that user can open multiple panels. Opening one, does not collapse already expanded panel.
+- The no-JS version of the accordion will have everything expanded and organized by the headings of the buttons.
+
+Is a button element with "FAQ..." as label.
+
+- "open" icon is decorative
+- Visible focus goes around full button and full button is clickable
+- Open
+
+Is a button element with "FAQ..." as label.
+
+- "close" icon is decorative
+- Visible focus goes around full button and full button is clickable
+
+Resources:
+
+- [W3C WAI-Aria Practices - Accordion](https://www.w3.org/TR/wai-aria-practices-1.1/#accordion)
+- [Chakra Accordion](https://chakra-ui.com/docs/components/disclosure/accordion)
+
+## FAQ Example
 
 export const faqContent = [
   {
@@ -197,7 +229,7 @@ Building out FAQ-like accordions happens automatically when there are more than
 one object in the array passed into the `contentData` prop.
 
 <Canvas withToolbar>
-  <Story name="FAQ">
+  <Story name="FAQ Example">
     <Accordion contentData={faqContent} />
   </Story>
 </Canvas>

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -78,6 +78,17 @@ import DSProvider from "../../theme/provider";
 | Added             | `0.25.4`   |
 | Latest            | `0.25.10`  |
 
+| Table of Contents                      |
+| -------------------------------------- |
+| 1. [Overview](#overview)               |
+| 2. [Component Props](#component-props) |
+| 3. [Accessibility](#accessibility)     |
+| 4. [RangeSlider](#range-slider)        |
+| 5. [Examples](#examples)               |
+| 6. [Get Data Values](#get-data-values) |
+
+## Overview
+
 <Description of={Slider} />
 
 The text input component doubles as a display for the slider's current value.
@@ -121,9 +132,29 @@ For this type of component, the `value` prop must be a single number.
   </Story>
 </Canvas>
 
+## Component Props
+
 <ArgsTable story="Slider with Controls" />
 
-### Accessibility
+## Accessibility
+
+- UI component should be accessible via keyboard. In addition to the text fields,
+  a keyboard user should be able to tab to the blue circle and then with left and
+  right arrows increase or decrease the value.
+- The color contrast between foreground color and background color should be
+  4.5:1 contrast ratio.
+- If text size is 200%, the button should scale with text so there is no overlap.
+- A `Slider` is an input component, so it should have a label. A `Slider` without a
+  label is ambiguous and not accessible.
+
+Resources:
+
+- [W3C WAI-Aria Practices - Slider](https://www.w3.org/TR/wai-aria-practices-1.1/#slider)
+- [W3C WAI-Aria Practices - Slider (Multi-Thumb)](https://www.w3.org/TR/wai-aria-practices-1.1/#slidertwothumb)
+- [Chakra Slider](https://chakra-ui.com/docs/components/form/slider)
+- [Chakra RangeSlider](https://chakra-ui.com/docs/components/form/range-slider)
+
+### Slider Accessibility Implementation
 
 Chakra's `Slider` component is accessible and, as recommended, we pass in an
 `aria-label` to their `Slider` component. On top of that, the DS `Slider`
@@ -179,7 +210,7 @@ numbers. This signifies the starting and ending values of the range slider.
   </Story>
 </Canvas>
 
-### Accessibility
+### RangeSlider Accessibility Implementation
 
 Chakra's `RangeSlider` component is accessible and, as recommended, we pass in
 two `aria-label`s to their `RangeSlider` component. The syntax is different than
@@ -191,6 +222,8 @@ When the input boxes are hidden, the `for` attribute in the `label` element is r
 
 Note that Chakra handles its two slider thumbs aria attributes: `aria-valuemin`,
 `aria-valuemax`, `aria-valuenow`, and `aria-orientation`.
+
+## Examples
 
 ### Single Slider States
 
@@ -483,7 +516,7 @@ In the following examples, all the labels are hidden.
   </DSProvider>
 </Canvas>
 
-### Get Data Values
+## Get Data Values
 
 Pass a callback function to the `onChange` prop to get the current number value
 of the `Slider` component or an array of two numbers when it is a range slider.
@@ -492,7 +525,7 @@ value or values. Once the value(s) is updated, the `onChange` callback will be
 called and the values will be passed. If no `onChange` callback is provided,
 you won't be able to get the updated value(s) of the `Slider` component.
 
-#### Single Slider Value
+### Single Slider Value
 
 Open up the browser's developer console to see the value of the `Slider`
 after updating it.
@@ -532,7 +565,7 @@ export function SliderExample() {
   </DSProvider>
 </Canvas>
 
-#### Range Slider Values
+### Range Slider Values
 
 Open up the browser's developer console to see the values of the `Slider`
 after updating it in the `isRangeSlider` state.

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -78,14 +78,14 @@ import DSProvider from "../../theme/provider";
 | Added             | `0.25.4`   |
 | Latest            | `0.25.10`  |
 
-| Table of Contents                      |
-| -------------------------------------- |
-| 1. [Overview](#overview)               |
-| 2. [Component Props](#component-props) |
-| 3. [Accessibility](#accessibility)     |
-| 4. [RangeSlider](#range-slider)        |
-| 5. [Examples](#examples)               |
-| 6. [Get Data Values](#get-data-values) |
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [RangeSlider](#range-slider)
+- [Examples](#examples)
+- [Get Input Values](#get-input-values)
 
 ## Overview
 
@@ -93,6 +93,8 @@ import DSProvider from "../../theme/provider";
 
 The text input component doubles as a display for the slider's current value.
 For this type of component, the `value` prop must be a single number.
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -132,8 +134,6 @@ For this type of component, the `value` prop must be a single number.
   </Story>
 </Canvas>
 
-## Component Props
-
 <ArgsTable story="Slider with Controls" />
 
 ## Accessibility
@@ -165,7 +165,7 @@ is hidden, the `for` attribute in the `label` element is removed.
 Note that Chakra handles its single slider thumb aria attributes: `aria-valuemin`,
 `aria-valuemax`, `aria-valuenow`, and `aria-orientation`.
 
-## Range Slider
+## RangeSlider with Controls
 
 Set `isRangeSlider` to `true` to create a range slider. The text input
 components double as displays for the slider's current minimum and maximum
@@ -174,7 +174,7 @@ numbers. This signifies the starting and ending values of the range slider.
 
 <Canvas withToolbar>
   <Story
-    name="Range Slider with Props"
+    name="RangeSlider with Controls"
     args={{
       className: undefined,
       defaultValue: [25, 75],

--- a/src/components/StructuredContent/StructuredContent.stories.mdx
+++ b/src/components/StructuredContent/StructuredContent.stories.mdx
@@ -70,7 +70,20 @@ export const imageSizeEnumValues = getStorybookEnumValues(
 | Added             | `0.25.9`   |
 | Latest            | `0.25.11`  |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [With HTML String Text Content](#with-html-string-text-content)
+- [With HTML Element Text Content](#with-html-element-text-content)
+- [Examples](#examples)
+
+## Overview
+
 <Description of={StructuredContent} />
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -127,6 +140,13 @@ export const imageSizeEnumValues = getStorybookEnumValues(
 </Canvas>
 
 <ArgsTable story="StructuredContent with Controls" />
+
+## Accessibility
+
+- Containers should allow font-size to be scaled to 200% without content overlapping.
+- Images should have descriptive (but not too lengthy) alt text.
+- Headings levels should not be skipped. Meaning, a `<h2>` should not be followed by a `<h4>`.
+- Any links or text with colors should have a 4.5:1 contrast ratio.
 
 ## With HTML String Text Content
 


### PR DESCRIPTION
POC

## This PR does the following:

The following is only for the `Accordion`, `Slider`, and `StructuredContent` components:

- Adds a "Table of Contents" section
- Adds an "Accessibility section
- Adds more sections as needed for each component
- Adds a "Get Input Values" section for the `Slider` which will be standardized for all input/form components (related to controlled/uncontrolled components).

Please review the following storybook pages and let me know if the added structure and sections (described below) make sense:
- [Accordion](https://pr896-kmwbzry03ejri9qs8dz5w4bw4dzjy2s8.tugboat.qa/?path=/docs/components-overlays-switchers-accordion--accordion-with-controls)
- [Slider](https://pr896-kmwbzry03ejri9qs8dz5w4bw4dzjy2s8.tugboat.qa/?path=/docs/components-form-elements-slider--slider-with-controls)
- [StructuredContent](https://pr896-kmwbzry03ejri9qs8dz5w4bw4dzjy2s8.tugboat.qa/?path=/docs/components-page-layout-structuredcontent--structured-content-with-controls)

If all looks well, we're going to make this update for all component Storybook pages.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- More docs!

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
