### PR TITLE
DSD-876: Hero Campaign mobile bottom spacing fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Fixes the `Breadcrumbs`' SVG arrow icon fill color for the "Blogs" variant.
 - Fixes the margin right value for list items in the `List` component for the inline style.
 - Fixes bug in the `Select` component where the SVG arrow hides when the component is focused.
+- Fixes the extra bottom spacing in the `HeroTypes.Campaign` `Hero` variant for the mobile view.
 
 ## 0.25.12 (March 18, 2022)
 

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -143,7 +143,7 @@ const campaign = {
   alignItems: "center",
   display: "flex",
   justifyContent: "center",
-  marginBottom: "xxl",
+  marginBottom: ["0", "0", "xxl"],
   minHeight: "300px",
   overflow: "visible",
   padding: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-876](https://jira.nypl.org/browse/DSD-876)

## This PR does the following:

- Fixes the mobile bottom spacing for the `HeroTypes.Campaign` `Hero` variant. Removes it for mobile but leaves it the desktop view.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
