### PR TITLE
Small fix for bad merge

### DIFF
--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -99,11 +99,13 @@ const CardActions = {
   baseStyle: (props) => {
     const { bottomBorder, isCentered, layout, topBorder } = props;
     let justifyContent = null;
-    if (isCentered) {
-      justifyContent = "center";
-    } else if (layout === "row") {
+    // Only center in the column layout.
+    if (layout === "row") {
       justifyContent = "left";
+    } else if (isCentered) {
+      justifyContent = "center";
     }
+
     const topBorderStyles = topBorder
       ? {
           borderTop: "1px solid",

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -34,8 +34,14 @@ const getBodyPaddingStyles = ({ border, hasImage, imageIsAtEnd, isRow }) => {
 const Card = {
   parts: ["body", "heading"],
   baseStyle: (props) => {
-    const { border, center, hasImage, imageIsAtEnd, layout, mainActionLink } =
-      props;
+    const {
+      border,
+      hasImage,
+      imageIsAtEnd,
+      isCentered,
+      layout,
+      mainActionLink,
+    } = props;
     const isRow = layout === "row";
     const layoutStyles = isRow
       ? {
@@ -46,7 +52,7 @@ const Card = {
           },
           maxWidth: "100%",
           textAlign: "left",
-          alignItems: center ? "center" : null,
+          alignItems: isCentered ? "center" : null,
         }
       : {};
     const baseBorderStyles = border
@@ -62,7 +68,7 @@ const Card = {
       isRow,
     });
     let bodyMargin = null;
-    if (center) {
+    if (isCentered) {
       bodyMargin = "auto";
       if (isRow) {
         bodyMargin = "0";
@@ -72,7 +78,7 @@ const Card = {
       alignItems: "flex-start",
       display: "flex",
       flexFlow: "column wrap",
-      textAlign: center ? "center" : null,
+      textAlign: isCentered ? "center" : null,
       heading: {
         marginBottom: "xs",
         a: mainActionLink ? { color: "ui.black" } : null,
@@ -91,9 +97,9 @@ const Card = {
 
 const CardActions = {
   baseStyle: (props) => {
-    const { bottomBorder, center, layout, topBorder } = props;
+    const { bottomBorder, isCentered, layout, topBorder } = props;
     let justifyContent = null;
-    if (center) {
+    if (isCentered) {
       justifyContent = "center";
     } else if (layout === "row") {
       justifyContent = "left";
@@ -135,7 +141,7 @@ const CardContent = {
 };
 
 const CardImage = {
-  baseStyle: ({ center, imageIsAtEnd, size, layout }) => {
+  baseStyle: ({ imageIsAtEnd, isCentered, size, layout }) => {
     // These sizes are only for the "row" layout.
     const imageSize = imageSizes[size] || {};
     const layoutStyles =
@@ -144,7 +150,7 @@ const CardImage = {
             flex: { md: "0 0 225px" },
             maxWidth: { base: "100%", md: "50%" },
             textAlign: "left",
-            alignItems: center ? "center" : null,
+            alignItems: isCentered ? "center" : null,
             margin: {
               base: imageIsAtEnd ? "var(--nypl-space-m) 0 0" : null,
               md: imageIsAtEnd


### PR DESCRIPTION
## This PR does the following:

- Fixes `isCentered` prop for the `Card` component. Merging updated the `center` prop to `isCentered` and thus the conflict and issue.

## How has this been tested?

Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
