### PR TITLE
DSD-854: Updating all console warnings with NYPL branding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates Storybook's sidebar categories and documentation.
 - Updates the `Image`'s caption font size to "12px" (`text.tag`).
+- Updates all the console warnings with consistent NYPL branding prefix label.
 
 ### Fixes
 

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -130,7 +130,7 @@ describe("Breadcrumbs Testing", () => {
 
   it("Throws error when nothing is passed into Breadcrumb", () => {
     expect(() => render(<Breadcrumbs breadcrumbsData={[]} />)).toThrowError(
-      "You must use the `breadcrumbsData` prop to pass a data object to the Breadcrumbs component. That prop is current empty."
+      "NYPL Reservoir Breadcrumbs: No data was passed to the `breadcrumbsData` prop."
     );
   });
 });

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -76,7 +76,7 @@ function Breadcrumbs(props: React.PropsWithChildren<BreadcrumbProps>) {
 
   if (!breadcrumbsData || breadcrumbsData.length === 0) {
     throw new Error(
-      "You must use the `breadcrumbsData` prop to pass a data object to the Breadcrumbs component. That prop is current empty."
+      "NYPL Reservoir Breadcrumbs: No data was passed to the `breadcrumbsData` prop."
     );
   }
 

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -307,7 +307,7 @@ describe("Card", () => {
     const warn = jest.spyOn(console, "warn");
     render(cardImageComponentAndRatio());
     expect(warn).toHaveBeenCalledWith(
-      "Both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
+      "NYPL Reservoir Card: both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
     );
   });
 

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -307,7 +307,9 @@ describe("Card", () => {
     const warn = jest.spyOn(console, "warn");
     render(cardImageComponentAndRatio());
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Card: both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
+      "NYPL Reservoir Card: Both the `imageComponent` and `imageAspectRatio` " +
+        "props were set but `imageAspectRatio` will be ignored in favor of the " +
+        "aspect ratio on `imageComponent` prop."
     );
   });
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -190,7 +190,7 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
 
   if (imageComponent && imageAspectRatio !== ImageRatios.Square) {
     console.warn(
-      "Both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
+      "NYPL Reservoir Card: both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
     );
   }
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -190,7 +190,9 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
 
   if (imageComponent && imageAspectRatio !== ImageRatios.Square) {
     console.warn(
-      "NYPL Reservoir Card: both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
+      "NYPL Reservoir Card: Both the `imageComponent` and `imageAspectRatio` " +
+        "props were set but `imageAspectRatio` will be ignored in favor of the " +
+        "aspect ratio on `imageComponent` prop."
     );
   }
 

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -366,7 +366,7 @@ describe("Checkbox", () => {
       </CheckboxGroup>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Only `Checkbox` components are allowed inside the `CheckboxGroup` component."
+      "NYPL Reservoir CheckboxGroup: only `Checkbox` components are allowed as children."
     );
   });
 });

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -366,7 +366,8 @@ describe("Checkbox", () => {
       </CheckboxGroup>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir CheckboxGroup: only `Checkbox` components are allowed as children."
+      "NYPL Reservoir CheckboxGroup: Only `Checkbox` components are " +
+        "allowed as children."
     );
   });
 });

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -98,7 +98,8 @@ const CheckboxGroup = React.forwardRef<HTMLInputElement, CheckboxGroupProps>(
           noop();
         } else {
           console.warn(
-            "NYPL Reservoir CheckboxGroup: only `Checkbox` components are allowed as children."
+            "NYPL Reservoir CheckboxGroup: Only `Checkbox` components are " +
+              "allowed as children."
           );
         }
       }

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -98,7 +98,7 @@ const CheckboxGroup = React.forwardRef<HTMLInputElement, CheckboxGroupProps>(
           noop();
         } else {
           console.warn(
-            "Only `Checkbox` components are allowed inside the `CheckboxGroup` component."
+            "NYPL Reservoir CheckboxGroup: only `Checkbox` components are allowed as children."
           );
         }
       }

--- a/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -46,7 +46,7 @@ function ComponentWrapper(
   // Note: Typescript warns when there are no children passed and
   // doesn't compile. This is meant to log in non-Typescript apps.
   if (!hasChildren) {
-    console.warn("NYPL Reservoir ComponentWrapper: no children were passed.");
+    console.warn("NYPL Reservoir ComponentWrapper: No children were passed.");
   }
 
   return (

--- a/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -46,7 +46,7 @@ function ComponentWrapper(
   // Note: Typescript warns when there are no children passed and
   // doesn't compile. This is meant to log in non-Typescript apps.
   if (!hasChildren) {
-    console.warn("`ComponentWrapper` has no children.");
+    console.warn("NYPL Reservoir ComponentWrapper: no children were passed.");
   }
 
   return (

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -344,7 +344,8 @@ describe("DatePicker", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir DatePicker: a `ref` or `refTo` prop was passed but not the equivalent `nameFrom` or `nameTo` prop."
+        "NYPL Reservoir DatePicker: A `ref` or `refTo` prop was passed but " +
+          "not the equivalent `nameFrom` or `nameTo` prop."
       );
     });
 
@@ -361,7 +362,9 @@ describe("DatePicker", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir DatePicker: React `ref` props were passed and an `onChange` prop as well. Use whichever is best for your app but not both."
+        "NYPL Reservoir DatePicker: A `ref`, `refTo`, `nameFrom`, or `nameTo` " +
+          "prop was passed and an `onChange` prop as well. Use whichever is best " +
+          "for your app but not both."
       );
     });
 

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -344,7 +344,7 @@ describe("DatePicker", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "A `ref` or `refTo` prop was passed but not the equivalent `nameFrom` or `nameTo` prop."
+        "NYPL Reservoir DatePicker: a `ref` or `refTo` prop was passed but not the equivalent `nameFrom` or `nameTo` prop."
       );
     });
 
@@ -361,7 +361,7 @@ describe("DatePicker", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "React `ref` props were passed and an `onChange` prop as well. Use whichever is best for your app but not both."
+        "NYPL Reservoir DatePicker: React `ref` props were passed and an `onChange` prop as well. Use whichever is best for your app but not both."
       );
     });
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -327,12 +327,12 @@ const DatePicker = React.forwardRef<TextInputRefType, DatePickerProps>(
 
     if ((ref && !nameFrom) || (refTo && !nameTo)) {
       console.warn(
-        "A `ref` or `refTo` prop was passed but not the equivalent `nameFrom` or `nameTo` prop."
+        "NYPL Reservoir DatePicker: a `ref` or `refTo` prop was passed but not the equivalent `nameFrom` or `nameTo` prop."
       );
     }
     if (onChange && (ref || refTo || nameFrom || nameTo)) {
       console.warn(
-        "React `ref` props were passed and an `onChange` prop as well. Use whichever is best for your app but not both."
+        "NYPL Reservoir DatePicker: React `ref` props were passed and an `onChange` prop as well. Use whichever is best for your app but not both."
       );
     }
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -327,12 +327,15 @@ const DatePicker = React.forwardRef<TextInputRefType, DatePickerProps>(
 
     if ((ref && !nameFrom) || (refTo && !nameTo)) {
       console.warn(
-        "NYPL Reservoir DatePicker: a `ref` or `refTo` prop was passed but not the equivalent `nameFrom` or `nameTo` prop."
+        "NYPL Reservoir DatePicker: A `ref` or `refTo` prop was passed but " +
+          "not the equivalent `nameFrom` or `nameTo` prop."
       );
     }
     if (onChange && (ref || refTo || nameFrom || nameTo)) {
       console.warn(
-        "NYPL Reservoir DatePicker: React `ref` props were passed and an `onChange` prop as well. Use whichever is best for your app but not both."
+        "NYPL Reservoir DatePicker: A `ref`, `refTo`, `nameFrom`, or `nameTo` " +
+          "prop was passed and an `onChange` prop as well. Use whichever is best " +
+          "for your app but not both."
       );
     }
 

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -169,7 +169,7 @@ describe("Form", () => {
       </Form>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir FormRow: children must be `FormField` components."
+      "NYPL Reservoir FormRow: Children must be `FormField` components."
     );
   });
 

--- a/src/components/Form/Form.test.tsx
+++ b/src/components/Form/Form.test.tsx
@@ -169,7 +169,7 @@ describe("Form", () => {
       </Form>
     );
     expect(warn).toHaveBeenCalledWith(
-      "FormRow children must be `FormField` components."
+      "NYPL Reservoir FormRow: children must be `FormField` components."
     );
   });
 

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -38,7 +38,7 @@ export function FormRow(props: React.PropsWithChildren<FormChildProps>) {
         return React.cloneElement(child, { id: `${id}-grandchild${i}` });
       }
       console.warn(
-        "NYPL Reservoir FormRow: children must be `FormField` components."
+        "NYPL Reservoir FormRow: Children must be `FormField` components."
       );
       return null;
     }

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -37,7 +37,9 @@ export function FormRow(props: React.PropsWithChildren<FormChildProps>) {
       if (child.type === FormField || child.props.mdxType === "FormField") {
         return React.cloneElement(child, { id: `${id}-grandchild${i}` });
       }
-      console.warn("FormRow children must be `FormField` components.");
+      console.warn(
+        "NYPL Reservoir FormRow: children must be `FormField` components."
+      );
       return null;
     }
   );

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -93,7 +93,7 @@ describe("Heading", () => {
 
   it("throws error when neither child nor text is passed", () => {
     expect(() => render(<Heading id="h1" level={HeadingLevels.One} />)).toThrow(
-      "Heading has no children, please pass prop: text"
+      "NYPL Reservoir Heading: No children or value was passed to the `text` prop."
     );
   });
 
@@ -105,7 +105,9 @@ describe("Heading", () => {
           <span>many</span>
         </Heading>
       )
-    ).toThrow("Please only pass one child into Heading, got span, span");
+    ).toThrow(
+      "NYPL Reservoir Heading: Only pass one child into Heading; got multiple children."
+    );
   });
 
   it("uses custom display size", () => {

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -105,9 +105,7 @@ describe("Heading", () => {
           <span>many</span>
         </Heading>
       )
-    ).toThrow(
-      "NYPL Reservoir Heading: Only pass one child into Heading; got multiple children."
-    );
+    ).toThrow("NYPL Reservoir Heading: Only pass one child into Heading.");
   });
 
   it("uses custom display size", () => {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -72,7 +72,7 @@ function Heading(props: React.PropsWithChildren<HeadingProps>) {
   if (React.Children.count(props.children) > 1) {
     // Catching the error because React's error isn't as helpful.
     throw new Error(
-      "NYPL Reservoir Heading: Only pass one child into Heading; got multiple children."
+      "NYPL Reservoir Heading: Only pass one child into Heading."
     );
   }
 

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -64,17 +64,15 @@ function Heading(props: React.PropsWithChildren<HeadingProps>) {
   const asHeading: any = `h${finalLevel}`;
 
   if (!props.children && !text) {
-    throw new Error("Heading has no children, please pass prop: text");
+    throw new Error(
+      "NYPL Reservoir Heading: No children or value was passed to the `text` prop."
+    );
   }
 
   if (React.Children.count(props.children) > 1) {
-    const children = React.Children.map(
-      props.children,
-      (child) => (child as JSX.Element).type
-    );
     // Catching the error because React's error isn't as helpful.
     throw new Error(
-      `Please only pass one child into Heading, got ${children.join(", ")}`
+      "NYPL Reservoir Heading: Only pass one child into Heading; got multiple children."
     );
   }
 

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -298,7 +298,7 @@ describe("Hero", () => {
       <Hero heroType={HeroTypes.Primary} heading={heading} />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: it is recommended to use the "backgroundImageSrc" prop for PRIMARY hero.`
+      `NYPL Reservoir Hero: it is recommended to use the "backgroundImageSrc" prop for PRIMARY hero.`
     );
 
     rerender(
@@ -310,7 +310,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: the "image" prop has been passed, but PRIMARY hero will not use it.`
+      `NYPL Reservoir Hero: the "image" prop has been passed, but PRIMARY hero will not use it.`
     );
   });
 
@@ -333,7 +333,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: Please provide "locationDetails" only to PRIMARY hero.`
+      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
     );
 
     rerender(
@@ -346,7 +346,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: the "backgroundImageSrc" prop has been passed, but SECONDARY hero will not use it.`
+      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but SECONDARY hero will not use it.`
     );
 
     rerender(
@@ -360,7 +360,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: the "foregroundColor" and/or "backgroundColor" props have been passed, but SECONDARY Hero will not use them.`
+      `NYPL Reservoir Hero: "foregroundColor" and/or "backgroundColor" props have been passed, but SECONDARY Hero will not use them.`
     );
   });
 
@@ -382,7 +382,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: Please provide "locationDetails" only to PRIMARY hero.`
+      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
     );
 
     rerender(
@@ -394,7 +394,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: TERTIARY hero will not use any of the image props.`
+      `NYPL Reservoir Hero: TERTIARY hero will not use any of the image props.`
     );
 
     rerender(
@@ -406,7 +406,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: TERTIARY hero will not use any of the image props.`
+      `NYPL Reservoir Hero: TERTIARY hero will not use any of the image props.`
     );
   });
 
@@ -430,7 +430,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: Please provide "locationDetails" only to PRIMARY hero.`
+      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
     );
 
     rerender(
@@ -443,7 +443,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
+      `NYPL Reservoir Hero: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
     );
 
     rerender(
@@ -456,7 +456,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
+      `NYPL Reservoir Hero: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
     );
   });
 
@@ -471,7 +471,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: Please provide "locationDetails" only to PRIMARY hero.`
+      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
     );
 
     rerender(
@@ -483,7 +483,7 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `Warning: the "backgroundImageSrc" prop has been passed, but FIFTYFIFTY hero will not use it.`
+      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but FIFTYFIFTY hero will not use it.`
     );
   });
 

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -18,7 +18,9 @@ export const subHeaderText = (
   </>
 );
 export const otherSubHeaderText =
-  "With 92 locations across the Bronx, Manhattan, and Staten Island, The New York Public Library is an essential part of neighborhoods across the city. Visit us today.";
+  "With 92 locations across the Bronx, Manhattan, and Staten Island, The New " +
+  "York Public Library is an essential part of neighborhoods across the city. " +
+  "Visit us today.";
 export const image = (
   <Image src="https://placeimg.com/800/400/animals" alt="Image example" />
 );
@@ -298,7 +300,8 @@ describe("Hero", () => {
       <Hero heroType={HeroTypes.Primary} heading={heading} />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: it is recommended to use the "backgroundImageSrc" prop for PRIMARY hero.`
+      "NYPL Reservoir Hero: It is recommended to use the `backgroundImageSrc` " +
+        "prop for the `HeroTypes.Primary` `heroType` variant."
     );
 
     rerender(
@@ -310,7 +313,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: the "image" prop has been passed, but PRIMARY hero will not use it.`
+      "NYPL Reservoir Hero: The `image` prop has been passed, but the " +
+        "`HeroTypes.Primary` `heroType` variant will not use it."
     );
   });
 
@@ -333,7 +337,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
+      "NYPL Reservoir Hero: The `locationDetails` prop should only be used " +
+        "with the `HeroTypes.Primary` `heroType` variant."
     );
 
     rerender(
@@ -346,7 +351,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but SECONDARY hero will not use it.`
+      "NYPL Reservoir Hero: The `backgroundImageSrc` prop has been passed, " +
+        "but the `HeroTypes.Secondary` `heroType` variant will not use it."
     );
 
     rerender(
@@ -360,7 +366,9 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: "foregroundColor" and/or "backgroundColor" props have been passed, but SECONDARY Hero will not use them.`
+      "NYPL Reservoir Hero: The `foregroundColor` and/or `backgroundColor` " +
+        "props have been passed, but the `HeroTypes.Secondary` `heroType` " +
+        "variant will not use them."
     );
   });
 
@@ -382,7 +390,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
+      "NYPL Reservoir Hero: The `locationDetails` prop should only be used " +
+        "with the `HeroTypes.Primary` `heroType` variant."
     );
 
     rerender(
@@ -394,7 +403,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: TERTIARY hero will not use any of the image props.`
+      "NYPL Reservoir Hero: The `HeroTypes.Tertiary` `heroType` variant hero " +
+        "will not use any of the image props."
     );
 
     rerender(
@@ -406,7 +416,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: TERTIARY hero will not use any of the image props.`
+      "NYPL Reservoir Hero: The `HeroTypes.Tertiary` `heroType` variant hero " +
+        "will not use any of the image props."
     );
   });
 
@@ -430,7 +441,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
+      "NYPL Reservoir Hero: The `locationDetails` prop should only be used " +
+        "with the `HeroTypes.Primary` `heroType` variant."
     );
 
     rerender(
@@ -443,7 +455,9 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
+      "NYPL Reservoir Hero: It is recommended to use both the " +
+        "`backgroundImageSrc` and `image` props for the `HeroTypes.Campaign` " +
+        "`heroType` variant."
     );
 
     rerender(
@@ -456,7 +470,9 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
+      "NYPL Reservoir Hero: It is recommended to use both the " +
+        "`backgroundImageSrc` and `image` props for the `HeroTypes.Campaign` " +
+        "`heroType` variant."
     );
   });
 
@@ -471,7 +487,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
+      "NYPL Reservoir Hero: The `locationDetails` prop should only be used " +
+        "with the `HeroTypes.Primary` `heroType` variant."
     );
 
     rerender(
@@ -483,7 +500,8 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but FIFTYFIFTY hero will not use it.`
+      "NYPL Reservoir Hero: The `backgroundImageSrc` prop has been passed, " +
+        "but the `HeroTypes.FiftyFifty` `heroType` variant hero will not use it."
     );
   });
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -68,35 +68,37 @@ export default function Hero(props: React.PropsWithChildren<HeroProps>) {
   if (heroType === HeroTypes.Primary) {
     if (!backgroundImageSrc) {
       console.warn(
-        `Warning: it is recommended to use the "backgroundImageSrc" prop for PRIMARY hero.`
+        `NYPL Reservoir Hero: it is recommended to use the "backgroundImageSrc" prop for PRIMARY hero.`
       );
     }
     if (image) {
       console.warn(
-        `Warning: the "image" prop has been passed, but PRIMARY hero will not use it.`
+        `NYPL Reservoir Hero: the "image" prop has been passed, but PRIMARY hero will not use it.`
       );
     }
   } else if (locationDetails) {
     console.warn(
-      `Warning: Please provide "locationDetails" only to PRIMARY hero.`
+      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
     );
   }
   if (HeroSecondaryTypes.includes(heroType) && backgroundImageSrc) {
     console.warn(
-      `Warning: the "backgroundImageSrc" prop has been passed, but SECONDARY hero will not use it.`
+      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but SECONDARY hero will not use it.`
     );
   }
   if (heroType === HeroTypes.Tertiary && (backgroundImageSrc || image)) {
-    console.warn(`Warning: TERTIARY hero will not use any of the image props.`);
+    console.warn(
+      `NYPL Reservoir Hero: TERTIARY hero will not use any of the image props.`
+    );
   }
   if (heroType === HeroTypes.Campaign && (!backgroundImageSrc || !image)) {
     console.warn(
-      `Warning: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
+      `NYPL Reservoir Hero: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
     );
   }
   if (heroType === HeroTypes.FiftyFifty && backgroundImageSrc) {
     console.warn(
-      `Warning: the "backgroundImageSrc" prop has been passed, but FIFTYFIFTY hero will not use it.`
+      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but FIFTYFIFTY hero will not use it.`
     );
   }
 
@@ -122,7 +124,7 @@ export default function Hero(props: React.PropsWithChildren<HeroProps>) {
     };
   } else if (foregroundColor || backgroundColor) {
     console.warn(
-      `Warning: the "foregroundColor" and/or "backgroundColor" props have been passed, but SECONDARY Hero will not use them.`
+      `NYPL Reservoir Hero: "foregroundColor" and/or "backgroundColor" props have been passed, but SECONDARY Hero will not use them.`
     );
   }
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -68,37 +68,45 @@ export default function Hero(props: React.PropsWithChildren<HeroProps>) {
   if (heroType === HeroTypes.Primary) {
     if (!backgroundImageSrc) {
       console.warn(
-        `NYPL Reservoir Hero: it is recommended to use the "backgroundImageSrc" prop for PRIMARY hero.`
+        "NYPL Reservoir Hero: It is recommended to use the `backgroundImageSrc` " +
+          "prop for the `HeroTypes.Primary` `heroType` variant."
       );
     }
     if (image) {
       console.warn(
-        `NYPL Reservoir Hero: the "image" prop has been passed, but PRIMARY hero will not use it.`
+        "NYPL Reservoir Hero: The `image` prop has been passed, but the " +
+          "`HeroTypes.Primary` `heroType` variant will not use it."
       );
     }
   } else if (locationDetails) {
     console.warn(
-      `NYPL Reservoir Hero: Please provide "locationDetails" only to PRIMARY hero.`
+      "NYPL Reservoir Hero: The `locationDetails` prop should only be used " +
+        "with the `HeroTypes.Primary` `heroType` variant."
     );
   }
   if (HeroSecondaryTypes.includes(heroType) && backgroundImageSrc) {
     console.warn(
-      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but SECONDARY hero will not use it.`
+      "NYPL Reservoir Hero: The `backgroundImageSrc` prop has been passed, " +
+        "but the `HeroTypes.Secondary` `heroType` variant will not use it."
     );
   }
   if (heroType === HeroTypes.Tertiary && (backgroundImageSrc || image)) {
     console.warn(
-      `NYPL Reservoir Hero: TERTIARY hero will not use any of the image props.`
+      "NYPL Reservoir Hero: The `HeroTypes.Tertiary` `heroType` variant hero " +
+        "will not use any of the image props."
     );
   }
   if (heroType === HeroTypes.Campaign && (!backgroundImageSrc || !image)) {
     console.warn(
-      `NYPL Reservoir Hero: it is recommended to use both "backgroundImageSrc" and "image" props for CAMPAIGN hero.`
+      "NYPL Reservoir Hero: It is recommended to use both the " +
+        "`backgroundImageSrc` and `image` props for the `HeroTypes.Campaign` " +
+        "`heroType` variant."
     );
   }
   if (heroType === HeroTypes.FiftyFifty && backgroundImageSrc) {
     console.warn(
-      `NYPL Reservoir Hero: the "backgroundImageSrc" prop has been passed, but FIFTYFIFTY hero will not use it.`
+      "NYPL Reservoir Hero: The `backgroundImageSrc` prop has been passed, " +
+        "but the `HeroTypes.FiftyFifty` `heroType` variant hero will not use it."
     );
   }
 
@@ -124,7 +132,9 @@ export default function Hero(props: React.PropsWithChildren<HeroProps>) {
     };
   } else if (foregroundColor || backgroundColor) {
     console.warn(
-      `NYPL Reservoir Hero: "foregroundColor" and/or "backgroundColor" props have been passed, but SECONDARY Hero will not use them.`
+      "NYPL Reservoir Hero: The `foregroundColor` and/or `backgroundColor` " +
+        "props have been passed, but the `HeroTypes.Secondary` `heroType` " +
+        "variant will not use them."
     );
   }
 

--- a/src/components/HorizontalRule/HorizontalRule.test.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.test.tsx
@@ -30,14 +30,16 @@ describe("HorizontalRule", () => {
       <HorizontalRule className="custom-hr" height="20px" />
     );
     expect(warn).not.toHaveBeenCalledWith(
-      "NYPL Reservoir HorizontalRule: For the `height` prop, use a whole number, a `px` " +
-        "value, a `em` value, or a `rem` value. Using the default of 2px."
+      "NYPL Reservoir HorizontalRule: An invalid value was passed for the " +
+        "`height` prop, so the default value of 2px will be used.  A valid " +
+        "value should be a whole number, a `px` value, a `em` value, or a `rem` value."
     );
 
     rerender(<HorizontalRule className="custom-hr" height="20%" />);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir HorizontalRule: For the `height` prop, use a whole number, a `px` " +
-        "value, a `em` value, or a `rem` value. Using the default of 2px."
+      "NYPL Reservoir HorizontalRule: An invalid value was passed for the " +
+        "`height` prop, so the default value of 2px will be used.  A valid " +
+        "value should be a whole number, a `px` value, a `em` value, or a `rem` value."
     );
   });
 

--- a/src/components/HorizontalRule/HorizontalRule.test.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.test.tsx
@@ -30,13 +30,13 @@ describe("HorizontalRule", () => {
       <HorizontalRule className="custom-hr" height="20px" />
     );
     expect(warn).not.toHaveBeenCalledWith(
-      "`HorizontalRule`: For the `height` prop, use a whole number, a `px` " +
+      "NYPL Reservoir HorizontalRule: For the `height` prop, use a whole number, a `px` " +
         "value, a `em` value, or a `rem` value. Using the default of 2px."
     );
 
     rerender(<HorizontalRule className="custom-hr" height="20%" />);
     expect(warn).toHaveBeenCalledWith(
-      "`HorizontalRule`: For the `height` prop, use a whole number, a `px` " +
+      "NYPL Reservoir HorizontalRule: For the `height` prop, use a whole number, a `px` " +
         "value, a `em` value, or a `rem` value. Using the default of 2px."
     );
   });

--- a/src/components/HorizontalRule/HorizontalRule.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.tsx
@@ -27,7 +27,7 @@ export default function HorizontalRule(props: HorizontalRuleProps) {
 
   if (height.endsWith("%")) {
     console.warn(
-      "`HorizontalRule`: For the `height` prop, use a whole number, a `px`" +
+      "NYPL Reservoir HorizontalRule: For the `height` prop, use a whole number, a `px`" +
         " value, a `em` value, or a `rem` value. Using the default of 2px."
     );
     finalHeight = "2px";

--- a/src/components/HorizontalRule/HorizontalRule.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.tsx
@@ -27,8 +27,9 @@ export default function HorizontalRule(props: HorizontalRuleProps) {
 
   if (height.endsWith("%")) {
     console.warn(
-      "NYPL Reservoir HorizontalRule: For the `height` prop, use a whole number, a `px`" +
-        " value, a `em` value, or a `rem` value. Using the default of 2px."
+      "NYPL Reservoir HorizontalRule: An invalid value was passed for the " +
+        "`height` prop, so the default value of 2px will be used.  A valid " +
+        "value should be a whole number, a `px` value, a `em` value, or a `rem` value."
     );
     finalHeight = "2px";
   }

--- a/src/components/Icons/Icon.test.tsx
+++ b/src/components/Icons/Icon.test.tsx
@@ -27,7 +27,7 @@ describe("Icon", () => {
       </Icon>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Icon accepts either a `name` prop or an `svg` element child, not both."
+      "NYPL Reservoir Icon: pass in either a `name` prop or an `svg` element child, not both."
     );
   });
 
@@ -35,7 +35,15 @@ describe("Icon", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Icon />);
     expect(warn).toHaveBeenCalledWith(
-      "Icon: Pass an icon `name` prop or an SVG child to ensure an icon appears."
+      "NYPL Reservoir Icon: pass an icon `name` prop or an SVG child to ensure an icon appears."
+    );
+  });
+
+  it("consoles a warning if name is not passed and a child is but it's not an SVG element", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(<Icon>Not an SVG</Icon>);
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Icon: an `svg` element must be passed to the `Icon` component."
     );
   });
 

--- a/src/components/Icons/Icon.test.tsx
+++ b/src/components/Icons/Icon.test.tsx
@@ -27,7 +27,8 @@ describe("Icon", () => {
       </Icon>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Icon: pass in either a `name` prop or an `svg` element child, not both."
+      "NYPL Reservoir Icon: Pass in either a `name` prop or an `svg` element " +
+        "child. Do not pass both."
     );
   });
 
@@ -35,7 +36,8 @@ describe("Icon", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Icon />);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Icon: pass an icon `name` prop or an SVG child to ensure an icon appears."
+      "NYPL Reservoir Icon: Pass an icon `name` prop or an SVG child to " +
+        "ensure an icon appears."
     );
   });
 
@@ -43,7 +45,8 @@ describe("Icon", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Icon>Not an SVG</Icon>);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Icon: an `svg` element must be passed to the `Icon` component."
+      "NYPL Reservoir Icon: An `svg` element must be passed to the `Icon` " +
+        "component as its child."
     );
   });
 

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -77,12 +77,12 @@ export default function Icon(props: React.PropsWithChildren<IconProps>) {
   // Component prop validation
   if (name && children) {
     console.warn(
-      "Icon accepts either a `name` prop or an `svg` element child, not both."
+      "NYPL Reservoir Icon: pass in either a `name` prop or an `svg` element child, not both."
     );
     return null;
   } else if (!name && !children) {
     console.warn(
-      "Icon: Pass an icon `name` prop or an SVG child to ensure an icon appears."
+      "NYPL Reservoir Icon: pass an icon `name` prop or an SVG child to ensure an icon appears."
     );
     return null;
   }
@@ -105,14 +105,16 @@ export default function Icon(props: React.PropsWithChildren<IconProps>) {
   // Apply icon props to the SVG child.
   if (
     (children as JSX.Element).type === "svg" ||
-    (children as JSX.Element).props.type === "svg" ||
-    (children as JSX.Element).props.mdxType === "svg"
+    (children as JSX.Element).props?.type === "svg" ||
+    (children as JSX.Element).props?.mdxType === "svg"
   ) {
     childSVG = React.cloneElement(children as JSX.Element, {
       ...iconProps,
     });
   } else {
-    console.warn("You must pass an `svg` element to the `Icon` component.");
+    console.warn(
+      "NYPL Reservoir Icon: an `svg` element must be passed to the `Icon` component."
+    );
   }
 
   return <Box __css={styles}>{childSVG}</Box>;

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -77,12 +77,14 @@ export default function Icon(props: React.PropsWithChildren<IconProps>) {
   // Component prop validation
   if (name && children) {
     console.warn(
-      "NYPL Reservoir Icon: pass in either a `name` prop or an `svg` element child, not both."
+      "NYPL Reservoir Icon: Pass in either a `name` prop or an `svg` element " +
+        "child. Do not pass both."
     );
     return null;
   } else if (!name && !children) {
     console.warn(
-      "NYPL Reservoir Icon: pass an icon `name` prop or an SVG child to ensure an icon appears."
+      "NYPL Reservoir Icon: Pass an icon `name` prop or an SVG child to " +
+        "ensure an icon appears."
     );
     return null;
   }
@@ -113,7 +115,8 @@ export default function Icon(props: React.PropsWithChildren<IconProps>) {
     });
   } else {
     console.warn(
-      "NYPL Reservoir Icon: an `svg` element must be passed to the `Icon` component."
+      "NYPL Reservoir Icon: An `svg` element must be passed to the `Icon` " +
+        "component as its child."
     );
   }
 

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -66,7 +66,9 @@ describe("Image", () => {
   it("throws error when alt text is too long", () => {
     expect(() =>
       render(<Image src="test.png" alt={tooManyChars} />)
-    ).toThrowError("Alt Text must be less than 300 characters");
+    ).toThrowError(
+      "NYPL Reservoir Image: Alt text must be less than 300 characters."
+    );
   });
 
   it("Renders the UI snapshot correctly", () => {

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -81,7 +81,9 @@ export default function Image(props: ImageProps) {
   });
 
   if (alt && alt.length > 300) {
-    throw new Error("Alt Text must be less than 300 characters");
+    throw new Error(
+      "NYPL Reservoir Image: Alt text must be less than 300 characters."
+    );
   }
 
   const imageComponent: JSX.Element = component ? (

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -138,7 +138,7 @@ describe("List", () => {
       </List>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Pass in either `<li>`, `<dt>`, or `<dd>` children or use the `listItems` data prop, but don't use both."
+      "NYPL Reservoir List: pass in either `<li>`, `<dt>`, or `<dd>` children or use the `listItems` data prop, but don't use both."
     );
   });
 
@@ -146,7 +146,7 @@ describe("List", () => {
     const warn = jest.spyOn(console, "warn");
     render(<List type={ListTypes.Ordered}></List>);
     expect(warn).toHaveBeenCalledWith(
-      "Either `<li>` children or the `listItems` prop must be used."
+      "NYPL Reservoir List: either `<li>` children or the `listItems` prop must be used."
     );
   });
 
@@ -160,7 +160,7 @@ describe("List", () => {
       </List>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Direct children of `List` (ol) should be `<li>`s."
+      "NYPL Reservoir List: direct children of `List` (ol) should be `<li>`s."
     );
   });
 
@@ -174,7 +174,7 @@ describe("List", () => {
       </List>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Direct children of `List` (definition) should be `<dt>`s and `<dd>`s."
+      "NYPL Reservoir List: direct children of `List` (definition) should be `<dt>`s and `<dd>`s."
     );
   });
 

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -138,7 +138,8 @@ describe("List", () => {
       </List>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir List: pass in either `<li>`, `<dt>`, or `<dd>` children or use the `listItems` data prop, but don't use both."
+      "NYPL Reservoir List: Pass in either `<li>`, `<dt>`, or `<dd>` children " +
+        "or use the `listItems` data prop. Do not use both."
     );
   });
 
@@ -146,7 +147,8 @@ describe("List", () => {
     const warn = jest.spyOn(console, "warn");
     render(<List type={ListTypes.Ordered}></List>);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir List: either `<li>` children or the `listItems` prop must be used."
+      "NYPL Reservoir List: Pass in either `<li>` children or pass data in " +
+        "the `listItems` prop, not both."
     );
   });
 
@@ -160,7 +162,7 @@ describe("List", () => {
       </List>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir List: direct children of `List` (ol) should be `<li>`s."
+      "NYPL Reservoir List: Direct children of `List` (ol) must be `<li>`s."
     );
   });
 
@@ -174,7 +176,8 @@ describe("List", () => {
       </List>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir List: direct children of `List` (definition) should be `<dt>`s and `<dd>`s."
+      "NYPL Reservoir List: Direct children of `List` (definition) must be " +
+        "`<dt>`s and `<dd>`s."
     );
   });
 

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -60,13 +60,13 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
   // prop must be used.
   if (children && (listItems || listItems?.length > 0)) {
     console.warn(
-      "Pass in either `<li>`, `<dt>`, or `<dd>` children or use the `listItems` data prop, but don't use both."
+      "NYPL Reservoir List: pass in either `<li>`, `<dt>`, or `<dd>` children or use the `listItems` data prop, but don't use both."
     );
     return null;
   }
   if (!children && !listItems) {
     console.warn(
-      "Either `<li>` children or the `listItems` prop must be used."
+      "NYPL Reservoir List: either `<li>` children or the `listItems` prop must be used."
     );
     return null;
   }
@@ -100,7 +100,7 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
     React.Children.map(children, (child: React.ReactElement) => {
       if (child && child?.type !== "li" && child?.props?.mdxType !== "li") {
         console.warn(
-          `Direct children of \`List\` (${listType}) should be \`<li>\`s.`
+          `NYPL Reservoir List: direct children of \`List\` (${listType}) should be \`<li>\`s.`
         );
       }
     });
@@ -120,7 +120,7 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
         child.props.mdxType !== React.Fragment
       ) {
         console.warn(
-          "Direct children of `List` (definition) should be `<dt>`s and `<dd>`s."
+          "NYPL Reservoir List: direct children of `List` (definition) should be `<dt>`s and `<dd>`s."
         );
       }
     });

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -60,13 +60,15 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
   // prop must be used.
   if (children && (listItems || listItems?.length > 0)) {
     console.warn(
-      "NYPL Reservoir List: pass in either `<li>`, `<dt>`, or `<dd>` children or use the `listItems` data prop, but don't use both."
+      "NYPL Reservoir List: Pass in either `<li>`, `<dt>`, or `<dd>` " +
+        "children or use the `listItems` data prop. Do not use both."
     );
     return null;
   }
   if (!children && !listItems) {
     console.warn(
-      "NYPL Reservoir List: either `<li>` children or the `listItems` prop must be used."
+      "NYPL Reservoir List: Pass in either `<li>` children or pass data in " +
+        "the `listItems` prop, not both."
     );
     return null;
   }
@@ -100,7 +102,7 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
     React.Children.map(children, (child: React.ReactElement) => {
       if (child && child?.type !== "li" && child?.props?.mdxType !== "li") {
         console.warn(
-          `NYPL Reservoir List: direct children of \`List\` (${listType}) should be \`<li>\`s.`
+          `NYPL Reservoir List: Direct children of \`List\` (${listType}) must be \`<li>\`s.`
         );
       }
     });
@@ -120,7 +122,8 @@ export default function List(props: React.PropsWithChildren<ListProps>) {
         child.props.mdxType !== React.Fragment
       ) {
         console.warn(
-          "NYPL Reservoir List: direct children of `List` (definition) should be `<dt>`s and `<dd>`s."
+          "NYPL Reservoir List: Direct children of `List` (definition) must " +
+            "be `<dt>`s and `<dd>`s."
         );
       }
     });

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -28,7 +28,7 @@ describe("Logo", () => {
       </Logo>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Logo: accepts either a `name` prop or an `svg` element child. It can not accept both."
+      "NYPL Reservoir Logo: Pass either a `name` prop or an `svg` element child. Do not pass both."
     );
   });
 
@@ -36,7 +36,8 @@ describe("Logo", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Logo />);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Logo: pass a logo `name` prop or an SVG child to `Logo` to ensure a logo appears."
+      "NYPL Reservoir Logo: Pass a logo `name` prop or an SVG child to " +
+        "`Logo` to ensure a logo appears."
     );
   });
 
@@ -44,7 +45,8 @@ describe("Logo", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Logo>Not an SVG</Logo>);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Logo: an `svg` element must be passed to the `Logo` component."
+      "NYPL Reservoir Logo: An `svg` element must be passed to the `Logo` " +
+        "component as its child."
     );
   });
 

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -28,7 +28,7 @@ describe("Logo", () => {
       </Logo>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Logo accepts either a `name` prop or an `svg` element child. It can not accept both."
+      "NYPL Reservoir Logo: accepts either a `name` prop or an `svg` element child. It can not accept both."
     );
   });
 
@@ -36,7 +36,15 @@ describe("Logo", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Logo />);
     expect(warn).toHaveBeenCalledWith(
-      "Pass a logo `name` prop or an SVG child to `Logo` to ensure a logo appears."
+      "NYPL Reservoir Logo: pass a logo `name` prop or an SVG child to `Logo` to ensure a logo appears."
+    );
+  });
+
+  it("consoles a warning if name is not passed and a child is but it's not an SVG element", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(<Logo>Not an SVG</Logo>);
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Logo: an `svg` element must be passed to the `Logo` component."
     );
   });
 

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -55,12 +55,14 @@ export default function Logo(props: React.PropsWithChildren<LogoProps>) {
   // Component prop validation
   if (name && children) {
     console.warn(
-      "NYPL Reservoir Logo: accepts either a `name` prop or an `svg` element child. It can not accept both."
+      "NYPL Reservoir Logo: Pass either a `name` prop or an `svg` element " +
+        "child. Do not pass both."
     );
     return null;
   } else if (!name && !children) {
     console.warn(
-      "NYPL Reservoir Logo: pass a logo `name` prop or an SVG child to `Logo` to ensure a logo appears."
+      "NYPL Reservoir Logo: Pass a logo `name` prop or an SVG child to " +
+        "`Logo` to ensure a logo appears."
     );
     return null;
   }
@@ -91,7 +93,8 @@ export default function Logo(props: React.PropsWithChildren<LogoProps>) {
     });
   } else {
     console.warn(
-      "NYPL Reservoir Logo: an `svg` element must be passed to the `Logo` component."
+      "NYPL Reservoir Logo: An `svg` element must be passed to the `Logo` " +
+        "component as its child."
     );
   }
 

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -55,12 +55,12 @@ export default function Logo(props: React.PropsWithChildren<LogoProps>) {
   // Component prop validation
   if (name && children) {
     console.warn(
-      "Logo accepts either a `name` prop or an `svg` element child. It can not accept both."
+      "NYPL Reservoir Logo: accepts either a `name` prop or an `svg` element child. It can not accept both."
     );
     return null;
   } else if (!name && !children) {
     console.warn(
-      "Pass a logo `name` prop or an SVG child to `Logo` to ensure a logo appears."
+      "NYPL Reservoir Logo: pass a logo `name` prop or an SVG child to `Logo` to ensure a logo appears."
     );
     return null;
   }
@@ -83,14 +83,16 @@ export default function Logo(props: React.PropsWithChildren<LogoProps>) {
   // Apply logo props to the SVG child.
   if (
     (children as JSX.Element).type === "svg" ||
-    (children as JSX.Element).props.type === "svg" ||
-    (children as JSX.Element).props.mdxType === "svg"
+    (children as JSX.Element).props?.type === "svg" ||
+    (children as JSX.Element).props?.mdxType === "svg"
   ) {
     childSVG = React.cloneElement(children as JSX.Element, {
       ...logoProps,
     });
   } else {
-    console.warn("You must pass an `svg` element to the `Logo` component.");
+    console.warn(
+      "NYPL Reservoir Logo: an `svg` element must be passed to the `Logo` component."
+    );
   }
 
   return <Box __css={styles}>{childSVG}</Box>;

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -374,7 +374,8 @@ describe("Pagination", () => {
       );
       expect(warn).toHaveBeenCalledWith(
         "NYPL Reservoir Pagination: Props for both `getPageHref` and " +
-          "`onPageChange` are passed. Will default to using `getPageHref`."
+          "`onPageChange` are passed. The component will default to using " +
+          "`getPageHref`."
       );
     });
 

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -373,7 +373,8 @@ describe("Pagination", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir Pagination: Props for both `getPageHref` and `onPageChange` are passed. Will default to using `getPageHref`."
+        "NYPL Reservoir Pagination: Props for both `getPageHref` and " +
+          "`onPageChange` are passed. Will default to using `getPageHref`."
       );
     });
 
@@ -384,7 +385,8 @@ describe("Pagination", () => {
         <Pagination pageCount={10} currentPage={2} getPageHref={getPageHref} />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir Pagination: The `currentPage` prop does not work with the `getPageHref` prop. Use `currentPage` with `onPageChange` instead."
+        "NYPL Reservoir Pagination: The `currentPage` prop does not work with " +
+          "the `getPageHref` prop. Use `currentPage` with `onPageChange` instead."
       );
     });
   });

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -64,13 +64,15 @@ const Pagination: React.FC<PaginationProps> = (props: PaginationProps) => {
   }
   if (getPageHref && onPageChange) {
     console.warn(
-      "NYPL Reservoir Pagination: Props for both `getPageHref` and `onPageChange` are passed. Will default to using `getPageHref`."
+      "NYPL Reservoir Pagination: Props for both `getPageHref` and " +
+        "`onPageChange` are passed. Will default to using `getPageHref`."
     );
   }
 
   if (getPageHref && currentPage) {
     console.warn(
-      "NYPL Reservoir Pagination: The `currentPage` prop does not work with the `getPageHref` prop. Use `currentPage` with `onPageChange` instead."
+      "NYPL Reservoir Pagination: The `currentPage` prop does not work with " +
+        "the `getPageHref` prop. Use `currentPage` with `onPageChange` instead."
     );
   }
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -65,7 +65,8 @@ const Pagination: React.FC<PaginationProps> = (props: PaginationProps) => {
   if (getPageHref && onPageChange) {
     console.warn(
       "NYPL Reservoir Pagination: Props for both `getPageHref` and " +
-        "`onPageChange` are passed. Will default to using `getPageHref`."
+        "`onPageChange` are passed. The component will default to using " +
+        "`getPageHref`."
     );
   }
 

--- a/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -120,7 +120,7 @@ describe("ProgressIndicator", () => {
     render(<ProgressIndicator labelText="Linear" value={-20} />);
 
     expect(warn).toHaveBeenCalledWith(
-      "ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
+      "NYPL Reservoir ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
     );
   });
 
@@ -129,7 +129,7 @@ describe("ProgressIndicator", () => {
     render(<ProgressIndicator labelText="Linear" value={150} />);
 
     expect(warn).toHaveBeenCalledWith(
-      "ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
+      "NYPL Reservoir ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
     );
   });
 

--- a/src/components/ProgressIndicator/ProgressIndicator.test.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.test.tsx
@@ -120,7 +120,9 @@ describe("ProgressIndicator", () => {
     render(<ProgressIndicator labelText="Linear" value={-20} />);
 
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
+      "NYPL Reservoir ProgressIndicator: An invalid value was passed for the" +
+        " `value` prop, so 0 will be used. A valid value should be a number" +
+        " between 0 and 100."
     );
   });
 
@@ -129,7 +131,9 @@ describe("ProgressIndicator", () => {
     render(<ProgressIndicator labelText="Linear" value={150} />);
 
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
+      "NYPL Reservoir ProgressIndicator: An invalid value was passed for the" +
+        " `value` prop, so 0 will be used. A valid value should be a number" +
+        " between 0 and 100."
     );
   });
 

--- a/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -60,7 +60,7 @@ const ProgressIndicator: React.FC<ProgressIndicatorProps> = (
   let finalValue = value;
   if (finalValue < 0 || finalValue > 100) {
     console.warn(
-      "ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
+      "NYPL Reservoir ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
     );
     finalValue = 0;
   }

--- a/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -60,7 +60,9 @@ const ProgressIndicator: React.FC<ProgressIndicatorProps> = (
   let finalValue = value;
   if (finalValue < 0 || finalValue > 100) {
     console.warn(
-      "NYPL Reservoir ProgressIndicator: pass in a `value` between 0 and 100. Defaulting to 0."
+      "NYPL Reservoir ProgressIndicator: An invalid value was passed for the" +
+        " `value` prop, so 0 will be used. A valid value should be a number" +
+        " between 0 and 100."
     );
     finalValue = 0;
   }

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -346,7 +346,7 @@ describe("Radio Button", () => {
       </RadioGroup>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Only `Radio` components are allowed inside the `RadioGroup` component."
+      "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside the `RadioGroup` component."
     );
   });
 });

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -346,7 +346,8 @@ describe("Radio Button", () => {
       </RadioGroup>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside the `RadioGroup` component."
+      "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside " +
+        "the `RadioGroup` component."
     );
   });
 });

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -100,7 +100,8 @@ const RadioGroup = React.forwardRef<
         noop();
       } else {
         console.warn(
-          "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside the `RadioGroup` component."
+          "NYPL Reservoir RadioGroup: Only `Radio` components are allowed " +
+            "inside the `RadioGroup` component."
         );
       }
     }

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -100,7 +100,7 @@ const RadioGroup = React.forwardRef<
         noop();
       } else {
         console.warn(
-          "Only `Radio` components are allowed inside the `RadioGroup` component."
+          "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside the `RadioGroup` component."
         );
       }
     }

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -67,7 +67,7 @@ export const enumValues = getStorybookEnumValues(SelectTypes, "SelectTypes");
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `0.25.12`  |
+| Latest            | `0.25.13`  |
 
 <Description of={Select} />
 
@@ -76,19 +76,6 @@ children. For optimal accessibility, the `labelText` property is a required
 prop, regardless of the label visibility. Additionally, while the `id` prop is
 optional, a unique `id` attribute is necessary for accessibility. If the prop
 is left blank, a value will be generated for you.
-
-The `Select` component renders all the necessary wrapping and associated text
-elements, but the select options _need_ to be child `<option>` HTML elements.
-
-```jsx
-<Select labelText="What is your favorite color?" name="color">
-  <option value="red">Red</option>
-  <option value="green">Green</option>
-  <option value="blue">Blue</option>
-  <option value="black">Black</option>
-  <option value="white">White</option>
-</Select>
-```
 
 <Canvas withToolbar>
   <Story
@@ -124,6 +111,29 @@ elements, but the select options _need_ to be child `<option>` HTML elements.
 </Canvas>
 
 <ArgsTable story="Select with Controls" />
+
+## Option Elements
+
+The `Select` component renders all the necessary wrapping and associated text
+elements, but the select options _need_ to be child `<option>` HTML elements.
+
+```jsx
+<Select labelText="What is your favorite color?" name="color">
+  <option value="red">Red</option>
+  <option value="green">Green</option>
+  <option value="blue">Blue</option>
+  <option value="black">Black</option>
+  <option value="white">White</option>
+</Select>
+```
+
+There are two NYPL best practices to consider when using the `Select` component
+and `option` HTML elements:
+
+- Use no more than 10 options. If more than 10 options are needed, an
+  auto-complete text input is a good alternative.
+- Use at least four options. If fewer than three options are needed, a radio
+  button group is a good alternative.
 
 ## Labelling Variations
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -222,45 +222,6 @@ describe("Select", () => {
     expect(value).toEqual("white");
   });
 
-  it("should throw warning when fewer than 4 options", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      <Select {...baseProps}>
-        <option value="red">Red</option>
-      </Select>
-    );
-    expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Select: It is recommended that <select> fields have " +
-        "at least 4 options; a radio button group is a good alternative for " +
-        "3 or fewer options."
-    );
-  });
-
-  it("should throw warning when there are more than 10 options", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      <Select {...baseProps}>
-        <option aria-selected={false}>test1</option>
-        <option aria-selected={false}>test2</option>
-        <option aria-selected={false}>test3</option>
-        <option aria-selected={false}>test4</option>
-        <option aria-selected={false}>test5</option>
-        <option aria-selected={false}>test6</option>
-        <option aria-selected={false}>test7</option>
-        <option aria-selected={false}>test8</option>
-        <option aria-selected={false}>test9</option>
-        <option aria-selected={false}>test10</option>
-        <option aria-selected={false}>test11</option>
-      </Select>
-    );
-
-    expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Select: It is recommended that <select> fields have " +
-        "no more than 10 options; an auto-complete text input is a good " +
-        "alternative for 11 or more options."
-    );
-  });
-
   it("Renders the UI snapshot correctly", () => {
     const siblings = ["Kendall", "Shiv", "Connor", "Roman", "Tom"];
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -230,7 +230,7 @@ describe("Select", () => {
       </Select>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL DS recommends that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
+      "NYPL Reservoir Select: it is recommended that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
     );
   });
 
@@ -253,7 +253,7 @@ describe("Select", () => {
     );
 
     expect(warn).toHaveBeenCalledWith(
-      "NYPL DS recommends that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
+      "NYPL Reservoir Select: it is recommended that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
     );
   });
 

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -230,7 +230,9 @@ describe("Select", () => {
       </Select>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Select: it is recommended that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
+      "NYPL Reservoir Select: It is recommended that <select> fields have " +
+        "at least 4 options; a radio button group is a good alternative for " +
+        "3 or fewer options."
     );
   });
 
@@ -253,7 +255,9 @@ describe("Select", () => {
     );
 
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Select: it is recommended that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
+      "NYPL Reservoir Select: It is recommended that <select> fields have " +
+        "no more than 10 options; an auto-complete text input is a good " +
+        "alternative for 11 or more options."
     );
   });
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -106,22 +106,6 @@ const Select = React.forwardRef<
     ariaAttributes["aria-describedby"] = `${id}-helperText`;
   }
 
-  if (React.Children.count(children) > 10) {
-    console.warn(
-      "NYPL Reservoir Select: It is recommended that <select> fields have " +
-        "no more than 10 options; an auto-complete text input is a good " +
-        "alternative for 11 or more options."
-    );
-  }
-
-  if (React.Children.count(children) < 4) {
-    console.warn(
-      "NYPL Reservoir Select: It is recommended that <select> fields have " +
-        "at least 4 options; a radio button group is a good alternative for " +
-        "3 or fewer options."
-    );
-  }
-
   return (
     <Box className={className} __css={{ ...styles, ...additionalStyles }}>
       {showLabel && (

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -108,13 +108,17 @@ const Select = React.forwardRef<
 
   if (React.Children.count(children) > 10) {
     console.warn(
-      "NYPL Reservoir Select: it is recommended that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
+      "NYPL Reservoir Select: It is recommended that <select> fields have " +
+        "no more than 10 options; an auto-complete text input is a good " +
+        "alternative for 11 or more options."
     );
   }
 
   if (React.Children.count(children) < 4) {
     console.warn(
-      "NYPL Reservoir Select: it is recommended that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
+      "NYPL Reservoir Select: It is recommended that <select> fields have " +
+        "at least 4 options; a radio button group is a good alternative for " +
+        "3 or fewer options."
     );
   }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -108,13 +108,13 @@ const Select = React.forwardRef<
 
   if (React.Children.count(children) > 10) {
     console.warn(
-      "NYPL DS recommends that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
+      "NYPL Reservoir Select: it is recommended that <select> fields have no more than 10 options; an auto-complete text input is a good alternative for 11 or more options."
     );
   }
 
   if (React.Children.count(children) < 4) {
     console.warn(
-      "NYPL DS recommends that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
+      "NYPL Reservoir Select: it is recommended that <select> fields have at least 4 options; a radio button group is a good alternative for 3 or fewer options."
     );
   }
 

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -24,7 +24,9 @@ describe("StatusBadge", () => {
   it("throws a warning when no children are passed", () => {
     const warn = jest.spyOn(console, "warn");
     render(<StatusBadge></StatusBadge>);
-    expect(warn).toHaveBeenCalledWith("Status Badge has no children.");
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir StatusBadge: no children were passed."
+    );
   });
 
   it("renders the UI snapshot correctly", () => {

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -25,7 +25,7 @@ describe("StatusBadge", () => {
     const warn = jest.spyOn(console, "warn");
     render(<StatusBadge></StatusBadge>);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir StatusBadge: no children were passed."
+      "NYPL Reservoir StatusBadge: No children were passed."
     );
   });
 

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -24,7 +24,7 @@ function StatusBadge(props: React.PropsWithChildren<StatusBadgeProps>) {
   const styles = useStyleConfig("StatusBadge", { variant: level });
 
   if (!children) {
-    console.warn("Status Badge has no children.");
+    console.warn("NYPL Reservoir StatusBadge: no children were passed.");
   }
 
   return (

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -24,7 +24,7 @@ function StatusBadge(props: React.PropsWithChildren<StatusBadgeProps>) {
   const styles = useStyleConfig("StatusBadge", { variant: level });
 
   if (!children) {
-    console.warn("NYPL Reservoir StatusBadge: no children were passed.");
+    console.warn("NYPL Reservoir StatusBadge: No children were passed.");
   }
 
   return (

--- a/src/components/StructuredContent/StructuredContent.test.tsx
+++ b/src/components/StructuredContent/StructuredContent.test.tsx
@@ -209,7 +209,8 @@ describe("StructuredContent", () => {
     );
 
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir StructuredContent: `imageAlt` prop is required when using an image."
+      "NYPL Reservoir StructuredContent: The `imageAlt` prop is required " +
+        "when using an image."
     );
     expect(screen.getByRole("img")).toBeInTheDocument();
   });

--- a/src/components/StructuredContent/StructuredContent.test.tsx
+++ b/src/components/StructuredContent/StructuredContent.test.tsx
@@ -209,7 +209,7 @@ describe("StructuredContent", () => {
     );
 
     expect(warn).toHaveBeenCalledWith(
-      "StructuredContent: `imageAlt` prop is required when using an image."
+      "NYPL Reservoir StructuredContent: `imageAlt` prop is required when using an image."
     );
     expect(screen.getByRole("img")).toBeInTheDocument();
   });

--- a/src/components/StructuredContent/StructuredContent.tsx
+++ b/src/components/StructuredContent/StructuredContent.tsx
@@ -113,7 +113,7 @@ export default function StructuredContent(
 
   if (hasImage && !imageAlt) {
     console.warn(
-      "StructuredContent: `imageAlt` prop is required when using an image."
+      "NYPL Reservoir StructuredContent: `imageAlt` prop is required when using an image."
     );
   }
 

--- a/src/components/StructuredContent/StructuredContent.tsx
+++ b/src/components/StructuredContent/StructuredContent.tsx
@@ -113,7 +113,8 @@ export default function StructuredContent(
 
   if (hasImage && !imageAlt) {
     console.warn(
-      "NYPL Reservoir StructuredContent: `imageAlt` prop is required when using an image."
+      "NYPL Reservoir StructuredContent: The `imageAlt` prop is required " +
+        "when using an image."
     );
   }
 

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -76,7 +76,7 @@ describe("Table", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Table tableData={[]} />);
     expect(warn).toHaveBeenCalledWith(
-      "Table: data should be two dimensional array."
+      "NYPL Reservoir Table: data should be two dimensional array."
     );
   });
 

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -76,7 +76,7 @@ describe("Table", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Table tableData={[]} />);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Table: data should be two dimensional array."
+      "NYPL Reservoir Table: Data in the `tableData` prop must be a two dimensional array."
     );
   });
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -92,7 +92,7 @@ function Table(props: React.PropsWithChildren<TableProps>) {
       tableData[0].constructor !== Array
     ) {
       console.warn(
-        "NYPL Reservoir Table: data should be two dimensional array."
+        "NYPL Reservoir Table: Data in the `tableData` prop must be a two dimensional array."
       );
       return null;
     }

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -91,7 +91,9 @@ function Table(props: React.PropsWithChildren<TableProps>) {
       tableData.length <= 0 ||
       tableData[0].constructor !== Array
     ) {
-      console.warn("Table: data should be two dimensional array.");
+      console.warn(
+        "NYPL Reservoir Table: data should be two dimensional array."
+      );
       return null;
     }
 

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -248,7 +248,7 @@ describe("Tabs", () => {
     );
     expect(warn).toHaveBeenCalledWith(
       "NYPL Reservoir Tabs: Only pass children or data in the `contentData` " +
-        "props but not both."
+        "prop. Do not pass both."
     );
   });
 

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -213,7 +213,7 @@ describe("Tabs", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Tabs />);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Tabs: pass data in the `data` props or as children."
+      "NYPL Reservoir Tabs: Pass data in the `contentData` props or as children."
     );
   });
 
@@ -247,7 +247,8 @@ describe("Tabs", () => {
       </Tabs>
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Tabs: only pass children or data in the `data` props but not both."
+      "NYPL Reservoir Tabs: Only pass children or data in the `contentData` " +
+        "props but not both."
     );
   });
 
@@ -267,7 +268,8 @@ describe("Tabs", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Tabs: it is recommended to use no more than six tabs. If more than six tabs are needed, consider other navigational patterns."
+      "NYPL Reservoir Tabs: it is recommended to use no more than six tabs. If " +
+        "more than six tabs are needed, consider other navigational patterns."
     );
   });
 

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -213,7 +213,7 @@ describe("Tabs", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Tabs />);
     expect(warn).toHaveBeenCalledWith(
-      "Tabs: Pass data in the `data` props or as children."
+      "NYPL Reservoir Tabs: pass data in the `data` props or as children."
     );
   });
 
@@ -247,7 +247,7 @@ describe("Tabs", () => {
       </Tabs>
     );
     expect(warn).toHaveBeenCalledWith(
-      "Tabs: Only pass children or data in the `data` props but not both."
+      "NYPL Reservoir Tabs: only pass children or data in the `data` props but not both."
     );
   });
 
@@ -267,7 +267,7 @@ describe("Tabs", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "Tabs: We recommend to use no more than six tabs. If more than six tabs are needed, consider other navigational patterns."
+      "NYPL Reservoir Tabs: it is recommended to use no more than six tabs. If more than six tabs are needed, consider other navigational patterns."
     );
   });
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -121,7 +121,7 @@ const getElementsFromChildren = (children): TabPanelProps => {
       const childTabs = React.Children.count(child.props.children);
       if (childTabs > 6) {
         console.warn(
-          "NYPL Reservoir Tabs: it is recommended to use no more than six tabs. " +
+          "NYPL Reservoir Tabs: It is recommended to use no more than six tabs. " +
             "If more than six tabs are needed, consider other navigational patterns."
         );
       }
@@ -161,7 +161,7 @@ function Tabs(props: React.PropsWithChildren<TabsProps>) {
 
   if (tabs.length === 0 || panels.length === 0) {
     console.warn(
-      "NYPL Reservoir Tabs: pass data in the `data` props or as children."
+      "NYPL Reservoir Tabs: Pass data in the `contentData` props or as children."
     );
   }
 
@@ -225,7 +225,8 @@ function Tabs(props: React.PropsWithChildren<TabsProps>) {
 
   if (children && contentData?.length) {
     console.warn(
-      "NYPL Reservoir Tabs: only pass children or data in the `data` props but not both."
+      "NYPL Reservoir Tabs: Only pass children or data in the `contentData` " +
+        "props but not both."
     );
   }
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -226,7 +226,7 @@ function Tabs(props: React.PropsWithChildren<TabsProps>) {
   if (children && contentData?.length) {
     console.warn(
       "NYPL Reservoir Tabs: Only pass children or data in the `contentData` " +
-        "props but not both."
+        "prop. Do not pass both."
     );
   }
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -65,8 +65,8 @@ const getElementsFromContentData = (data, useHash): TabPanelProps => {
 
   if (data?.length > 6) {
     console.warn(
-      "Tabs: We recommend to use no more than six tabs. If more than six tabs " +
-        "are needed, consider other navigational patterns."
+      "NYPL Reservoir Tabs: it is recommended to use no more than six tabs. If " +
+        "more than six tabs are needed, consider other navigational patterns."
     );
   }
   data.forEach((tab, index) => {
@@ -121,8 +121,8 @@ const getElementsFromChildren = (children): TabPanelProps => {
       const childTabs = React.Children.count(child.props.children);
       if (childTabs > 6) {
         console.warn(
-          "Tabs: We recommend to use no more than six tabs. If more than six " +
-            "tabs are needed, consider other navigational patterns."
+          "NYPL Reservoir Tabs: it is recommended to use no more than six tabs. " +
+            "If more than six tabs are needed, consider other navigational patterns."
         );
       }
     }
@@ -160,7 +160,9 @@ function Tabs(props: React.PropsWithChildren<TabsProps>) {
     : getElementsFromChildren(children);
 
   if (tabs.length === 0 || panels.length === 0) {
-    console.warn("Tabs: Pass data in the `data` props or as children.");
+    console.warn(
+      "NYPL Reservoir Tabs: pass data in the `data` props or as children."
+    );
   }
 
   // `tabs` is an array for the children component approach but an object for
@@ -223,7 +225,7 @@ function Tabs(props: React.PropsWithChildren<TabsProps>) {
 
   if (children && contentData?.length) {
     console.warn(
-      "Tabs: Only pass children or data in the `data` props but not both."
+      "NYPL Reservoir Tabs: only pass children or data in the `data` props but not both."
     );
   }
 

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -151,7 +151,7 @@ describe("TemplateAppContainer component", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "`TemplateHeader`: An HTML `header` element was passed in. Set " +
+      "NYPL Reservoir TemplateHeader: an HTML `header` element was passed in. Set " +
         "`renderHeaderElement` to `false` to avoid nested HTML `header` elements."
     );
   });
@@ -189,7 +189,7 @@ describe("TemplateAppContainer component", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "`TemplateFooter`: An HTML `footer` element was passed in. Set " +
+      "NYPL Reservoir TemplateFooter: an HTML `footer` element was passed in. Set " +
         "`renderFooterElement` to `false` to avoid nested HTML `footer` elements."
     );
   });

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -151,8 +151,9 @@ describe("TemplateAppContainer component", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir TemplateHeader: an HTML `header` element was passed in. Set " +
-        "`renderHeaderElement` to `false` to avoid nested HTML `header` elements."
+      "NYPL Reservoir TemplateHeader: An HTML `header` element was passed " +
+        "in. Set `renderHeaderElement` to `false` to avoid nested HTML " +
+        "`header` elements."
     );
   });
 
@@ -189,8 +190,9 @@ describe("TemplateAppContainer component", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir TemplateFooter: an HTML `footer` element was passed in. Set " +
-        "`renderFooterElement` to `false` to avoid nested HTML `footer` elements."
+      "NYPL Reservoir TemplateFooter: An HTML `footer` element was passed " +
+        "in. Set `renderFooterElement` to `false` to avoid nested HTML " +
+        "`footer` elements."
     );
   });
 });

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -88,7 +88,7 @@ const TemplateHeader = ({
     React.Children.map(children, (child: React.ReactElement) => {
       if (child?.type === "header" || child?.props?.mdxType === "header") {
         console.warn(
-          "`TemplateHeader`: An HTML `header` element was passed in. Set " +
+          "NYPL Reservoir TemplateHeader: an HTML `header` element was passed in. Set " +
             "`renderHeaderElement` to `false` to avoid nested HTML `header` elements."
         );
       }
@@ -222,7 +222,7 @@ const TemplateFooter = ({
     React.Children.map(children, (child: React.ReactElement) => {
       if (child?.type === "footer" || child?.props?.mdxType === "footer") {
         console.warn(
-          "`TemplateFooter`: An HTML `footer` element was passed in. Set " +
+          "NYPL Reservoir TemplateFooter: an HTML `footer` element was passed in. Set " +
             "`renderFooterElement` to `false` to avoid nested HTML `footer` elements."
         );
       }

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -88,8 +88,9 @@ const TemplateHeader = ({
     React.Children.map(children, (child: React.ReactElement) => {
       if (child?.type === "header" || child?.props?.mdxType === "header") {
         console.warn(
-          "NYPL Reservoir TemplateHeader: an HTML `header` element was passed in. Set " +
-            "`renderHeaderElement` to `false` to avoid nested HTML `header` elements."
+          "NYPL Reservoir TemplateHeader: An HTML `header` element was passed " +
+            "in. Set `renderHeaderElement` to `false` to avoid nested HTML " +
+            "`header` elements."
         );
       }
     });
@@ -222,8 +223,9 @@ const TemplateFooter = ({
     React.Children.map(children, (child: React.ReactElement) => {
       if (child?.type === "footer" || child?.props?.mdxType === "footer") {
         console.warn(
-          "NYPL Reservoir TemplateFooter: an HTML `footer` element was passed in. Set " +
-            "`renderFooterElement` to `false` to avoid nested HTML `footer` elements."
+          "NYPL Reservoir TemplateFooter: An HTML `footer` element was passed " +
+            "in. Set `renderFooterElement` to `false` to avoid nested HTML " +
+            "`footer` elements."
         );
       }
     });

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -25,7 +25,7 @@ describe("Text", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Text></Text>);
     expect(warn).toHaveBeenCalledWith(
-      "The Text component has no children and will not render correctly."
+      "NYPL Reservoir Text: no children were passed and Text will not render correctly."
     );
   });
 

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -25,7 +25,8 @@ describe("Text", () => {
     const warn = jest.spyOn(console, "warn");
     render(<Text></Text>);
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Text: no children were passed and Text will not render correctly."
+      "NYPL Reservoir Text: No children were passed and the `Text` component " +
+        "will not render correctly."
     );
   });
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -41,7 +41,8 @@ function Text(props: React.PropsWithChildren<TextProps>) {
 
   if (!children) {
     console.warn(
-      "NYPL Reservoir Text: no children were passed and Text will not render correctly."
+      "NYPL Reservoir Text: No children were passed and the `Text` component " +
+        "will not render correctly."
     );
   }
 

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -41,7 +41,7 @@ function Text(props: React.PropsWithChildren<TextProps>) {
 
   if (!children) {
     console.warn(
-      "The Text component has no children and will not render correctly."
+      "NYPL Reservoir Text: no children were passed and Text will not render correctly."
     );
   }
 

--- a/src/components/VideoPlayer/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.test.tsx
@@ -181,17 +181,20 @@ describe("VideoPlayer", () => {
 
       render(<VideoPlayer />);
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: requires either the `embedCode` prop or both the `videoType` and `videoId` props."
+        "NYPL Reservoir VideoPlayer: Pass in either the `embedCode` prop or " +
+          "both the `videoType` and `videoId` props; none were passed."
       );
 
       render(<VideoPlayer videoId="http://vimeo.com/474719268" />);
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: requires the `videoType` prop. Only the `videoId` prop was set."
+        "NYPL Reservoir VideoPlayer: The `videoType` prop is also required. " +
+          "Only the `videoId` prop was set."
       );
 
       render(<VideoPlayer videoType={VideoPlayerTypes.Vimeo} />);
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: requires the `videoId` prop. Only the `videoType` prop was set."
+        "NYPL Reservoir VideoPlayer: The `videoId` prop is also required. " +
+          "Only the `videoType` prop was set."
       );
 
       render(
@@ -202,7 +205,8 @@ describe("VideoPlayer", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
+        "NYPL Reservoir VideoPlayer: Pass in either the `embedCode` prop or " +
+          "both the `videoType` and `videoId` props; all were set."
       );
 
       render(
@@ -212,7 +216,8 @@ describe("VideoPlayer", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
+        "NYPL Reservoir VideoPlayer: Pass in either the `embedCode` prop or " +
+          "both the `videoType` and `videoId` props; all were set."
       );
 
       render(
@@ -222,13 +227,14 @@ describe("VideoPlayer", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
+        "NYPL Reservoir VideoPlayer: Pass in either the `embedCode` prop or " +
+          "both the `videoType` and `videoId` props; all were set."
       );
 
       const embedCode = `<iframe src="https://player./video/421404144?h=5467db7edd"></iframe>`;
       render(<VideoPlayer embedCode={embedCode} />);
       expect(warn).toHaveBeenCalledWith(
-        "NYPL Reservoir VideoPlayer: `embedCode` prop is not configured properly."
+        "NYPL Reservoir VideoPlayer: The `embedCode` prop is not configured properly."
       );
     });
   });

--- a/src/components/VideoPlayer/VideoPlayer.test.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.test.tsx
@@ -181,17 +181,17 @@ describe("VideoPlayer", () => {
 
       render(<VideoPlayer />);
       expect(warn).toHaveBeenCalledWith(
-        "VideoPlayer requires either the `embedCode` prop or both the `videoType` and `videoId` props."
+        "NYPL Reservoir VideoPlayer: requires either the `embedCode` prop or both the `videoType` and `videoId` props."
       );
 
       render(<VideoPlayer videoId="http://vimeo.com/474719268" />);
       expect(warn).toHaveBeenCalledWith(
-        "VideoPlayer also requires the `videoType` prop. You have only set the `videoId` prop."
+        "NYPL Reservoir VideoPlayer: requires the `videoType` prop. Only the `videoId` prop was set."
       );
 
       render(<VideoPlayer videoType={VideoPlayerTypes.Vimeo} />);
       expect(warn).toHaveBeenCalledWith(
-        "VideoPlayer also requires the `videoId` prop. You have only set the `videoType` prop."
+        "NYPL Reservoir VideoPlayer: requires the `videoId` prop. Only the `videoType` prop was set."
       );
 
       render(
@@ -202,7 +202,7 @@ describe("VideoPlayer", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "VideoPlayer can accept the `embedCode` prop or the `videoType` and `videoId` props. You have set both."
+        "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
       );
 
       render(
@@ -212,7 +212,7 @@ describe("VideoPlayer", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "VideoPlayer can accept the `embedCode` prop or the `videoType` and `videoId` props. You have set both."
+        "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
       );
 
       render(
@@ -222,7 +222,13 @@ describe("VideoPlayer", () => {
         />
       );
       expect(warn).toHaveBeenCalledWith(
-        "VideoPlayer can accept the `embedCode` prop or the `videoType` and `videoId` props. You have set both."
+        "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
+      );
+
+      const embedCode = `<iframe src="https://player./video/421404144?h=5467db7edd"></iframe>`;
+      render(<VideoPlayer embedCode={embedCode} />);
+      expect(warn).toHaveBeenCalledWith(
+        "NYPL Reservoir VideoPlayer: `embedCode` prop is not configured properly."
       );
     });
   });

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -78,27 +78,32 @@ export default function VideoPlayer(
       : embedCode;
 
   const errorMessage =
-    "<strong>Error:</strong> This video player has not been configured properly. Please contact the site administrator.";
+    "<strong>Error:</strong> This video player has not been configured " +
+    "properly. Please contact the site administrator.";
 
   let isInvalid = false;
   if (!embedCodeFinal && !videoType && !videoId) {
     console.warn(
-      "NYPL Reservoir VideoPlayer: requires either the `embedCode` prop or both the `videoType` and `videoId` props."
+      "NYPL Reservoir VideoPlayer: Pass in either the `embedCode` prop or " +
+        "both the `videoType` and `videoId` props; none were passed."
     );
     isInvalid = true;
   } else if (!embedCodeFinal && !videoType) {
     console.warn(
-      "NYPL Reservoir VideoPlayer: requires the `videoType` prop. Only the `videoId` prop was set."
+      "NYPL Reservoir VideoPlayer: The `videoType` prop is also required. " +
+        "Only the `videoId` prop was set."
     );
     isInvalid = true;
   } else if (!embedCodeFinal && !videoId) {
     console.warn(
-      "NYPL Reservoir VideoPlayer: requires the `videoId` prop. Only the `videoType` prop was set."
+      "NYPL Reservoir VideoPlayer: The `videoId` prop is also required. " +
+        "Only the `videoType` prop was set."
     );
     isInvalid = true;
   } else if (embedCodeFinal && (videoType || videoId)) {
     console.warn(
-      "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
+      "NYPL Reservoir VideoPlayer: Pass in either the `embedCode` prop or " +
+        "both the `videoType` and `videoId` props; all were set."
     );
     isInvalid = true;
   }
@@ -112,7 +117,7 @@ export default function VideoPlayer(
       videoId.includes("vimeo"))
   ) {
     console.warn(
-      "NYPL Reservoir VideoPlayer: `videoId` prop is not configured properly."
+      "NYPL Reservoir VideoPlayer: The `videoId` prop is not configured properly."
     );
     isInvalid = true;
   }
@@ -125,7 +130,7 @@ export default function VideoPlayer(
       !embedCodeFinal.includes("</iframe"))
   ) {
     console.warn(
-      "NYPL Reservoir VideoPlayer: `embedCode` prop is not configured properly."
+      "NYPL Reservoir VideoPlayer: The `embedCode` prop is not configured properly."
     );
     isInvalid = true;
   }

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -83,22 +83,22 @@ export default function VideoPlayer(
   let isInvalid = false;
   if (!embedCodeFinal && !videoType && !videoId) {
     console.warn(
-      "VideoPlayer requires either the `embedCode` prop or both the `videoType` and `videoId` props."
+      "NYPL Reservoir VideoPlayer: requires either the `embedCode` prop or both the `videoType` and `videoId` props."
     );
     isInvalid = true;
   } else if (!embedCodeFinal && !videoType) {
     console.warn(
-      "VideoPlayer also requires the `videoType` prop. You have only set the `videoId` prop."
+      "NYPL Reservoir VideoPlayer: requires the `videoType` prop. Only the `videoId` prop was set."
     );
     isInvalid = true;
   } else if (!embedCodeFinal && !videoId) {
     console.warn(
-      "VideoPlayer also requires the `videoId` prop. You have only set the `videoType` prop."
+      "NYPL Reservoir VideoPlayer: requires the `videoId` prop. Only the `videoType` prop was set."
     );
     isInvalid = true;
   } else if (embedCodeFinal && (videoType || videoId)) {
     console.warn(
-      "VideoPlayer can accept the `embedCode` prop or the `videoType` and `videoId` props. You have set both."
+      "NYPL Reservoir VideoPlayer: accepts the `embedCode` prop or the `videoType` and `videoId` props; both were set."
     );
     isInvalid = true;
   }
@@ -111,7 +111,9 @@ export default function VideoPlayer(
       videoId.includes("youtube") ||
       videoId.includes("vimeo"))
   ) {
-    console.warn("The VideoPlayer `videoId` prop is not configured properly.");
+    console.warn(
+      "NYPL Reservoir VideoPlayer: `videoId` prop is not configured properly."
+    );
     isInvalid = true;
   }
 
@@ -123,7 +125,7 @@ export default function VideoPlayer(
       !embedCodeFinal.includes("</iframe"))
   ) {
     console.warn(
-      "The VideoPlayer `embedCode` prop is not configured properly."
+      "NYPL Reservoir VideoPlayer: `embedCode` prop is not configured properly."
     );
     isInvalid = true;
   }

--- a/src/hooks/tests/useNYPLTheme.test.tsx
+++ b/src/hooks/tests/useNYPLTheme.test.tsx
@@ -10,7 +10,7 @@ describe("useNYPLTheme", () => {
     const { result } = renderHook(() => useNYPLTheme());
 
     expect(warn).toHaveBeenCalledWith(
-      "The `useNYPLTheme` hook must be used inside of `<DSProvider />`."
+      "NYPL Reservoir useNYPLTheme: hook must be used inside of `<DSProvider />`."
     );
     expect(result.current).toEqual({});
   });

--- a/src/hooks/useNYPLTheme.ts
+++ b/src/hooks/useNYPLTheme.ts
@@ -9,7 +9,7 @@ function useNYPLTheme() {
   const theme = useTheme();
   if (!theme || Object.keys(theme).length === 0) {
     console.warn(
-      "The `useNYPLTheme` hook must be used inside of `<DSProvider />`."
+      "NYPL Reservoir useNYPLTheme: hook must be used inside of `<DSProvider />`."
     );
     return {};
   }


### PR DESCRIPTION
Fixes JIRA ticket [DSD-854](https://jira.nypl.org/browse/DSD-854)

## This PR does the following:

- Updates all console warnings with NYPL branding.
- Some of the language was updated so we don't have "we" or "you" in the message and it can be more direct and active.
- Adds missing tests for some console warning messages.

## How has this been tested?

Unit tests

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
