### PR TITLE
DSD-1015: mobile styles for Button, Select and TextInput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates to Storybook version 6.5.
 - Explicitly sets the default color mode value to `"light"`.
 - Updates how the `styles.scss` and `resources.scss` files are organized and compiled so that they can be imported in any tech stack.
+- Updates the `Button`, `Select` and `TextInput` components to use NYPL standard minimum height in mobile viewport.
 
 ## 1.0.3 (June 9, 2022)
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -95,7 +95,7 @@ export const iconNames = [
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.0.2`    |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -66,7 +66,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `1.0.3`    |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -51,7 +51,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.22.0`   |
-| Latest            | `1.0.3`    |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,3 +1,5 @@
+import { defaultElementSizes } from "./global";
+
 // Style object for base or default style
 const baseStyle = {
   alignItems: "center",
@@ -9,7 +11,7 @@ const baseStyle = {
   justifyContent: "center",
   lineHeight: "1.5",
   maxHeight: "2.5rem",
-  minHeight: { base: "44px", md: "auto" },
+  minHeight: { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
   py: "inset.narrow",
   px: "inset.default",
   textDecoration: "none",
@@ -17,7 +19,6 @@ const baseStyle = {
   fontWeight: "button.default",
   svg: {
     fill: "currentColor",
-    // marginTop: "xxs",
   },
   _hover: {
     bg: "ui.link.secondary",

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,12 +1,15 @@
 // Style object for base or default style
 const baseStyle = {
+  alignItems: "center",
   borderRadius: "sm",
-  lineHeight: "1.5",
   display: "flex",
   cursor: "pointer",
   color: "ui.white",
+  height: "10",
   justifyContent: "center",
+  lineHeight: "1.5",
   maxHeight: "2.5rem",
+  minHeight: { base: "44px", md: "auto" },
   py: "inset.narrow",
   px: "inset.default",
   textDecoration: "none",
@@ -14,7 +17,7 @@ const baseStyle = {
   fontWeight: "button.default",
   svg: {
     fill: "currentColor",
-    marginTop: "xxs",
+    // marginTop: "xxs",
   },
   _hover: {
     bg: "ui.link.secondary",

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -49,6 +49,10 @@ const checkboxRadioGroupStyles = (isFullWidth = false) => ({
     width: isFullWidth ? "100%" : "fit-content",
   },
 });
+// Default sizes used throughout the codebase.
+const defaultElementSizes = {
+  mobileFieldHeight: "44px",
+};
 // Used in `Label` and `Fieldset`.
 const labelLegendText = {
   display: "inline-block",
@@ -84,6 +88,7 @@ export {
   checkboxRadioGroupStyles,
   checkboxRadioHelperErrorTextStyle,
   checkboxRadioLabelStyles,
+  defaultElementSizes,
   labelLegendText,
   selectTextInputDisabledStyles,
   selectTextInputFocusStyles,

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -1,4 +1,5 @@
 import {
+  defaultElementSizes,
   selectTextInputDisabledStyles,
   selectTextInputFocusStyles,
 } from "./global";
@@ -12,7 +13,7 @@ const select = {
   borderRadius: "sm",
   borderColor: "ui.gray.medium",
   fontSize: "text.caption",
-  minHeight: { base: "44px", md: "auto" },
+  minHeight: { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
   paddingTop: "inset.narrow",
   paddingRight: "inset.extrawide",
   paddingBottom: "inset.narrow",

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -12,6 +12,7 @@ const select = {
   borderRadius: "sm",
   borderColor: "ui.gray.medium",
   fontSize: "text.caption",
+  minHeight: { base: "44px", md: "auto" },
   paddingTop: "inset.narrow",
   paddingRight: "inset.extrawide",
   paddingBottom: "inset.narrow",

--- a/src/theme/components/textInput.ts
+++ b/src/theme/components/textInput.ts
@@ -1,4 +1,5 @@
 import {
+  defaultElementSizes,
   selectTextInputDisabledStyles,
   selectTextInputFocusStyles,
 } from "./global";
@@ -9,7 +10,7 @@ const input = {
   borderColor: "ui.gray.medium",
   borderRadius: "sm",
   fontSize: "text.caption",
-  minHeight: { base: "44px", md: "auto" },
+  minHeight: { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
   py: "inset.narrow",
   px: "inset.default",
   _hover: {

--- a/src/theme/components/textInput.ts
+++ b/src/theme/components/textInput.ts
@@ -9,6 +9,7 @@ const input = {
   borderColor: "ui.gray.medium",
   borderRadius: "sm",
   fontSize: "text.caption",
+  minHeight: { base: "44px", md: "auto" },
   py: "inset.narrow",
   px: "inset.default",
   _hover: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1015](https://jira.nypl.org/browse/DSD-1015)

## This PR does the following:

- Updates the `Button`, `Select` and `TextInput` components to use NYPL standard minimum height in mobile viewport (44px).

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
