### PR TITLE
DSD-674: Button layout in Form components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Removes the default `Optional` text displayed in the `Label` and `Fieldset` components.
 - Removes the `optReqFlag` prop in the `Label` component.
 
+### Fixes
+
+- Fixes how the `Button` component gets rendered inside the `Form` and `FormField` component layout.
+
 ## 0.25.13 (April 1, 2022)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Exports the `useCarouselStyles` and `useWindowSize` hooks and adds documentation for all hooks in Storybook.
 - Adds additional semantic design tokens from `fontWeights` and `fontSizes` to the `useNYPLTheme` hook.
 - Adds the `isRequired` prop to the `Label` component.
+- Adds the `isAlignedRight` prop to the `CardActions` component. This aligns `CardActions` component to the right of the main content area in the `Card` component. This only works for the `LayoutTypes.Row` layout.
 
 ### Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Exports the `useCarouselStyles` and `useWindowSize` hooks and adds documentation for all hooks in Storybook.
 - Adds additional semantic design tokens from `fontWeights` and `fontSizes` to the `useNYPLTheme` hook.
 - Adds the `isRequired` prop to the `Label` component.
-- Adds the `isAlignedRight` prop to the `CardActions` component. This aligns `CardActions` component to the right of the main content area in the `Card` component. This only works for the `LayoutTypes.Row` layout.
+- Adds the `isAlignedRightActions` prop to the `Card` component to render `CardActions` components to the right of the main content area. This only works for the `Card`'s row layout.
 
 ### Changes
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -65,7 +65,7 @@ export const enumValues = getStorybookEnumValues(ButtonTypes, "ButtonTypes");
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `0.25.9`   |
+| Latest            | `0.26.0`   |
 
 <Description of={Button} />
 

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -81,6 +81,9 @@ export const LayoutTypesEnumValues = getStorybookEnumValues(
     "imageProps.src": {
       table: { defaultValue: { summary: "" } },
     },
+    isAlignedRightActions: {
+      table: { defaultValue: { summary: false } },
+    },
     isCentered: {
       table: { defaultValue: { summary: false } },
     },
@@ -137,9 +140,9 @@ The `CardActions` component is used to display "call to action" (CTA) buttons
 and links for the card. The DS `Button` and `Link` components should be passed
 as children into the `CardActions` component.
 
-Use the `isAlignedRight` prop to align the `CardActions` to the right of the
-the main `CardContent` component area. This is only applicable in the row layout
-of the `Card` component.
+Set the `isAlignedRightActions` prop to true in the `Card` component to align the
+`CardActions` to the right of the the main content area. This is only applicable
+in the row layout of the `Card` component.
 
 ### CardContent
 
@@ -163,6 +166,7 @@ headings and CTAs.
       "imageProps.isAtEnd": false,
       "imageProps.size": "ImageSizes.Default",
       "imageProps.src": "https://placeimg.com/400/300/animals",
+      isAlignedRightActions: false,
       isCentered: false,
       layout: "LayoutTypes.Row",
       mainActionLink: undefined,
@@ -776,7 +780,7 @@ from being having the full-click functionality.
 
 It's possible to set only the `CardActions` component on the right side of the
 main content area of the `Card`. This is possible only in the "LayoutTypes.Row"
-layout and through the `CardActions` component's `isAlignedRight` prop which
+layout and through the `Card` component's `isAlignedRightActions` prop which
 must be set to `true`.
 
 <Canvas>
@@ -802,7 +806,7 @@ must be set to `true`.
         libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel
         eu leo. Nulla vitae elit libero, a pharetra augue.
       </CardContent>
-      <CardActions topBorder bottomBorder isAlignedRight>
+      <CardActions topBorder bottomBorder>
         <Button
           onClick={action("clicked")}
           id="main-button1"
@@ -820,7 +824,7 @@ must be set to `true`.
           Secondary
         </Button>
       </CardActions>
-      <CardActions isAlignedRight>
+      <CardActions>
         <Link href="#">#hash1</Link>,<Link href="#">#hash2</Link>,
         <Link href="#">#hash3</Link>
       </CardActions>

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -97,7 +97,7 @@ export const LayoutTypesEnumValues = getStorybookEnumValues(
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `0.25.13`  |
+| Latest            | `0.26.0`   |
 
 ## Table of Contents
 
@@ -109,6 +109,7 @@ export const LayoutTypesEnumValues = getStorybookEnumValues(
 - [Custom Image Component](#custom-image-component)
 - [Card With Link Heading](#card-with-link-heading)
 - [Card With Full-Click Functionality](#card-with-full-click-functionality)
+- [Card with Right Side CardActions](#card-with-right-side-cardactions)
 - [Cards in a Grid](#cards-in-a-grid)
 - [Cards in a Stack](#cards-in-a-stack)
 - [Card Without Images](#card-without-images)
@@ -135,6 +136,10 @@ accepts the [same props](https://nypl.github.io/nypl-design-system/storybook-sta
 The `CardActions` component is used to display "call to action" (CTA) buttons
 and links for the card. The DS `Button` and `Link` components should be passed
 as children into the `CardActions` component.
+
+Use the `isAlignedRight` prop to align the `CardActions` to the right of the
+the main `CardContent` component area. This is only applicable in the row layout
+of the `Card` component.
 
 ### CardContent
 
@@ -764,6 +769,62 @@ from being having the full-click functionality.
         </CardContent>
       </Card>
     </SimpleGrid>
+  </Story>
+</Canvas>
+
+## Card with Right Side CardActions
+
+It's possible to set only the `CardActions` component on the right side of the
+main content area of the `Card`. This is possible only in the "LayoutTypes.Row"
+layout and through the `CardActions` component's `isAlignedRight` prop which
+must be set to `true`.
+
+<Canvas>
+  <Story name="Card with Right Side CardActions">
+    <Card
+      imageProps={{
+        alt: "Alt text",
+        aspectRatio: ImageRatios.TwoByOne,
+        size: ImageSizes.Medium,
+        src: "https://placeimg.com/400/200/animals",
+      }}
+      isCentered
+      layout={LayoutTypes.Row}
+    >
+      <CardHeading level={HeadingLevels.Two} id="main-heading1">
+        Optional Header
+      </CardHeading>
+      <CardHeading level={HeadingLevels.Three} id="main-heading2">
+        Sollicitudin Lorem Tortor Purus Ornare
+      </CardHeading>
+      <CardContent>
+        Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+        libero, a pharetra augue. Nullam quis risus eget urna mollis ornare vel
+        eu leo. Nulla vitae elit libero, a pharetra augue.
+      </CardContent>
+      <CardActions topBorder bottomBorder isAlignedRight>
+        <Button
+          onClick={action("clicked")}
+          id="main-button1"
+          buttonType={ButtonTypes.Primary}
+          type="submit"
+        >
+          Primary
+        </Button>
+        <Button
+          onClick={action("clicked")}
+          id="main-button2"
+          buttonType={ButtonTypes.Secondary}
+          type="submit"
+        >
+          Secondary
+        </Button>
+      </CardActions>
+      <CardActions isAlignedRight>
+        <Link href="#">#hash1</Link>,<Link href="#">#hash2</Link>,
+        <Link href="#">#hash3</Link>
+      </CardActions>
+    </Card>
   </Story>
 </Canvas>
 

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -250,6 +250,40 @@ describe("Card", () => {
       <CardContent>middle column content</CardContent>
     </Card>
   );
+  const cardWithRightActions = () => (
+    <Card
+      id="cardID"
+      imageProps={{
+        alt: "Alt text",
+        src: "https://placeimg.com/400/200/arch",
+      }}
+    >
+      <CardHeading level={HeadingLevels.Three} id="heading1">
+        The Card Heading
+      </CardHeading>
+      <CardContent>middle column content</CardContent>
+      <CardActions isAlignedRight>
+        <Button
+          onClick={() => {}}
+          id="button1"
+          buttonType={ButtonTypes.Primary}
+          type="submit"
+        >
+          Example CTA
+        </Button>
+      </CardActions>
+      <CardActions isAlignedRight>
+        <Button
+          onClick={() => {}}
+          id="button2"
+          buttonType={ButtonTypes.Primary}
+          type="submit"
+        >
+          Example CTA
+        </Button>
+      </CardActions>
+    </Card>
+  );
   let container;
 
   it("renders a Card with a header, image, content, and CTAs", () => {
@@ -336,6 +370,7 @@ describe("Card", () => {
     const withNoContent = renderer.create(cardWithNoContent).toJSON();
     const withNoImage = renderer.create(cardWithNoImage).toJSON();
     const withFullClick = renderer.create(cardFullClick()).toJSON();
+    const withRightActions = renderer.create(cardWithRightActions()).toJSON();
 
     expect(regular).toMatchSnapshot();
     expect(withExtendedStyles).toMatchSnapshot();
@@ -343,5 +378,6 @@ describe("Card", () => {
     expect(withNoContent).toMatchSnapshot();
     expect(withNoImage).toMatchSnapshot();
     expect(withFullClick).toMatchSnapshot();
+    expect(withRightActions).toMatchSnapshot();
   });
 });

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -257,12 +257,13 @@ describe("Card", () => {
         alt: "Alt text",
         src: "https://placeimg.com/400/200/arch",
       }}
+      isAlignedRightActions
     >
       <CardHeading level={HeadingLevels.Three} id="heading1">
         The Card Heading
       </CardHeading>
       <CardContent>middle column content</CardContent>
-      <CardActions isAlignedRight>
+      <CardActions>
         <Button
           onClick={() => {}}
           id="button1"
@@ -272,7 +273,7 @@ describe("Card", () => {
           Example CTA
         </Button>
       </CardActions>
-      <CardActions isAlignedRight>
+      <CardActions>
         <Button
           onClick={() => {}}
           id="button2"

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -35,6 +35,8 @@ interface CardActionsProps extends CardBaseProps {
   /** Optional boolean value to control visibility of border on the bottom edge
    * of the card actions element */
   bottomBorder?: boolean;
+  /**  */
+  isAlignedRight?: boolean;
   /** Optional boolean value to control visibility of border on the top edge of
    * the card actions element */
   topBorder?: boolean;
@@ -116,9 +118,17 @@ export function CardContent(props: React.PropsWithChildren<{}>) {
 
 // CardActions child-component
 export function CardActions(props: React.PropsWithChildren<CardActionsProps>) {
-  const { bottomBorder, children, isCentered, layout, topBorder } = props;
+  const {
+    bottomBorder,
+    children,
+    isAlignedRight,
+    isCentered,
+    layout,
+    topBorder,
+  } = props;
   const styles = useStyleConfig("CardActions", {
     bottomBorder,
+    isAlignedRight,
     isCentered,
     layout,
     topBorder,
@@ -192,6 +202,7 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
     : imageProps.aspectRatio;
   const customColors = {};
   const cardContents = [];
+  const cardRightContents = [];
   const windowDimensions = useWindowSize();
   let cardHeadingCount = 0;
 
@@ -262,7 +273,14 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
       child.props.mdxType === "CardActions"
     ) {
       const elem = React.cloneElement(child, { key, isCentered, layout });
-      cardContents.push(elem);
+
+      // Only allow `CardActions` to align to the right of the main
+      // `CardContent` component when in the row layout.
+      if (child.props.isAlignedRight && layout === LayoutTypes.Row) {
+        cardRightContents.push(elem);
+      } else {
+        cardContents.push(elem);
+      }
     }
   });
 
@@ -292,6 +310,14 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
         <Box className="card-body" __css={styles.body}>
           {cardContents}
         </Box>
+        {cardRightContents.length ? (
+          <Box
+            className="card-right"
+            __css={{ ...styles.body, marginLeft: "m" }}
+          >
+            {cardRightContents}
+          </Box>
+        ) : null}
       </Box>
     </CardLinkBox>
   );

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -35,8 +35,6 @@ interface CardActionsProps extends CardBaseProps {
   /** Optional boolean value to control visibility of border on the bottom edge
    * of the card actions element */
   bottomBorder?: boolean;
-  /**  */
-  isAlignedRight?: boolean;
   /** Optional boolean value to control visibility of border on the top edge of
    * the card actions element */
   topBorder?: boolean;
@@ -62,6 +60,9 @@ export interface CardProps extends CardBaseProps, CardLinkBoxProps {
   id?: string;
   /** Object used to create and render the `Image` component. */
   imageProps?: CardImageProps;
+  /** Set CardActions to the right content side. This only works in
+   * the row layout. */
+  isAlignedRightActions?: boolean;
 }
 
 /**
@@ -118,17 +119,9 @@ export function CardContent(props: React.PropsWithChildren<{}>) {
 
 // CardActions child-component
 export function CardActions(props: React.PropsWithChildren<CardActionsProps>) {
-  const {
-    bottomBorder,
-    children,
-    isAlignedRight,
-    isCentered,
-    layout,
-    topBorder,
-  } = props;
+  const { bottomBorder, children, isCentered, layout, topBorder } = props;
   const styles = useStyleConfig("CardActions", {
     bottomBorder,
-    isAlignedRight,
     isCentered,
     layout,
     topBorder,
@@ -189,6 +182,7 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
       size: ImageSizes.Default,
       src: "",
     },
+    isAlignedRightActions = false,
     isCentered = false,
     layout = LayoutTypes.Column,
     mainActionLink,
@@ -239,6 +233,9 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
   });
 
   React.Children.map(children, (child: React.ReactElement, key) => {
+    const isCardActions =
+      child.type === CardActions || child.props.mdxType === "CardActions";
+
     if (child.type === CardHeading || child.props.mdxType === "CardHeading") {
       // If the child is a `CardHeading` component, then we add the
       // `CardLinkOverlay` inside of the `Heading` component and wrap its text.
@@ -269,14 +266,17 @@ export default function Card(props: React.PropsWithChildren<CardProps>) {
     } else if (
       child.type === CardContent ||
       child.props.mdxType === "CardContent" ||
-      child.type === CardActions ||
-      child.props.mdxType === "CardActions"
+      isCardActions
     ) {
       const elem = React.cloneElement(child, { key, isCentered, layout });
 
       // Only allow `CardActions` to align to the right of the main
       // `CardContent` component when in the row layout.
-      if (child.props.isAlignedRight && layout === LayoutTypes.Row) {
+      if (
+        isCardActions &&
+        isAlignedRightActions &&
+        layout === LayoutTypes.Row
+      ) {
         cardRightContents.push(elem);
       } else {
         cardContents.push(elem);

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -406,3 +406,61 @@ exports[`Card Renders the UI snapshot correctly 6`] = `
   </div>
 </div>
 `;
+
+exports[`Card Renders the UI snapshot correctly 7`] = `
+<div
+  className="css-0"
+  id="cardID"
+>
+  <div
+    className="css-0"
+  >
+    <img
+      alt="Alt text"
+      className="css-0"
+      src="https://placeimg.com/400/200/arch"
+    />
+  </div>
+  <div
+    className="card-body css-0"
+  >
+    <h3
+      className="chakra-heading css-0"
+      id="heading1"
+    >
+      The Card Heading
+    </h3>
+    <div
+      className="css-0"
+    >
+      middle column content
+    </div>
+    <div
+      className="css-0"
+    >
+      <button
+        className="chakra-button css-0"
+        data-testid="button"
+        id="button1"
+        onClick={[Function]}
+        type="submit"
+      >
+        Example CTA
+      </button>
+    </div>
+    <div
+      className="css-0"
+    >
+      <button
+        className="chakra-button css-0"
+        data-testid="button"
+        id="button2"
+        onClick={[Function]}
+        type="submit"
+      >
+        Example CTA
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/Form/Form.stories.mdx
+++ b/src/components/Form/Form.stories.mdx
@@ -1,4 +1,4 @@
-import { Flex, Spacer } from "@chakra-ui/react";
+import { ButtonGroup, Flex, Spacer } from "@chakra-ui/react";
 import { action } from "@storybook/addon-actions";
 import {
   ArgsTable,
@@ -231,7 +231,6 @@ need to render multiple input components in a horizontal row.
             <Select
               helperText="The select field helper text."
               labelText="Select Field"
-              showLabel={true}
             >
               <option>Option 1</option>
               <option>Option 2</option>
@@ -241,9 +240,22 @@ need to render multiple input components in a horizontal row.
             </Select>
           </FormField>
         </FormRow>
-        <FormField>
-          <Button>Submit</Button>
-        </FormField>
+        <FormRow>
+          <FormField>
+            <Select labelText="Select Field" showLabel={false}>
+              <option>Option 1</option>
+              <option>Option 2</option>
+              <option>Option 3</option>
+              <option>Option 4</option>
+              <option>Option 5</option>
+            </Select>
+          </FormField>
+          <FormField>
+            <ButtonGroup>
+              <Button>Submit</Button>
+            </ButtonGroup>
+          </FormField>
+        </FormRow>
       </Form>
     )}
   </Story>

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -6,6 +6,7 @@ const baseStyle = {
   cursor: "pointer",
   color: "ui.white",
   justifyContent: "center",
+  maxHeight: "2.5rem",
   py: "xs",
   px: "s",
   textDecoration: "none",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-674](https://jira.nypl.org/browse/DSD-674)

## This PR does the following:

- Adding a `maxHeight` to the `Button` allows it to render correctly in the `Form` and `FormField` components, when rendered alone or in a `ButtonGroup`.

- Please review this after #946  -- I accidentally added the update commit to that PR but messed up reverting the commit. So it'll be easier to review once that PR is merged.
- Or, review just the last commit as the previous ones are in #946.

## How has this been tested?

Storybook in the `Form` page.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
