### PR TITLE
DSD-872: Updating the Card's image styling for mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Image`'s caption font size to "12px" (`text.tag`).
 - Updates the `Checkbox`'s and `Radio`'s `labelText` prop to accept strings and JSX Elements.
 - Updates the `Toggle`'s internal styling for the default and small sizes.
+- Updates the `CardImage`'s margin bottom in the row and column layouts for mobile to be the same.
+- Updates the `CardImage` to have width 100% on mobile regardless of size.
 
 ### Fixes
 

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -93,7 +93,7 @@ export const cardLayoutsEnumValues = getStorybookEnumValues(
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `0.25.10`  |
+| Latest            | `0.25.13`  |
 
 <Description of={Card} />
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -199,12 +199,12 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
   }
 
   // The `Card`'s image should always display as 100% width on mobile. To
-  // achieve this, we set the size to `ImageSizes.Large` only when the
+  // achieve this, we set the size to `ImageSizes.Default` only when the
   // viewport is less than "600px". Otherwise, we set the size to
   // the value passed in via `imageSize`.
   React.useEffect(() => {
     if (windowDimensions.width < 600) {
-      setFinalImageSize(ImageSizes.Large);
+      setFinalImageSize(ImageSizes.Default);
     } else {
       setFinalImageSize(imageSize);
     }

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -11,6 +11,7 @@ import { CardLayouts } from "./CardTypes";
 import Heading from "../Heading/Heading";
 import Image, { ImageProps } from "../Image/Image";
 import { ImageRatios, ImageSizes } from "../Image/ImageTypes";
+import useWindowSize from "../../hooks/useWindowSize";
 import generateUUID from "../../helpers/generateUUID";
 
 interface CardBaseProps {
@@ -180,12 +181,15 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
     layout = CardLayouts.Column,
     mainActionLink,
   } = props;
+  const [finalImageSize, setFinalImageSize] =
+    React.useState<ImageSizes>(imageSize);
   const hasImage = imageSrc || imageComponent;
   const finalImageAspectRatio = imageComponent
     ? ImageRatios.Original
     : imageAspectRatio;
   const customColors = {};
   const cardContents = [];
+  const windowDimensions = useWindowSize();
   let cardHeadingCount = 0;
 
   if (imageComponent && imageAspectRatio !== ImageRatios.Square) {
@@ -193,6 +197,18 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
       "Both `imageComponent` and `imageAspectRatio` are set but `imageAspectRatio` will be ignored in favor of the aspect ratio on `imageComponent`."
     );
   }
+
+  // The `Card`'s image should always display as 100% width on mobile. To
+  // achieve this, we set the size to `ImageSizes.Large` only when the
+  // viewport is less than "600px". Otherwise, we set the size to
+  // the value passed in via `imageSize`.
+  React.useEffect(() => {
+    if (windowDimensions.width < 600) {
+      setFinalImageSize(ImageSizes.Large);
+    } else {
+      setFinalImageSize(imageSize);
+    }
+  }, [windowDimensions.width, imageSize]);
 
   backgroundColor && (customColors["backgroundColor"] = backgroundColor);
   foregroundColor && (customColors["color"] = foregroundColor);
@@ -260,7 +276,7 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
             src={imageSrc ? imageSrc : null}
             component={imageComponent}
             alt={imageAlt}
-            imageSize={imageSize}
+            imageSize={finalImageSize}
             imageAspectRatio={finalImageAspectRatio}
             imageAtEnd={imageAtEnd}
             layout={layout}

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -152,6 +152,7 @@ const CardImage = {
                 : "0 var(--nypl-space-m) 0 0",
             },
             width: { base: "100%", md: null },
+            marginBottom: ["xs", "xs"],
             ...size,
           }
         : {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-872](https://jira.nypl.org/browse/DSD-872)

## This PR does the following:

- Updates the `CardImage`'s margin-bottom in the row and column layouts for mobile to be the same.
- Updates the `CardImage` to have a width of 100% on mobile regardless of size. This is done through the `useWindowSize` hook.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
