### PR TITLE
DSD-863: Adding mainContent id to the TemplateAppContainer and a11y guides

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -6,6 +6,7 @@ module.exports = {
   stories: [
     "../src/docs/Intro.stories.mdx",
     "../src/docs/Chakra.stories.mdx",
+    "../src/components/AccessibilityGuide/*.stories.@(tsx|mdx)",
     "../src/components/StyleGuide/*.stories.@(tsx|mdx)",
     "../src/components/**/*.stories.@(tsx|mdx)",
   ],

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -18,7 +18,12 @@ addParameters({
   options: {
     storySort: {
       method: "alphabetical",
-      order: ["Introduction", "Components", "Documentation"],
+      order: [
+        "Introduction",
+        "Accessibility Guide",
+        "Components",
+        "Documentation",
+      ],
     },
   },
 });

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+## Adds
+
+- Adds a `contentId` prop to the `TemplateAppContainer` component. The default value is set to "mainContent" and will render as an attribute on the `main` HTML element. This is used as the target for the skip navigation link in consuming application.
+- Adds an `Accessibility Guide` section to Storybook with a "Skip Navigation" page.
+
 ## 0.25.12 (March 18, 2022)
 
 ## Adds

--- a/src/components/AccessibilityGuide/SkipNavigation.stories.mdx
+++ b/src/components/AccessibilityGuide/SkipNavigation.stories.mdx
@@ -1,0 +1,34 @@
+import { Meta } from "@storybook/addon-docs";
+
+import { getCategory } from "../../utils/componentCategories";
+
+<Meta title={getCategory("Skip Navigation")} />
+
+# Skip Navigation
+
+| Table of Contents                              |
+| ---------------------------------------------- |
+| 1. [General Information](#general-information) |
+| 2. [Resources](#resources)                     |
+
+## General Information
+
+An application's "skip navigation link" is used to skip to the primary or main
+content of a page. This link is located at the top of the page and is usually
+visually hidden until a user focuses on the link. For most applications at
+NYPL, the [NYPL Header](https://github.com/NYPL/dgx-header-component) is used
+and this component already renders a skip navigation link.
+
+The link must target an existing anchor on the page and is typically the `id`
+`"#mainContent"` set on the `main` HTML element on the page. While the DS does not
+currently, as of `v0.25.13`, provide a skip navigation link, it does provide the
+anchor element for the link through the `TemplateAppContainer` component.
+
+The `TemplateAppContainer` component renders as a `main` HTML element with a
+default `id` of `"mainContent"`. This should be used as the anchor element that
+the skip navigation link points to.
+
+## Resources
+
+- [WebAim Skip Navigation Link](https://webaim.org/techniques/skipnav/)
+- [A11ymatters Skip Navigation Link](https://www.a11ymatters.com/pattern/skip-link/)

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -60,7 +60,43 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.3.6`    |
-| Latest            | `0.25.12`  |
+| Latest            | `0.25.13`  |
+
+## Table of Contents
+
+- [Accessibility for TemplateAppContainer](#accessibility-for-templateappcontainer)
+- [TemplateAppContainer Component](#templateappcontainer-component)
+- [TemplateAppContainer Props](#templateappcontainer-props)
+- [Template Children Components](#template-children-components)
+- [Template Children Props](#template-children-props)
+- [Full Example with Template Children Components](#full-example-with-template-children-components)
+
+## Accessibility
+
+**The `TemplateAppContainer` component is the recommended way to render the entire
+application.** Therefore, this accessibility section is specifically for the
+`TemplateAppContainer` but the same rules apply to the individual "Template"
+components.
+
+If you need to render an alert or notification at the top of the page with an
+`aside` HTML element or HTML element with the `role="complementary"` attribute,
+then pass that alert or notification component to the `aboveHeader` prop. These
+elements should _not_ be rendered in the `header` HTML section since that's an
+accessibility violation.
+
+The `TemplateAppContainer` component renders as a `main` HTML element with a
+default "id" of `"mainContent"`. This should be used as the anchor element that
+the skip navigation link points to. As of v0.25.13, the consuming application is
+responsible for adding the skip navigation feature to the application. If your
+application is using the current NYPL Header, it already contains the skip
+navigation feature but make sure it is pointing to the correct anchor element.
+
+Resources
+
+- [W3C Aria Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/complementary.html)
+- [Digital A11y Role=Complementary](https://www.digitala11y.com/complementary-role/)
+- [WebAim Skip Navigation Link](https://webaim.org/techniques/skipnav/)
+- [A11ymatters Skip Navigation Link](https://www.a11ymatters.com/pattern/skip-link/)
 
 ## TemplateAppContainer Component
 
@@ -74,13 +110,7 @@ Likewise, if you have a custom `Footer` component that _already_ renders an HTML
 `<footer>` element, set `renderFooterElement` to false so only one `<footer>`
 element is rendered.
 
-If you need to render an alert or notification at the top of the page with an
-`aside` HTML element or HTML element with the `role="complementary"` attribute,
-then pass that alert or notification component to the `aboveHeader` prop. These
-elements should _not_ be rendered in the `header` HTML section since that's an
-accessibility violation.
-
-<b>This is the recommended way to render an app page template.</b>
+**This is the recommended way to render an app page template.**
 
 ```jsx
 import { TemplateAppContainer } from "@nypl/design-system-react-components";
@@ -107,6 +137,8 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
 />;
 ```
 
+## TemplateAppContainer Props
+
 <Canvas>
   <Story
     name="TemplateAppContainer Component"
@@ -124,6 +156,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
           <Placeholder variant="short">More Content</Placeholder>
         </>
       ),
+      contentId: "mainContent",
       contentSidebar: <Placeholder>Left Sidebar</Placeholder>,
       contentTop: <Placeholder>Content Top</Placeholder>,
       footer: <Placeholder variant="short">Footer</Placeholder>,
@@ -203,6 +236,8 @@ import {
 </Template>
 ```
 
+## Template Children Props
+
 <Canvas>
   <Story
     name="Template Children Components"
@@ -212,6 +247,7 @@ import {
     argTypes={{
       aboveHeader: { table: { disable: true } },
       breakout: { table: { disable: true } },
+      contentId: { table: { disable: true } },
       contentPrimary: { table: { disable: true } },
       contentSidebar: { table: { disable: true } },
       contentTop: { table: { disable: true } },
@@ -334,7 +370,7 @@ The components consist of:
 ```
 <Template>
   <TemplateHeader>...</TemplateHeader>
-  <TemplateContent sidebar="left">
+  <TemplateContent id="mainContent" sidebar="left">
     // ...
   </TemplateContent>
 <Template>

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -100,6 +100,23 @@ describe("TemplateAppContainer component", () => {
     expect(screen.getByText("Footer")).toBeInTheDocument();
   });
 
+  it("renders a #mainContent id in the `main` DOM element", () => {
+    const { container } = render(
+      <TemplateAppContainer
+        aboveHeader={aboveHeader}
+        header={header}
+        breakout={breakout}
+        sidebar={sidebar}
+        contentTop={contentTop}
+        contentSidebar={contentSidebar}
+        contentPrimary={contentPrimary}
+        footer={footer}
+      />
+    );
+    expect(container.querySelector("#mainContent")).toBeInTheDocument();
+    expect(screen.getByRole("main")).toHaveAttribute("id", "mainContent");
+  });
+
   it("renders only one header in a custom header component", () => {
     const customHeader = <header>Custom header</header>;
     render(
@@ -207,7 +224,18 @@ describe("Template components", () => {
     expect(screen.getByText("Footer")).toBeInTheDocument();
   });
 
-  it("Renders the UI snapshot correctly", () => {
+  it("renders a #mainContent id in the TemplateContent component", () => {
+    const { container } = render(
+      <TemplateContent>
+        <TemplateContentPrimary>{contentPrimary}</TemplateContentPrimary>
+      </TemplateContent>
+    );
+
+    expect(container.querySelector("#mainContent")).toBeInTheDocument();
+    expect(screen.getByRole("main")).toHaveAttribute("id", "mainContent");
+  });
+
+  it("renders the UI snapshot correctly", () => {
     const templateComponents = renderer
       .create(
         <Template>

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -15,7 +15,12 @@ export interface TemplateSidebarProps {
    * right side of the `TemplateContentPrimary` component. */
   sidebar?: "none" | "left" | "right";
 }
-export interface TemplateContentProps extends TemplateSidebarProps {}
+export interface TemplateContentProps extends TemplateSidebarProps {
+  /** ID used for the `main` HTML element. Defaults to "mainContent". Useful
+   * anchor for the application skip navigation. */
+  id?: string;
+}
+
 export interface TemplateAppContainerProps
   extends TemplateFooterProps,
     TemplateHeaderProps,
@@ -25,6 +30,9 @@ export interface TemplateAppContainerProps
   aboveHeader?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateBreakout` component section. */
   breakout?: React.ReactElement;
+  /** ID used for the `main` HTML element. Defaults to "mainContent". Useful
+   * anchor for the application skip navigation. */
+  contentId?: string;
   /** DOM that will be rendered in the `TemplateContentPrimary` component section. */
   contentPrimary?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateContentSidebar` component section. */
@@ -106,16 +114,18 @@ const TemplateBreakout = (props: React.PropsWithChildren<TemplateProps>) => {
 
 /**
  * This component is most useful to render content on the page. This renders an
- * HTML `<main>` element and takes a `sidebar` prop with optional "left" or
- * "right" values. This will set the correct styling needed for the
- * `TemplateContentPrimary` and `TemplateContentSidebar` components. Note that
- * `TemplateContentPrimary` and `TemplateContentSidebar` must be ordered
- * correctly as children elements for the appropriate styles to take effect.
+ * HTML `<main>` element with an id of "mainContent". The "mainContent" id should
+ * be used as the consuming application's skip navigation link. The `TemplateContent`
+ * component also takes a `sidebar` prop with optional "left" or "right" values.
+ * This will set the correct *styling* needed for the `TemplateContentPrimary`
+ * and `TemplateContentSidebar` components. Note that `TemplateContentPrimary`
+ * and `TemplateContentSidebar` must be ordered correctly as children elements
+ * for the appropriate styles to take effect.
  */
 const TemplateContent = (
   props: React.PropsWithChildren<TemplateContentProps>
 ) => {
-  const { sidebar = "none", children } = props;
+  const { children, id = "mainContent", sidebar = "none" } = props;
   const styles = useStyleConfig("TemplateContent", {
     variant: sidebar !== "none" ? "sidebar" : null,
   });
@@ -139,7 +149,7 @@ const TemplateContent = (
   );
 
   return (
-    <Box as="main" __css={styles}>
+    <Box as="main" id={id} __css={styles}>
       {newChildren}
     </Box>
   );
@@ -235,6 +245,7 @@ const TemplateAppContainer = (
   const {
     aboveHeader,
     breakout,
+    contentId = "mainContent",
     contentPrimary,
     contentSidebar,
     contentTop,
@@ -270,7 +281,7 @@ const TemplateAppContainer = (
       )}
       {/* Note that setting `sidebar` as a prop here affects the
        TemplateContentSidebar and TemplateContentPrimary components. */}
-      <TemplateContent sidebar={sidebar}>
+      <TemplateContent id={contentId} sidebar={sidebar}>
         {contentTopElem}
 
         {sidebar === "left" && contentSidebarElem}

--- a/src/components/Template/__snapshots__/Template.test.tsx.snap
+++ b/src/components/Template/__snapshots__/Template.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Template components Renders the UI snapshot correctly 1`] = `
+exports[`Template components renders the UI snapshot correctly 1`] = `
 <div
   className="css-0"
 >
@@ -38,6 +38,7 @@ exports[`Template components Renders the UI snapshot correctly 1`] = `
   </header>
   <main
     className="css-0"
+    id="mainContent"
   >
     <div
       className="css-0"
@@ -84,7 +85,7 @@ exports[`Template components Renders the UI snapshot correctly 1`] = `
 </div>
 `;
 
-exports[`Template components Renders the UI snapshot correctly 2`] = `
+exports[`Template components renders the UI snapshot correctly 2`] = `
 <div
   className="css-0"
 >
@@ -122,6 +123,7 @@ exports[`Template components Renders the UI snapshot correctly 2`] = `
   </header>
   <main
     className="css-0"
+    id="mainContent"
   >
     <div
       className="css-0"

--- a/src/utils/componentCategories.ts
+++ b/src/utils/componentCategories.ts
@@ -1,6 +1,10 @@
 // NYPL Design System Component Categories
 
 const categories = {
+  accessibility: {
+    title: "Accessibility Guide",
+    components: ["Skip Navigation"],
+  },
   basicContent: {
     title: "Components/Basic Elements",
     components: ["Card", "Hero", "Promo", "Sponsor"],


### PR DESCRIPTION
Fixes JIRA ticket [DSD-863](https://jira.nypl.org/browse/DSD-863)

## This PR does the following:

- Adds a `contentId` prop to the `TemplateAppContainer` component and adds an `id` prop to the `TemplateContent` component. The default value of these `id`s are both set to "mainContent" and it will render as an attribute on the `main` HTML element. This is used as the target for the skip navigation link in consuming applications.
- Adds an `Accessibility Guide` section to Storybook with a "Skip Navigation" page: https://pr911-zocq9v2lgrhu7brmfjuiyis9wjhfcey3.tugboat.qa/?path=/story/accessibility-guide-skip-navigation--page
  - PR #907 is open and updates the sidebar. I think adding an "Accessiblity Guide" might be useful but let me know what you think. It should be more general guides for consuming applications and how it fits with DS components.

**Do note that the NYPL Header may render _any_ skip navigation string.** It is currently set to "mainContent" in the DS Test app but there are some instances where it is "main-content". The [Staff Picks](https://www.nypl.org/books-more/recommendations/staff-picks/adults) site, for example, uses "main-content" whereas the [homepage](https://www.nypl.org/) uses "mainContent".

Once, and if, we build the NYPL Header and perhaps a separate "SkipNavigation" DS component, we will have more control over this. This is why I made the id customizable but set the default to `"mainContent"` in the `TemplateAppContainer` and `TemplateContent` components. For the moment, this is an issue in our own DS Test app and, similarly, each app is responsible to configure this correctly.

## How has this been tested?

Locally and through Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Adds information on the skip navigation link and the `main` element's id attribute.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
