### PR TITLE
DSD-1037: Adding new svg icons to mobile Header nav

### DIFF
--- a/src/components/Header/components/MobileNav.tsx
+++ b/src/components/Header/components/MobileNav.tsx
@@ -89,7 +89,7 @@ const MobileNav = chakra(() => {
             align="left"
             color="ui.white"
             name="decorativeEnvelope"
-            size="medium"
+            size="large"
           />
           Get Email Updates
         </Link>
@@ -102,7 +102,7 @@ const MobileNav = chakra(() => {
             align="left"
             color="ui.white"
             name="decorativeShoppingBag"
-            size="medium"
+            size="large"
           />
           Shop NYPL
         </Link>

--- a/src/components/Header/components/MobileNav.tsx
+++ b/src/components/Header/components/MobileNav.tsx
@@ -12,6 +12,7 @@ import List from "../../List/List";
 import Logo from "../../Logo/Logo";
 import SimpleGrid from "../../Grid/SimpleGrid";
 import { upperNavLinks, lowerNavLinks } from "../utils/headerUtils";
+import Icon from "../../Icons/Icon";
 
 /**
  * The Header navigation for the mobile view.
@@ -71,6 +72,12 @@ const MobileNav = chakra(() => {
           borderRight="1px solid rgb(54, 54, 54)"
           gridColumn="1 / span 1"
         >
+          <Icon
+            align="left"
+            color="ui.white"
+            name="decorativeLibraryCard"
+            size="large"
+          />
           Get a Library Card
         </Link>
         <Link
@@ -78,6 +85,12 @@ const MobileNav = chakra(() => {
           borderTop="1px solid rgb(54, 54, 54)"
           gridColumn="2 / span 1"
         >
+          <Icon
+            align="left"
+            color="ui.white"
+            name="decorativeEnvelope"
+            size="medium"
+          />
           Get Email Updates
         </Link>
         <Link
@@ -85,6 +98,12 @@ const MobileNav = chakra(() => {
           borderTop="1px solid rgb(54, 54, 54)"
           gridColumn="1 / span 2"
         >
+          <Icon
+            align="left"
+            color="ui.white"
+            name="decorativeShoppingBag"
+            size="medium"
+          />
           Shop NYPL
         </Link>
         <Link href={upperNavLinks.donate} gridColumn="1 / span 2">

--- a/src/components/Header/components/__snapshots__/MobileNav.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/MobileNav.test.tsx.snap
@@ -135,6 +135,37 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
       rel={null}
       target={null}
     >
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-1g9tbrc"
+        focusable={false}
+        role="img"
+        title="decorativeLibraryCard icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
       Get a Library Card
     </a>
     <a
@@ -143,6 +174,37 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
       rel={null}
       target={null}
     >
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-1g9tbrc"
+        focusable={false}
+        role="img"
+        title="decorativeEnvelope icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
       Get Email Updates
     </a>
     <a
@@ -151,6 +213,37 @@ exports[`MobileNav renders the UI snapshot correctly 1`] = `
       rel={null}
       target={null}
     >
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-1g9tbrc"
+        focusable={false}
+        role="img"
+        title="decorativeShoppingBag icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
       Shop NYPL
     </a>
     <a

--- a/src/theme/components/header/headerMobileNav.ts
+++ b/src/theme/components/header/headerMobileNav.ts
@@ -43,11 +43,16 @@ const HeaderMobileNav = {
       display: "grid",
       gridTemplateColumns: "1fr 1fr",
       a: {
+        alignItems: "center",
         color: "white",
-        display: "block",
+        display: "flex",
+        justifyContent: "center",
         textDecoration: "none",
-        textAlign: "center",
-        padding: "27px",
+        paddingY: "27px",
+        paddingLeft: "15px",
+        svg: {
+          marginRight: "s",
+        },
         _hover: {
           color: "ui.white",
           backgroundColor: "ui.black",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1037](https://jira.nypl.org/browse/DSD-1037)

## This PR does the following:

- Adds new SVG to mobile nav in the `Header` component.
<img width="565" alt="Screen Shot 2022-06-27 at 12 04 04 PM" src="https://user-images.githubusercontent.com/1280564/175985765-981e498a-ab63-4a02-92bc-01508c9b7f40.png">


## How has this been tested?

Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
