### PR TITLE
DSD-875: Refactor various input component to use the ComponentWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `noSpace` prop to the `Heading` component.
 - Adds validation for equal headers and data column to the `Table` component.
+- Adds `className`, `helperTextStyles`, and `showHelperInvalidText` props to the `ComponentWrapper` component.
 
 ### Updates
 
@@ -19,6 +20,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates all QA urls from Tugboat QA to Vercel.
 - Updates the `Logo` component to include new variants for `Apple App Store`, `Clever Badge` and `Google Play`.
 - Pins the Chakra UI "react" and "system" packages to a certain range since Chakra v2 uses React 18 and creates backwards compatibility issues.
+- Updates and refactors the `Checkbox`, `Radio`, `Select`, `Slider, `TextInput`, and `Toggle`components to use the`ComponentWrapper` component for similar DOM structure.
 
 ### Fixes
 

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -39,12 +39,6 @@ describe("Checkbox Accessibility", () => {
 });
 
 describe("Checkbox", () => {
-  let changeHandler: jest.MockedFunction<() => void>;
-
-  beforeEach(() => {
-    changeHandler = jest.fn();
-  });
-
   it("Renders with a checkbox input and label", () => {
     render(<Checkbox id="inputID" labelText="Test Label" />);
     expect(screen.getByLabelText("Test Label")).toBeInTheDocument();
@@ -190,19 +184,36 @@ describe("Checkbox", () => {
   });
 
   it("Changing the value calls the onChange handler", () => {
+    let isChecked = false;
+    const onChange = (e) => {
+      isChecked = e.target.checked;
+    };
     const utils = render(
       <Checkbox
         id="onChangeTest"
-        onChange={changeHandler}
+        onChange={onChange}
         labelText="onChangeTest Lab"
         showLabel={true}
-        isChecked
+        isChecked={isChecked}
       />
     );
 
-    expect(changeHandler).toHaveBeenCalledTimes(0);
-    userEvent.type(utils.getByText("onChangeTest Lab"), "Hello");
-    expect(changeHandler).toHaveBeenCalledTimes(1);
+    expect(isChecked).toEqual(false);
+    userEvent.click(utils.getByText("onChangeTest Lab"));
+    expect(isChecked).toEqual(true);
+
+    utils.rerender(
+      <Checkbox
+        id="onChangeTest"
+        onChange={onChange}
+        labelText="onChangeTest Lab"
+        showLabel={true}
+        isChecked={isChecked}
+      />
+    );
+
+    userEvent.click(utils.getByText("onChangeTest Lab"));
+    expect(isChecked).toEqual(false);
   });
 
   it("logs a warning if `labelText` is not a string and `showLabel` is false", () => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -5,11 +5,10 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { AriaAttributes } from "../../utils/interfaces";
 
-import HelperErrorText, {
-  HelperErrorTextType,
-} from "../HelperErrorText/HelperErrorText";
+import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
+import { getAriaAttrs } from "../../utils/utils";
 
 interface CheckboxIconProps {
   /** When using the Checkbox as a "controlled" form element, you can specify
@@ -97,10 +96,16 @@ export const Checkbox = chakra(
     } = props;
     const styles = useMultiStyleConfig("Checkbox", {});
     const footnote = isInvalid ? invalidText : helperText;
-    const ariaAttributes: AriaAttributes = {};
     const onChange = props.onChange || onChangeDefault;
     // Use Chakra's default indeterminate icon.
     const icon = !isIndeterminate ? <CheckboxIcon /> : undefined;
+    const ariaAttributes = getAriaAttrs({
+      footnote,
+      id,
+      labelText,
+      name: "Checkbox",
+      showLabel,
+    });
 
     if (!id) {
       console.warn(
@@ -108,30 +113,25 @@ export const Checkbox = chakra(
       );
     }
 
-    if (!showLabel) {
-      if (typeof labelText !== "string") {
-        console.warn(
-          "NYPL Reservoir Checkbox: `labelText` must be a string when `showLabel` is false."
-        );
-      }
-      ariaAttributes["aria-label"] =
-        labelText && footnote
-          ? `${labelText} - ${footnote}`
-          : (labelText as string);
-    } else {
-      if (footnote) ariaAttributes["aria-describedby"] = `${id}-helperText`;
-    }
-
     return (
-      <>
+      <ComponentWrapper
+        helperText={helperText}
+        helperTextStyles={styles.helperErrorText}
+        id={id}
+        invalidText={invalidText}
+        isInvalid={isInvalid}
+        showHelperInvalidText={showHelperInvalidText}
+        {...rest}
+      >
         <ChakraCheckbox
-          id={id}
           className={className}
-          name={name || "default"}
+          icon={icon}
+          id={id}
           isDisabled={isDisabled}
+          isIndeterminate={isIndeterminate}
           isInvalid={isInvalid}
           isRequired={isRequired}
-          isIndeterminate={isIndeterminate}
+          name={name || "default"}
           ref={ref}
           value={value}
           {...(isChecked !== undefined
@@ -142,23 +142,13 @@ export const Checkbox = chakra(
             : {
                 defaultIsChecked: false,
               })}
-          icon={icon}
           alignItems="flex-start"
           __css={styles}
           {...ariaAttributes}
-          {...rest}
         >
           {showLabel && labelText}
         </ChakraCheckbox>
-        {footnote && showHelperInvalidText && (
-          <HelperErrorText
-            id={`${id}-helperText`}
-            isInvalid={isInvalid}
-            text={footnote}
-            __css={styles.helperErrorText}
-          />
-        )}
-      </>
+      </ComponentWrapper>
     );
   })
 );

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -1,616 +1,661 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Checkbox Renders the UI snapshot correctly 1`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="inputID-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="inputID"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="inputID"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 2`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  data-checked=""
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="checkbox-checked-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={true}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="checkbox-checked"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    data-checked=""
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={true}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="checkbox-checked"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    data-checked=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-oi1lnb"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      data-checked=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    data-checked=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-oi1lnb"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      data-checked=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 3`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  data-checked=""
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="checkbox-checked-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={true}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="checkbox-checked"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
+  <label
+    className="chakra-checkbox css-scawxr"
     data-checked=""
-    data-indeterminate=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
+    onClick={[Function]}
   >
-    <div
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={true}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="checkbox-checked"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
       style={
         Object {
-          "alignItems": "center",
-          "display": "flex",
-          "height": "100%",
-          "justifyContent": "center",
-          "transform": "none",
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
         }
       }
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      data-checked=""
+      data-indeterminate=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <svg
-        className="css-o8vbdw"
+      <div
         style={
           Object {
-            "opacity": 1,
-            "stroke": "currentColor",
-            "strokeWidth": 4,
+            "alignItems": "center",
+            "display": "flex",
+            "height": "100%",
+            "justifyContent": "center",
             "transform": "none",
           }
         }
-        viewBox="0 0 24 24"
       >
-        <line
-          x1="21"
-          x2="3"
-          y1="12"
-          y2="12"
-        />
-      </svg>
-    </div>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    data-checked=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+        <svg
+          className="css-o8vbdw"
+          style={
+            Object {
+              "opacity": 1,
+              "stroke": "currentColor",
+              "strokeWidth": 4,
+              "transform": "none",
+            }
+          }
+          viewBox="0 0 24 24"
+        >
+          <line
+            x1="21"
+            x2="3"
+            y1="12"
+            y2="12"
+          />
+        </svg>
+      </div>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      data-checked=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 4`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="checkbox-required-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="checkbox-required"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={true}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="checkbox-required"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={true}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 5`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  data-invalid=""
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="checkbox-invalid-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={true}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="checkbox-invalid"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    data-invalid=""
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={true}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="checkbox-invalid"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    data-invalid=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      data-invalid=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    data-invalid=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      data-invalid=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 6`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  data-disabled=""
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="checkbox-disabled-wrapper"
 >
-  <input
-    aria-disabled={true}
-    aria-invalid={false}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={true}
-    id="checkbox-disabled"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    data-disabled=""
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={true}
+      aria-invalid={false}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={true}
+      id="checkbox-disabled"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    data-disabled=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      data-disabled=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    data-disabled=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      data-disabled=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 7`] = `
-<label
-  className="chakra-checkbox css-scawxr"
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="jsxLabel-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="jsxLabel"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="jsxLabel"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-    value="arts"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+      value="arts"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    <div
-      className="css-k008qs"
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <span>
-        Arts
-      </span>
       <div
-        className="css-17xejub"
-      />
-      <span>
-        4
-      </span>
-    </div>
-  </span>
-</label>
+        className="css-k008qs"
+      >
+        <span>
+          Arts
+        </span>
+        <div
+          className="css-17xejub"
+        />
+        <span>
+          4
+        </span>
+      </div>
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 8`] = `
-<label
-  className="chakra-checkbox css-wkfjn4"
-  onClick={[Function]}
+<div
+  className="css-1xdhyk6"
+  id="checkbox-chakra-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="checkbox-chakra"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-wkfjn4"
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="checkbox-chakra"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Checkbox Renders the UI snapshot correctly 9`] = `
-<label
-  className="chakra-checkbox css-scawxr"
+<div
+  className="css-1xdhyk6"
   data-testid="testid"
-  onClick={[Function]}
+  id="checkbox-props-wrapper"
 >
-  <input
-    aria-disabled={false}
-    aria-invalid={false}
-    checked={false}
-    className="chakra-checkbox__input"
-    disabled={false}
-    id="checkbox-props"
-    name="default"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
+  <label
+    className="chakra-checkbox css-scawxr"
+    onClick={[Function]}
+  >
+    <input
+      aria-disabled={false}
+      aria-invalid={false}
+      checked={false}
+      className="chakra-checkbox__input"
+      disabled={false}
+      id="checkbox-props"
+      name="default"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
       }
-    }
-    type="checkbox"
-  />
-  <span
-    aria-hidden={true}
-    className="chakra-checkbox__control css-dnty2r"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  >
-    <svg
-      className="chakra-icon css-1vfv7ic"
-      focusable={false}
-      viewBox="0 0 24 24"
+      type="checkbox"
+    />
+    <span
+      aria-hidden={true}
+      className="chakra-checkbox__control css-dnty2r"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
     >
-      <path
-        d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-        fill="currentColor"
-      />
-    </svg>
-  </span>
-  <span
-    className="chakra-checkbox__label css-1oeb2oe"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
-  >
-    Test Label
-  </span>
-</label>
+      <svg
+        className="chakra-icon css-1vfv7ic"
+        focusable={false}
+        viewBox="0 0 24 24"
+      >
+        <path
+          d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+          fill="currentColor"
+        />
+      </svg>
+    </span>
+    <span
+      className="chakra-checkbox__label css-1oeb2oe"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;

--- a/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -13,128 +13,138 @@ exports[`Checkbox renders the UI snapshot correctly 1`] = `
     data-testid="checkbox-group"
     id="column"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="column-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="column-0"
-        name="column"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="column-0"
+          name="column"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="column-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="column-1"
-        name="column"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="column-1"
+          name="column"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -152,128 +162,138 @@ exports[`Checkbox renders the UI snapshot correctly 2`] = `
     data-testid="checkbox-group"
     id="row"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="row-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="row-0"
-        name="row"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="row-0"
+          name="row"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="row-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="row-1"
-        name="row"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="row-1"
+          name="row"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -292,128 +312,138 @@ exports[`Checkbox renders the UI snapshot correctly 3`] = `
     data-testid="checkbox-group"
     id="noLabel"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="noLabel-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="noLabel-0"
-        name="noLabel"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="noLabel-0"
+          name="noLabel"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="noLabel-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="noLabel-1"
-        name="noLabel"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="noLabel-1"
+          name="noLabel"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -431,128 +461,138 @@ exports[`Checkbox renders the UI snapshot correctly 4`] = `
     data-testid="checkbox-group"
     id="helperText"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="helperText-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="helperText-0"
-        name="helperText"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="helperText-0"
+          name="helperText"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="helperText-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="helperText-1"
-        name="helperText"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="helperText-1"
+          name="helperText"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
   <div
     aria-atomic={true}
@@ -582,128 +622,138 @@ exports[`Checkbox renders the UI snapshot correctly 5`] = `
     data-testid="checkbox-group"
     id="invalidText"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="invalidText-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="invalidText-0"
-        name="invalidText"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="invalidText-0"
+          name="invalidText"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="invalidText-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="invalidText-1"
-        name="invalidText"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="invalidText-1"
+          name="invalidText"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -721,128 +771,138 @@ exports[`Checkbox renders the UI snapshot correctly 6`] = `
     data-testid="checkbox-group"
     id="noRequiredLabel"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="noRequiredLabel-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="noRequiredLabel-0"
-        name="noRequiredLabel"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={true}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="noRequiredLabel-0"
+          name="noRequiredLabel"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={true}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="noRequiredLabel-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="noRequiredLabel-1"
-        name="noRequiredLabel"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={true}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="noRequiredLabel-1"
+          name="noRequiredLabel"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={true}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -863,128 +923,138 @@ exports[`Checkbox renders the UI snapshot correctly 7`] = `
     data-testid="checkbox-group"
     id="required"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="required-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="required-0"
-        name="required"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={true}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="required-0"
+          name="required"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={true}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="required-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="required-1"
-        name="required"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={true}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="required-1"
+          name="required"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={true}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -1002,134 +1072,144 @@ exports[`Checkbox renders the UI snapshot correctly 8`] = `
     data-testid="checkbox-group"
     id="invalid"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      data-invalid=""
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="invalid-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={true}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="invalid-0"
-        name="invalid"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        data-invalid=""
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={true}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="invalid-0"
+          name="invalid"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        data-invalid=""
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          data-invalid=""
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        data-invalid=""
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      data-invalid=""
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          data-invalid=""
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="invalid-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={true}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="invalid-1"
-        name="invalid"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        data-invalid=""
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={true}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="invalid-1"
+          name="invalid"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        data-invalid=""
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          data-invalid=""
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        data-invalid=""
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          data-invalid=""
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -1147,134 +1227,144 @@ exports[`Checkbox renders the UI snapshot correctly 9`] = `
     data-testid="checkbox-group"
     id="disabled"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      data-disabled=""
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="disabled-0-wrapper"
     >
-      <input
-        aria-disabled={true}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={true}
-        id="disabled-0"
-        name="disabled"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        data-disabled=""
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={true}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={true}
+          id="disabled-0"
+          name="disabled"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        data-disabled=""
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          data-disabled=""
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        data-disabled=""
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      data-disabled=""
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          data-disabled=""
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="disabled-1-wrapper"
     >
-      <input
-        aria-disabled={true}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={true}
-        id="disabled-1"
-        name="disabled"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        data-disabled=""
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={true}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={true}
+          id="disabled-1"
+          name="disabled"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        data-disabled=""
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          data-disabled=""
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        data-disabled=""
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          data-disabled=""
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -1292,152 +1382,162 @@ exports[`Checkbox renders the UI snapshot correctly 10`] = `
     data-testid="checkbox-group"
     id="jsxLabels"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="jsxLabels-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="jsxLabels-0"
-        name="jsxLabels"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="jsxLabels-0"
+          name="jsxLabels"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="arts"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="arts"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        <div
-          className="css-k008qs"
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
         >
-          <span>
-            Arts
-          </span>
           <div
-            className="css-17xejub"
-          />
-          <span>
-            4
-          </span>
-        </div>
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+            className="css-k008qs"
+          >
+            <span>
+              Arts
+            </span>
+            <div
+              className="css-17xejub"
+            />
+            <span>
+              4
+            </span>
+          </div>
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="jsxLabels-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="jsxLabels-1"
-        name="jsxLabels"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="jsxLabels-1"
+          name="jsxLabels"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="English"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="English"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        <div
-          className="css-k008qs"
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
         >
-          <span>
-            English
-          </span>
           <div
-            className="css-17xejub"
-          />
-          <span>
-            23
-          </span>
-        </div>
-      </span>
-    </label>
+            className="css-k008qs"
+          >
+            <span>
+              English
+            </span>
+            <div
+              className="css-17xejub"
+            />
+            <span>
+              23
+            </span>
+          </div>
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -1455,128 +1555,138 @@ exports[`Checkbox renders the UI snapshot correctly 11`] = `
     data-testid="checkbox-group"
     id="chakraProps"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="chakraProps-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="chakraProps-0"
-        name="chakraProps"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="chakraProps-0"
+          name="chakraProps"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="chakraProps-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="chakraProps-1"
-        name="chakraProps"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="chakraProps-1"
+          name="chakraProps"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;
@@ -1595,128 +1705,138 @@ exports[`Checkbox renders the UI snapshot correctly 12`] = `
     data-testid="checkbox-group"
     id="otherProps"
   >
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+    <div
+      className="css-1xdhyk6"
+      id="otherProps-0-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="otherProps-0"
-        name="otherProps"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="otherProps-0"
+          name="otherProps"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="2"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="2"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 2
-      </span>
-    </label>
-    <label
-      className="chakra-checkbox css-scawxr"
-      onClick={[Function]}
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 2
+        </span>
+      </label>
+    </div>
+    <div
+      className="css-1xdhyk6"
+      id="otherProps-1-wrapper"
     >
-      <input
-        aria-disabled={false}
-        aria-invalid={false}
-        checked={false}
-        className="chakra-checkbox__input"
-        disabled={false}
-        id="otherProps-1"
-        name="otherProps"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        required={false}
-        style={
-          Object {
-            "border": "0px",
-            "clip": "rect(0px, 0px, 0px, 0px)",
-            "height": "1px",
-            "margin": "-1px",
-            "overflow": "hidden",
-            "padding": "0px",
-            "position": "absolute",
-            "whiteSpace": "nowrap",
-            "width": "1px",
+      <label
+        className="chakra-checkbox css-scawxr"
+        onClick={[Function]}
+      >
+        <input
+          aria-disabled={false}
+          aria-invalid={false}
+          checked={false}
+          className="chakra-checkbox__input"
+          disabled={false}
+          id="otherProps-1"
+          name="otherProps"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          required={false}
+          style={
+            Object {
+              "border": "0px",
+              "clip": "rect(0px, 0px, 0px, 0px)",
+              "height": "1px",
+              "margin": "-1px",
+              "overflow": "hidden",
+              "padding": "0px",
+              "position": "absolute",
+              "whiteSpace": "nowrap",
+              "width": "1px",
+            }
           }
-        }
-        type="checkbox"
-        value="3"
-      />
-      <span
-        aria-hidden={true}
-        className="chakra-checkbox__control css-dnty2r"
-        onMouseDown={[Function]}
-        onMouseEnter={[Function]}
-        onMouseLeave={[Function]}
-        onMouseUp={[Function]}
-      >
-        <svg
-          className="chakra-icon css-1vfv7ic"
-          focusable={false}
-          viewBox="0 0 24 24"
+          type="checkbox"
+          value="3"
+        />
+        <span
+          aria-hidden={true}
+          className="chakra-checkbox__control css-dnty2r"
+          onMouseDown={[Function]}
+          onMouseEnter={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
         >
-          <path
-            d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
-            fill="currentColor"
-          />
-        </svg>
-      </span>
-      <span
-        className="chakra-checkbox__label css-1oeb2oe"
-        onMouseDown={[Function]}
-        onTouchStart={[Function]}
-      >
-        Checkbox 3
-      </span>
-    </label>
+          <svg
+            className="chakra-icon css-1vfv7ic"
+            focusable={false}
+            viewBox="0 0 24 24"
+          >
+            <path
+              d="M8.795 15.875l-4.17-4.17-1.42 1.41 5.59 5.59 12-12-1.41-1.41-10.59 10.58z"
+              fill="currentColor"
+            />
+          </svg>
+        </span>
+        <span
+          className="chakra-checkbox__label css-1oeb2oe"
+          onMouseDown={[Function]}
+          onTouchStart={[Function]}
+        >
+          Checkbox 3
+        </span>
+      </label>
+    </div>
   </div>
 </fieldset>
 `;

--- a/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -9,12 +9,16 @@ import Text from "../Text/Text";
 export interface ComponentWrapperProps {
   /** The UI elements that will be wrapped by this component */
   children: React.ReactNode;
+  /** A class name for the `div` parent element. */
+  className?: string;
   /** Optional string to set the text for the component's description */
   descriptionText?: string;
   /** Optional string to set the text for a `Heading` component */
   headingText?: string;
   /** Optional string to set the text for a `HelperErrorText` component */
   helperText?: HelperErrorTextType;
+  /** Styles that target the helper text. */
+  helperTextStyles?: { [key: string]: any };
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Optional string to populate the `HelperErrorText` for the error state
@@ -22,18 +26,23 @@ export interface ComponentWrapperProps {
   invalidText?: HelperErrorTextType;
   /** Sets invalid text in the error state. */
   isInvalid?: boolean;
+  /** Offers the ability to hide the helper/invalid text. */
+  showHelperInvalidText?: boolean;
 }
 
 export const ComponentWrapper = chakra(
   (props: React.PropsWithChildren<ComponentWrapperProps>) => {
     const {
       children,
+      className,
       descriptionText,
       headingText,
       helperText,
+      helperTextStyles = {},
       id,
       invalidText,
       isInvalid = false,
+      showHelperInvalidText = true,
       ...rest
     } = props;
     const hasChildren = !!children;
@@ -47,16 +56,16 @@ export const ComponentWrapper = chakra(
     }
 
     return (
-      <Box __css={styles} {...rest}>
+      <Box className={className} id={`${id}-wrapper`} __css={styles} {...rest}>
         {headingText && <Heading id={`${id}-heading`} text={headingText} />}
         {descriptionText && <Text>{descriptionText}</Text>}
         {children}
-        {footnote && (
+        {footnote && showHelperInvalidText && (
           <HelperErrorText
             id={`${id}-helperText`}
             isInvalid={isInvalid}
             text={footnote}
-            __css={styles.helperErrorText}
+            __css={{ ...styles.helperErrorText, ...helperTextStyles }}
           />
         )}
       </Box>

--- a/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
+++ b/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`ComponentWrapper Renders the UI snapshot correctly 1`] = `
 <div
   className="css-1xdhyk6"
+  id="id-wrapper"
 >
   <h2
     className="chakra-heading css-1xdhyk6"
@@ -36,6 +37,7 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 1`] = `
 exports[`ComponentWrapper Renders the UI snapshot correctly 2`] = `
 <div
   className="css-1xdhyk6"
+  id="id-wrapper"
 >
   <div>
     children elements
@@ -46,6 +48,7 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 2`] = `
 exports[`ComponentWrapper Renders the UI snapshot correctly 3`] = `
 <div
   className="css-1xdhyk6"
+  id="id-wrapper"
 >
   <h2
     className="chakra-heading css-1xdhyk6"
@@ -79,6 +82,7 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 3`] = `
 exports[`ComponentWrapper Renders the UI snapshot correctly 4`] = `
 <div
   className="css-kle7zy"
+  id="chakra-wrapper"
 >
   <div>
     children elements
@@ -90,6 +94,7 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 5`] = `
 <div
   className="css-1xdhyk6"
   data-testid="props"
+  id="props-wrapper"
 >
   <div>
     children elements

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -27,7 +27,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="basic-start-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -64,7 +65,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="basic-end-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -122,7 +124,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="no-label-start-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -159,7 +162,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="no-label-end-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -217,7 +221,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="custom-format-start-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -254,7 +259,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="custom-format-end-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -312,7 +318,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="invalid-start-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -322,6 +329,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 From
               </label>
               <input
+                aria-describedby="invalid-start-helperText"
                 aria-invalid={true}
                 className="chakra-input css-0"
                 disabled={false}
@@ -362,7 +370,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="invalid-end-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -372,6 +381,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 To
               </label>
               <input
+                aria-describedby="invalid-end-helperText"
                 aria-invalid={true}
                 className="chakra-input css-0"
                 disabled={false}
@@ -445,7 +455,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="disabled-start-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -482,7 +493,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
             className="react-datepicker__input-container"
           >
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
+              id="disabled-end-wrapper"
             >
               <label
                 className="css-1xdhyk6"
@@ -541,7 +553,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="basic-start-wrapper"
         >
           <label
             className="css-1xdhyk6"
@@ -586,7 +599,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="no-label-start-wrapper"
         >
           <input
             aria-label="Select the date you want to visit NYPL"
@@ -625,7 +639,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="custom-format-start-wrapper"
         >
           <label
             className="css-1xdhyk6"
@@ -670,7 +685,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="invalid-start-wrapper"
         >
           <label
             className="css-1xdhyk6"
@@ -729,7 +745,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="disabled-start-wrapper"
         >
           <label
             className="css-1xdhyk6"
@@ -787,7 +804,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="chakra-start-wrapper"
         >
           <label
             className="css-1xdhyk6"
@@ -846,7 +864,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
         className="react-datepicker__input-container"
       >
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
+          id="props-start-wrapper"
         >
           <label
             className="css-1xdhyk6"

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -4,11 +4,11 @@ import {
   useMultiStyleConfig,
 } from "@chakra-ui/react";
 import * as React from "react";
-import { AriaAttributes } from "../../utils/interfaces";
 
-import HelperErrorText, {
-  HelperErrorTextType,
-} from "../HelperErrorText/HelperErrorText";
+import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
+import { getAriaAttrs } from "../../utils/utils";
+
 export interface RadioProps {
   /** Additional class name. */
   className?: string;
@@ -70,7 +70,13 @@ export const Radio = chakra(
     } = props;
     const styles = useMultiStyleConfig("Radio", {});
     const footnote = isInvalid ? invalidText : helperText;
-    const ariaAttributes: AriaAttributes = {};
+    const ariaAttributes = getAriaAttrs({
+      footnote,
+      id,
+      labelText,
+      name: "Radio",
+      showLabel,
+    });
 
     if (!id) {
       console.warn(
@@ -78,22 +84,16 @@ export const Radio = chakra(
       );
     }
 
-    if (!showLabel) {
-      if (typeof labelText !== "string") {
-        console.warn(
-          "NYPL Reservoir Radio: `labelText` must be a string when `showLabel` is false."
-        );
-      }
-      ariaAttributes["aria-label"] =
-        labelText && footnote
-          ? `${labelText} - ${footnote}`
-          : (labelText as string);
-    } else if (footnote) {
-      ariaAttributes["aria-describedby"] = `${id}-helperText`;
-    }
-
     return (
-      <>
+      <ComponentWrapper
+        helperText={helperText}
+        helperTextStyles={styles.helperErrorText}
+        id={id}
+        invalidText={invalidText}
+        isInvalid={isInvalid}
+        showHelperInvalidText={showHelperInvalidText}
+        {...rest}
+      >
         <ChakraRadio
           className={className}
           id={id}
@@ -103,24 +103,15 @@ export const Radio = chakra(
           isRequired={isRequired}
           name={name}
           onChange={onChange}
-          value={value}
           ref={ref}
+          value={value}
           alignItems="flex-start"
           __css={styles}
           {...ariaAttributes}
-          {...rest}
         >
           {showLabel && labelText}
         </ChakraRadio>
-        {footnote && showHelperInvalidText && (
-          <HelperErrorText
-            id={`${id}-helperText`}
-            isInvalid={isInvalid}
-            text={footnote}
-            __css={styles.helperErrorText}
-          />
-        )}
-      </>
+      </ComponentWrapper>
     );
   })
 );

--- a/src/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/src/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -1,411 +1,451 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio Button renders the UI snapshot correctly 1`] = `
-<label
-  className="chakra-radio css-13p0l12"
+<div
+  className="css-1xdhyk6"
+  id="inputID-wrapper"
 >
-  <input
-    checked={false}
-    className="chakra-radio__input"
-    disabled={false}
-    id="inputID"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <label
+    className="chakra-radio css-13p0l12"
   >
-    Test Label
-  </span>
-</label>
+    <input
+      checked={false}
+      className="chakra-radio__input"
+      disabled={false}
+      id="inputID"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 2`] = `
-<label
-  className="chakra-radio css-13p0l12"
-  data-checked=""
+<div
+  className="css-1xdhyk6"
+  id="radio-checked-wrapper"
 >
-  <input
-    checked={true}
-    className="chakra-radio__input"
-    disabled={false}
-    id="radio-checked"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
+  <label
+    className="chakra-radio css-13p0l12"
     data-checked=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    data-checked=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
   >
-    Test Label
-  </span>
-</label>
+    <input
+      checked={true}
+      className="chakra-radio__input"
+      disabled={false}
+      id="radio-checked"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      data-checked=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      data-checked=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 3`] = `
-<label
-  className="chakra-radio css-13p0l12"
+<div
+  className="css-1xdhyk6"
+  id="radio-required-wrapper"
 >
-  <input
-    aria-required={true}
-    checked={false}
-    className="chakra-radio__input"
-    disabled={false}
-    id="radio-required"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={true}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <label
+    className="chakra-radio css-13p0l12"
   >
-    Test Label
-  </span>
-</label>
+    <input
+      aria-required={true}
+      checked={false}
+      className="chakra-radio__input"
+      disabled={false}
+      id="radio-required"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={true}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 4`] = `
-<label
-  className="chakra-radio css-13p0l12"
-  data-invalid=""
+<div
+  className="css-1xdhyk6"
+  id="radio-invalid-wrapper"
 >
-  <input
-    aria-invalid={true}
-    checked={false}
-    className="chakra-radio__input"
-    disabled={false}
-    id="radio-invalid"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
+  <label
+    className="chakra-radio css-13p0l12"
     data-invalid=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    data-invalid=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
   >
-    Test Label
-  </span>
-</label>
+    <input
+      aria-invalid={true}
+      checked={false}
+      className="chakra-radio__input"
+      disabled={false}
+      id="radio-invalid"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      data-invalid=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      data-invalid=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 5`] = `
-<label
-  className="chakra-radio css-13p0l12"
-  data-disabled=""
+<div
+  className="css-1xdhyk6"
+  id="radio-disabled-wrapper"
 >
-  <input
-    aria-disabled={true}
-    checked={false}
-    className="chakra-radio__input"
-    disabled={true}
-    id="radio-disabled"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
+  <label
+    className="chakra-radio css-13p0l12"
     data-disabled=""
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    data-disabled=""
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
   >
-    Test Label
-  </span>
-</label>
+    <input
+      aria-disabled={true}
+      checked={false}
+      className="chakra-radio__input"
+      disabled={true}
+      id="radio-disabled"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      data-disabled=""
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      data-disabled=""
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 6`] = `
-<label
-  className="chakra-radio css-13p0l12"
+<div
+  className="css-1xdhyk6"
+  id="jsxLabel-wrapper"
 >
-  <input
-    checked={false}
-    className="chakra-radio__input"
-    disabled={false}
-    id="jsxLabel"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-    value="arts"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <label
+    className="chakra-radio css-13p0l12"
   >
-    <div
-      className="css-k008qs"
+    <input
+      checked={false}
+      className="chakra-radio__input"
+      disabled={false}
+      id="jsxLabel"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+      value="arts"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
     >
-      <span>
-        Arts
-      </span>
       <div
-        className="css-17xejub"
-      />
-      <span>
-        4
-      </span>
-    </div>
-  </span>
-</label>
+        className="css-k008qs"
+      >
+        <span>
+          Arts
+        </span>
+        <div
+          className="css-17xejub"
+        />
+        <span>
+          4
+        </span>
+      </div>
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 7`] = `
-<label
-  className="chakra-radio css-13p0l12"
+<div
+  className="css-1xdhyk6"
+  id="chakra-wrapper"
 >
-  <input
-    checked={false}
-    className="chakra-radio__input"
-    disabled={false}
-    id="chakra"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-1dwi2jm"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <label
+    className="chakra-radio css-13p0l12"
   >
-    Test Label
-  </span>
-</label>
+    <input
+      checked={false}
+      className="chakra-radio__input"
+      disabled={false}
+      id="chakra"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-1dwi2jm"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 8`] = `
-<label
-  className="chakra-radio css-13p0l12"
+<div
+  className="css-1xdhyk6"
+  data-testid="props"
+  id="props-wrapper"
 >
-  <input
-    checked={false}
-    className="chakra-radio__input"
-    disabled={false}
-    id="props"
-    onBlur={[Function]}
-    onChange={[Function]}
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onKeyUp={[Function]}
-    required={false}
-    style={
-      Object {
-        "border": "0px",
-        "clip": "rect(0px, 0px, 0px, 0px)",
-        "height": "1px",
-        "margin": "-1px",
-        "overflow": "hidden",
-        "padding": "0px",
-        "position": "absolute",
-        "whiteSpace": "nowrap",
-        "width": "1px",
-      }
-    }
-    type="radio"
-  />
-  <span
-    aria-hidden={true}
-    className="css-14wybg9"
-    data-testid="props"
-    onMouseDown={[Function]}
-    onMouseEnter={[Function]}
-    onMouseLeave={[Function]}
-    onMouseUp={[Function]}
-  />
-  <span
-    className="chakra-radio__label css-1y8kf23"
-    onMouseDown={[Function]}
-    onTouchStart={[Function]}
+  <label
+    className="chakra-radio css-13p0l12"
   >
-    Test Label
-  </span>
-</label>
+    <input
+      checked={false}
+      className="chakra-radio__input"
+      disabled={false}
+      id="props"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      onKeyDown={[Function]}
+      onKeyUp={[Function]}
+      required={false}
+      style={
+        Object {
+          "border": "0px",
+          "clip": "rect(0px, 0px, 0px, 0px)",
+          "height": "1px",
+          "margin": "-1px",
+          "overflow": "hidden",
+          "padding": "0px",
+          "position": "absolute",
+          "whiteSpace": "nowrap",
+          "width": "1px",
+        }
+      }
+      type="radio"
+    />
+    <span
+      aria-hidden={true}
+      className="css-14wybg9"
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseUp={[Function]}
+    />
+    <span
+      className="chakra-radio__label css-1y8kf23"
+      onMouseDown={[Function]}
+      onTouchStart={[Function]}
+    >
+      Test Label
+    </span>
+  </label>
+</div>
 `;

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -15,100 +15,110 @@ exports[`Radio Button renders the UI snapshot correctly 1`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="column"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="column"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="column"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="column"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -129,100 +139,110 @@ exports[`Radio Button renders the UI snapshot correctly 2`] = `
     <div
       className="chakra-stack css-1objuxj"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="row"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="row"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="row"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="row"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -244,100 +264,110 @@ exports[`Radio Button renders the UI snapshot correctly 3`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="noLabel"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="noLabel"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="noLabel"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="noLabel"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -358,100 +388,110 @@ exports[`Radio Button renders the UI snapshot correctly 4`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="helperText"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="helperText"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="helperText"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="helperText"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
   <div
@@ -484,100 +524,110 @@ exports[`Radio Button renders the UI snapshot correctly 5`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="invalidText"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="invalidText"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="invalidText"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="invalidText"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -598,102 +648,112 @@ exports[`Radio Button renders the UI snapshot correctly 6`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          aria-required={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="noRequiredLabel"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={true}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            aria-required={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="noRequiredLabel"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={true}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          aria-required={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="noRequiredLabel"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={true}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            aria-required={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="noRequiredLabel"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={true}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -717,102 +777,112 @@ exports[`Radio Button renders the UI snapshot correctly 7`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          aria-required={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="required"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={true}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            aria-required={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="required"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={true}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          aria-required={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="required"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={true}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            aria-required={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="required"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={true}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -833,108 +903,118 @@ exports[`Radio Button renders the UI snapshot correctly 8`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
-        data-invalid=""
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          aria-invalid={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="invalid"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
+        <label
+          className="chakra-radio css-13p0l12"
           data-invalid=""
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          data-invalid=""
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
-        data-invalid=""
+          <input
+            aria-invalid={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="invalid"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            data-invalid=""
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            data-invalid=""
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          aria-invalid={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="invalid"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
+        <label
+          className="chakra-radio css-13p0l12"
           data-invalid=""
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          data-invalid=""
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            aria-invalid={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="invalid"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            data-invalid=""
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            data-invalid=""
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -955,108 +1035,118 @@ exports[`Radio Button renders the UI snapshot correctly 9`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
-        data-disabled=""
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          aria-disabled={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={true}
-          id="radio-2"
-          name="disabled"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
+        <label
+          className="chakra-radio css-13p0l12"
           data-disabled=""
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          data-disabled=""
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
-        data-disabled=""
+          <input
+            aria-disabled={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={true}
+            id="radio-2"
+            name="disabled"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            data-disabled=""
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            data-disabled=""
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          aria-disabled={true}
-          checked={false}
-          className="chakra-radio__input"
-          disabled={true}
-          id="radio-3"
-          name="disabled"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
+        <label
+          className="chakra-radio css-13p0l12"
           data-disabled=""
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          data-disabled=""
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            aria-disabled={true}
+            checked={false}
+            className="chakra-radio__input"
+            disabled={true}
+            id="radio-3"
+            name="disabled"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            data-disabled=""
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            data-disabled=""
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -1077,124 +1167,134 @@ exports[`Radio Button renders the UI snapshot correctly 10`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="arts-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="arts"
-          name="a11y-test"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="arts"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          <div
-            className="css-k008qs"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="arts"
+            name="a11y-test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="arts"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <span>
-              Arts
-            </span>
             <div
-              className="css-17xejub"
-            />
-            <span>
-              4
-            </span>
-          </div>
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+              className="css-k008qs"
+            >
+              <span>
+                Arts
+              </span>
+              <div
+                className="css-17xejub"
+              />
+              <span>
+                4
+              </span>
+            </div>
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="English-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="English"
-          name="a11y-test"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="English"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          <div
-            className="css-k008qs"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="English"
+            name="a11y-test"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="English"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
           >
-            <span>
-              English
-            </span>
             <div
-              className="css-17xejub"
-            />
-            <span>
-              23
-            </span>
-          </div>
-        </span>
-      </label>
+              className="css-k008qs"
+            >
+              <span>
+                English
+              </span>
+              <div
+                className="css-17xejub"
+              />
+              <span>
+                23
+              </span>
+            </div>
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -1215,100 +1315,110 @@ exports[`Radio Button renders the UI snapshot correctly 11`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="chakra"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="chakra"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="chakra"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="chakra"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>
@@ -1330,100 +1440,110 @@ exports[`Radio Button renders the UI snapshot correctly 12`] = `
     <div
       className="chakra-stack css-1wdv1uh"
     >
-      <label
-        className="chakra-radio css-13p0l12"
+      <div
+        className="css-1xdhyk6"
+        id="radio-2-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-2"
-          name="props"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="2"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 2
-        </span>
-      </label>
-      <label
-        className="chakra-radio css-13p0l12"
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-2"
+            name="props"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="2"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 2
+          </span>
+        </label>
+      </div>
+      <div
+        className="css-1xdhyk6"
+        id="radio-3-wrapper"
       >
-        <input
-          checked={false}
-          className="chakra-radio__input"
-          disabled={false}
-          id="radio-3"
-          name="props"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onKeyUp={[Function]}
-          required={false}
-          style={
-            Object {
-              "border": "0px",
-              "clip": "rect(0px, 0px, 0px, 0px)",
-              "height": "1px",
-              "margin": "-1px",
-              "overflow": "hidden",
-              "padding": "0px",
-              "position": "absolute",
-              "whiteSpace": "nowrap",
-              "width": "1px",
-            }
-          }
-          type="radio"
-          value="3"
-        />
-        <span
-          aria-hidden={true}
-          className="css-14wybg9"
-          onMouseDown={[Function]}
-          onMouseEnter={[Function]}
-          onMouseLeave={[Function]}
-          onMouseUp={[Function]}
-        />
-        <span
-          className="chakra-radio__label css-1y8kf23"
-          onMouseDown={[Function]}
-          onTouchStart={[Function]}
+        <label
+          className="chakra-radio css-13p0l12"
         >
-          Radio 3
-        </span>
-      </label>
+          <input
+            checked={false}
+            className="chakra-radio__input"
+            disabled={false}
+            id="radio-3"
+            name="props"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            required={false}
+            style={
+              Object {
+                "border": "0px",
+                "clip": "rect(0px, 0px, 0px, 0px)",
+                "height": "1px",
+                "margin": "-1px",
+                "overflow": "hidden",
+                "padding": "0px",
+                "position": "absolute",
+                "whiteSpace": "nowrap",
+                "width": "1px",
+              }
+            }
+            type="radio"
+            value="3"
+          />
+          <span
+            aria-hidden={true}
+            className="css-14wybg9"
+            onMouseDown={[Function]}
+            onMouseEnter={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+          />
+          <span
+            className="chakra-radio__label css-1y8kf23"
+            onMouseDown={[Function]}
+            onTouchStart={[Function]}
+          >
+            Radio 3
+          </span>
+        </label>
+      </div>
     </div>
   </div>
 </fieldset>

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`SearchBar renders the UI snapshot correctly 1`] = `
 <div
   className="css-1xdhyk6"
+  id="basic-wrapper"
 >
   <form
     aria-label="SearchBar label - Search for items in Animal Crossing New Horizons"
@@ -12,7 +13,8 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-basic-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -89,6 +91,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
 exports[`SearchBar renders the UI snapshot correctly 2`] = `
 <div
   className="css-1xdhyk6"
+  id="withSelect-wrapper"
 >
   <form
     aria-label="SearchBar label - Search for items in Animal Crossing New Horizons"
@@ -98,7 +101,8 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-select-withSelect-wrapper"
     >
       <div
         className="css-0"
@@ -217,7 +221,8 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
       
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-withSelect-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -294,6 +299,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
 exports[`SearchBar renders the UI snapshot correctly 3`] = `
 <div
   className="css-1xdhyk6"
+  id="withoutHelperText-wrapper"
 >
   <form
     aria-label="SearchBar label"
@@ -303,7 +309,8 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-withoutHelperText-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -368,6 +375,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
 exports[`SearchBar renders the UI snapshot correctly 4`] = `
 <div
   className="css-1xdhyk6"
+  id="invalidState-wrapper"
 >
   <form
     aria-label="SearchBar label"
@@ -377,7 +385,8 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-invalidState-wrapper"
     >
       <input
         aria-invalid={true}
@@ -442,6 +451,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
 exports[`SearchBar renders the UI snapshot correctly 5`] = `
 <div
   className="css-1xdhyk6"
+  id="disabledState-wrapper"
 >
   <form
     aria-label="SearchBar label"
@@ -451,7 +461,8 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-disabledState-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -517,6 +528,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
 exports[`SearchBar renders the UI snapshot correctly 6`] = `
 <div
   className="css-1xdhyk6"
+  id="requiredState-wrapper"
 >
   <form
     aria-label="SearchBar label"
@@ -526,7 +538,8 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-requiredState-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -593,6 +606,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
 exports[`SearchBar renders the UI snapshot correctly 7`] = `
 <div
   className="css-1xdhyk6"
+  id="noBrandButtonType-wrapper"
 >
   <form
     aria-label="SearchBar label"
@@ -602,7 +616,8 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-noBrandButtonType-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -669,6 +684,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
 exports[`SearchBar renders the UI snapshot correctly 8`] = `
 <div
   className="css-1xdhyk6"
+  id="withHeading-wrapper"
 >
   <h2
     className="chakra-heading css-1xdhyk6"
@@ -730,6 +746,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
 exports[`SearchBar renders the UI snapshot correctly 9`] = `
 <div
   className="css-1xdhyk6"
+  id="withDescription-wrapper"
 >
   <p
     className="chakra-text css-1xdhyk6"
@@ -790,6 +807,7 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
 exports[`SearchBar renders the UI snapshot correctly 10`] = `
 <div
   className="css-1xdhyk6"
+  id="withHeadingAndDescription-wrapper"
 >
   <h2
     className="chakra-heading css-1xdhyk6"
@@ -856,6 +874,7 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
 exports[`SearchBar renders the UI snapshot correctly 11`] = `
 <div
   className="css-1xdhyk6"
+  id="chakra-wrapper"
 >
   <form
     aria-label="SearchBar label - Search for items in Animal Crossing New Horizons"
@@ -865,7 +884,8 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-chakra-wrapper"
     >
       <input
         aria-label="Item Search"
@@ -943,6 +963,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
 <div
   className="css-1xdhyk6"
   data-testid="props"
+  id="props-wrapper"
 >
   <form
     aria-label="SearchBar label - Search for items in Animal Crossing New Horizons"
@@ -952,7 +973,8 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
     role="search"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-1u8qly9"
+      id="searchbar-textinput-props-wrapper"
     >
       <input
         aria-label="Item Search"

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -6,12 +6,11 @@ import {
 } from "@chakra-ui/react";
 import React, { useEffect, useState, useRef } from "react";
 
-import HelperErrorText, {
-  HelperErrorTextType,
-} from "../HelperErrorText/HelperErrorText";
+import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
 import Icon from "../Icons/Icon";
 import Label from "../Label/Label";
-import { AriaAttributes } from "../../utils/interfaces";
+import { getAriaAttrs } from "../../utils/utils";
 
 export type SelectTypes = "default" | "searchbar";
 export type LabelPositions = "default" | "inline";
@@ -89,7 +88,6 @@ export const Select = chakra(
         value = "",
         ...rest
       } = props;
-      const ariaAttributes: AriaAttributes = {};
       const [labelWidth, setLabelWidth] = useState<number>(0);
       const labelRef = useRef<HTMLDivElement>(null);
       const styles = useMultiStyleConfig("CustomSelect", {
@@ -100,6 +98,13 @@ export const Select = chakra(
         ? invalidText
         : "There is an error related to this field.";
       const footnote = isInvalid ? finalInvalidText : helperText;
+      const ariaAttributes = getAriaAttrs({
+        footnote,
+        id,
+        labelText,
+        name: "Select",
+        showLabel,
+      });
       // To control the `Select` component, both `onChange` and `value`
       // must be passed.
       const controlledProps = onChange ? { onChange, value } : {};
@@ -107,13 +112,6 @@ export const Select = chakra(
       // The number of pixels between the label and select elements
       // when the labelPosition is inline (equivalent to --nypl-space-xs).
       const labelSelectGap = 8;
-
-      if (!showLabel) {
-        ariaAttributes["aria-label"] =
-          labelText && footnote ? `${labelText} - ${footnote}` : labelText;
-      } else if (helperText) {
-        ariaAttributes["aria-describedby"] = `${id}-helperText`;
-      }
 
       if (!id) {
         console.warn(
@@ -133,7 +131,19 @@ export const Select = chakra(
       }, [labelPosition]);
 
       return (
-        <Box className={className} __css={styles} {...rest}>
+        <ComponentWrapper
+          className={className}
+          helperText={helperText}
+          helperTextStyles={{
+            marginLeft: { sm: "auto", md: `${labelWidth}px` },
+          }}
+          id={id}
+          invalidText={finalInvalidText}
+          isInvalid={isInvalid}
+          showHelperInvalidText={showHelperInvalidText}
+          __css={styles}
+          {...rest}
+        >
           <Box __css={labelPosition === "inline" && styles.inline}>
             {showLabel && (
               <Box ref={labelRef}>
@@ -164,15 +174,7 @@ export const Select = chakra(
               {children}
             </ChakraSelect>
           </Box>
-          {footnote && showHelperInvalidText && (
-            <HelperErrorText
-              id={`${id}-helperText`}
-              isInvalid={isInvalid}
-              text={footnote}
-              ml={{ sm: "auto", md: `${labelWidth}px` }}
-            />
-          )}
-        </Box>
+        </ComponentWrapper>
       );
     }
   )

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Select Renders the UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -96,7 +97,8 @@ exports[`Select Renders the UI snapshot correctly 1`] = `
 
 exports[`Select Renders the UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -191,7 +193,8 @@ exports[`Select Renders the UI snapshot correctly 2`] = `
 
 exports[`Select Renders the UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -211,6 +214,7 @@ exports[`Select Renders the UI snapshot correctly 3`] = `
       className="chakra-select__wrapper css-42b2qy"
     >
       <select
+        aria-describedby="select-helperText"
         aria-invalid={true}
         className="chakra-select css-1ik61og"
         disabled={false}
@@ -284,7 +288,7 @@ exports[`Select Renders the UI snapshot correctly 3`] = `
   <div
     aria-atomic={true}
     aria-live="polite"
-    className="css-1mpebub"
+    className="css-1sax8hu"
     dangerouslySetInnerHTML={
       Object {
         "__html": "Tom doesn't count as a sibling :(.",
@@ -298,7 +302,8 @@ exports[`Select Renders the UI snapshot correctly 3`] = `
 
 exports[`Select Renders the UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -391,7 +396,7 @@ exports[`Select Renders the UI snapshot correctly 4`] = `
   <div
     aria-atomic={true}
     aria-live="off"
-    className="css-1mpebub"
+    className="css-1sax8hu"
     dangerouslySetInnerHTML={
       Object {
         "__html": "Remember, Logan will judge you no matter who you pick.",
@@ -405,7 +410,8 @@ exports[`Select Renders the UI snapshot correctly 4`] = `
 
 exports[`Select Renders the UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -503,7 +509,8 @@ exports[`Select Renders the UI snapshot correctly 5`] = `
 
 exports[`Select Renders the UI snapshot correctly 6`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -601,7 +608,8 @@ exports[`Select Renders the UI snapshot correctly 6`] = `
 
 exports[`Select Renders the UI snapshot correctly 7`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="select-wrapper"
 >
   <div
     className="css-0"
@@ -697,7 +705,8 @@ exports[`Select Renders the UI snapshot correctly 7`] = `
 
 exports[`Select Renders the UI snapshot correctly 8`] = `
 <div
-  className="css-kle7zy"
+  className="css-1y4kn3e"
+  id="chakra-wrapper"
 >
   <div
     className="css-0"
@@ -791,8 +800,9 @@ exports[`Select Renders the UI snapshot correctly 8`] = `
 
 exports[`Select Renders the UI snapshot correctly 9`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="props"
+  id="props-wrapper"
 >
   <div
     className="css-0"

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -13,10 +13,9 @@ import {
 } from "@chakra-ui/react";
 import * as React from "react";
 
+import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import Label from "../Label/Label";
-import HelperErrorText, {
-  HelperErrorTextType,
-} from "../HelperErrorText/HelperErrorText";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
 import TextInput, { TextInputTypes } from "../TextInput/TextInput";
 
 export interface SliderProps {
@@ -120,7 +119,7 @@ export const Slider = chakra((props: React.PropsWithChildren<SliderProps>) => {
   if (isRangeSlider && currentValue[0] > currentValue[1]) {
     finalIsInvalid = true;
   }
-  const footnote = finalIsInvalid ? invalidText : helperText;
+  // const footnote = finalIsInvalid ? invalidText : helperText;
   const styles = useMultiStyleConfig("CustomSlider", {
     isDisabled,
     isInvalid: finalIsInvalid,
@@ -276,7 +275,16 @@ export const Slider = chakra((props: React.PropsWithChildren<SliderProps>) => {
   };
 
   return (
-    <Box className={className} __css={styles} {...rest}>
+    <ComponentWrapper
+      className={className}
+      helperText={helperText}
+      id={id}
+      invalidText={invalidText}
+      isInvalid={finalIsInvalid}
+      showHelperInvalidText={showHelperInvalidText}
+      __css={styles}
+      {...rest}
+    >
       {showLabel && (
         <Label
           id={`${id}-label`}
@@ -307,15 +315,7 @@ export const Slider = chakra((props: React.PropsWithChildren<SliderProps>) => {
 
         {showBoxes && getTextInput("end")}
       </Box>
-
-      {footnote && showHelperInvalidText && (
-        <HelperErrorText
-          id={`${id}-helperText`}
-          isInvalid={finalIsInvalid}
-          text={footnote}
-        />
-      )}
-    </Box>
+    </ComponentWrapper>
   );
 });
 

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="defaultRangeSlider-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -15,7 +16,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
     className="css-0"
   >
     <div
-      className="css-bunm4f"
+      className="css-ho21zx"
+      id="defaultRangeSlider-textInput-start-wrapper"
     >
       <input
         aria-label="Label - start value"
@@ -138,7 +140,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="defaultRangeSlider-textInput-end-wrapper"
     >
       <input
         aria-label="Label - end value"
@@ -174,7 +177,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
 
 exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="errored-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -187,7 +191,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
     className="css-0"
   >
     <div
-      className="css-bunm4f"
+      className="css-ho21zx"
+      id="errored-textInput-start-wrapper"
     >
       <input
         aria-invalid={true}
@@ -311,7 +316,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="errored-textInput-end-wrapper"
     >
       <input
         aria-invalid={true}
@@ -348,7 +354,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
 
 exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="required-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -364,7 +371,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
     className="css-0"
   >
     <div
-      className="css-bunm4f"
+      className="css-ho21zx"
+      id="required-textInput-start-wrapper"
     >
       <input
         aria-label="Label - start value"
@@ -488,7 +496,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="required-textInput-end-wrapper"
     >
       <input
         aria-label="Label - end value"
@@ -525,7 +534,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
 
 exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="disabled-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -538,7 +548,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
     className="css-0"
   >
     <div
-      className="css-bunm4f"
+      className="css-ho21zx"
+      id="disabled-textInput-start-wrapper"
     >
       <input
         aria-label="Label - start value"
@@ -663,7 +674,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="disabled-textInput-end-wrapper"
     >
       <input
         aria-label="Label - end value"
@@ -699,13 +711,15 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
 
 exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="noLabels-wrapper"
 >
   <div
     className="css-0"
   >
     <div
-      className="css-bunm4f"
+      className="css-ho21zx"
+      id="noLabels-textInput-start-wrapper"
     >
       <input
         aria-label="Label - start value"
@@ -828,7 +842,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="noLabels-textInput-end-wrapper"
     >
       <input
         aria-label="Label - end value"
@@ -852,7 +867,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
 
 exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="noVisibleValues-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -976,7 +992,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
 
 exports[`Slider Range Slider renders the UI snapshot correctly 7`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="onlySlider-wrapper"
 >
   <div
     className="css-0"
@@ -1081,7 +1098,8 @@ exports[`Slider Range Slider renders the UI snapshot correctly 7`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="defaultSlider-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -1174,7 +1192,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="defaultSlider-textInput-end-wrapper"
     >
       <input
         aria-label="Label"
@@ -1210,7 +1229,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="errored-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -1303,7 +1323,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="errored-textInput-end-wrapper"
     >
       <input
         aria-invalid={true}
@@ -1340,7 +1361,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="required-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -1436,7 +1458,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="required-textInput-end-wrapper"
     >
       <input
         aria-label="Label"
@@ -1473,7 +1496,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="disabled-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -1568,7 +1592,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="disabled-textInput-end-wrapper"
     >
       <input
         aria-label="Label"
@@ -1604,7 +1629,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="noLabels-wrapper"
 >
   <div
     className="css-0"
@@ -1690,7 +1716,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="noLabels-textInput-end-wrapper"
     >
       <input
         aria-label="Label"
@@ -1714,7 +1741,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 6`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="noVisibleValues-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -1814,7 +1842,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 6`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 7`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="onlySlider-wrapper"
 >
   <div
     className="css-0"
@@ -1895,7 +1924,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 7`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
 <div
-  className="css-kle7zy"
+  className="css-1y4kn3e"
+  id="chakra-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -1988,7 +2018,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="chakra-textInput-end-wrapper"
     >
       <input
         aria-label="Label"
@@ -2024,8 +2055,9 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
 
 exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="props"
+  id="props-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -2118,7 +2150,8 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
       100
     </div>
     <div
-      className="css-1ebeaqx"
+      className="css-1f1uedm"
+      id="props-textInput-end-wrapper"
     >
       <input
         aria-label="Label"

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   chakra,
   Input as ChakraInput,
   Textarea as ChakraTextarea,
@@ -7,10 +6,10 @@ import {
 } from "@chakra-ui/react";
 import * as React from "react";
 
+import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import Label from "../Label/Label";
-import HelperErrorText, {
-  HelperErrorTextType,
-} from "../HelperErrorText/HelperErrorText";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
+import { getAriaAttrs } from "../../utils/utils";
 
 // HTML Input types as defined by MDN: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input
 export type TextInputTypes =
@@ -147,7 +146,13 @@ export const TextInput = chakra(
       let footnote: HelperErrorTextType = isInvalid
         ? finalInvalidText
         : helperText;
-      let ariaAttributes = {};
+      const ariaAttributes = getAriaAttrs({
+        footnote,
+        id,
+        labelText,
+        name: "TextInput",
+        showLabel,
+      });
       let fieldOutput;
       let options;
 
@@ -155,13 +160,6 @@ export const TextInput = chakra(
         console.warn(
           "NYPL Reservoir TextInput: This component's required `id` prop was not passed."
         );
-      }
-
-      if (!showLabel) {
-        ariaAttributes["aria-label"] =
-          labelText && footnote ? `${labelText} - ${footnote}` : labelText;
-      } else if (helperText) {
-        ariaAttributes["aria-describedby"] = `${id}-helperText`;
       }
 
       if (type === "tel" || type === "url" || type === "email") {
@@ -213,7 +211,16 @@ export const TextInput = chakra(
       }
 
       return (
-        <Box __css={styles} className={className} {...rest}>
+        <ComponentWrapper
+          className={className}
+          helperText={helperText}
+          id={id}
+          invalidText={finalInvalidText}
+          isInvalid={isInvalid}
+          showHelperInvalidText={showHelperInvalidText && !isHidden}
+          __css={styles}
+          {...rest}
+        >
           {labelText && showLabel && !isHidden && (
             <Label
               htmlFor={id}
@@ -224,14 +231,7 @@ export const TextInput = chakra(
             </Label>
           )}
           {fieldOutput}
-          {footnote && showHelperInvalidText && !isHidden && (
-            <HelperErrorText
-              id={`${id}-helperText`}
-              isInvalid={isInvalid}
-              text={footnote}
-            />
-          )}
-        </Box>
+        </ComponentWrapper>
       );
     }
   )

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -2,7 +2,8 @@
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextInput-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -31,7 +32,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextInput-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -56,7 +58,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextInput-wrapper"
 >
   <input
     aria-label="Custom Input Label"
@@ -76,7 +79,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextInput-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -118,7 +122,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextInput-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -131,6 +136,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
     </span>
   </label>
   <input
+    aria-describedby="myTextInput-helperText"
     aria-invalid={true}
     aria-required={true}
     className="chakra-input css-0"
@@ -160,7 +166,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextInput-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -189,7 +196,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
 <div
-  className="css-kle7zy"
+  className="css-1y4kn3e"
+  id="chakra-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -214,8 +222,9 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="props"
+  id="props-wrapper"
 >
   <label
     className="css-1xdhyk6"
@@ -241,7 +250,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
 
 exports[`UI Snapshots renders the textarea UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="myTextarea-wrapper"
 >
   <label
     className="css-1xdhyk6"

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -7,10 +7,9 @@ import {
 } from "@chakra-ui/react";
 import * as React from "react";
 
-import HelperErrorText, {
-  HelperErrorTextType,
-} from "../HelperErrorText/HelperErrorText";
-import { AriaAttributes } from "../../utils/interfaces";
+import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
+import { getAriaAttrs } from "../../utils/utils";
 
 export type ToggleSizes = "default" | "small";
 export interface ToggleProps {
@@ -71,12 +70,16 @@ export const Toggle = chakra(
       size = "default",
       ...rest
     } = props;
-    const footnote = isInvalid ? invalidText : helperText;
-    const ariaAttributes: AriaAttributes = {};
     const styles = useMultiStyleConfig("Toggle", { isDisabled, size });
     const switchStyles = useStyleConfig("Switch", { size });
-    ariaAttributes["aria-label"] =
-      labelText && footnote ? `${labelText} - ${footnote}` : labelText;
+    const footnote = isInvalid ? invalidText : helperText;
+    const ariaAttributes = getAriaAttrs({
+      footnote,
+      id,
+      labelText,
+      name: "Toggle",
+      showLabel: true,
+    });
 
     if (!id) {
       console.warn(
@@ -85,14 +88,21 @@ export const Toggle = chakra(
     }
 
     return (
-      <>
-        <Box __css={styles} {...rest}>
+      <ComponentWrapper
+        helperText={helperText}
+        helperTextStyles={styles.helperErrorText}
+        id={id}
+        invalidText={invalidText}
+        isInvalid={isInvalid}
+        {...rest}
+      >
+        <Box __css={styles}>
           <Switch
             id={id}
-            name={name || "default"}
             isDisabled={isDisabled}
             isInvalid={isInvalid}
             isRequired={isRequired}
+            name={name || "default"}
             ref={ref}
             size={size === "default" ? "lg" : "sm"}
             lineHeight="1.5"
@@ -110,15 +120,7 @@ export const Toggle = chakra(
             {labelText}
           </Switch>
         </Box>
-        {footnote && (
-          <HelperErrorText
-            id={`${id}-helperText`}
-            isInvalid={isInvalid}
-            text={footnote}
-            __css={styles.helperErrorText}
-          />
-        )}
-      </>
+      </ComponentWrapper>
     );
   })
 );

--- a/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -2,441 +2,469 @@
 
 exports[`Toggle Renders the UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="inputID-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={false}
-      aria-invalid={false}
-      aria-label="Test Label"
-      checked={false}
-      className="chakra-switch__input"
-      disabled={false}
-      id="inputID"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={false}
+        aria-invalid={false}
+        checked={false}
+        className="chakra-switch__input"
+        disabled={false}
+        id="inputID"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Toggle Renders the UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="Toggle-checked-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    data-checked=""
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={false}
-      aria-invalid={false}
-      aria-label="Test Label"
-      checked={true}
-      className="chakra-switch__input"
-      disabled={false}
-      id="Toggle-checked"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      data-checked=""
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={false}
+        aria-invalid={false}
+        checked={true}
+        className="chakra-switch__input"
+        disabled={false}
+        id="Toggle-checked"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      data-checked=""
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
-        data-checked=""
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      data-checked=""
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        data-checked=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+          data-checked=""
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        data-checked=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Toggle Renders the UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="Toggle-invalid-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    data-invalid=""
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={false}
-      aria-invalid={true}
-      aria-label="Test Label"
-      checked={false}
-      className="chakra-switch__input"
-      disabled={false}
-      id="Toggle-invalid"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      data-invalid=""
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={false}
+        aria-invalid={true}
+        checked={false}
+        className="chakra-switch__input"
+        disabled={false}
+        id="Toggle-invalid"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      data-invalid=""
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      data-invalid=""
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        data-invalid=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        data-invalid=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Toggle Renders the UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="Toggle-disabled-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    data-disabled=""
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={true}
-      aria-invalid={false}
-      aria-label="Test Label"
-      checked={false}
-      className="chakra-switch__input"
-      disabled={true}
-      id="Toggle-disabled"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      data-disabled=""
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={true}
+        aria-invalid={false}
+        checked={false}
+        className="chakra-switch__input"
+        disabled={true}
+        id="Toggle-disabled"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      data-disabled=""
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      data-disabled=""
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Toggle Renders the UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
+  id="Toggle-disabled-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    data-disabled=""
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={true}
-      aria-invalid={false}
-      aria-label="Test Label"
-      checked={false}
-      className="chakra-switch__input"
-      disabled={true}
-      id="Toggle-disabled"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      data-disabled=""
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={true}
+        aria-invalid={false}
+        checked={false}
+        className="chakra-switch__input"
+        disabled={true}
+        id="Toggle-disabled"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      data-disabled=""
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      data-disabled=""
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        data-disabled=""
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Toggle Renders the UI snapshot correctly 6`] = `
 <div
-  className="css-13xjm0o"
+  className="css-7zjd3y"
+  id="chakra-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={false}
-      aria-invalid={false}
-      aria-label="Test Label"
-      checked={false}
-      className="chakra-switch__input"
-      disabled={false}
-      id="chakra"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={false}
+        aria-invalid={false}
+        checked={false}
+        className="chakra-switch__input"
+        disabled={false}
+        id="chakra"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;
 
 exports[`Toggle Renders the UI snapshot correctly 7`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="props"
+  id="props-wrapper"
 >
-  <label
-    className="chakra-switch css-18x0has"
-    onClick={[Function]}
+  <div
+    className="css-0"
   >
-    <input
-      aria-disabled={false}
-      aria-invalid={false}
-      aria-label="Test Label"
-      checked={false}
-      className="chakra-switch__input"
-      disabled={false}
-      id="props"
-      name="default"
-      onBlur={[Function]}
-      onChange={[Function]}
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onKeyUp={[Function]}
-      required={false}
-      style={
-        Object {
-          "border": "0px",
-          "clip": "rect(0px, 0px, 0px, 0px)",
-          "height": "1px",
-          "margin": "-1px",
-          "overflow": "hidden",
-          "padding": "0px",
-          "position": "absolute",
-          "whiteSpace": "nowrap",
-          "width": "1px",
+    <label
+      className="chakra-switch css-18x0has"
+      onClick={[Function]}
+    >
+      <input
+        aria-disabled={false}
+        aria-invalid={false}
+        checked={false}
+        className="chakra-switch__input"
+        disabled={false}
+        id="props"
+        name="default"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        required={false}
+        style={
+          Object {
+            "border": "0px",
+            "clip": "rect(0px, 0px, 0px, 0px)",
+            "height": "1px",
+            "margin": "-1px",
+            "overflow": "hidden",
+            "padding": "0px",
+            "position": "absolute",
+            "whiteSpace": "nowrap",
+            "width": "1px",
+          }
         }
-      }
-      type="checkbox"
-    />
-    <span
-      aria-hidden={true}
-      className="chakra-switch__track css-14qxnv8"
-      onMouseDown={[Function]}
-      onMouseEnter={[Function]}
-      onMouseLeave={[Function]}
-      onMouseUp={[Function]}
-    >
-      <span
-        className="chakra-switch__thumb css-0"
+        type="checkbox"
       />
-    </span>
-    <span
-      className="chakra-switch__label css-1y8kf23"
-      onMouseDown={[Function]}
-      onTouchStart={[Function]}
-    >
-      Test Label
-    </span>
-  </label>
+      <span
+        aria-hidden={true}
+        className="chakra-switch__track css-14qxnv8"
+        onMouseDown={[Function]}
+        onMouseEnter={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+      >
+        <span
+          className="chakra-switch__thumb css-0"
+        />
+      </span>
+      <span
+        className="chakra-switch__label css-1y8kf23"
+        onMouseDown={[Function]}
+        onTouchStart={[Function]}
+      >
+        Test Label
+      </span>
+    </label>
+  </div>
 </div>
 `;

--- a/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
+++ b/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
@@ -8,6 +8,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 1`] = `
 >
   <div
     className="css-1xdhyk6"
+    id="video-player-without-text-componentWrapper-wrapper"
   >
     <div
       className="css-0"
@@ -33,6 +34,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 2`] = `
 >
   <div
     className="css-1xdhyk6"
+    id="video-player-with-text-componentWrapper-wrapper"
   >
     <h2
       className="chakra-heading css-1xdhyk6"
@@ -81,6 +83,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 3`] = `
 >
   <div
     className="css-1xdhyk6"
+    id="video-player-with-text-componentWrapper-wrapper"
   >
     <h2
       className="chakra-heading css-1xdhyk6"
@@ -144,6 +147,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 5`] = `
 >
   <div
     className="css-1xdhyk6"
+    id="chakra-componentWrapper-wrapper"
   >
     <div
       className="css-0"
@@ -169,6 +173,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 6`] = `
 >
   <div
     className="css-1xdhyk6"
+    id="props-componentWrapper-wrapper"
   >
     <div
       className="css-0"

--- a/src/theme/components/componentWrapper.ts
+++ b/src/theme/components/componentWrapper.ts
@@ -6,7 +6,7 @@ const ComponentWrapper = {
   parts: ["helperErrorText"],
   baseStyle: ({ hasChildren }: ComponentWrapperProps) => ({
     helperErrorText: {
-      marginTop: hasChildren ? "xs" : "0",
+      marginTop: hasChildren ? null : "0",
     },
   }),
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,3 +1,6 @@
+import { HelperErrorTextType } from "../components/HelperErrorText/HelperErrorText";
+import { AriaAttributes } from "./interfaces";
+
 // Utility functions to use throughout the codebase
 
 /**
@@ -41,4 +44,41 @@ export const getStorybookHrefProps = (pageCount: number) => {
   };
 
   return { computedCurrentPage, getPageHref };
+};
+
+interface GetAriaAttrsProps {
+  footnote: HelperErrorTextType;
+  id: string;
+  labelText: HelperErrorTextType;
+  name: string;
+  showLabel: boolean;
+}
+/**
+ * Get aria-* attributes for input components. This sets the `aria-label` and
+ * `aria-describedby` attributes, based on the label and footnote values.
+ */
+export const getAriaAttrs = ({
+  footnote,
+  id,
+  labelText,
+  name,
+  showLabel,
+}: GetAriaAttrsProps): AriaAttributes => {
+  let ariaAttributes: AriaAttributes = {};
+
+  if (!showLabel) {
+    if (typeof labelText !== "string") {
+      console.warn(
+        `NYPL Reservoir ${name}: \`labelText\` must be a string when \`showLabel\` is false.`
+      );
+    }
+    ariaAttributes["aria-label"] =
+      labelText && footnote
+        ? `${labelText} - ${footnote}`
+        : (labelText as string);
+  } else if (footnote) {
+    ariaAttributes["aria-describedby"] = `${id}-helperText`;
+  }
+
+  return ariaAttributes;
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-875](https://jira.nypl.org/browse/DSD-875)

## This PR does the following:

- Refactors the following components  `Checkbox`, `Radio`, `Select`, `Slider`, `TextInput`, and `Toggle`components to use the`ComponentWrapper` component for similar DOM structure.
- Adds `className`, `helperTextStyles`, and `showHelperInvalidText` props to the `ComponentWrapper` component.
- Even though the components above were updated, the internal updates also affects`CheckboxGroup`, `DatePicker`, `RadioGroup`, `SearchBar`,  and `VideoPlayer`.
- Adds a `getAriaAttrs` function to get aria-* attributes for input components.

All components above should be reviewed and tested.

## How has this been tested?

Visually and functionally tested all components in Storybook. All unit tests still passed. One test for `Checkbox` was testing it incorrectly. I'm not sure why or how it passed but it has now been updated.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
