### PR TITLE
DSD-891: Adding a11y docs for page layout components

### DIFF
--- a/src/components/Grid/SimpleGrid.stories.mdx
+++ b/src/components/Grid/SimpleGrid.stories.mdx
@@ -59,6 +59,15 @@ export const enumValues = getStorybookEnumValues(GridGaps, "GridGaps");
 | Added             | `0.25.1`   |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Other SimpleGrid Examples](#other-simplegrid-examples)
+
+## Overview
+
 <Description of={SimpleGrid} />
 
 The `SimpleGrid` component is used to render UI elements in a uniform grid layout,
@@ -69,6 +78,8 @@ tablet and `1` for mobile. By default, the `SimpleGrid` component uses these
 standards and the `columns` prop is optional. If the `columns` prop is used, the
 tablet breakpoint will be dropped and only the mobile breakpoint (1 item per row)
 will be triggered.
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -166,6 +177,18 @@ will be triggered.
 </Canvas>
 
 <ArgsTable story="SimpleGrid with Controls" />
+
+## Accessibility
+
+The CSS grid layout properties are used for the `SimpleGrid` component. We don't
+recommend using property rules that change the visual order of elements on the
+page that don't match with its DOM order. This is because a screenreader won't
+pick up `SimpleGrid` CSS rules and will read the page in the expected DOM order
+rather than the visual order.
+
+Resources:
+
+- [MDN CSS Grid Layout and Accessibility](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout/CSS_Grid_Layout_and_Accessibility)
 
 ## Other SimpleGrid Examples
 

--- a/src/components/HorizontalRule/HorizontalRule.stories.mdx
+++ b/src/components/HorizontalRule/HorizontalRule.stories.mdx
@@ -35,12 +35,22 @@ import { getCategory } from "../../utils/componentCategories";
 | Added             | `0.23.0`   |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+
+## Overview
+
 <Description of={HorizontalRule} />
 
 The `HorizontalRule` component renders a basic `<hr>` element. The `height`,
 `width`, and `align` props can be customized. For the `height` prop, use a whole
 number, a `px` value, a `em` value, or a `rem` value. Otherwise, the default
 value of "2px" will be used.
+
+## Component Props
 
 <Canvas withToolbar>
   <Story name="HorizontalRule" args={{ align: "left" }}>
@@ -49,3 +59,15 @@ value of "2px" will be used.
 </Canvas>
 
 <ArgsTable story="HorizontalRule" />
+
+## Accessibility
+
+The `HorizontalRule` component is not just a visual thematic break between
+content or interfaces, it is also picked up by screenreaders. Internally, the
+`HorizontalRule` component uses the `<hr>` element which has a `role` of
+`"separator"`.
+
+Resources:
+
+- [MDN hr: The Thematic Break (Horizontal Rule) element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/hr)
+- [Not Your Typical Horizontal Rules](https://www.sarasoueidan.com/blog/horizontal-rules/#)

--- a/src/components/StructuredContent/StructuredContent.stories.mdx
+++ b/src/components/StructuredContent/StructuredContent.stories.mdx
@@ -161,10 +161,18 @@ export const imageSizeEnumValues = getStorybookEnumValues(
 
 ## Accessibility
 
-- Containers should allow font-size to be scaled to 200% without content overlapping.
-- Images should have descriptive (but not too lengthy) alt text.
-- Headings levels should not be skipped. Meaning, a `<h2>` should not be followed
-  by a `<h4>`.
+The `StructuredContent` component is a structured container around a specific
+set of content. While the main image can be controlled through the `imageProps`
+prop, the content will not always be controlled. If the content that is being
+passed is coming from a CMS, the content can contain any set of HTML elements that
+are _not_ controlled through Reservoir DS components. While this component
+attempts to style the added elements, we cannot guarantee that the content will
+be accessible. Please review your content and make sure that:
+
+- The content's font-size to be scaled to 200% without content overlapping.
+- Any additional images have descriptive (but not too lengthy) alt text.
+- Any additional heading levels should not be skipped. Meaning, a `<h2>` should
+  not be followed by a `<h4>`.
 - Any links or text with colors should have a 4.5:1 contrast ratio.
 
 ## With HTML String Text Content

--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -123,6 +123,7 @@ Resources:
 - [W3C Tables Tutorial](https://www.w3.org/WAI/tutorials/tables/)
 - [MDN table: The Table element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)
 - [MDN HTML table advance features and accessibility](https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced)
+- [Chakra UI Table](https://chakra-ui.com/docs/components/data-display/table)
 
 ## With a title
 

--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -38,6 +38,18 @@ import { getCategory } from "../../utils/componentCategories";
 | Added             | `0.25.9`   |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [With a title](#with-a-title)
+- [With Row Dividers](#with-row-dividers)
+- [With Row Headers](#with-row-headers)
+- [With Custom Header Colors](#with-custom-header-colors)
+
+## Overview
+
 <Description of={Table} />
 
 export const columnHeaders = [
@@ -64,6 +76,8 @@ export const tableData = [
   ],
 ];
 
+## Component Props
+
 <Canvas withToolbar>
   <Story
     name="Table"
@@ -87,16 +101,28 @@ export const tableData = [
 
 ## Accessibility
 
-- The HTML for the `Table` element is structured with proper semantic use of the
-  `table`, `caption`, `thead`, `tbody`, `tr`, and `td` HTML elements.
-- When titles are added through the `titleText` prop, the `caption` element will
-  be rendered on the page.
-- The first row and/or the first cell in a `tr` row can be headers. Each `th`
-  header cell has an appropriate scope attribute set to either `scope="col"` or
-  `scope="row"`. For example, every `th` cell in a `thead` `tr` row will have
-  `scope="col"`. Every `th` cell in a `tbody` `tr` row will have `scope="row"`.
-  These headers are visually different from the data. Use the `useRowHeaders`
-  prop to render the first cell in every row as a header.
+Internally, the HTML for the `Table` element is structured with proper semantic
+use of the `table`, `caption`, `thead`, `tbody`, `tr`, and `td` HTML elements.
+When titles are added through the `titleText` prop, the `caption` element will
+be rendered above the `thead` element.
+
+This component should be used to render tabular data only and not used for layout
+purposes.
+
+The first row and/or the first cell in a `tr` row can be headers. Each `th`
+header cell has an appropriate scope attribute set to either `scope="col"` or
+`scope="row"`. For example, every `th` cell in a `thead` `tr` row will have
+`scope="col"`. Every `th` cell in a `tbody` `tr` row will have `scope="row"`.
+These headers are visually different from the data. Use the `useRowHeaders`
+prop to render the first cell in every row as a header. If a table has two levels
+of headers (such as two levels of horizontal headers), break the data into two
+separate tables.
+
+Resources:
+
+- [W3C Tables Tutorial](https://www.w3.org/WAI/tutorials/tables/)
+- [MDN table: The Table element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/table)
+- [MDN HTML table advance features and accessibility](https://developer.mozilla.org/en-US/docs/Learn/HTML/Tables/Advanced)
 
 ## With a title
 

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -64,43 +64,12 @@ import { getCategory } from "../../utils/componentCategories";
 
 ## Table of Contents
 
-- [Accessibility for TemplateAppContainer](#accessibility-for-templateappcontainer)
 - [TemplateAppContainer Overview](#templateappcontainer-overview)
 - [TemplateAppContainer Component Props](#templateappcontainer-component-props)
+- [TemplateAppContainer Accessibility](#templateappcontainer-accessibility)
 - [Template Children Overview](#template-children-overview)
 - [Template Children Component Props](#template-children-component-props)
 - [Full Example with Template Children Components](#full-example-with-template-children-components)
-
-## Accessibility
-
-**The `TemplateAppContainer` component is the recommended way to render the entire
-application.** Therefore, this accessibility section is specifically for the
-`TemplateAppContainer` but the same rules apply to the individual "Template"
-components.
-
-The `TemplateAppContainer` component renders the header as a `<header>` element,
-the content as a `<main>` element, and the footer as a `<footer>` element.
-
-If you need to render an alert or notification at the top of the page with an
-`aside` HTML element or HTML element with the `role="complementary"` attribute,
-then pass that alert or notification component to the `aboveHeader` prop. These
-elements should _not_ be rendered in the `header` HTML section since that's an
-accessibility violation.
-
-The `TemplateAppContainer` component renders a full DOM and one of the children
-is the `main` HTML element with a default "id" of `"mainContent"`. This should
-be used as the anchor element that the skip navigation link points to. As of
-v0.25.13, the consuming application is responsible for adding the skip
-navigation feature to the application. If your application is using the current
-NYPL Header, it already contains the skip navigation feature but make sure it is
-pointing to the correct anchor element.
-
-Resources
-
-- [W3C Aria Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/complementary.html)
-- [Digital A11y Role=Complementary](https://www.digitala11y.com/complementary-role/)
-- [WebAim Skip Navigation Link](https://webaim.org/techniques/skipnav/)
-- [A11ymatters Skip Navigation Link](https://www.a11ymatters.com/pattern/skip-link/)
 
 ## TemplateAppContainer Overview
 
@@ -188,6 +157,37 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
 </Canvas>
 
 <ArgsTable story="TemplateAppContainer Component" />
+
+## TemplateAppContainer Accessibility
+
+**The `TemplateAppContainer` component is the recommended way to render the entire
+application.** Therefore, this accessibility section is specifically for the
+`TemplateAppContainer` but the same rules apply to the individual "Template"
+components.
+
+The `TemplateAppContainer` component renders the header as a `<header>` element,
+the content as a `<main>` element, and the footer as a `<footer>` element.
+
+If you need to render an alert or notification at the top of the page with an
+`aside` HTML element or HTML element with the `role="complementary"` attribute,
+then pass that alert or notification component to the `aboveHeader` prop. These
+elements should _not_ be rendered in the `header` HTML section since that's an
+accessibility violation.
+
+The `TemplateAppContainer` component renders a full DOM and one of the children
+is the `main` HTML element with a default "id" of `"mainContent"`. This should
+be used as the anchor element that the skip navigation link points to. As of
+v0.25.13, the consuming application is responsible for adding the skip
+navigation feature to the application. If your application is using the current
+NYPL Header, it already contains the skip navigation feature but make sure it is
+pointing to the correct anchor element.
+
+Resources
+
+- [W3C Aria Landmarks Example](https://www.w3.org/TR/wai-aria-practices/examples/landmarks/complementary.html)
+- [Digital A11y Role=Complementary](https://www.digitala11y.com/complementary-role/)
+- [WebAim Skip Navigation Link](https://webaim.org/techniques/skipnav/)
+- [A11ymatters Skip Navigation Link](https://www.a11ymatters.com/pattern/skip-link/)
 
 ## Template Children Overview
 

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -65,10 +65,10 @@ import { getCategory } from "../../utils/componentCategories";
 ## Table of Contents
 
 - [Accessibility for TemplateAppContainer](#accessibility-for-templateappcontainer)
-- [TemplateAppContainer Component](#templateappcontainer-component)
-- [TemplateAppContainer Props](#templateappcontainer-props)
-- [Template Children Components](#template-children-components)
-- [Template Children Props](#template-children-props)
+- [TemplateAppContainer Overview](#templateappcontainer-overview)
+- [TemplateAppContainer Component Props](#templateappcontainer-component-props)
+- [Template Children Overview](#template-children-overview)
+- [Template Children Component Props](#template-children-component-props)
 - [Full Example with Template Children Components](#full-example-with-template-children-components)
 
 ## Accessibility
@@ -77,6 +77,9 @@ import { getCategory } from "../../utils/componentCategories";
 application.** Therefore, this accessibility section is specifically for the
 `TemplateAppContainer` but the same rules apply to the individual "Template"
 components.
+
+The `TemplateAppContainer` component renders the header as a `<header>` element,
+the content as a `<main>` element, and the footer as a `<footer>` element.
 
 If you need to render an alert or notification at the top of the page with an
 `aside` HTML element or HTML element with the `role="complementary"` attribute,
@@ -99,7 +102,7 @@ Resources
 - [WebAim Skip Navigation Link](https://webaim.org/techniques/skipnav/)
 - [A11ymatters Skip Navigation Link](https://www.a11ymatters.com/pattern/skip-link/)
 
-## TemplateAppContainer Component
+## TemplateAppContainer Overview
 
 <Description of={TemplateAppContainer} />
 
@@ -138,7 +141,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
 />;
 ```
 
-## TemplateAppContainer Props
+## TemplateAppContainer Component Props
 
 <Canvas>
   <Story
@@ -186,7 +189,7 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
 
 <ArgsTable story="TemplateAppContainer Component" />
 
-## Template Children Components
+## Template Children Overview
 
 The DS also provides a set of "template" components that work together to
 render a consistent mobile and desktop layout. More information on individual
@@ -237,7 +240,7 @@ import {
 </Template>
 ```
 
-## Template Children Props
+## Template Children Component Props
 
 <Canvas>
   <Story

--- a/src/utils/componentCategories.ts
+++ b/src/utils/componentCategories.ts
@@ -83,7 +83,6 @@ const categories = {
       "StructuredContent",
       "ContentSwitcher",
       "Footer",
-      "Grid",
       "Header",
       "HorizontalRule",
       "Section",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-891](https://jira.nypl.org/browse/DSD-891)

## This PR does the following:

- Adds table of contents and accessibility docs for `HorizontalRule`, `SimpleGrid`, `StructuredContent`, `Table`, and `Template`.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- More docs.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
