### PR TITLE
DSD-845: Hooks Storybook documentation & more exposed design tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Exports the `useCarouselStyles` and `useWindowSize` hooks and adds documentation for all hooks in Storybook.
+- Adds additional semantic design tokens from `fontWeights` and `fontSizes` to the `useNYPLTheme` hook.
+
 ## 0.25.13 (April 1, 2022)
 
 ### Adds
@@ -54,7 +59,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `StructuredContent` image-related props into one main prop named `imageProps`. This new prop contains the following properties: alt, aspectRatio, caption, component, credit, position, size, and src.
 - Renames the `ToggleSizes.tsx` file to `ToggleTypes.tsx`. Updates the values from `Large` and `Small` to `Default` and `Small`.
 - Minor update to the logic for the `ProgressIndicator` sizing prop and styles.
-- Exports the `useCarouselStyles` and `useWindowSize` hooks and adds documentation for all hooks in Storybook.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `StructuredContent` image-related props into one main prop named `imageProps`. This new prop contains the following properties: alt, aspectRatio, caption, component, credit, position, size, and src.
 - Renames the `ToggleSizes.tsx` file to `ToggleTypes.tsx`. Updates the values from `Large` and `Small` to `Default` and `Small`.
 - Minor update to the logic for the `ProgressIndicator` sizing prop and styles.
+- Exports the `useCarouselStyles` and `useWindowSize` hooks and adds documentation for all hooks in Storybook.
 
 ### Fixes
 

--- a/src/docs/Chakra.stories.mdx
+++ b/src/docs/Chakra.stories.mdx
@@ -10,7 +10,6 @@ import { Meta } from "@storybook/addon-docs";
 | 2. [DSProvider](#dsprovider)        |
 | 3. [Components](#components)        |
 | 4. [Styling](#styling)              |
-| 5. [Hooks](#hooks)                  |
 | 5. [Testing](#testing)              |
 
 ## Why Chakra UI?
@@ -411,109 +410,9 @@ All typography values can be found in the `src/theme/foundations/typography.ts`
 file. These values declare the font family, font sizes, and font weights to use
 for all text.
 
-## Hooks
-
-The following hooks are available to use and can be imported from
-`@nypl/design-system-react-components`.
-
-### useNYPLTheme
-
-If your application does not use CSS or SCSS files and you want to write
-CSS-in-JS styles in your React components, the `useNYPLTheme` hook will provide
-you with NYPL-specific style values. This hook depends on the `DSProvider`
-component and if the function is used outside of this wrapper component, then
-the theme object will be empty.
-
-After importing and rendering the `DSProvider` wrapper component, as explained
-in the [DSProvider](#dsprovider) section, your children components can use this
-hook function.
-
-```tsx
-import { useNYPLTheme } from "@nypl/design-system-react-components";
-// ...
-
-const theme = useNYPLTheme();
-```
-
-The `theme` variable will be a JS object with style values discussed in the
-sections above. This will allow you to use NYPL-specific styles in your
-components through CSS-in-JS.
-
-```ts
-// theme:
-{
-  breakpoints: { ... },
-  colors: {
-    brand: { ... },
-    section: { ... },
-    transparent: { ... },
-    ui: { ... },
-  },
-  fontSizes: { ... },
-  fontWeights: { ... },
-  fonts: { ... },
-  radii: { ... },
-  space: { ... },
-}
-```
-
-#### Usage
-
-_Note: more patterns will be added._
-
-1. NYPL DS Components
-
-All DS components _should_ be used with their current styles. If a DS component
-needs an updated style, first contact the Design System and UX teams about this
-update. If you really _need_ to update a style and there is no available
-variant, then you can add styles directly to the `additionalStyles` prop. At the
-moment, not all DS components have this prop or feature.
-
-For example, if the `Heading` component should render the text in NYPL's green
-color used for "success primary" and add a bold font weight, then you can do
-the following:
-
-```tsx
-const theme = useNYPLTheme();
-
-// ...
-return (
-  <div>
-    <Heading
-      level={2}
-      additionalStyles={{
-        color: theme.colors.ui.sucess.primary,
-        fontWeight: theme.fontWeights.bold,
-      }}
-    >
-      Get a Digital Library Card Today in a Few Easy Steps
-    </Heading>
-
-    {/* Other components */}
-  </div>
-);
-```
-
-Of course, you can destructure the `theme` object to only get the object keys
-you need for your component (this is a general example). Log the object to the
-console to see all the available styles.
-
-2. HTML Components
-
-Use the `style` attribute in HTML components to add inline styles.
-
-```tsx
-<p style={{ color: theme.colors.ui.success.primary }}>
-  If you are 13 or older and live, work, attend school, or pay property taxes in
-  New York State, you can get a free digital library card right now using this
-  online form. Visitors to New York State can also use this form to apply for a
-  temporary card.
-</p>
-```
-
 ## Testing
 
 Do not re-test Chakra components that are re-exported since they are already
-tested in the `@chakra-ui/react` package. We do expect all new components
-composed from Chakra to have tests for functionality and styling
-(such as snapshots).
+tested in the `@chakra-ui/react` package. We expect all new components composed
+with Chakra components to have tests for functionality and styling, including
+snapshot tests.

--- a/src/hooks/useCarouselStyles.stories.mdx
+++ b/src/hooks/useCarouselStyles.stories.mdx
@@ -1,3 +1,5 @@
+import { Meta, Description } from "@storybook/addon-docs";
+
 import { getCategory } from "../utils/componentCategories";
 
 <Meta title={getCategory("useCarouselStyles")} />
@@ -6,5 +8,23 @@ import { getCategory } from "../utils/componentCategories";
 
 | Hook Version | DS Version |
 | ------------ | ---------- |
-| Added        | `?`        |
-| Latest       | `?`        |
+| Added        | `0.25.2`   |
+| Latest       | `0.25.2`   |
+
+This custom hook, inspired by this [codesandbox example](https://codesandbox.io/s/fxjeo),
+exposes functions used for carousel-like components that have sliding features.
+The two main functions are `prevSlide` and `nextSlide` used for buttons to
+navigate between slides, and a `carouselStyle` style object for the main wrapper
+element. If the carousel should programmatically slide to the first slide, use
+the `goToStart` function.
+
+## Usage
+
+For a full implementation examle, view the [`Tabs` component](https://github.com/NYPL/nypl-design-system/blob/development/src/components/Tabs/Tabs.tsx).
+
+```tsx
+const { prevSlide, nextSlide, carouselStyle, goToStart } = useCarouselStyles(
+  slidesCount,
+  slideWidth
+);
+```

--- a/src/hooks/useCarouselStyles.ts
+++ b/src/hooks/useCarouselStyles.ts
@@ -3,10 +3,11 @@ import React from "react";
 /**
  * Custom hook that controls the sliding function for the carousel wrapper.
  * This returns functions to use for the "previous" and "next" buttons as well
- * as a CSS style object that should be use to transition between slides.
+ * as a CSS style object that should be use to transition between slides. There
+ * is also a function to programmatically slide to the first slide.
  * Inspired by: https://codesandbox.io/s/fxjeo
  */
-const useCarouselStyles = (slidesCount = 0, slideWidth = 100) => {
+export const useCarouselStyles = (slidesCount = 0, slideWidth = 100) => {
   const [currentSlide, setCurrentSlide] = React.useState(0);
   // This wraps around to the last slide if this is invoked while the
   // first slide is active.

--- a/src/hooks/useNYPLTheme.stories.mdx
+++ b/src/hooks/useNYPLTheme.stories.mdx
@@ -1,0 +1,101 @@
+import { Meta } from "@storybook/addon-docs";
+import { getCategory } from "../utils/componentCategories";
+
+<Meta title={getCategory("useNYPLTheme")} />
+
+# useNYPLTheme
+
+| Hook Version | DS Version |
+| ------------ | ---------- |
+| Added        | `0.25.2`   |
+| Latest       | `0.25.2`   |
+
+This custom hook is based on Chakra UI's `useTheme` hook. If your application
+does not use CSS or SCSS files and you want to write CSS-in-JS styles in your
+React components, the `useNYPLTheme` hook will provide you with NYPL-specific
+style values.
+
+## Usage
+
+This hook depends on the `DSProvider` component and if the function is used
+outside of this wrapper component, then the theme object will be empty. After
+importing and rendering the `DSProvider` wrapper component, your children
+components can use this hook function.
+
+```tsx
+import { useNYPLTheme } from "@nypl/design-system-react-components";
+// ...
+
+const theme = useNYPLTheme();
+```
+
+The `theme` variable will be a JS object with design token style values.
+This will allow you to use NYPL-specific styles in your components through CSS-in-JS.
+
+```ts
+// theme:
+{
+  breakpoints: { ... },
+  colors: {
+    brand: { ... },
+    section: { ... },
+    transparent: { ... },
+    ui: { ... },
+  },
+  fontSizes: { ... },
+  fontWeights: { ... },
+  fonts: { ... },
+  radii: { ... },
+  space: { ... },
+}
+```
+
+1. NYPL DS Components
+
+All DS components _should_ be used with their current styles. If a DS component
+needs an updated style, first contact the Design System and UX teams about this
+update. If you really _need_ to update a style and there is no available
+variant, then you can add styles directly to the `additionalStyles` prop. At the
+moment, not all DS components have this prop or feature.
+
+For example, if the `Heading` component should render the text in NYPL's green
+color used for "success primary" and add a bold font weight, then you can do
+the following:
+
+```tsx
+const theme = useNYPLTheme();
+
+// ...
+return (
+  <div>
+    <Heading
+      level={2}
+      additionalStyles={{
+        color: theme.colors.ui.sucess.primary,
+        fontWeight: theme.fontWeights.bold,
+      }}
+    >
+      Get a Digital Library Card Today in a Few Easy Steps
+    </Heading>
+
+    {/* Other components */}
+  </div>
+);
+```
+
+Of course, you can destructure the `theme` object to only get the object keys
+you need for your component (this is a general example). Log the object to the
+console to see all the available styles.
+
+2. HTML Components
+
+Use the `style` attribute in HTML components to add inline styles.
+
+```tsx
+<p style={{ color: theme.colors.ui.success.primary }}>
+  If you are 13 or older and live, work, attend school, or pay property taxes in
+  New York State, you can get a free digital library card right now using this
+  online form. Visitors to New York State can also use this form to apply for a
+  temporary card.
+</p>
+```

--- a/src/hooks/useNYPLTheme.ts
+++ b/src/hooks/useNYPLTheme.ts
@@ -22,8 +22,8 @@ function useNYPLTheme() {
     colors: {
       // primary, secondary
       brand: theme.colors.brand,
-      // blogs, books-and-more, locations, research,
-      // research-library, whats-on
+      // blogs, books-and-more, education, locations,
+      // research, research-library, whats-on
       section: theme.colors.section,
       transparent: theme.colors.transparent,
       // black, disabled, error, focus, gray, link,
@@ -32,19 +32,43 @@ function useNYPLTheme() {
     },
     fontSizes: {
       "-3": theme.fontSizes["-3"],
-      "-2": theme.fontSizes.xs,
-      "-1": theme.fontSizes.sm,
-      "0": theme.fontSizes.md,
-      "1": theme.fontSizes.lg,
+      "-2": theme.fontSizes["-2"],
+      "-1": theme.fontSizes["-1"],
+      "0": theme.fontSizes["0"],
+      "1": theme.fontSizes["1"],
       "2": theme.fontSizes["2"],
       "3": theme.fontSizes["3"],
       "4": theme.fontSizes["4"],
+      // default
+      breadcrumbs: theme.fontSizes.breadcrumbs,
+      // default
+      button: theme.fontSizes.button,
+      // primary, secondary, tertiary, callout
+      heading: theme.fontSizes.heading,
+      // default
+      helper: theme.fontSizes.helper,
+      // default, secondary
+      label: theme.fontSizes.label,
+      // default, caption, tag, mini
+      text: theme.fontSizes.text,
     },
     fontWeights: {
       light: theme.fontWeights.light,
       regular: theme.fontWeights.regular,
       medium: theme.fontWeights.medium,
       bold: theme.fontWeights.bold,
+      // default, lastChild
+      breadcrumbs: theme.fontWeights.breadcrumbs,
+      // default
+      button: theme.fontWeights.button,
+      // primary, secondary, tertiary, callout
+      heading: theme.fontWeights.heading,
+      // default
+      helper: theme.fontWeights.helper,
+      // default
+      label: theme.fontWeights.label,
+      // default, caption, tag, mini
+      text: theme.fontWeights.text,
     },
     fonts: {
       body: theme.fonts.body,

--- a/src/hooks/useWindowSize.stories.mdx
+++ b/src/hooks/useWindowSize.stories.mdx
@@ -1,0 +1,23 @@
+import { Meta } from "@storybook/addon-docs";
+import { getCategory } from "../utils/componentCategories";
+
+<Meta title={getCategory("useWindowSize")} />
+
+# useWindowSize
+
+| Hook Version | DS Version |
+| ------------ | ---------- |
+| Added        | `0.25.2`   |
+| Latest       | `0.25.2`   |
+
+This hook is based on [Typescript hooks](https://usehooks-typescript.com/react-hook/use-window-size).
+It returns an object with `width` and `height` properties that can be used to
+update a component's UI based on the size of the browser window.
+
+## Usage
+
+For an example implementation, view the [`Tabs` component](https://github.com/NYPL/nypl-design-system/blob/development/src/components/Tabs/Tabs.tsx).
+
+```tsx
+const { height, width } = useWindowSize();
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,9 @@ export {
 export { TextInputTypes } from "./components/TextInput/TextInputTypes";
 export { default as Toggle } from "./components/Toggle/Toggle";
 export { ToggleSizes } from "./components/Toggle/ToggleTypes";
+export { default as useCarouselStyles } from "./hooks/useCarouselStyles";
 export { default as useNYPLTheme } from "./hooks/useNYPLTheme";
+export { default as useWindowSize } from "./hooks/useWindowSize";
 export { default as VideoPlayer } from "./components/VideoPlayer/VideoPlayer";
 export {
   VideoPlayerAspectRatios,

--- a/src/theme/foundations/spacing.ts
+++ b/src/theme/foundations/spacing.ts
@@ -22,7 +22,7 @@
  *
  * Chakra Number Value | Chakra Name value | DS Variable
  * ------------------- | ----------------- | -----------------
- *        0.5            |         xxxs       |   --nypl-space-xxxs
+ *        0.5          |         xxxs      |   --nypl-space-xxxs
  *        1            |         xxs       |   --nypl-space-xxs
  *        2            |         xs        |   --nypl-space-xs
  *        4            |         s         |   --nypl-space-s


### PR DESCRIPTION
Fixes JIRA ticket [DSD-845](https://jira.nypl.org/browse/DSD-845) and [DSD-722](https://jira.nypl.org/browse/DSD-722)

## This PR does the following:

- Adds Storybook documentation pages for the `useCarouselStyles`, `useNYPLTheme`, and `useWindowSize` custom hooks.
- Exports the `useCarouselStyles` and `useWindowSize` hooks.
- Moves `useNYPLTheme` documentation  from the "Chakra UI" page to its own page.
- Then worked on DSD-722 to include new typography design tokens into the `useNYPLTheme` hook and its returned style object.

## How has this been tested?

Storybook, including testing the new fontSizes and fontWeights design tokens in Charka components and HTML elements.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
