### PR TITLE
DSD-953: Removing the attributes prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,17 +8,25 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds `max`, `maxLength`, `min`, and `onClick` props to the `TextInput` component.
+
 ### Updates
 
 - Updates how styles are passed down to internal components in `Card`, `Checkbox`, `CheckboxGroup`, `ComponentWrapper`, `DatePicker`, `Hero`, `Notification`, `Pagination`, `Radio`, `RadioGroup`, `SearchBar`, and `Slider`. This is based on removing the `additionalStyles` prop and passing down styles to the `__css` prop.
 - Updates how the `id` is passed in the `DatePicker`'s custom `TextInput` component.
 - Updates how some prop values are passed. Instead of using a Typescript enum object, a Typescript type with the string literal values is used. This still restricts the accepted values for certain props. The enum to string literal type conversion includes the following variables: `AccordionType`, `BreadcrumbsTypes`, `ButtonTypes`, `DatePickerTypes`, `FormGaps` (deleted), `GridGaps`, `HeadingSizes`, `HeadingLevels`, `HeroTypes`, `IconAlign`, `IconTypes`, `IconRotationTypes`, `IconColors`, `IconSizes`, `IconNames`, `LinkTypes`, `ListTypes`, `LogoColors`, `LogoSizes`, `LogoNames`, `NotificationTypes`, `SelectTypes`, `LabelPositions`, `SkeletonLoaderImageRatios`, `StatusBadgeTypes`, `StructuredContentImagePosition`, `TextSizes`, `TextInputTypes`, `TextInputFormats`, `TextInputVariants`, `ToggleSizes`, `VideoPlayerTypes`, `VideoPlayerAspectRatios`, and `LayoutTypes`.
+- Updates how the `DatePicker` and `Slider` components internally use `TextInput`.
+- Updates how the `Pagination` component internally uses `Link`.
+- Updates how the `Tabs` component internally uses `Button`.
 
 ### Removals
 
 - Removes the `additionalStyles` attributes from the `Breadcrumbs`, `Button`, `Heading`, `HelperErrorText`, `Icon`, `Link`, `List`, `Logo`, `Select`, `TextInput`, and `Toggle` components.
 - Removes `getVariant` and `getStorybookEnumValues` helper functions.
 - Removes all Typescript enum objects in favor of string literal types.
+- Removes the `attributes` prop from: `Button`, `Link`, and `TextInput` components.
 
 ## 0.27.0 (April 27, 2022)
 

--- a/src/components/Autosuggest/Autosuggest.stories.tsx
+++ b/src/components/Autosuggest/Autosuggest.stories.tsx
@@ -13,19 +13,15 @@ const StoryWrapper = ({ children }) => (
   <div style={{ padding: "5px", minHeight: "400px" }}>{children}</div>
 );
 
-const libraryRenderInputComponent = (
-  inputProps: React.HTMLProps<HTMLInputElement>
-) => {
+const libraryRenderInputComponent = (inputProps: any) => {
   return (
     <TextInput
-      attributes={{
-        ...inputProps,
-      }}
       id="library-autosuggest"
       isRequired
       labelText="Home Library"
       name="homeLibraryName"
       helperText="Select your home library. Start by typing the name of the library. Try 'ba'."
+      {...inputProps}
     />
   );
 };
@@ -132,12 +128,10 @@ const FishExample = () => {
   const renderInputComponent = (inputProps) => {
     return (
       <TextInput
-        attributes={{
-          ...inputProps,
-        }}
         id="library-fish-autosuggest"
         labelText="Fish in Animal Crossing"
         name="favoriteFish"
+        {...inputProps}
       />
     );
   };
@@ -191,18 +185,14 @@ export const AutosuggestFish = () => (
   </StoryWrapper>
 );
 
-const searchBarRenderInputComponent = (
-  inputProps: React.HTMLProps<HTMLInputElement>
-) => {
+const searchBarRenderInputComponent = (inputProps: any) => {
   return (
     <TextInput
-      attributes={{
-        ...inputProps,
-      }}
       id="autosuggest-searchBar"
       isRequired
       labelText="home library"
       name="homeLibraryName"
+      {...inputProps}
     />
   );
 };

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -58,7 +58,6 @@ export const iconNames = [
     jest: ["Button.test.tsx"],
   }}
   argTypes={{
-    attributes: { control: false },
     buttonText: { description: "Only used for Storybook" },
     buttonType: {
       table: { defaultValue: { summary: "primary" } },
@@ -121,7 +120,6 @@ no text, it will automatically be configured to use the `"iconOnly"` type.
   <Story
     name="Button with Controls"
     args={{
-      attributes: undefined,
       buttonText: "Button Text",
       buttonType: "primary",
       className: undefined,
@@ -137,7 +135,6 @@ no text, it will automatically be configured to use the `"iconOnly"` type.
   >
     {(args) => (
       <Button
-        attributes={args.attributes}
         buttonType={args.buttonType}
         className={args.className}
         id={args.id}
@@ -236,37 +233,18 @@ The icon can be placed to the left or the right of the button text.
 </Canvas>
 
 Text in a button is optional if an icon is rendered, but make sure that there
-is an `aria-label` passed to the `Button` component through the `attributes` prop:
-`attributes={{ "aria-label": "Previous" }}`
+is an `aria-label` passed to the `Button` component `aria-label="Previous"`.
 
 <Canvas>
   <DSProvider>
     <ButtonGroup>
-      <Button
-        attributes={{
-          "aria-label": "Previous",
-        }}
-        buttonType="secondary"
-        id="prev-btn"
-      >
+      <Button aria-label="Previous" buttonType="secondary" id="prev-btn">
         <Icon name="arrow" iconRotation="rotate90" size="small" />
       </Button>
-      <Button
-        attributes={{
-          "aria-label": "Next",
-        }}
-        buttonType="secondary"
-        id="next-btn"
-      >
+      <Button aria-label="Next" buttonType="secondary" id="next-btn">
         <Icon name="arrow" iconRotation="rotate270" size="small" />
       </Button>
-      <Button
-        attributes={{
-          "aria-label": "Close",
-        }}
-        buttonType="secondary"
-        id="close-btn"
-      >
+      <Button aria-label="Close" buttonType="secondary" id="close-btn">
         <Icon name="close" size="small" />
       </Button>
     </ButtonGroup>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -17,8 +17,6 @@ export type ButtonTypes =
   | "noBrand";
 
 interface ButtonProps {
-  /** Additional attributes passed to the button. */
-  attributes?: { [key: string]: any };
   /** The button variation to render based on the `ButtonTypes` type.*/
   buttonType?: ButtonTypes;
   /** Additional className to use. */
@@ -41,7 +39,6 @@ interface ButtonProps {
  */
 export const Button = chakra((props: React.PropsWithChildren<ButtonProps>) => {
   const {
-    attributes,
     buttonType = "primary",
     children,
     className = "",
@@ -89,7 +86,6 @@ export const Button = chakra((props: React.PropsWithChildren<ButtonProps>) => {
       className={className}
       type={type}
       isDisabled={isDisabled}
-      {...attributes}
       {...btnCallback}
       __css={styles}
       {...rest}

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -121,7 +121,6 @@ export interface DatePickerProps extends DatePickerWrapperProps {
 const CustomTextInput = forwardRef<TextInputRefType, CustomTextInputProps>(
   (
     {
-      attributes,
       dsRef,
       helperText,
       id,
@@ -130,19 +129,18 @@ const CustomTextInput = forwardRef<TextInputRefType, CustomTextInputProps>(
       isInvalid,
       isRequired,
       labelText,
+      name,
       onChange,
       onClick,
       showLabel,
       showHelperInvalidText,
       showRequiredLabel,
       value,
-      ...rest
     },
     ref: React.Ref<TextInputRefType>
   ) => {
     return (
       <TextInput
-        attributes={{ ...attributes, onClick }}
         helperText={helperText}
         id={id}
         invalidText={invalidText}
@@ -150,7 +148,9 @@ const CustomTextInput = forwardRef<TextInputRefType, CustomTextInputProps>(
         isInvalid={isInvalid}
         isRequired={isRequired}
         labelText={labelText}
+        name={name}
         onChange={onChange}
+        onClick={onClick}
         showHelperInvalidText={showHelperInvalidText}
         showLabel={showLabel}
         showRequiredLabel={showRequiredLabel}
@@ -159,7 +159,6 @@ const CustomTextInput = forwardRef<TextInputRefType, CustomTextInputProps>(
         // `react-datepicker` manipulates the `ref` value so when we
         // want a specific ref, use the `dsRef` prop.
         ref={dsRef || ref}
-        {...rest}
       />
     );
   }
@@ -374,13 +373,13 @@ export const DatePicker = chakra(
         <ReactDatePicker
           customInput={
             <CustomTextInput
-              attributes={{ name: nameTo }}
               dsRef={refTo}
               labelText="To"
               {...endCustomTextInputAttrs}
             />
           }
           id={`${id}-end`}
+          name={nameTo}
           onChange={(date) => onChangeDefault(date, "endDate")}
           selected={fullDate.endDate}
           {...endDatePickerAttrs}
@@ -391,13 +390,13 @@ export const DatePicker = chakra(
       <ReactDatePicker
         customInput={
           <CustomTextInput
-            attributes={{ name: nameFrom }}
             dsRef={ref}
             labelText={startLabelText}
             {...baseCustomTextInputAttrs}
           />
         }
         id={`${id}-start`}
+        name={nameFrom}
         onChange={(date) => onChangeDefault(date, "startDate")}
         selected={fullDate.startDate}
         {...startDatePickerAttrs}

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -27,12 +27,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -69,12 +64,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -132,12 +122,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -174,12 +159,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -237,12 +217,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -279,12 +254,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -342,12 +312,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -397,12 +362,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -485,12 +445,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -527,12 +482,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className=" css-1xdhyk6"
-              disabled={false}
-              onBlur={[Function]}
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
+              className="css-1xdhyk6"
             >
               <label
                 className="css-1xdhyk6"
@@ -591,12 +541,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <label
             className="css-1xdhyk6"
@@ -641,12 +586,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <input
             aria-label="Select the date you want to visit NYPL"
@@ -685,12 +625,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <label
             className="css-1xdhyk6"
@@ -735,12 +670,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <label
             className="css-1xdhyk6"
@@ -799,12 +729,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <label
             className="css-1xdhyk6"
@@ -862,12 +787,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <label
             className="css-1xdhyk6"
@@ -926,12 +846,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className=" css-1xdhyk6"
-          disabled={false}
-          onBlur={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          readOnly={false}
+          className="css-1xdhyk6"
         >
           <label
             className="css-1xdhyk6"

--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -25,7 +25,6 @@ import DSProvider from "../../theme/provider";
     jest: ["Link.test.tsx"],
   }}
   argTypes={{
-    attributes: { control: false },
     children: { table: { disable: true } },
     key: { table: { disable: true } },
     ref: { table: { disable: true } },
@@ -61,10 +60,6 @@ import DSProvider from "../../theme/provider";
   <Story
     name="Link with Controls"
     args={{
-      attributes: {
-        rel: "nofollow",
-        onClick: (e) => e.preventDefault(),
-      },
       className: "custom-class",
       href: "https://nypl.org",
       id: "nypl-link",

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -11,8 +11,6 @@ export type LinkTypes =
   | "external"
   | "forwards";
 export interface LinkProps {
-  /** Additional attributes, such as `rel=nofollow`, to pass to the `<a>` tag. */
-  attributes?: { [key: string]: any };
   /** Any child node passed to the component. */
   children: React.ReactNode;
   /** Additional class name to render in the `Link` component. */
@@ -92,22 +90,14 @@ function getExternalIcon(children, linkId) {
  */
 export const Link = chakra(
   React.forwardRef<HTMLAnchorElement, LinkProps>((props, ref: any) => {
-    const {
-      attributes,
-      children,
-      className,
-      href,
-      id,
-      type = "default",
-      ...rest
-    } = props;
+    const { children, className, href, id, type = "default", ...rest } = props;
 
     // Merge the necessary props alongside any extra props for the
     // anchor element.
     const linkProps = {
       id,
       href,
-      ...attributes,
+      ...rest,
     };
     // The "default" type.
     let variant = "link";
@@ -149,7 +139,7 @@ export const Link = chakra(
       const childrenToClone: any = children[0] ? children[0] : children;
       const childProps = childrenToClone.props;
       return (
-        <Box as="span" __css={style} {...rest}>
+        <Box as="span" __css={style}>
           {React.cloneElement(
             childrenToClone,
             {
@@ -174,7 +164,6 @@ export const Link = chakra(
           target={target}
           {...linkProps}
           __css={style}
-          {...rest}
         >
           {newChildren}
         </Box>

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -161,9 +161,7 @@ export const Notification = chakra((props: NotificationProps) => {
   };
   const dismissibleButton = dismissible && (
     <Button
-      attributes={{
-        "aria-label": "Close the notification",
-      }}
+      aria-label="Close the notification"
       buttonType="link"
       id={`${id}-notification-dismissible-button`}
       onClick={handleClose}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -149,9 +149,9 @@ export const Pagination = chakra((props: PaginationProps) => {
     const linkAttrs = allAttrs[type];
     return (
       <Link
-        attributes={linkAttrs.attributes}
         href={linkAttrs.href}
         id={`${id}-${linkAttrs.text}`}
+        {...linkAttrs.attributes}
         __css={{
           ...styles.link,
           ...currentStyles,

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -69,7 +69,7 @@ export const Radio = chakra(
     } = props;
     const styles = useMultiStyleConfig("Radio", {});
     const footnote = isInvalid ? invalidText : helperText;
-    const attributes = {};
+    const ariaAttributes = {};
 
     if (!id) {
       console.warn(
@@ -83,10 +83,10 @@ export const Radio = chakra(
           "NYPL Reservoir Radio: `labelText` must be a string when `showLabel` is false."
         );
       }
-      attributes["aria-label"] =
+      ariaAttributes["aria-label"] =
         labelText && footnote ? `${labelText} - ${footnote}` : labelText;
     } else if (footnote) {
-      attributes["aria-describedby"] = `${id}-helperText`;
+      ariaAttributes["aria-describedby"] = `${id}-helperText`;
     }
 
     return (
@@ -104,7 +104,7 @@ export const Radio = chakra(
           ref={ref}
           alignItems="flex-start"
           __css={styles}
-          {...attributes}
+          {...ariaAttributes}
           {...rest}
         >
           {showLabel && labelText}

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -150,10 +150,11 @@ export const Slider = chakra((props: React.PropsWithChildren<SliderProps>) => {
   };
   // Props that the two `TextInput` components use.
   const textInputSharedProps = {
-    attributes: { max, min },
     isDisabled,
     isInvalid: finalIsInvalid,
     isRequired,
+    max,
+    min,
     // Never show the label or helper text for the `TextInput` component.
     showHelperInvalidText: false,
     showLabel: false,

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -16,8 +16,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
   >
     <div
       className="css-bunm4f"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -141,8 +139,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -192,8 +188,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
   >
     <div
       className="css-bunm4f"
-      max={100}
-      min={0}
     >
       <input
         aria-invalid={true}
@@ -318,8 +312,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-invalid={true}
@@ -373,8 +365,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
   >
     <div
       className="css-bunm4f"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -499,8 +489,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -551,8 +539,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
   >
     <div
       className="css-bunm4f"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -678,8 +664,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -722,8 +706,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
   >
     <div
       className="css-bunm4f"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -847,8 +829,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -1196,8 +1176,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label"
@@ -1328,8 +1306,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-invalid={true}
@@ -1464,8 +1440,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label"
@@ -1599,8 +1573,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label"
@@ -1723,8 +1695,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label"
@@ -2025,8 +1995,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label"
@@ -2158,8 +2126,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
     </div>
     <div
       className="css-1ebeaqx"
-      max={100}
-      min={0}
     >
       <input
         aria-label="Label"

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -16,6 +16,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
   >
     <div
       className="css-bunm4f"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -139,6 +141,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -188,6 +192,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
   >
     <div
       className="css-bunm4f"
+      max={100}
+      min={0}
     >
       <input
         aria-invalid={true}
@@ -312,6 +318,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-invalid={true}
@@ -365,6 +373,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
   >
     <div
       className="css-bunm4f"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -489,6 +499,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -539,6 +551,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
   >
     <div
       className="css-bunm4f"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -664,6 +678,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -706,6 +722,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
   >
     <div
       className="css-bunm4f"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - start value"
@@ -829,6 +847,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label - end value"
@@ -1176,6 +1196,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label"
@@ -1306,6 +1328,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-invalid={true}
@@ -1440,6 +1464,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label"
@@ -1573,6 +1599,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label"
@@ -1695,6 +1723,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label"
@@ -1995,6 +2025,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label"
@@ -2126,6 +2158,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
     </div>
     <div
       className="css-1ebeaqx"
+      max={100}
+      min={0}
     >
       <input
         aria-label="Label"

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -185,13 +185,13 @@ export const Tabs = chakra((props: React.PropsWithChildren<TabsProps>) => {
   }, [goToStart, windowDimensions.width]);
   const previousButton = (
     <Button
-      attributes={{
-        "aria-label": "Previous",
+      aria-label="Previous"
+      id={`tabs-previous-${id}`}
+      onClick={prevSlide}
+      __css={{
         ...styles.buttonArrows,
         left: "0",
       }}
-      id={`tabs-previous-${id}`}
-      onClick={prevSlide}
     >
       <Icon
         iconRotation="rotate90"
@@ -203,13 +203,13 @@ export const Tabs = chakra((props: React.PropsWithChildren<TabsProps>) => {
   );
   const nextButton = (
     <Button
-      attributes={{
-        "aria-label": "Next",
+      aria-label="Next"
+      id={`tabs-next-${id}`}
+      onClick={nextSlide}
+      __css={{
         ...styles.buttonArrows,
         right: "0",
       }}
-      id={`tabs-next-${id}`}
-      onClick={nextSlide}
     >
       <Icon
         iconRotation="rotate270"

--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -656,27 +656,12 @@ This is best viewed in the Storybook "Canvas" and not "Docs" section.
             </p>
           </CardContent>
           <CardActions>
-            <Link
-              attributes={{
-                style: { color: "#FFF", textDecoration: "underline" },
-              }}
-              href="#"
-            >
+            <Link color="#FFF" href="#" textDecoration="underline">
               Facebook
             </Link>
-            ,<Link
-              attributes={{
-                style: { color: "#FFF", textDecoration: "underline" },
-              }}
-              href="#"
-            >
+            ,<Link color="#FFF" href="#" textDecoration="underline">
               Instagram
-            </Link>,<Link
-              attributes={{
-                style: { color: "#FFF", textDecoration: "underline" },
-              }}
-              href="#"
-            >
+            </Link>,<Link color="#FFF" href="#" textDecoration="underline">
               Twitter
             </Link>
           </CardActions>

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -24,7 +24,6 @@ import DSProvider from "../../theme/provider";
     jest: ["TextInput.test.tsx"],
   }}
   argTypes={{
-    attributes: { control: false },
     id: { control: false },
     isDisabled: { table: { defaultValue: { summary: false } } },
     isInvalid: { table: { defaultValue: { summary: false } } },
@@ -79,7 +78,6 @@ is left blank, a value will be generated for you.
   <Story
     name="TextInput with Controls"
     args={{
-      attributes: undefined,
       className: undefined,
       defaultValue: undefined,
       helperText: "Choose wisely.",

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -213,7 +213,7 @@ describe("TextInput shows error state", () => {
   });
 });
 
-describe("Renders HTML attributes passed through", () => {
+describe("Renders HTML attributes passed", () => {
   const onChangeSpy = jest.fn();
   beforeEach(() => {
     render(

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
 import renderer from "react-test-renderer";
 import userEvent from "@testing-library/user-event";
@@ -39,14 +39,11 @@ describe("TextInput Accessibility", () => {
 describe("TextInput", () => {
   let utils;
   let changeHandler;
-  let focusHandler;
 
   beforeEach(() => {
-    focusHandler = jest.fn();
     changeHandler = jest.fn();
     utils = render(
       <TextInput
-        attributes={{ onFocus: focusHandler }}
         id="myTextInput"
         isRequired
         labelText="Custom Input Label"
@@ -73,7 +70,6 @@ describe("TextInput", () => {
   it("does not render '(Required)' along with the label text", () => {
     utils.rerender(
       <TextInput
-        attributes={{ onFocus: focusHandler }}
         id="myTextInput"
         isRequired
         labelText="Custom Input Label"
@@ -105,12 +101,6 @@ describe("TextInput", () => {
     expect(screen.getByLabelText(/Custom Input Label/i)).toHaveAttribute(
       "aria-required"
     );
-  });
-
-  it("allows user to pass in additional attributes", () => {
-    expect(focusHandler).toHaveBeenCalledTimes(0);
-    fireEvent.focus(screen.getByLabelText(/Custom Input Label/i));
-    expect(focusHandler).toHaveBeenCalledTimes(1);
   });
 
   it("changing the value calls the onChange handler", () => {
@@ -223,20 +213,15 @@ describe("TextInput shows error state", () => {
   });
 });
 
-describe("Renders HTML attributes passed through the `attributes` prop", () => {
+describe("Renders HTML attributes passed through", () => {
   const onChangeSpy = jest.fn();
-  const onBlurSpy = jest.fn();
   beforeEach(() => {
     render(
       <TextInput
-        attributes={{
-          onChange: onChangeSpy,
-          onBlur: onBlurSpy,
-          maxLength: 10,
-          tabIndex: 0,
-        }}
         id="inputID-attributes"
         labelText="Input Label"
+        maxLength={10}
+        onChange={onChangeSpy}
         placeholder="Input Placeholder"
         type="text"
       />
@@ -250,23 +235,10 @@ describe("Renders HTML attributes passed through the `attributes` prop", () => {
     );
   });
 
-  it("has a tabIndex", () => {
-    expect(screen.getByLabelText(/Input Label/i)).toHaveAttribute(
-      "tabIndex",
-      "0"
-    );
-  });
-
   it("calls the onChange function", () => {
     expect(onChangeSpy).toHaveBeenCalledTimes(0);
     userEvent.type(screen.getByLabelText(/Input Label/i), "Hello");
     expect(onChangeSpy).toHaveBeenCalledTimes(5);
-  });
-
-  it("calls the onBlur function", () => {
-    expect(onBlurSpy).toHaveBeenCalledTimes(0);
-    fireEvent.blur(screen.getByLabelText(/Input Label/i));
-    expect(onBlurSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -73,6 +73,8 @@ export interface InputProps {
   ) => void;
   /** The action to perform on the `input`/`textarea`'s onClick function  */
   onClick?: (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
+  /** The action to perform on the `input`/`textarea`'s onFocus function  */
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
   /** Populates the placeholder for the input/textarea elements */
   placeholder?: string;
   /** Offers the ability to hide the helper/invalid text. */
@@ -123,6 +125,7 @@ export const TextInput = chakra(
         name,
         onChange,
         onClick,
+        onFocus,
         placeholder,
         showHelperInvalidText = true,
         showLabel = true,
@@ -188,6 +191,7 @@ export const TextInput = chakra(
             name,
             onChange,
             onClick,
+            onFocus,
             placeholder,
             ref,
             // The `step` attribute is useful for the number type.

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -38,8 +38,6 @@ export const TextInputFormats = {
 export type TextInputVariants = "default" | "searchBar" | "searchBarSelect";
 
 export interface InputProps {
-  /** Additional attributes to pass to the `<input>` or `<textarea>` element */
-  attributes?: { [key: string]: any };
   /** A class name for the TextInput parent div. */
   className?: string;
   /** The starting value of the input field. */
@@ -59,6 +57,12 @@ export interface InputProps {
   /** Provides text for a `Label` component if `showLabel` is set to true;
    * populates an `aria-label` attribute if `showLabel` is set to false. */
   labelText: string;
+  /** The max number for a `number` TextInput type. */
+  max?: number;
+  /** The max length of the input field. */
+  maxLength?: number;
+  /** The min number for a `number` TextInput type. */
+  min?: number;
   /** Used to reference the input element in forms. */
   name?: string;
   /** The action to perform on the `input`/`textarea`'s onChange function  */
@@ -67,6 +71,8 @@ export interface InputProps {
       | React.ChangeEvent<HTMLInputElement>
       | React.ChangeEvent<HTMLTextAreaElement>
   ) => void;
+  /** The action to perform on the `input`/`textarea`'s onClick function  */
+  onClick?: (event: React.MouseEvent<HTMLInputElement, MouseEvent>) => void;
   /** Populates the placeholder for the input/textarea elements */
   placeholder?: string;
   /** Offers the ability to hide the helper/invalid text. */
@@ -102,7 +108,6 @@ export const TextInput = chakra(
   React.forwardRef<TextInputRefType, InputProps>(
     (props, ref: React.Ref<TextInputRefType>) => {
       const {
-        attributes = {},
         className,
         defaultValue,
         helperText,
@@ -112,8 +117,12 @@ export const TextInput = chakra(
         isInvalid = false,
         isRequired = false,
         labelText,
+        max,
+        maxLength,
+        min,
         name,
         onChange,
+        onClick,
         placeholder,
         showHelperInvalidText = true,
         showLabel = true,
@@ -135,6 +144,7 @@ export const TextInput = chakra(
       let footnote: HelperErrorTextType = isInvalid
         ? finalInvalidText
         : helperText;
+      let ariaAttributes = {};
       let fieldOutput;
       let options;
 
@@ -145,10 +155,10 @@ export const TextInput = chakra(
       }
 
       if (!showLabel) {
-        attributes["aria-label"] =
+        ariaAttributes["aria-label"] =
           labelText && footnote ? `${labelText} - ${footnote}` : labelText;
       } else if (helperText) {
-        attributes["aria-describedby"] = `${id}-helperText`;
+        ariaAttributes["aria-describedby"] = `${id}-helperText`;
       }
 
       if (type === "tel" || type === "url" || type === "email") {
@@ -172,13 +182,18 @@ export const TextInput = chakra(
             isDisabled,
             isRequired,
             isInvalid,
-            placeholder,
+            max,
+            maxLength,
+            min,
             name,
             onChange,
+            onClick,
+            placeholder,
             ref,
             // The `step` attribute is useful for the number type.
             step: type === "number" ? step : null,
-            ...attributes,
+            ...ariaAttributes,
+            ...rest,
           };
       // For `input` and `textarea`, all attributes are the same but `input`
       // also needs `type` and `value` to render correctly.

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -226,6 +226,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
   </label>
   <input
     className="chakra-input css-0"
+    data-testid="props"
     disabled={false}
     id="props"
     onBlur={[Function]}


### PR DESCRIPTION
Fixes JIRA ticket [DSD-953](https://jira.nypl.org/browse/DSD-953)

## This PR does the following:

We don't need the `attributes` prop since we can pass any prop now. But, some props still need to be declared and that's mostly in the `TextInput` component.

- Adds `max`, `maxLength`, `min`, and `onClick` props to the `TextInput` component.
- Updates how the `DatePicker` and `Slider` components internally use `TextInput`.
- Updates how the `Pagination` component internally uses `Link`.
- Updates how the `Tabs` component internally uses `Button`.
- Removes the `attributes` prop from: `Button`, `Link`, and `TextInput` components.

## How has this been tested?

Storybook and tests

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Tugboat creates a static Storybook preview URL once the PR is created. -->
<!--- Copy the URL to the relevant Storybook page here. -->

- [ ] View [the example in Storybook]()
