### PR TITLE
Fixes one instance where value should have been gotten from context

### DIFF
--- a/src/components/Header/components/HeaderLogin.test.tsx
+++ b/src/components/Header/components/HeaderLogin.test.tsx
@@ -9,7 +9,7 @@ describe("HeaderLogin Accessibility", () => {
   it("passes axe accessibility test", async () => {
     const { container } = render(
       <HeaderProvider>
-        <HeaderLogin patronName="" />
+        <HeaderLogin />
       </HeaderProvider>
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -18,7 +18,7 @@ describe("HeaderLogin Accessibility", () => {
   it("passes axe accessibility test for mobile", async () => {
     const { container } = render(
       <HeaderProvider>
-        <HeaderLogin isMobile patronName="" />
+        <HeaderLogin isMobile />
       </HeaderProvider>
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -30,7 +30,7 @@ describe("HeaderLogin", () => {
     it("renders the logged out UI if there is no `patronName` value", () => {
       render(
         <HeaderProvider>
-          <HeaderLogin patronName="" />
+          <HeaderLogin />
         </HeaderProvider>
       );
 
@@ -43,8 +43,8 @@ describe("HeaderLogin", () => {
 
     it("renders the logged in UI if there is a `patronName` value", () => {
       render(
-        <HeaderProvider>
-          <HeaderLogin patronName="PATRON, JANE A" />
+        <HeaderProvider patronName="PATRON, JANE A">
+          <HeaderLogin />
         </HeaderProvider>
       );
 
@@ -69,7 +69,7 @@ describe("HeaderLogin", () => {
     it("renders the logged out UI if there is no `patronName` value", () => {
       render(
         <HeaderProvider>
-          <HeaderLogin isMobile patronName="" />
+          <HeaderLogin isMobile />
         </HeaderProvider>
       );
 
@@ -82,8 +82,8 @@ describe("HeaderLogin", () => {
 
     it("renders the logged in UI if there is a `patronName` value", () => {
       render(
-        <HeaderProvider>
-          <HeaderLogin isMobile patronName="PATRON, JANE A" />
+        <HeaderProvider patronName="PATRON, JANE A">
+          <HeaderLogin isMobile />
         </HeaderProvider>
       );
 

--- a/src/components/Header/components/HeaderLogin.tsx
+++ b/src/components/Header/components/HeaderLogin.tsx
@@ -13,12 +13,11 @@ export interface HeaderLoginProps {
   catalogRef?: React.RefObject<HTMLDivElement & HTMLAnchorElement>;
   greetingRef?: React.RefObject<HTMLDivElement>;
   isMobile?: boolean;
-  patronName?: string;
 }
 
 const HeaderLogin = chakra(
-  ({ catalogRef, greetingRef, isMobile, patronName }: HeaderLoginProps) => {
-    const { isProduction } = useContext(HeaderContext);
+  ({ catalogRef, greetingRef, isMobile }: HeaderLoginProps) => {
+    const { isProduction, patronName } = useContext(HeaderContext);
     const { catalogLink, researchLink, logOutLink } = getLoginLinks(
       patronName,
       isProduction

--- a/src/components/Header/components/HeaderLoginButton.tsx
+++ b/src/components/Header/components/HeaderLoginButton.tsx
@@ -80,7 +80,6 @@ const HeaderLoginButton = chakra(
               catalogRef={catalogRef}
               greetingRef={greetingRef}
               isMobile={isMobile}
-              patronName={patronName}
             />
           )}
         </FocusLock>


### PR DESCRIPTION
Fixes JIRA ticket xxx

## This PR does the following:

- There was one occurrence in the `Header` component where a value that exists in context was being passed to a child component through props. Any values that exist in context should be accessed through context and this PR fixes that one instance.

## How has this been tested?

- All existing unit tests pass.

## Accessibility concerns or updates

- None.

### Checklist:

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
