### PR TITLE
DSD-1018: docs for Table component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates to Storybook version 6.5.
 - Explicitly sets the default color mode value to `"light"`.
 - Updates how the `styles.scss` and `resources.scss` files are organized and compiled so that they can be imported in any tech stack.
+- Updates the docs for the `Table` commponent to remove the example that does not include column headers.
 
 ## 1.0.3 (June 9, 2022)
 

--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -49,7 +49,6 @@ import { getCategory } from "../../utils/componentCategories";
 - [With Row Dividers](#with-row-dividers)
 - [With Row Headers](#with-row-headers)
 - [With Custom Header Colors](#with-custom-header-colors)
-- [Without columnHeaders](#without-columnheaders)
 - [With JSX Elements](#with-jsx-elements)
 - [Responsive Mobile Layout](#responsive-mobile-layout)
 
@@ -201,18 +200,6 @@ color contrast.
   </DSProvider>
 </Canvas>
 
-## Without columnHeaders
-
-Column headers are optional and don't need to be set. It is recommended that if
-column headers are not needed, to set row headers through the `useRowHeaders`
-prop.
-
-<Canvas>
-  <DSProvider>
-    <Table id="no-columnHeaders-table" tableData={tableData} useRowHeaders />
-  </DSProvider>
-</Canvas>
-
 ## With JSX Elements
 
 export const characterHeaders = ["First Name", "Last Name", "Avatar"];
@@ -295,9 +282,9 @@ export const charactersData = [
 
 The `Table` component is responsive. Please note that for a mobile viewport the
 standard horizontal layout of an HTML table is converted to a stacked vertical
-layout, with each "row" visually separated by a prominent horizontal rule. Despite 
-the significant visual changes in the responsive layout, all component props are 
+layout, with each "row" visually separated by a prominent horizontal rule. Despite
+the significant visual changes in the responsive layout, all component props are
 still functional.
 
-To view and test this in Storybook, go to the "[Canvas](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/components-page-layout-table--table)" 
+To view and test this in Storybook, go to the "[Canvas](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/components-page-layout-table--table)"
 tab and change the viewport in the Storybook toolbar at the top of the page.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1018](https://jira.nypl.org/browse/DSD-1018)

## This PR does the following:

- Updates the docs for the `Table` commponent to remove the example that does not include column headers.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
