### PR TITLE
DSD-889: Adding a11y docs for navigation components

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.stories.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.mdx
@@ -51,11 +51,23 @@ export const enumValues = getStorybookEnumValues(
 | Added             | `0.0.3`    |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Long Titles](#long-titles)
+- [Color Variations](#color-variations)
+
+## Overview
+
 <Description of={Breadcrumbs} />
 
 The `Breadcrumbs` component is a navigation element that provides a breadcrumb
 path that reflects the site structure and allows a user to navigate to any page
 available in the breadcrumb hierarchy.
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -86,13 +98,17 @@ available in the breadcrumb hierarchy.
 ### Accessibility
 
 Only one `Breadcrumbs` component should be rendered on a page. This is because
-only one HTML `<nav>` element with `aria-label` attribute of "Breadcrumbs"
-should be rendered. The DS `Breadcrumbs` component renders this HTML landmark
-so only one component must be rendered on a page.
+only one HTML `<nav>` element with an `aria-label` attribute value of
+"Breadcrumbs" should be rendered on a page. The DS `Breadcrumbs` component
+renders this HTML landmark so only one component must be rendered on a page.
+
+Internally, links are organized in a `ul` list element. The current page link is
+denoted by an `aria-current` attribute value of "page".
 
 - [W3 Breadcrumbs Practice](https://www.w3.org/TR/wai-aria-practices/examples/breadcrumb/index.html)
+- [Chakra UI Breadcrumb](https://chakra-ui.com/docs/components/navigation/breadcrumb)
 
-### Long Titles
+## Long Titles
 
 <Canvas>
   <DSProvider>

--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -54,7 +54,20 @@ export const enumValues = getStorybookEnumValues(LinkTypes, "LinkTypes");
 | Added             | `0.0.4`    |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Links With Icons](#links-with-icons)
+- [Anchor Element Rendering](#anchor-element-rendering)
+- [Link with Routers](#link-with-routers)
+
+## Overview
+
 <Description of={Link} />
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -80,6 +93,17 @@ export const enumValues = getStorybookEnumValues(LinkTypes, "LinkTypes");
 </Canvas>
 
 <ArgsTable story="Link with Controls" />
+
+## Accessibility
+
+The `Link` component should be used for navigation. If an `onClick` user
+interface action is required, a `Button` component should be used instead. The
+`Link` component renders an `<a>` element with the `href` attribute.
+
+Resources:
+
+- [W3C WAI Link Examples](https://www.w3.org/TR/wai-aria-practices-1.1/examples/link/link.html)
+- [Yale Usability & Web Accessibility Links](https://usability.yale.edu/web-accessibility/articles/links)
 
 ## Links With Icons
 

--- a/src/components/Pagination/Pagination.stories.mdx
+++ b/src/components/Pagination/Pagination.stories.mdx
@@ -46,13 +46,33 @@ export const hrefProps = getStorybookHrefProps(10);
 | Added             | `0.0.10`   |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Accessibility](#accessibility)
+- [Pagination with URL Updates](#pagination-with-url-updates)
+- [Pagination with Unchanging URL](#pagination-with-unchanging-url)
+
+## Overview
+
 <Description of={Pagination} />
 
 The `Pagination` component helps navigate between pages of a multi-page
 application. It is commonly used on a search results page. Update the `pageCount`
 prop in the Controls to explore this component with many or few pages.
 
-Pagination uses anchor tags because it is navigating between URLs.
+## Accessibility
+
+Internally, the `Pagination` component is implemented with a `<nav>` element with
+an `aria-label` attribute of `"Pagination"` and an unordered `<ul>` element. This
+component uses anchor `<a>` tags because it is navigating between URLs. In the
+"unchanging URL" variation, each anchor tag has an `href` attribute with a value
+of `"#"`, because the URL is not changing.
+
+Resources:
+
+- [W3C Design System Pagination](https://design-system.w3.org/components/pagination.html)
+- [a11ymatters Accessible Pagination](https://www.a11ymatters.com/pattern/pagination/)
 
 ## Pagination with URL Updates
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-889](https://jira.nypl.org/browse/DSD-889)

## This PR does the following:

- Adds table of contents and accessibility documentation for the `Breadcrumbs`, `Link`, and `Pagination` components.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- More docs.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
