### PR TITLE
DSD-982: Allows Buttons in the ButtonGroup to be disabled individually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Fixes the extra margin added by the `SkipNavigation` component.
 - Updates various component implementations in Storybook documentation pages to remove inadvertent console errors and warnings.
 - Fixes sizing in the `Card` component for the "body" and "right" sections when the `isAlignedRightActions` prop is set to `true`.
+- Allows `Button`s in the `ButtonGroup` to manage their own `isDisabled` state.
 
 ## 1.0.0 (May 12, 2022)
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -85,7 +85,7 @@ export const iconNames = [
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.1`    |
 
 ## Table of Contents
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.mdx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.mdx
@@ -35,7 +35,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.28.0`   |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.1`    |
 
 ## Table of Contents
 
@@ -44,6 +44,7 @@ import DSProvider from "../../theme/provider";
 - [Accessibility](#accessibility)
 - [Button Width](#button-width)
 - [Layout](#layout)
+- [isDisabled](#isDisabled)
 
 ## Overview
 
@@ -141,6 +142,36 @@ The `layout` prop can be used to set the layout to either `row` or `column`.
           Button
         </Button>
         <Button id="column-full-2">Submit</Button>
+      </ButtonGroup>
+    </SimpleGrid>
+  </DSProvider>
+</Canvas>
+
+## isDisabled
+
+The `isDisabled` prop can be used to disable all the `Button` children at once.
+Individual `Button`s can still be disabled with their own `isDisabled` prop.
+
+<Canvas>
+  <DSProvider>
+    <SimpleGrid columns={1}>
+      <Heading level="three">ButtonGroup isDisabled</Heading>
+      <ButtonGroup isDisabled>
+        <Button buttonType="secondary" id="group-disabled-1">
+          Button disabled
+        </Button>
+        <Button buttonType="secondary" id="group-disabled-2">
+          Button disabled
+        </Button>
+      </ButtonGroup>
+      <Heading level="three">Individual Button isDisabled</Heading>
+      <ButtonGroup>
+        <Button buttonType="secondary" id="individual-disabled-1">
+          Button not disabled
+        </Button>
+        <Button buttonType="secondary" id="individual-disabled-2" isDisabled>
+          Button disabled
+        </Button>
       </ButtonGroup>
     </SimpleGrid>
   </DSProvider>

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -76,7 +76,8 @@ export const ButtonGroup = chakra(
             return;
           }
         }
-        newChildren.push(React.cloneElement(child, { key, isDisabled }));
+        const disabledProps = isDisabled ? { isDisabled } : {};
+        newChildren.push(React.cloneElement(child, { key, ...disabledProps }));
       }
     );
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-982](https://jira.nypl.org/browse/DSD-982)

## This PR does the following:

- Allows `Button`s in the `ButtonGroup` component to handle their own `isDisabled` state. When `ButtonGroup`'s `isDisabled` is set to true, all buttons will be disabled regardless of their own state.

## How has this been tested?

Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
