### PR TITLE
DSD-989: Fixing Checkbox's onChange function call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates various component implementations in Storybook documentation pages to remove inadvertent console errors and warnings.
 - Fixes sizing in the `Card` component for the "body" and "right" sections when the `isAlignedRightActions` prop is set to `true`.
 - Allows `Button`s in the `ButtonGroup` to manage their own `isDisabled` state.
+- Fixes how the `onChange` prop is set in `Checkbox` so it only gets called once per rendering.
 
 ## 1.0.0 (May 12, 2022)
 

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -183,6 +183,26 @@ describe("Checkbox", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("should call onChange only once when checkbox is clicked", () => {
+    const onChangeMock = jest.fn();
+
+    render(
+      <Checkbox
+        id="onChangeCalledOnce"
+        onChange={onChangeMock}
+        labelText="onChangeTest"
+        showLabel={true}
+        isChecked={false}
+      />
+    );
+
+    expect(
+      screen.getByRole("checkbox", { name: /onchangetest/i })
+    ).toBeInTheDocument();
+    userEvent.click(screen.getByRole("checkbox", { name: /onchangetest/i }));
+    expect(onChangeMock).toBeCalledTimes(1);
+  });
+
   it("Changing the value calls the onChange handler", () => {
     let isChecked = false;
     const onChange = (e) => {

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -55,10 +55,6 @@ export interface CheckboxProps extends CheckboxIconProps {
   value?: string;
 }
 
-export const onChangeDefault = () => {
-  return;
-};
-
 function CheckboxIcon(props: CheckboxIconProps) {
   // We don't need the `isIndeterminate` or `isChecked` props but it
   // causes rendering issues on the SVG element, so we remove them
@@ -89,6 +85,7 @@ export const Checkbox = chakra(
       isRequired = false,
       labelText,
       name,
+      onChange,
       showHelperInvalidText = true,
       showLabel = true,
       value,
@@ -96,7 +93,6 @@ export const Checkbox = chakra(
     } = props;
     const styles = useMultiStyleConfig("Checkbox", {});
     const footnote = isInvalid ? invalidText : helperText;
-    const onChange = props.onChange || onChangeDefault;
     // Use Chakra's default indeterminate icon.
     const icon = !isIndeterminate ? <CheckboxIcon /> : undefined;
     const ariaAttributes = getAriaAttrs({


### PR DESCRIPTION
Fixes JIRA ticket [DSD-989](https://jira.nypl.org/browse/DSD-989)

## This PR does the following:

- Fixes how `onChange` is set in the `Checkbox` component so it only gets called once when it is rendered and triggered. Passing it around accidentally called it.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
