### PR TITLE
DSD-984: useNYPLBreakpoints hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,16 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `useNYPLBreakpoints` hook. This hook internally uses Chakra's `useMediaQuery` hook to get the current responsive media query breakpoint.
+
 ## 1.0.3 (June 9, 2022)
 
 ### Adds
 
 - Adds prop validation for the `TextInput` "number" type for the `min` and `max` props.
 - Adds `min` and `max` prop value validation for the `Slider` component, including in the "range" mode.
-- Adds the `useNYPLBreakpoints` hook. This hook internally uses Chakra's `useMediaQuery` hook to get the current responsive media query breakpoint.
 
 ### Updates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds prop validation for the `TextInput` "number" type for the `min` and `max` props.
 - Adds `min` and `max` prop value validation for the `Slider` component, including in the "range" mode.
+- Adds the `useNYPLBreakpoints` hook. This hook internally uses Chakra's `useMediaQuery` hook to get the current responsive media query breakpoint.
 
 ### Updates
 

--- a/src/__tests__/mediaMatchMock.ts
+++ b/src/__tests__/mediaMatchMock.ts
@@ -1,0 +1,266 @@
+/**
+ * NYPL Note:
+ * This file is directly taken from Chakra:
+ * https://github.com/chakra-ui/chakra-ui/blob/main/packages/media-query/tests/matchmedia-mock-plus.ts
+ *
+ * We need this to test the `useNYPLBreakpoints` hook and, unfortunately,
+ * this function is not exported by Chakra.
+ */
+
+/**
+ * This mock is a combination of jest-matchmedia-mock
+ * https://github.com/dyakovk/jest-matchmedia-mock and
+ * mq-polyfill https://github.com/bigslycat/mq-polyfill.
+ *
+ * A solution which allowed resizing and a more realistic implementation of
+ * matchMedia was the reason for its creation. Neither project provided a good
+ * solution. Combining their strong points does. The class will listen for a
+ * resize event which is provided by a resizeTo function defined in the test:
+ *
+ *  window.resizeTo = function resizeTo(width, height) {
+ *    Object.assign(this, {
+ *      innerWidth: width,
+ *      innerHeight: height,
+ *      outerWidth: width,
+ *      outerHeight: height,
+ *    }).dispatchEvent(new this.Event('resize'))
+ *  }
+ *
+ * Listeners are only called if there has been a change in the match
+ * status for their media query.
+ */
+type MediaQueryListener = (this: MediaQueryList) => void;
+
+interface MediaQueryList {
+  readonly matches: boolean;
+  readonly media: string;
+  onchange: MediaQueryListener | null;
+  addListener(listener: MediaQueryListener): void;
+  removeListener(listener: MediaQueryListener): void;
+  addEventListener(type: "change", listener: MediaQueryListener): void;
+  removeEventListener(type: "change", listener: MediaQueryListener): void;
+  dispatchEvent(event: Event): boolean;
+}
+
+type MediaQueriesType = { [key: string]: MediaQueryListener[] };
+
+export default class MatchMedia {
+  private mediaQueries: MediaQueriesType = {};
+  private prevMatchMap = new Map<string, boolean>();
+
+  private mediaQueryList!: MediaQueryList;
+
+  constructor() {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      configurable: true,
+      value: (query: string): MediaQueryList => {
+        this.mediaQueryList = {
+          matches: this.evalQuery(query),
+          media: query,
+          onchange: null,
+          addListener: (listener) => {
+            this.addListener(query, listener);
+          },
+          removeListener: (listener) => {
+            this.removeListener(query, listener);
+          },
+          addEventListener: (type, listener) => {
+            if (type !== "change") return;
+
+            this.addListener(query, listener);
+          },
+          removeEventListener: (type, listener) => {
+            if (type !== "change") return;
+
+            this.removeListener(query, listener);
+          },
+          dispatchEvent: jest.fn(),
+        };
+
+        return this.mediaQueryList;
+      },
+    });
+
+    window.addEventListener("resize", () => this.handleResize());
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  private compileQuery(query: string) {
+    type UnitsReplaceType = ($0: string, $1: string, $2: UnitType) => string;
+
+    type UnitType =
+      | "cm"
+      | "em"
+      | "rem"
+      | "in"
+      | "dppx"
+      | "mm"
+      | "pc"
+      | "pt"
+      | "px";
+
+    function unitToPixels(unit: UnitType): number {
+      switch (unit) {
+        case "cm":
+          return 0.3937 * 96;
+        case "em":
+        case "rem":
+          return 16;
+        case "in":
+        case "dppx":
+          return 96;
+        case "mm":
+          return (0.3937 * 96) / 10;
+        case "pc":
+          return (12 * 96) / 72;
+        case "pt":
+          return 96 / 72;
+        case "px":
+        default:
+          return 1;
+      }
+    }
+
+    const unitsReplace: UnitsReplaceType = (_, $1, $2) =>
+      String(+$1 * unitToPixels($2));
+
+    return "try { return !!(%s) } catch(e) { return false }".replace(
+      "%s",
+      query
+        .split(/\s*,\s*/g)
+        .map((part) =>
+          part
+            .replace(/^\s*only\s+/, "")
+            .replace(/^\s*not\s*(.+)/, "!($1)")
+            .replace(/(?:min-)([\w.]+)\s*:\s*/g, "media.$1 >= ")
+            .replace(/(?:max-)([\w.]+)\s*:\s*/g, "media.$1 <= ")
+            .replace(/([\w.]+)\s*:\s*/g, "media.$1 === ")
+            .replace(/\s*all|screen\s*/g, "true")
+            .replace(/\s*print\s*/g, "false")
+            .replace(/[\s()]+or[\s()]+/g, " || ")
+            .replace(/\s*and\s*/g, " && ")
+            .replace(/dpi/g, "")
+            .replace(/(\d+)(cm|em|in|dppx|mm|pc|pt|px|rem)/g, unitsReplace)
+            .replace(/^(.*)$/, "($1)")
+        )
+        .join(" || ")
+    );
+  }
+
+  private evalQuery(query: string): boolean {
+    const result = !!(
+      // eslint-disable-next-line no-new-func,@typescript-eslint/no-implied-eval
+      new Function("media", this.compileQuery(query))({
+        width: window.innerWidth,
+        height: window.innerHeight,
+        orientation: window.screen.orientation
+          ? window.screen.orientation.type.replace(
+              /^(landscape|portrait).*$/,
+              "$1"
+            )
+          : "landscape",
+      })
+    );
+
+    return result;
+  }
+
+  /**
+   *
+   * Adds a listener function for the window resize event
+   * @private
+   */
+  private handleResize() {
+    for (const [query, listeners] of Object.entries(this.mediaQueries)) {
+      const matches = this.evalQuery(query);
+
+      if (this.prevMatchMap.get(query) !== matches) {
+        this.prevMatchMap.set(query, matches);
+
+        const mqListEvent: Partial<MediaQueryListEvent> = {
+          matches,
+          media: query,
+        };
+
+        listeners.forEach((listener) => {
+          (listener as Function)?.call(
+            this.mediaQueryList,
+            mqListEvent as MediaQueryListEvent
+          );
+        });
+      }
+    }
+  }
+
+  private addListener(mediaQuery: string, listener: MediaQueryListener): void {
+    if (!this.mediaQueries[mediaQuery]) {
+      this.mediaQueries[mediaQuery] = [];
+    }
+
+    const query = this.mediaQueries[mediaQuery];
+    const listenerIndex = query.indexOf(listener);
+
+    if (listenerIndex !== -1) return;
+    query.push(listener);
+
+    if (!this.prevMatchMap.has(mediaQuery)) {
+      this.prevMatchMap.set(mediaQuery, this.evalQuery(mediaQuery));
+    }
+  }
+
+  private removeListener(
+    mediaQuery: string,
+    listener: MediaQueryListener
+  ): void {
+    if (!this.mediaQueries[mediaQuery]) {
+      return;
+    }
+
+    const query = this.mediaQueries[mediaQuery];
+    const listenerIndex = query.indexOf(listener);
+
+    if (listenerIndex !== -1) return;
+    query.splice(listenerIndex, 1);
+
+    if (query.length === 0 && this.prevMatchMap.has(mediaQuery)) {
+      this.prevMatchMap.delete(mediaQuery);
+    }
+  }
+
+  /**
+   * Returns an array listing the media queries for which the matchMedia has registered listeners
+   * @public
+   */
+  public getMediaQueries(): string[] {
+    return Object.keys(this.mediaQueries);
+  }
+
+  /**
+   * Returns a copy of the array of listeners for the specified media query
+   * @public
+   */
+  public getListeners(mediaQuery: string): MediaQueryListener[] {
+    if (!this.mediaQueries[mediaQuery]) return [];
+    return this.mediaQueries[mediaQuery].slice();
+  }
+
+  /**
+   * Clears all registered media queries and their listeners
+   * @public
+   */
+  public clear(): void {
+    this.mediaQueries = {};
+  }
+
+  /**
+   * Clears all registered media queries and their listeners,
+   * and destroys the implementation of `window.matchMedia`
+   * @public
+   */
+  public destroy(): void {
+    this.clear();
+    // @ts-ignore
+    delete window.matchMedia;
+  }
+}

--- a/src/components/ButtonGroup/ButtonGroup.stories.mdx
+++ b/src/components/ButtonGroup/ButtonGroup.stories.mdx
@@ -35,7 +35,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.28.0`   |
-| Latest            | `1.0.2`    |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 
 import Button from "../Button/Button";
 import { LayoutTypes } from "../../helpers/types";
-import useWindowSize from "../../hooks/useWindowSize";
+import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 export type ButtonGroupWidths = "default" | "full";
 
@@ -39,25 +39,9 @@ export const ButtonGroup = chakra(
       ...rest
     } = props;
     const newChildren: JSX.Element[] = [];
-    // Based on --nypl-breakpoint-medium
-    const breakpointMedium = 600;
-    const [finalLayout, setFinalLayout] = React.useState<LayoutTypes>(layout);
-    const [finalButtonWidth, setFinalButtonWidth] =
-      React.useState<ButtonGroupWidths>(buttonWidth);
-    const windowDimensions = useWindowSize();
-    React.useEffect(() => {
-      // When on a mobile device or narrow window, always set the layout to
-      // column and the button width to "full".
-      if (windowDimensions.width <= breakpointMedium) {
-        setFinalButtonWidth("full");
-        setFinalLayout("column");
-      } else {
-        // Otherwise, set the layout and button width to the values
-        // passed in via the `buttonWidth` and `layout` props.
-        setFinalButtonWidth(buttonWidth);
-        setFinalLayout(layout);
-      }
-    }, [buttonWidth, layout, windowDimensions.width]);
+    const { isLargerThanMedium } = useNYPLBreakpoints();
+    const finalLayout = isLargerThanMedium ? layout : "column";
+    const finalButtonWidth = isLargerThanMedium ? buttonWidth : "full";
     const styles = useStyleConfig("ButtonGroup", {
       buttonWidth: finalButtonWidth,
     });

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -39,9 +39,9 @@ export const ButtonGroup = chakra(
       ...rest
     } = props;
     const newChildren: JSX.Element[] = [];
-    const { isLargerThanMedium } = useNYPLBreakpoints();
-    const finalLayout = isLargerThanMedium ? layout : "column";
-    const finalButtonWidth = isLargerThanMedium ? buttonWidth : "full";
+    const { isLargerThanMobile } = useNYPLBreakpoints();
+    const finalLayout = isLargerThanMobile ? layout : "column";
+    const finalButtonWidth = isLargerThanMobile ? buttonWidth : "full";
     const styles = useStyleConfig("ButtonGroup", {
       buttonWidth: finalButtonWidth,
     });

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 1`] = `
 <div
-  className="chakra-stack css-ytb711"
+  className="chakra-stack css-6dfzd0"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -25,7 +25,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 1`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 2`] = `
 <div
-  className="chakra-stack css-ytb711"
+  className="chakra-stack css-6dfzd0"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -71,7 +71,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 3`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 4`] = `
 <div
-  className="chakra-stack css-1pxah8o"
+  className="chakra-stack css-1txj82p"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -94,7 +94,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 4`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 5`] = `
 <div
-  className="chakra-stack css-ytb711"
+  className="chakra-stack css-6dfzd0"
   data-testid="testid"
 >
   <button

--- a/src/components/Modal/Modal.stories.mdx
+++ b/src/components/Modal/Modal.stories.mdx
@@ -27,7 +27,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.1.0`    |
-| Latest            | `0.27.0`   |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 
 import Button from "../Button/Button";
 import ButtonGroup from "../ButtonGroup/ButtonGroup";
-import useWindowSize from "../../hooks/useWindowSize";
+import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 interface BaseModalProps {
   bodyContent?: string | JSX.Element;
@@ -42,19 +42,11 @@ const BaseModal = chakra(
     onClose,
     ...rest
   }: React.PropsWithChildren<BaseModalProps>) => {
-    // Based on --nypl-breakpoint-medium
-    const breakpointMedium = 600;
-    const defaultSize = "xl";
+    const xlarge = "xl";
     const fullSize = "full";
-    const [size, setSize] = React.useState<string>(defaultSize);
-    const windowDimensions = useWindowSize();
-    React.useEffect(() => {
-      if (windowDimensions.width <= breakpointMedium) {
-        setSize(fullSize);
-      } else {
-        setSize(defaultSize);
-      }
-    }, [windowDimensions.width]);
+    const { isLargerThanMedium } = useNYPLBreakpoints();
+    // For larger screens, set the size to xl, otherwise set it to full.
+    const size = isLargerThanMedium ? xlarge : fullSize;
 
     return (
       <ChakraModal

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -44,9 +44,9 @@ const BaseModal = chakra(
   }: React.PropsWithChildren<BaseModalProps>) => {
     const xlarge = "xl";
     const fullSize = "full";
-    const { isLargerThanMedium } = useNYPLBreakpoints();
+    const { isLargerThanMobile } = useNYPLBreakpoints();
     // For larger screens, set the size to xl, otherwise set it to full.
-    const size = isLargerThanMedium ? xlarge : fullSize;
+    const size = isLargerThanMobile ? xlarge : fullSize;
 
     return (
       <ChakraModal

--- a/src/components/Tabs/Tabs.stories.mdx
+++ b/src/components/Tabs/Tabs.stories.mdx
@@ -41,7 +41,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -13,7 +13,7 @@ import * as React from "react";
 import Button from "../Button/Button";
 import Icon from "../Icons/Icon";
 import useCarouselStyles from "../../hooks/useCarouselStyles";
-import useWindowSize from "../../hooks/useWindowSize";
+import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 // Internal interface used for rendering `Tabs` tab and panel
 // elements, either from data or from children.
@@ -155,8 +155,9 @@ export const Tabs = chakra((props: React.PropsWithChildren<TabsProps>) => {
   const initTabWidth = 65;
   // An estimate for the tab width for larger device widths.
   const mediumTabWidth = 40;
-  const [tabWidth, setTabWidth] = React.useState(initTabWidth);
-  const windowDimensions = useWindowSize();
+  const { isLargerThanSmall, isLargerThanMedium } = useNYPLBreakpoints();
+  const tabWidth = isLargerThanSmall ? initTabWidth : mediumTabWidth;
+
   const { tabs, panels }: any = tabsData
     ? getElementsFromData(tabsData, useHash)
     : getElementsFromChildren(children);
@@ -175,17 +176,14 @@ export const Tabs = chakra((props: React.PropsWithChildren<TabsProps>) => {
     tabProps?.children?.length,
     tabWidth
   );
+
   React.useEffect(() => {
-    if (windowDimensions.width > 320) {
-      setTabWidth(mediumTabWidth);
-    } else {
-      setTabWidth(initTabWidth);
-    }
     // If we are on larger viewports, reset the carousel so all tabs display.
-    if (windowDimensions.width > 600) {
+    if (isLargerThanMedium) {
       goToStart();
     }
-  }, [goToStart, windowDimensions.width]);
+  }, [goToStart, isLargerThanMedium]);
+
   const previousButton = (
     <Button
       aria-label="Previous"

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -155,7 +155,7 @@ export const Tabs = chakra((props: React.PropsWithChildren<TabsProps>) => {
   const initTabWidth = 65;
   // An estimate for the tab width for larger device widths.
   const mediumTabWidth = 40;
-  const { isLargerThanSmall, isLargerThanMedium } = useNYPLBreakpoints();
+  const { isLargerThanSmall, isLargerThanMobile } = useNYPLBreakpoints();
   const tabWidth = isLargerThanSmall ? initTabWidth : mediumTabWidth;
 
   const { tabs, panels }: any = tabsData
@@ -179,10 +179,10 @@ export const Tabs = chakra((props: React.PropsWithChildren<TabsProps>) => {
 
   React.useEffect(() => {
     // If we are on larger viewports, reset the carousel so all tabs display.
-    if (isLargerThanMedium) {
+    if (isLargerThanMobile) {
       goToStart();
     }
-  }, [goToStart, isLargerThanMedium]);
+  }, [goToStart, isLargerThanMobile]);
 
   const previousButton = (
     <Button

--- a/src/hooks/__tests__/useNYPLBreakpoints.test.ts
+++ b/src/hooks/__tests__/useNYPLBreakpoints.test.ts
@@ -29,6 +29,7 @@ describe("useNYPLBreakpoints", () => {
     expect(result.current).toEqual({
       isLargerThanSmall: false,
       isLargerThanMedium: false,
+      isLargerThanMobile: false,
       isLargerThanLarge: false,
       isLargerThanXLarge: false,
     });
@@ -37,6 +38,7 @@ describe("useNYPLBreakpoints", () => {
     expect(result.current).toEqual({
       isLargerThanSmall: true,
       isLargerThanMedium: false,
+      isLargerThanMobile: false,
       isLargerThanLarge: false,
       isLargerThanXLarge: false,
     });
@@ -45,6 +47,7 @@ describe("useNYPLBreakpoints", () => {
     expect(result.current).toEqual({
       isLargerThanSmall: true,
       isLargerThanMedium: true,
+      isLargerThanMobile: true,
       isLargerThanLarge: false,
       isLargerThanXLarge: false,
     });
@@ -53,6 +56,7 @@ describe("useNYPLBreakpoints", () => {
     expect(result.current).toEqual({
       isLargerThanSmall: true,
       isLargerThanMedium: true,
+      isLargerThanMobile: true,
       isLargerThanLarge: true,
       isLargerThanXLarge: false,
     });
@@ -61,6 +65,7 @@ describe("useNYPLBreakpoints", () => {
     expect(result.current).toEqual({
       isLargerThanSmall: true,
       isLargerThanMedium: true,
+      isLargerThanMobile: true,
       isLargerThanLarge: true,
       isLargerThanXLarge: true,
     });

--- a/src/hooks/__tests__/useNYPLBreakpoints.test.ts
+++ b/src/hooks/__tests__/useNYPLBreakpoints.test.ts
@@ -1,0 +1,68 @@
+import { act, renderHook } from "@testing-library/react-hooks";
+import MatchMedia from "../../__tests__/mediaMatchMock";
+import useNYPLBreakpoints from "../useNYPLBreakpoints";
+
+let matchMedia: MatchMedia;
+
+describe("useNYPLBreakpoints", () => {
+  beforeAll(() => {
+    matchMedia = new MatchMedia();
+
+    window.resizeTo = function resizeTo(width, height) {
+      Object.assign(this, {
+        innerWidth: width,
+        innerHeight: height,
+        outerWidth: width,
+        outerHeight: height,
+      }).dispatchEvent(new this.Event("resize"));
+    };
+  });
+
+  afterEach(() => {
+    matchMedia.clear();
+  });
+
+  it("should report the correct media query match on window resize", () => {
+    const { result } = renderHook(() => useNYPLBreakpoints());
+
+    act(() => window.resizeTo(300, 600));
+    expect(result.current).toEqual({
+      isLargerThanSmall: false,
+      isLargerThanMedium: false,
+      isLargerThanLarge: false,
+      isLargerThanXLarge: false,
+    });
+
+    act(() => window.resizeTo(360, 600));
+    expect(result.current).toEqual({
+      isLargerThanSmall: true,
+      isLargerThanMedium: false,
+      isLargerThanLarge: false,
+      isLargerThanXLarge: false,
+    });
+
+    act(() => window.resizeTo(736, 600));
+    expect(result.current).toEqual({
+      isLargerThanSmall: true,
+      isLargerThanMedium: true,
+      isLargerThanLarge: false,
+      isLargerThanXLarge: false,
+    });
+
+    act(() => window.resizeTo(1000, 600));
+    expect(result.current).toEqual({
+      isLargerThanSmall: true,
+      isLargerThanMedium: true,
+      isLargerThanLarge: true,
+      isLargerThanXLarge: false,
+    });
+
+    act(() => window.resizeTo(1300, 600));
+    expect(result.current).toEqual({
+      isLargerThanSmall: true,
+      isLargerThanMedium: true,
+      isLargerThanLarge: true,
+      isLargerThanXLarge: true,
+    });
+  });
+});

--- a/src/hooks/useCarouselStyles.stories.mdx
+++ b/src/hooks/useCarouselStyles.stories.mdx
@@ -20,7 +20,7 @@ the `goToStart` function.
 
 ## Usage
 
-For a full implementation examle, view the [`Tabs` component](https://github.com/NYPL/nypl-design-system/blob/development/src/components/Tabs/Tabs.tsx).
+For a full implementation example, view the [`Tabs` component](https://github.com/NYPL/nypl-design-system/blob/development/src/components/Tabs/Tabs.tsx).
 
 ```tsx
 const { prevSlide, nextSlide, carouselStyle, goToStart } = useCarouselStyles(

--- a/src/hooks/useNYPLBreakpoints.stories.mdx
+++ b/src/hooks/useNYPLBreakpoints.stories.mdx
@@ -1,0 +1,50 @@
+import { Meta, Description } from "@storybook/addon-docs";
+
+import { getCategory } from "../utils/componentCategories";
+
+<Meta title={getCategory("useNYPLBreakpoints")} />
+
+# useNYPLBreakpoints
+
+| Hook Version | DS Version |
+| ------------ | ---------- |
+| Added        | `1.0.4`    |
+| Latest       | `1.0.4`    |
+
+This custom hook is inspired by Chakra's `useMediaQuery` hook. Internally,
+the hook uses the `useMediaQuery` hook and the `MediaMatch` API to determine
+the current breakpoint size based on NYPL's breakpoint configuration. In order
+to follow responsive design patterns, the "min-width" media query is used
+with the breakpoint configuration. The list of breakpoints can be found on
+the [Reservoir's Breakpoints](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/style-guide-breakpoints--page)
+style guide.
+
+## Usage
+
+The hook returns an object with four boolean values:
+
+```tsx
+const {
+  isLargerThanSmall,
+  isLargerThanMedium,
+  isLargerThanLarge,
+  isLargerThanXLarge,
+} = useNYPLBreakpoints();
+```
+
+For the following example, we'll use the NYPL "medium" breakpoint value. The
+"medium" breakpoint has a value of `"38em"` (or `"600px"`). If different
+components need to be conditionally rendered based on the current size of the
+viewport, we can use the `isLargerThanMedium` boolean value.
+
+```tsx
+const DesktopLayout = () => ...
+const MobileLayout = () => ...
+
+<Box>
+  <Text>
+    {isLargerThanMedium ? "Larger than medium" : "Smaller than medium"}
+  </Text>
+  {isLargerThanMedium ? <DesktopLayout /> : <MobileLayout />}
+</Box>
+```

--- a/src/hooks/useNYPLBreakpoints.stories.mdx
+++ b/src/hooks/useNYPLBreakpoints.stories.mdx
@@ -27,15 +27,17 @@ The hook returns an object with four boolean values:
 const {
   isLargerThanSmall,
   isLargerThanMedium,
+  isLargerThanMobile,
   isLargerThanLarge,
   isLargerThanXLarge,
 } = useNYPLBreakpoints();
 ```
 
-For the following example, we'll use the NYPL "medium" breakpoint value. The
-"medium" breakpoint has a value of `"38em"` (or `"600px"`). If different
-components need to be conditionally rendered based on the current size of the
-viewport, we can use the `isLargerThanMedium` boolean value.
+For the following example, we'll use the NYPL specific mobile breakpoint value.
+This breakpoint value is based on the "medium" breakpoint value of `"38em"`
+(or `"600px"`). If different components need to be conditionally rendered based
+on the current size of the viewport, we can use the `isLargerThanMobile`
+boolean value.
 
 ```tsx
 const DesktopLayout = () => ...
@@ -43,8 +45,8 @@ const MobileLayout = () => ...
 
 <Box>
   <Text>
-    {isLargerThanMedium ? "Larger than medium" : "Smaller than medium"}
+    {isLargerThanMobile ? "Larger than mobile" : "Smaller than mobile"}
   </Text>
-  {isLargerThanMedium ? <DesktopLayout /> : <MobileLayout />}
+  {isLargerThanMobile ? <DesktopLayout /> : <MobileLayout />}
 </Box>
 ```

--- a/src/hooks/useNYPLBreakpoints.ts
+++ b/src/hooks/useNYPLBreakpoints.ts
@@ -1,0 +1,29 @@
+import { useMediaQuery } from "@chakra-ui/react";
+
+/**
+ * This hook is used to determine if the current screen size is larger than
+ * the specific NYPL breakpoint values. The returned value is an object with
+ * boolean values for each breakpoint.
+ */
+const useNYPLBreakpoints = () => {
+  const [
+    isLargerThanSmall,
+    isLargerThanMedium,
+    isLargerThanLarge,
+    isLargerThanXLarge,
+  ] = useMediaQuery([
+    "(min-width: 320px)",
+    "(min-width: 600px)",
+    "(min-width: 960px)",
+    "(min-width: 1280px)",
+  ]);
+
+  return {
+    isLargerThanSmall,
+    isLargerThanMedium,
+    isLargerThanLarge,
+    isLargerThanXLarge,
+  };
+};
+
+export default useNYPLBreakpoints;

--- a/src/hooks/useNYPLBreakpoints.ts
+++ b/src/hooks/useNYPLBreakpoints.ts
@@ -21,6 +21,9 @@ const useNYPLBreakpoints = () => {
   return {
     isLargerThanSmall,
     isLargerThanMedium,
+    // NYPL uses the medium 600px breakpoint to determine if the screen is
+    // in the mobile view. This is the recommended boolean value to use.
+    isLargerThanMobile: isLargerThanMedium,
     isLargerThanLarge,
     isLargerThanXLarge,
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ export {
 } from "./components/TextInput/TextInput";
 export { default as Toggle, ToggleSizes } from "./components/Toggle/Toggle";
 export { default as useCarouselStyles } from "./hooks/useCarouselStyles";
+export { default as useNYPLBreakpoints } from "./hooks/useNYPLBreakpoints";
 export { default as useNYPLTheme } from "./hooks/useNYPLTheme";
 export { default as useWindowSize } from "./hooks/useWindowSize";
 export {

--- a/src/utils/componentCategories.ts
+++ b/src/utils/componentCategories.ts
@@ -76,7 +76,12 @@ const categories = {
   },
   hooks: {
     title: "Hooks",
-    components: ["useCarouselStyles", "useNYPLTheme", "useWindowSize"],
+    components: [
+      "useCarouselStyles",
+      "useNYPLBreakpoints",
+      "useNYPLTheme",
+      "useWindowSize",
+    ],
   },
   layout: {
     title: "Components/Page Layout",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-984](https://jira.nypl.org/browse/DSD-984)

## This PR does the following:

- Creates a `useNYPLBreakpoints` hook to replace manually doing conditional checks with the `useWindowSize` hook and using magic numbers for breakpoint values.
- Now, instead of setting a setting a temporary value to "600", using `useEffect`, and the width from `useWindowSize`, this hook returns all of that combined into a single boolean value.

```
const {
  isLargerThanSmall,
  isLargerThanMedium,
  isLargerThanLarge,
  isLargerThanXLarge
} = useNYPLBreakpoints();
```

And now this can be used such as `{isLargerThanMedium ? <DesktopView /> : <MobileView />}`, for example.

## How has this been tested?

Locally in storybook and unit tests.
Note: a file was brought in from Chakra to help mocking the `MediaMatch` API.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
