### PR TITLE
Dsd 856/pagination alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Fixes
 
 - Fixes bug where the Next button in `Pagination` would navigate to the previous page.
+- Fixes the alignment of the first link in the `Pagination` component.
 
 ## 0.25.12 (March 18, 2022)
 

--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { VStack } from "@chakra-ui/react";
 import {
   ArgsTable,
   Canvas,
@@ -43,7 +44,7 @@ export const hrefProps = getStorybookHrefProps(10);
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `0.25.12`  |
+| Latest            | `0.25.13`  |
 
 <Description of={Pagination} />
 
@@ -144,7 +145,7 @@ export function CurrentPagePaginationExample() {
   const handleClick = () => setPage(1);
   const handleSelection = (selectedPage) => setPage(selectedPage);
   return (
-    <>
+    <VStack align="start" spacing={6}>
       <Pagination
         pageCount={10}
         currentPage={page}
@@ -153,7 +154,7 @@ export function CurrentPagePaginationExample() {
       <Button type="button" buttonType="primary" onClick={handleClick}>
         Go to Page 1
       </Button>
-    </>
+    </VStack>
   );
 }
 

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -1,13 +1,15 @@
 const Pagination = {
   parts: ["link"],
   baseStyle: {
-    marginBottom: "l",
     alignItems: "stretch",
     display: "flex",
     width: "100%",
     link: {
       lineHeight: "1.15",
       textDecoration: "none",
+    },
+    ul: {
+      marginBottom: "0",
     },
   },
 };

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -9,11 +9,6 @@ const Pagination = {
       lineHeight: "1.15",
       textDecoration: "none",
     },
-    li: {
-      _first: {
-        marginTop: "xxs",
-      },
-    },
   },
 };
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-856](https://jira.nypl.org/browse/DSD-856).

## This PR does the following:

- The first link in the `Pagination` component was slightly lower than the rest. This change fixes that alignment issue.

## How has this been tested?

- Locally.

## Accessibility concerns or updates

- No accessibility concerns. This was a very minor update. However, I am curious why the marginTop I deleted was added to begin with. There may be some unintended consequences of removing it. Would love to hear from Marty + Edwin on this front.

### Checklist:

- [ ] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

- [ ] View [the example in Storybook]()
