### PR TITLE
DSD-948 - add hover state to icon only button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates all QA urls from Tugboat QA to Vercel.
 - Updates the `Logo` component to include new variants for `Apple App Store`, `Clever Badge` and `Google Play`.
 - Pins the Chakra UI "react" and "system" packages to a certain range since Chakra v2 uses React 18 and creates backwards compatibility issues.
+- Updates buttons setup as icon only to get the same hover styles as `secondary` button in the Button component.
 
 ### Fixes
 

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -88,6 +88,7 @@ const iconOnly = {
   color: "inherit",
   _hover: {
     bg: "ui.gray.xx-light-cool",
+    borderColor: "ui.gray.medium",
   },
   paddingInlineStart: "inset.narrow",
   paddingInlineEnd: "inset.narrow",


### PR DESCRIPTION
Fixes JIRA ticket DSD-948

## This PR does the following:

- Button with icon only hover states gets the styles of `secondary` button.

## How has this been tested?

Storybook

## Accessibility concerns or updates

N/A

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
