### PR TITLE
DSD-996: Bumping up to 1.0.2 and writing why

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,8 +54,9 @@ jobs:
         with:
           node-version: 14.x
           registry-url: "https://registry.npmjs.org"
-      - run: npm install -g npm@latest && npm install
+      - name: Cache and install node modules
+        uses: bahmutov/npm-install@v1
       - name: Publish
-        uses: JS-DevTools/npm-publish@v1
-        with:
-          token: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
-## 1.0.1 (May 31, 2022)
+## 1.0.2 (June 1, 2022)
 
 ### Adds
 
@@ -34,6 +34,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Fixes sizing in the `Card` component for the "body" and "right" sections when the `isAlignedRightActions` prop is set to `true`.
 - Allows `Button`s in the `ButtonGroup` to manage their own `isDisabled` state.
 - Fixes how the `onChange` prop is set in `Checkbox` so it only gets called once per rendering.
+
+## 1.0.1 (May 31, 2022)
+
+_NOTE_: This version number was previously released in 2019 and is marked as deprecated in npm. The next version bump from `1.0.0` is `1.0.2`.
 
 ## 1.0.0 (May 12, 2022)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/design-system-react-components",
-      "version": "1.0.1",
+      "version": "1.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/react": ">=1.8.5 <=1.8.8",
@@ -6344,9 +6344,9 @@
       }
     },
     "node_modules/@storybook/builder-webpack4/node_modules/@types/node": {
-      "version": "14.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+      "version": "14.18.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+      "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
       "dev": true
     },
     "node_modules/@storybook/builder-webpack4/node_modules/babel-plugin-polyfill-corejs3": {
@@ -6867,9 +6867,9 @@
       }
     },
     "node_modules/@storybook/core-common/node_modules/@types/node": {
-      "version": "14.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+      "version": "14.18.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+      "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
       "dev": true
     },
     "node_modules/@storybook/core-common/node_modules/ansi-styles": {
@@ -7244,9 +7244,9 @@
       }
     },
     "node_modules/@storybook/core-server/node_modules/@types/node": {
-      "version": "14.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+      "version": "14.18.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+      "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
       "dev": true
     },
     "node_modules/@storybook/core-server/node_modules/ansi-styles": {
@@ -7409,9 +7409,9 @@
       }
     },
     "node_modules/@storybook/manager-webpack4/node_modules/@types/node": {
-      "version": "14.18.18",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-      "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+      "version": "14.18.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+      "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
       "dev": true
     },
     "node_modules/@storybook/manager-webpack4/node_modules/ansi-styles": {
@@ -48601,9 +48601,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-          "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+          "version": "14.18.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+          "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
           "dev": true
         },
         "babel-plugin-polyfill-corejs3": {
@@ -48984,9 +48984,9 @@
           }
         },
         "@types/node": {
-          "version": "14.18.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-          "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+          "version": "14.18.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+          "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
           "dev": true
         },
         "ansi-styles": {
@@ -49242,9 +49242,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-          "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+          "version": "14.18.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+          "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
           "dev": true
         },
         "ansi-styles": {
@@ -49370,9 +49370,9 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.18.18",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.18.tgz",
-          "integrity": "sha512-B9EoJFjhqcQ9OmQrNorItO+OwEOORNn3S31WuiHvZY/dm9ajkB7AKD/8toessEtHHNL+58jofbq7hMMY9v4yig==",
+          "version": "14.18.20",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.20.tgz",
+          "integrity": "sha512-Q8KKwm9YqEmUBRsqJ2GWJDtXltBDxTdC4m5vTdXBolu2PeQh8LX+f6BTwU+OuXPu37fLxoN6gidqBmnky36FXA==",
           "dev": true
         },
         "ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "NYPL Reservoir Design System React Components",
   "repository": {
     "type": "git",

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -35,7 +35,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.1.0`    |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -85,7 +85,7 @@ export const iconNames = [
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/ButtonGroup/ButtonGroup.stories.mdx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.mdx
@@ -35,7 +35,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.28.0`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -75,7 +75,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -57,7 +57,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.1.0`    |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -64,7 +64,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.1`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Heading/Heading.stories.mdx
+++ b/src/components/Heading/Heading.stories.mdx
@@ -36,7 +36,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.0.1`   |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -66,7 +66,7 @@ export const imageBlockStyles = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.6`    |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Logo/Logo.stories.mdx
+++ b/src/components/Logo/Logo.stories.mdx
@@ -44,7 +44,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.9`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Radio/Radio.stories.mdx
+++ b/src/components/Radio/Radio.stories.mdx
@@ -53,7 +53,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.22.0`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -67,7 +67,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.0`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -66,7 +66,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/SkipNavigation/SkipNavigation.stories.mdx
+++ b/src/components/SkipNavigation/SkipNavigation.stories.mdx
@@ -29,7 +29,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.28.0`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -74,7 +74,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.4`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -37,7 +37,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.9`   |
-| Latest            | `1.0.1`   |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -51,7 +51,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.22.0`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 

--- a/src/components/Toggle/Toggle.stories.mdx
+++ b/src/components/Toggle/Toggle.stories.mdx
@@ -45,7 +45,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.8`   |
-| Latest            | `1.0.1`    |
+| Latest            | `1.0.2`    |
 
 ## Table of Contents
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-996](https://jira.nypl.org/browse/DSD-996)

## This PR does the following:

- Bumps up the version to `1.0.2`.
- Version `1.0.1` was supposed to be our next release after `1.0.0` but it was previously published on npm in 2019. It was marked as "deprecated" at some point and because it's deprecated, npm doesn't display it. We were unaware of this and now have to use version `1.0.2`.

## How has this been tested?

Through lots of commits in `development` and `release`. Initially, I thought it was related to the version of npm that the Github Action used (version 6.x) while installing the repo and attempting to release. Once npm was updated to 8.x, publishing still failed. The "deprecated" warning didn't make sense as it didn't say that 1.0.1 is an existing version and was already published.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
