### PR TITLE
DSD-1053: top border color for Description List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates border color in the `Description` variant of the `List` component.
+
 ## 1.0.6 (July 21, 2022)
 
 ### Adds

--- a/src/components/List/List.stories.mdx
+++ b/src/components/List/List.stories.mdx
@@ -42,7 +42,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `1.0.6`    |
+| Latest            | `1.0.7`    |
 
 ## Table of Contents
 

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -39,19 +39,19 @@ export const baseUnorderedStyles = (noStyling = false) => ({
     },
   },
 });
-export const baseSectionDefinitionStyles = {
+export const baseSectionDescriptionStyles = {
   borderBottom: "1px solid",
   borderColor: "ui.gray.light-cool",
   paddingStart: "0",
   h2: {
     borderTop: "3px solid",
-    borderColor: "section.research.primary",
+    borderColor: "ui.gray.medium",
     margin: "0",
     padding: "var(--nypl-space-xs) 0 0",
   },
 };
-export const baseDefinitionStyles = {
-  ...baseSectionDefinitionStyles,
+export const baseDescriptionStyles = {
+  ...baseSectionDescriptionStyles,
   dl: {
     display: "grid",
     gridTemplateColumns: { base: "100%", md: "max(250px) 1fr" },
@@ -81,7 +81,7 @@ const List = {
   variants: {
     ul: ({ noStyling }: ListBaseStyle) => baseUnorderedStyles(noStyling),
     ol: textMargin,
-    dl: baseDefinitionStyles,
+    dl: baseDescriptionStyles,
   },
 };
 

--- a/src/theme/components/structuredContent.ts
+++ b/src/theme/components/structuredContent.ts
@@ -3,9 +3,9 @@ import { textMargin } from "./global";
 import { headings } from "./heading";
 import { baseLinkStyles } from "./link";
 import {
-  baseDefinitionStyles,
+  baseDescriptionStyles,
   baseListStyles,
-  baseSectionDefinitionStyles,
+  baseSectionDescriptionStyles,
   baseUnorderedStyles,
 } from "./list";
 
@@ -111,10 +111,10 @@ const StructuredContent = {
         ...textMargin,
       },
       // For section, h2 in the definition list.
-      section: baseSectionDefinitionStyles,
-      dl: baseDefinitionStyles.dl,
-      dt: baseDefinitionStyles.dt,
-      dd: baseDefinitionStyles.dd,
+      section: baseSectionDescriptionStyles,
+      dl: baseDescriptionStyles.dl,
+      dt: baseDescriptionStyles.dt,
+      dd: baseDescriptionStyles.dd,
       table: {
         width: "100%",
         th: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1053](https://jira.nypl.org/browse/DSD-1053)

## This PR does the following:

- Updates border color in the `Description` variant of the `List` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The element that was updated is ornamental and not critical for a11y.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
