### PR TITLE
DSD-983: Adding mobile Header nav menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds the `SitewideAlerts` component used internally in the `Header` component. This component dynamically fetches and renders NYPL sitewide alerts.
 - Adds the desktop search form to the `Header` component with the `SearchButton` and `SearchForm` components.
 - Refactors `SearchButton` and `SearchForm` to implement the mobile search form.
+- Adds the mobile navigation menu for the `Header` component with `MobileNav` and `MobileNavButton` components.
 
 ## Prerelease
 

--- a/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -291,7 +291,7 @@ exports[`Header renders the UI snapshot correctly 1`] = `
             >
               <svg
                 aria-hidden={true}
-                className="chakra-icon css-q3eg3a"
+                className="chakra-icon css-1grhd2q"
                 focusable={false}
                 role="img"
                 title="utilityHamburger icon"

--- a/src/components/Header/__snapshots__/Header.test.tsx.snap
+++ b/src/components/Header/__snapshots__/Header.test.tsx.snap
@@ -244,38 +244,99 @@ exports[`Header renders the UI snapshot correctly 1`] = `
             }
             tabIndex={-1}
           />
-          <svg
-            aria-hidden={true}
-            className="chakra-icon css-1grhd2q"
-            focusable={false}
-            id="hamburger-icon"
-            role="img"
-            title="Menu"
-            viewBox="0 0 24 24"
+          <div
+            data-focus-guard={true}
+            style={
+              Object {
+                "height": "0px",
+                "left": "1px",
+                "overflow": "hidden",
+                "padding": 0,
+                "position": "fixed",
+                "top": "1px",
+                "width": "1px",
+              }
+            }
+            tabIndex={-1}
+          />
+          <div
+            data-focus-guard={true}
+            style={
+              Object {
+                "height": "0px",
+                "left": "1px",
+                "overflow": "hidden",
+                "padding": 0,
+                "position": "fixed",
+                "top": "1px",
+                "width": "1px",
+              }
+            }
+            tabIndex={-1}
+          />
+          <div
+            data-focus-lock-disabled="disabled"
+            onBlur={[Function]}
+            onFocus={[Function]}
           >
-            <g
-              stroke="currentColor"
-              strokeWidth="1.5"
+            <button
+              aria-expanded={null}
+              aria-haspopup="true"
+              aria-label="Open Navigation"
+              className="chakra-button css-1xdhyk6"
+              data-testid="button"
+              id="mobileNav"
+              onClick={[Function]}
+              type="button"
             >
-              <path
-                d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-                fill="none"
-                strokeLinecap="round"
-              />
-              <path
-                d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-                fill="currentColor"
-                strokeLinecap="round"
-              />
-              <circle
-                cx="12"
-                cy="12"
-                fill="none"
-                r="11.25"
-                strokeMiterlimit="10"
-              />
-            </g>
-          </svg>
+              <svg
+                aria-hidden={true}
+                className="chakra-icon css-q3eg3a"
+                focusable={false}
+                role="img"
+                title="utilityHamburger icon"
+                viewBox="0 0 24 24"
+              >
+                <g
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                >
+                  <path
+                    d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+                    fill="none"
+                    strokeLinecap="round"
+                  />
+                  <path
+                    d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+                    fill="currentColor"
+                    strokeLinecap="round"
+                  />
+                  <circle
+                    cx="12"
+                    cy="12"
+                    fill="none"
+                    r="11.25"
+                    strokeMiterlimit="10"
+                  />
+                </g>
+              </svg>
+            </button>
+          </div>
+          <div
+            data-focus-guard={true}
+            style={
+              Object {
+                "height": "0px",
+                "left": "1px",
+                "overflow": "hidden",
+                "padding": 0,
+                "position": "fixed",
+                "top": "1px",
+                "width": "1px",
+              }
+            }
+            tabIndex={-1}
+          />
         </div>
       </div>
     </div>

--- a/src/components/Header/components/Mobile.tsx
+++ b/src/components/Header/components/Mobile.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { chakra, Flex, HStack, useMultiStyleConfig } from "@chakra-ui/react";
 
 import Icon from "../../Icons/Icon";
+import MobileNavButton from "./MobileNavButton";
 import SearchButton from "./SearchButton";
 
 const Mobile = chakra(() => {
@@ -22,12 +23,7 @@ const Mobile = chakra(() => {
           title="NYPL Locator"
         />
         <SearchButton isMobile />
-        <Icon
-          id="hamburger-icon"
-          name="utilityHamburger"
-          size="medium"
-          title="Menu"
-        />
+        <MobileNavButton />
       </HStack>
     </Flex>
   );

--- a/src/components/Header/components/MobileNav.test.tsx
+++ b/src/components/Header/components/MobileNav.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen, within } from "@testing-library/react";
+
+import { axe } from "jest-axe";
+import * as React from "react";
+import renderer from "react-test-renderer";
+
+import MobileNav from "./MobileNav";
+
+describe("MobileNav Accessibility", () => {
+  it("passes axe accessibility test", async () => {
+    const { container } = render(<MobileNav />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("MobileNav", () => {
+  beforeEach(() => {
+    render(<MobileNav />);
+  });
+
+  it("renders the NYPL logo", () => {
+    const logo = screen.getByRole("img");
+
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute("title", "NYPL Header Logo");
+  });
+
+  it("renders a nav list", () => {
+    const navList = screen.getByRole("navigation");
+    const links = within(navList).getAllByRole("link");
+
+    expect(links).toHaveLength(7);
+    expect(links[0]).toHaveTextContent("Books/Music/Movies");
+    expect(links[1]).toHaveTextContent("Research");
+    expect(links[2]).toHaveTextContent("Education");
+    expect(links[3]).toHaveTextContent("Events");
+    expect(links[4]).toHaveTextContent("Connect");
+    expect(links[5]).toHaveTextContent("Give");
+    expect(links[6]).toHaveTextContent("Get Help");
+  });
+
+  it("renders the bottom links", () => {
+    const bottomGrid = screen.getByTestId("bottomLinks");
+    const links = within(bottomGrid).getAllByRole("link");
+
+    expect(links).toHaveLength(4);
+    expect(links[0]).toHaveTextContent("Get a Library Card");
+    expect(links[1]).toHaveTextContent("Get Email Updates");
+    expect(links[2]).toHaveTextContent("Shop NYPL");
+    expect(links[3]).toHaveTextContent("Donate");
+  });
+
+  it("renders the UI snapshot correctly", () => {
+    const mobileNav = renderer.create(<MobileNav />).toJSON();
+
+    expect(mobileNav).toMatchSnapshot();
+  });
+});

--- a/src/components/Header/components/MobileNav.tsx
+++ b/src/components/Header/components/MobileNav.tsx
@@ -69,17 +69,25 @@ const MobileNav = chakra(() => {
           href="#"
           borderTop="1px solid rgb(54, 54, 54)"
           borderRight="1px solid rgb(54, 54, 54)"
-          gridColumn="2 / 1"
+          gridColumn="1 / span 1"
         >
           Get a Library Card
         </Link>
-        <Link href="#" borderTop="1px solid rgb(54, 54, 54)" gridColumn="2 / 2">
+        <Link
+          href="#"
+          borderTop="1px solid rgb(54, 54, 54)"
+          gridColumn="2 / span 1"
+        >
           Get Email Updates
         </Link>
-        <Link href="#" borderTop="1px solid rgb(54, 54, 54)" gridColumn="1 / 3">
+        <Link
+          href="#"
+          borderTop="1px solid rgb(54, 54, 54)"
+          gridColumn="1 / span 2"
+        >
           Shop NYPL
         </Link>
-        <Link href="#" gridColumn="1 / 3">
+        <Link href="#" gridColumn="1 / span 2">
           Donate
         </Link>
       </SimpleGrid>

--- a/src/components/Header/components/MobileNav.tsx
+++ b/src/components/Header/components/MobileNav.tsx
@@ -1,0 +1,90 @@
+import {
+  Box,
+  chakra,
+  Flex,
+  Spacer,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
+import React from "react";
+
+import Link from "../../Link/Link";
+import List from "../../List/List";
+import Logo from "../../Logo/Logo";
+import SimpleGrid from "../../Grid/SimpleGrid";
+
+/**
+ * The Header navigation for the mobile view.
+ */
+const MobileNav = chakra(() => {
+  const styles = useMultiStyleConfig("HeaderMobileNav", {});
+
+  return (
+    <Box __css={styles}>
+      <Flex>
+        <Box>
+          <Logo
+            name="nyplLionWhite"
+            size="xxsmall"
+            marginTop="15px"
+            marginLeft="15px"
+            decorative={false}
+            title="NYPL Header Logo"
+          />
+        </Box>
+        <Spacer />
+        <nav aria-label="Header mobile links">
+          <List
+            id="header-mobile-nav"
+            listItems={[
+              <Link href="#" key="booksMusicMoviesLink">
+                Books/Music/Movies
+              </Link>,
+              <Link href="#" key="researchLink">
+                Research
+              </Link>,
+              <Link href="#" key="educationLink">
+                Education
+              </Link>,
+              <Link href="#" key="eventsLink">
+                Events
+              </Link>,
+              <Link href="#" key="connectLink">
+                Connect
+              </Link>,
+              <Link href="#" key="giveLink">
+                Give
+              </Link>,
+              <Link href="#" key="getHelpLink">
+                Get Help
+              </Link>,
+            ]}
+            noStyling
+            type="ul"
+            __css={styles.sideNav}
+          />
+        </nav>
+      </Flex>
+      <SimpleGrid gap="0" data-testid="bottomLinks" __css={styles.bottomLinks}>
+        <Link
+          href="#"
+          borderTop="1px solid rgb(54, 54, 54)"
+          borderRight="1px solid rgb(54, 54, 54)"
+          gridColumn="2 / 1"
+        >
+          Get a Library Card
+        </Link>
+        <Link href="#" borderTop="1px solid rgb(54, 54, 54)" gridColumn="2 / 2">
+          Get Email Updates
+        </Link>
+        <Link href="#" borderTop="1px solid rgb(54, 54, 54)" gridColumn="1 / 3">
+          Shop NYPL
+        </Link>
+        <Link href="#" gridColumn="1 / 3">
+          Donate
+        </Link>
+      </SimpleGrid>
+    </Box>
+  );
+});
+
+export default MobileNav;

--- a/src/components/Header/components/MobileNavButton.test.tsx
+++ b/src/components/Header/components/MobileNavButton.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { axe } from "jest-axe";
+import * as React from "react";
+import renderer from "react-test-renderer";
+
+import MobileNavButton from "./MobileNavButton";
+
+describe("MobileNavButton Accessibility", () => {
+  it("passes axe accessibility test", async () => {
+    const { container } = render(<MobileNavButton />);
+    expect(await axe(container)).toHaveNoViolations();
+  });
+});
+
+describe("MobileNavButton", () => {
+  beforeEach(() => {
+    render(<MobileNavButton />);
+  });
+
+  it("renders a menu button", () => {
+    const button = screen.getByRole("button");
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("aria-label", "Open Navigation");
+  });
+
+  it("renders a Close button when clicked", () => {
+    const menuBtn = screen.getByRole("button");
+
+    expect(menuBtn).toHaveAttribute("aria-label", "Open Navigation");
+
+    userEvent.click(menuBtn);
+
+    expect(menuBtn).toHaveAttribute("aria-label", "Close Navigation");
+  });
+
+  it("renders the mobile navigation menu when clicked", () => {
+    const menuBtn = screen.getByRole("button");
+
+    userEvent.click(menuBtn);
+
+    const logo = screen.getByRole("img");
+    const navList = screen.getByRole("navigation");
+    const links = screen.getAllByRole("link");
+
+    expect(logo).toBeInTheDocument();
+    expect(navList).toBeInTheDocument();
+    expect(links).toHaveLength(11);
+  });
+
+  it("renders the UI snapshot correctly", () => {
+    const mobileNavButton = renderer.create(<MobileNavButton />).toJSON();
+
+    expect(mobileNavButton).toMatchSnapshot();
+  });
+});

--- a/src/components/Header/components/MobileNavButton.tsx
+++ b/src/components/Header/components/MobileNavButton.tsx
@@ -1,0 +1,37 @@
+import FocusLock from "@chakra-ui/focus-lock";
+import { chakra, useStyleConfig } from "@chakra-ui/react";
+import React, { useState } from "react";
+
+import Button from "../../Button/Button";
+import Icon from "../../Icons/Icon";
+import MobileNav from "./MobileNav";
+
+const mobileNav = chakra(() => {
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const styles = useStyleConfig("HeaderMobileNavButton", { isOpen });
+  const buttonTextColor = isOpen ? "ui.white" : "ui.black";
+
+  return (
+    <FocusLock isDisabled={!isOpen}>
+      <Button
+        aria-haspopup="true"
+        aria-label={isOpen ? "Close Navigation" : "Open Navigation"}
+        aria-expanded={isOpen ? true : null}
+        buttonType="link"
+        id="mobileNav"
+        onClick={() => setIsOpen(!isOpen)}
+        __css={styles}
+      >
+        <Icon
+          align="none"
+          color={buttonTextColor}
+          name={isOpen ? "close" : "utilityHamburger"}
+          size="large"
+        />
+      </Button>
+      {isOpen && <MobileNav />}
+    </FocusLock>
+  );
+});
+
+export default mobileNav;

--- a/src/components/Header/components/MobileNavButton.tsx
+++ b/src/components/Header/components/MobileNavButton.tsx
@@ -9,7 +9,6 @@ import MobileNav from "./MobileNav";
 const mobileNav = chakra(() => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const styles = useStyleConfig("HeaderMobileNavButton", { isOpen });
-  const buttonTextColor = isOpen ? "ui.white" : "ui.black";
 
   return (
     <FocusLock isDisabled={!isOpen}>
@@ -24,7 +23,6 @@ const mobileNav = chakra(() => {
       >
         <Icon
           align="none"
-          color={buttonTextColor}
           name={isOpen ? "close" : "utilityHamburger"}
           size="large"
         />

--- a/src/components/Header/components/__snapshots__/MobileNav.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/MobileNav.test.tsx.snap
@@ -1,0 +1,166 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MobileNav renders the UI snapshot correctly 1`] = `
+<div
+  className="css-0"
+>
+  <div
+    className="css-k008qs"
+  >
+    <div
+      className="css-0"
+    >
+      <svg
+        aria-hidden={false}
+        className="chakra-icon css-qpytvg"
+        focusable={false}
+        role="img"
+        title="NYPL Header Logo"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
+    </div>
+    <div
+      className="css-17xejub"
+    />
+    <nav
+      aria-label="Header mobile links"
+    >
+      <ul
+        className="css-1xdhyk6"
+        id="header-mobile-nav"
+      >
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Books/Music/Movies
+          </a>
+        </li>
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Research
+          </a>
+        </li>
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Education
+          </a>
+        </li>
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Events
+          </a>
+        </li>
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Connect
+          </a>
+        </li>
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Give
+          </a>
+        </li>
+        <li>
+          <a
+            className="css-1xdhyk6"
+            href="#"
+            rel={null}
+            target={null}
+          >
+            Get Help
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
+  <div
+    className="css-wcncoc"
+    data-testid="bottomLinks"
+  >
+    <a
+      className="css-gycobi"
+      href="#"
+      rel={null}
+      target={null}
+    >
+      Get a Library Card
+    </a>
+    <a
+      className="css-r4vexk"
+      href="#"
+      rel={null}
+      target={null}
+    >
+      Get Email Updates
+    </a>
+    <a
+      className="css-1r9wdse"
+      href="#"
+      rel={null}
+      target={null}
+    >
+      Shop NYPL
+    </a>
+    <a
+      className="css-345wwt"
+      href="#"
+      rel={null}
+      target={null}
+    >
+      Donate
+    </a>
+  </div>
+</div>
+`;

--- a/src/components/Header/components/__snapshots__/MobileNav.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/MobileNav.test.tsx.snap
@@ -130,7 +130,7 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
     data-testid="bottomLinks"
   >
     <a
-      className="css-gycobi"
+      className="css-g8syzw"
       href="#"
       rel={null}
       target={null}
@@ -138,7 +138,7 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
       Get a Library Card
     </a>
     <a
-      className="css-r4vexk"
+      className="css-1i5qkun"
       href="#"
       rel={null}
       target={null}
@@ -146,7 +146,7 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
       Get Email Updates
     </a>
     <a
-      className="css-1r9wdse"
+      className="css-1hbu0qa"
       href="#"
       rel={null}
       target={null}
@@ -154,7 +154,7 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
       Shop NYPL
     </a>
     <a
-      className="css-345wwt"
+      className="css-847rpw"
       href="#"
       rel={null}
       target={null}

--- a/src/components/Header/components/__snapshots__/MobileNavButton.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/MobileNavButton.test.tsx.snap
@@ -1,0 +1,99 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MobileNavButton renders the UI snapshot correctly 1`] = `
+Array [
+  <div
+    data-focus-guard={true}
+    style={
+      Object {
+        "height": "0px",
+        "left": "1px",
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "fixed",
+        "top": "1px",
+        "width": "1px",
+      }
+    }
+    tabIndex={-1}
+  />,
+  <div
+    data-focus-guard={true}
+    style={
+      Object {
+        "height": "0px",
+        "left": "1px",
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "fixed",
+        "top": "1px",
+        "width": "1px",
+      }
+    }
+    tabIndex={-1}
+  />,
+  <div
+    data-focus-lock-disabled="disabled"
+    onBlur={[Function]}
+    onFocus={[Function]}
+  >
+    <button
+      aria-expanded={null}
+      aria-haspopup="true"
+      aria-label="Open Navigation"
+      className="chakra-button css-1xdhyk6"
+      data-testid="button"
+      id="mobileNav"
+      onClick={[Function]}
+      type="button"
+    >
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-q3eg3a"
+        focusable={false}
+        role="img"
+        title="utilityHamburger icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
+    </button>
+  </div>,
+  <div
+    data-focus-guard={true}
+    style={
+      Object {
+        "height": "0px",
+        "left": "1px",
+        "overflow": "hidden",
+        "padding": 0,
+        "position": "fixed",
+        "top": "1px",
+        "width": "1px",
+      }
+    }
+    tabIndex={-1}
+  />,
+]
+`;

--- a/src/components/Header/components/__snapshots__/MobileNavButton.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/MobileNavButton.test.tsx.snap
@@ -49,7 +49,7 @@ Array [
     >
       <svg
         aria-hidden={true}
-        className="chakra-icon css-q3eg3a"
+        className="chakra-icon css-1grhd2q"
         focusable={false}
         role="img"
         title="utilityHamburger icon"

--- a/src/theme/components/headerMobileNav.ts
+++ b/src/theme/components/headerMobileNav.ts
@@ -1,0 +1,59 @@
+const HeaderMobileNav = {
+  parts: ["bottomLinks", "sideNav"],
+  baseStyle: () => ({
+    whiteSpace: "initial",
+    position: "absolute",
+    left: "0px",
+    backgroundColor: "ui.black",
+    width: "100%",
+    zIndex: "99999",
+    color: "ui.white",
+    sideNav: {
+      textAlign: "right",
+      padding: "15px",
+      marginBottom: "0",
+      "li:not(:first-child)": {
+        marginTop: "10px",
+      },
+      a: {
+        color: "ui.white",
+        textDecoration: "none",
+        _hover: {
+          color: "ui.white",
+          textDecoration: "none",
+        },
+      },
+    },
+    bottomLinks: {
+      display: "grid",
+      gridTemplateColumns: "1fr 1fr",
+      a: {
+        color: "white",
+        display: "block",
+        textDecoration: "none",
+        textAlign: "center",
+        padding: "20px",
+        _hover: {
+          color: "ui.white",
+          backgroundColor: "ui.black",
+          textDecoration: "none",
+        },
+        _last: {
+          backgroundColor: "brand.primary",
+          _hover: {
+            backgroundColor: "brand.primary",
+          },
+        },
+        _focus: {
+          borderRadius: "none",
+          outlineColor: "#135772 !important",
+          outlineOffset: "0 !important",
+          outlineStyle: "solid !important",
+          outlineWidth: "0.1875em !important",
+        },
+      },
+    },
+  }),
+};
+
+export default HeaderMobileNav;

--- a/src/theme/components/headerMobileNavButton.ts
+++ b/src/theme/components/headerMobileNavButton.ts
@@ -1,0 +1,30 @@
+const HeaderMobileNavButton = {
+  baseStyle: ({ isOpen }) => ({
+    alignItems: "center",
+    backgroundColor: isOpen ? "ui.black" : "transparent",
+    border: "none",
+    fontSize: "inherit",
+    fontWeight: 500,
+    minHeight: "50px",
+    minWidth: "50px",
+    svg: {
+      fill: isOpen ? "ui.white" : "ui.black",
+      marginLeft: "0",
+    },
+    _hover: {
+      backgroundColor: isOpen ? "ui.black" : "transparent",
+      svg: {
+        fill: isOpen ? "ui.white" : "ui.black",
+      },
+    },
+    _focus: {
+      borderRadius: "none",
+      outlineColor: "#135772 !important",
+      outlineOffset: "0 !important",
+      outlineStyle: "solid !important",
+      outlineWidth: "0.1875em !important",
+    },
+  }),
+};
+
+export default HeaderMobileNavButton;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -23,6 +23,8 @@ import Fieldset from "./components/fieldset";
 import Header from "./components/header";
 import HeaderLowerNav from "./components/headerLowerNav";
 import HeaderMobile from "./components/headerMobile";
+import HeaderMobileNav from "./components/headerMobileNav";
+import HeaderMobileNavButton from "./components/headerMobileNavButton";
 import HeaderSearchForm from "./components/headerSearchForm";
 import HeaderSearchButton from "./components/headerSearchButton";
 import HeaderUpperNav from "./components/headerUpperNav";
@@ -102,6 +104,8 @@ const theme = extendTheme({
     Header,
     HeaderLowerNav,
     HeaderMobile,
+    HeaderMobileNav,
+    HeaderMobileNavButton,
     HeaderSearchForm,
     HeaderSearchButton,
     HeaderUpperNav,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-983](https://jira.nypl.org/browse/DSD-983)

## This PR does the following:

- Adds `MobileNav` and `MobileNavButton` to implement the `Header`'s 
mobile nav menu.
- @bigfishdesign13 we need the NYPL logo that is _just_ the text.
<img width="133" alt="Screen Shot 2022-05-25 at 5 05 42 PM" src="https://user-images.githubusercontent.com/1280564/170367231-ca87dcae-aa66-4339-a9a7-79095b58dd8f.png">
- @bigfishdesign13 I also have some concerns throughout which I'll add comments for.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Just minor concern about the logo not being decorative and having the right title.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
