### PR TITLE
DSD-1068: Updating how rest props propagate in the Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates how style props are passed to the `Link` component when using with third-party libraries, such as React Router.
+
 ## 1.0.6 (July 21, 2022)
 
 ### Adds

--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -39,7 +39,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `0.28.0`   |
+| Latest            | `1.0.7`    |
 
 ## Table of Contents
 

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -97,7 +97,7 @@ describe("Link", () => {
 
   it("throws an error if text is passed but no url is passed", () => {
     expect(() => render(<Link>Test</Link>)).toThrowError(
-      "`Link` needs the `href` prop."
+      "NYPL Reservoir Link: The `Link` component needs the `href` prop if its child element is a string."
     );
   });
 
@@ -109,7 +109,9 @@ describe("Link", () => {
           <a href="#test">Test</a>
         </Link>
       )
-    ).toThrowError("Please pass only one child into `Link`.");
+    ).toThrowError(
+      "NYPL Reservoir Link: Please pass only one child into the `Link` component."
+    );
   });
 
   it("renders the UI snapshot correctly", () => {
@@ -198,6 +200,13 @@ describe("Link", () => {
         </Link>
       )
       .toJSON();
+    const withOtherPropsAndChild = renderer
+      .create(
+        <Link id="props" data-testid="props">
+          <a href="#passed-in-link">Standard</a>
+        </Link>
+      )
+      .toJSON();
 
     expect(standard).toMatchSnapshot();
     expect(typeForwards).toMatchSnapshot();
@@ -209,6 +218,7 @@ describe("Link", () => {
     expect(withAchorChildAndIcon).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
+    expect(withOtherPropsAndChild).toMatchSnapshot();
   });
 
   it("passes a ref to the anchor element", () => {

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -107,7 +107,9 @@ export const Link = chakra(
     let variant = "link";
 
     if (typeof children === "string" && !href) {
-      throw new Error("`Link` needs the `href` prop.");
+      throw new Error(
+        "NYPL Reservoir Link: The `Link` component needs the `href` prop if its child element is a string."
+      );
     }
 
     if (
@@ -137,12 +139,14 @@ export const Link = chakra(
       // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/32832
       // let children = React.Children.only(children);
       if (React.Children.count(children) > 1) {
-        throw new Error("Please pass only one child into `Link`.");
+        throw new Error(
+          "NYPL Reservoir Link: Please pass only one child into the `Link` component."
+        );
       }
       const childrenToClone: any = children[0] ? children[0] : children;
       const childProps = childrenToClone.props;
       return (
-        <Box as="span" __css={style}>
+        <Box as="span" __css={style} {...rest}>
           {React.cloneElement(
             childrenToClone,
             {

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -284,3 +284,21 @@ exports[`Link renders the UI snapshot correctly 10`] = `
   Standard
 </a>
 `;
+
+exports[`Link renders the UI snapshot correctly 11`] = `
+<span
+  className="css-0"
+  data-testid="props"
+>
+  <a
+    className="css-0"
+    data-testid="props"
+    href="#passed-in-link"
+    id="props"
+    rel={null}
+    target={null}
+  >
+    Standard
+  </a>
+</span>
+`;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1068](https://jira.nypl.org/browse/DSD-1068)

## This PR does the following:

- Propagates the `rest` props, usually style props, from the `Link` component into its span element when used with third-party libraries such as React Router.

## How has this been tested?

Locally and in Turbine.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
