### PR TITLE
DSD-888: Adding a11y docs for Media components

### DIFF
--- a/src/components/Icons/Icon.stories.mdx
+++ b/src/components/Icons/Icon.stories.mdx
@@ -93,7 +93,22 @@ export const rotationEnumValues = getStorybookEnumValues(
 | Added             | `0.0.4`    |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Rotation Types](#rotation-types)
+- [IconColors Types](#icon-colors-types)
+- [IconSizes Types](#icon-sizes-types)
+- [All Display Icons](#all-display-icons)
+- [Custom Icons](#custom-icons)
+
+## Overview
+
 <Description of={Icon} />
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -219,6 +234,16 @@ its icon name in the `title` element. The default text in the `title` element
 is the icon's code name. Pass in better descriptive text in the `title` prop
 when using the `Icon` component in your application. This will give screenreaders
 a better descriptive title for the `svg` graphic.
+
+`Icon`s are decorative by default. This means that they are presentational and
+screenreaders will not read them because the `aria-hidden` attribute is set to
+`true`.
+
+Resources:
+
+- [W3C Design System SVG Icons](https://design-system.w3.org/styles/svg-icons.html)
+- [CSS-Tricks Accessible SVG Icons](https://css-tricks.com/accessible-svg-icons/)
+- [Chakra UI Icon](https://chakra-ui.com/docs/components/media-and-icons/icon)
 
 ## Rotation Types
 

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -84,12 +84,24 @@ export const imageBlockStyles = {
 | Added             | `0.0.6`    |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Image Figure](#image-figure)
+- [Image Sizes](#image-sizes)
+- [Image Aspect Ratios](#image-aspect-ratios)
+- [Image Types](#image-types)
+
+## Overview
+
 <Description of={Image} />
 
-<p>
-  If you want a simple HTML `img` element then don't pass in values for the
-  `aspectRatio` or `size` props.
-</p>
+If you want a simple HTML `img` element then don't pass in values for the
+`aspectRatio` or `size` props.
+
+## Component Props
 
 <Canvas>
   <Story
@@ -121,6 +133,18 @@ export const imageBlockStyles = {
 </Canvas>
 
 <ArgsTable story="Image with Controls" />
+
+## Accessibility
+
+All images must have an `alt` attribute, even if it's empty. The `alt` prop should
+be used to concisely describe the image. If the image is decorative, then the
+`alt` prop should be an empty string `""`.
+
+Resources:
+
+- [W3C WAI Images Tutorial](https://www.w3.org/WAI/tutorials/images/)
+- [WebAIM Accessible Images](https://webaim.org/techniques/images/)
+- [Yale Usability & Web Accessibility](https://usability.yale.edu/web-accessibility/articles/images)
 
 ## Image Figure
 

--- a/src/components/Logo/Logo.stories.mdx
+++ b/src/components/Logo/Logo.stories.mdx
@@ -59,7 +59,20 @@ export const sizesEnumValues = getStorybookEnumValues(LogoSizes, "LogoSizes");
 | Added             | `0.25.9`   |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Logo Sizes](#logo-sizes)
+- [All Logos](#all-logos)
+- [Custom Logos](#custom-logos)
+
+## Overview
+
 <Description of={Logo} />
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -147,6 +160,16 @@ its `svg` file name in the `title` element. The default text in the `title` elem
 is the logo's code name. Pass in better descriptive text in the `title` prop
 when using the `Logo` component in your application. This will give screenreaders
 a better descriptive title for the `svg` graphic.
+
+`Logos`s are decorative by default. This means that they are presentational and
+screenreaders will not read them because the `aria-hidden` attribute is set to
+`true`.
+
+Resources:
+
+- [W3C Design System SVG Icons](https://design-system.w3.org/styles/svg-icons.html)
+- [CSS-Tricks Accessible SVG Icons](https://css-tricks.com/accessible-svg-icons/)
+- [Chakra UI Icon](https://chakra-ui.com/docs/components/media-and-icons/icon)
 
 ## Logo Sizes
 

--- a/src/components/VideoPlayer/VideoPlayer.stories.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.stories.mdx
@@ -61,6 +61,18 @@ export const typesEnumValues = getStorybookEnumValues(
 | Added             | `0.23.2`   |
 | Latest            | `0.26.0`   |
 
+## Table of Contents
+
+- [Overview](#overview)
+- [Component Props](#component-props)
+- [Accessibility](#accessibility)
+- [Extracting Video IDs](#extracting-video-ids)
+- [Example Embed Code Snippets](#example-embed-code-snippets)
+- [Errored](#errored)
+- [HTML in Helper Text](#html-in-helper-text)
+
+## Overview
+
 <Description of={VideoPlayer} />
 
 The `VideoPlayer` component is used to embed a `Vimeo` or `YouTube` video player
@@ -75,6 +87,8 @@ The `aspectRatio` prop is used to control the sizing of the space allotted for
 the video rendering. Ultimately, the `aspectRatio` prop should be set to match
 the aspect ratio of the video that is being rendered. The default aspect ratio
 is `16:9`.
+
+## Component Props
 
 <Canvas withToolbar>
   <Story
@@ -110,6 +124,33 @@ is `16:9`.
 
 **Example Vimeo IDs:** `474719268`, `491405018`, `493795778` (square)<br />
 **Example YouTube IDs:** `PfqgDG1qrKg`, `roi5V8ppi7Y`, `nm-dD2tx6bk`
+
+## Accessibility
+
+The `VideoPlayer` component renders an `iframe` element with either a Vimeo or
+YouTube video. `iframe`s can be accessible if a `title` attribute is provided.
+When passing in a video type and a video `id`, make sure to pass a title. Otherwise,
+the title must already be provided in the embed code value that is passed to the
+`embedCode` prop. A default one is provided but a custom one is recommended.
+
+Not all the Vimeo or YouTube videos passed to the `VideoPlayer` component will
+be owned by The New York Public Library. Because these videos are hosted on a
+third-party platform, we cannot guarantee that the video will be accessible.
+Besides setting the `title` in the embedded `iframe`, there are _some_ ways we
+can reduce accessibility issues.
+
+- Never use autoplay on videos; a user must click the play button to start the
+  video.
+- Always show all the video player's controls for the user to interact with
+  the video.
+- Keep the full screen option available.
+
+Resources:
+
+- [W3C Making Audio and Video Media Accessible](https://www.w3.org/WAI/media/av/)
+- [WebAIM Creating Accessible Frames and Iframes](https://webaim.org/techniques/frames/)
+- [MDN iframe: The Inline Frame element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe)
+- [Deque University Be Sure to Provide Titles for Iframes](https://dequeuniversity.com/tips/provide-iframe-titles)
 
 ## Extracting Video IDs
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-888](https://jira.nypl.org/browse/DSD-888)

## This PR does the following:

- Adds table of contents and accessibility docs to the `Icon`, `Image`, `Logo`, and `VideoPlayer` components.

## How has this been tested?

Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- More docs.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
