### PR TITLE
DSD-1026: width of select in SearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates to Storybook version 6.5.
 - Explicitly sets the default color mode value to `"light"`.
 - Updates how the `styles.scss` and `resources.scss` files are organized and compiled so that they can be imported in any tech stack.
+- Updates the `FilterBar` component to change how the width of the internal `Select` component is handled.
 
 ## 1.0.3 (June 9, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates to Storybook version 6.5.
 - Explicitly sets the default color mode value to `"light"`.
 - Updates how the `styles.scss` and `resources.scss` files are organized and compiled so that they can be imported in any tech stack.
-- Updates the `FilterBar` component to change how the width of the internal `Select` component is handled.
+- Updates the `SearchBar` component to change how the width of the internal `Select` component is handled.
 
 ## 1.0.3 (June 9, 2022)
 

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -60,7 +60,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.4`    |
 
 ## Table of Contents
 
@@ -99,7 +99,7 @@ export const optionsGroup = [
   "Furniture",
   "Songs",
   "Tools",
-  "Villagers",
+  "Villagers and their beloved pets",
 ];
 
 ## Component Props

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -11,7 +11,10 @@ const SearchBar = {
       md: "row nowrap",
     },
     select: {
+      flexShrink: "0",
       marginBottom: "0",
+      maxWidth: { base: undefined, md: "255px" },
+      textOverflow: "ellipsis",
     },
   },
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1026](https://jira.nypl.org/browse/DSD-1026)

## This PR does the following:

- Updates the `SearchBar` component to change how the width of the internal `Select` component is handled.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
