### PR TITLE
DSD-986: Fixing styles for CheckboxGroup and RadioGroup 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Pins the Chakra UI "react" and "system" packages to a certain range since Chakra v2 uses React 18 and creates backwards compatibility issues.
 - Updates buttons setup as icon only to get the same hover styles as `secondary` button in the Button component.
 - Updates and refactors the `Checkbox`, `Radio`, `Select`, `Slider, `TextInput`, and `Toggle`components to use the`ComponentWrapper` component for similar DOM structure.
+- Updates how `CheckboxGroup` and `RadioGroup` handle `Checkbox` and `Radio` components when `isFullWidth` is true and there is JSX as labels.
 
 ### Fixes
 

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -64,7 +64,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.1`   |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.1`    |
 
 ## Table of Contents
 

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -143,6 +143,7 @@ export const CheckboxGroup = chakra(
         legendText={labelText}
         showRequiredLabel={showRequiredLabel}
         {...rest}
+        __css={styles}
       >
         <ChakraCheckboxGroup {...checkboxProps}>
           <Stack
@@ -152,7 +153,6 @@ export const CheckboxGroup = chakra(
             spacing={spacingProp}
             ref={ref}
             aria-label={!showLabel ? labelText : undefined}
-            sx={styles.stack}
           >
             {newChildren}
           </Stack>

--- a/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -67,7 +67,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.0`   |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.1`    |
 
 ## Table of Contents
 

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -147,9 +147,10 @@ export const RadioGroup = chakra(
           legendText={labelText}
           showRequiredLabel={showRequiredLabel}
           {...rest}
+          __css={styles}
         >
           <ChakraRadioGroup {...radioGroupProps}>
-            <Stack direction={[layout]} spacing={spacingProp} sx={styles.stack}>
+            <Stack direction={[layout]} spacing={spacingProp}>
               {newChildren}
             </Stack>
           </ChakraRadioGroup>

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -45,7 +45,7 @@ const checkboxRadioGroupStyles = (isFullWidth = false) => ({
   helperErrorText: {
     marginTop: "xs",
   },
-  stack: {
+  label: {
     width: isFullWidth ? "100%" : "fit-content",
   },
 });


### PR DESCRIPTION
Fixes JIRA ticket [DSD-986](https://jira.nypl.org/browse/DSD-986)

## This PR does the following:

- Fixes the styles for `Checkbox` and `Radio` components that use JSX labels when `isFullWidth` is set to true for `CheckboxGroup` and `RadioGroup` components.

## How has this been tested?

Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
