### PR TITLE
DSD-1069: Updating select options props in SearchBar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates how options are passed to the `SearchBar` component for its internal `Select` component.
+
 ## 1.0.6 (July 21, 2022)
 
 ### Adds

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -60,7 +60,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.0.6`    |
+| Latest            | `1.0.7`    |
 
 ## Table of Contents
 
@@ -90,16 +90,16 @@ Note: The labels for the `Select` and `TextInput` components are not visible but
 aria-labels are used to make these children components accessible.
 
 export const optionsGroup = [
-  "Art",
-  "Bushes",
-  "Clothing",
-  "Flowers",
-  "Fossils",
-  "Fruits",
-  "Furniture",
-  "Songs",
-  "Tools",
-  "Villagers and their beloved pets",
+  { text: "Art", value: "art" },
+  { text: "Bushes", value: "bushes" },
+  { text: "Clothing", value: "clothing" },
+  { text: "Flowers", value: "flowers" },
+  { text: "Fossils", value: "fossils" },
+  { text: "Fruits", value: "fruits" },
+  { text: "Furniture", value: "furniture" },
+  { text: "Songs", value: "songs" },
+  { text: "Tools", value: "tools" },
+  { text: "Villagers and their beloved pets", value: "villagers" },
 ];
 
 ## Component Props
@@ -175,13 +175,35 @@ Resources:
 
 To render an optional `Select` component, an object must be passed to the
 `selectProps` prop. It _must_ include `name`, `labelText`, and `optionsData`
-properties. The `onChange` and `value` properties are optional. The `labelText`
-value won't be rendered but will be used for its `aria-label` attribute.
+properties. The `id`, `onChange`, and `value` properties are optional. The
+`labelText` value won't be rendered but will be used for its `aria-label`
+attribute.
 
 If you want to control the `Select` component, you **must** pass the `onChange`
 and `value` props to the `selectProps` prop object. You must then control the
 state of the selected value in your application. See the example at end of this
 page for a full demonstration.
+
+The `optionsData` prop is an array of objects that contain the `text` and
+`value` properties.
+
+```tsx
+const optionsGroup = [
+  { text: "Art", value: "art" },
+  { text: "Bushes", value: "bushes" },
+  { text: "Clothing", value: "clothing" },
+  { text: "Flowers", value: "flowers" },
+  { text: "Fossils", value: "fossils" },
+  { text: "Fruits", value: "fruits" },
+  { text: "Furniture", value: "furniture" },
+  { text: "Songs", value: "songs" },
+  { text: "Tools", value: "tools" },
+  { text: "Villagers and their beloved pets", value: "villagers" },
+];
+```
+
+Add the rest of the properties to the object that will be passed to the
+`selectProps` prop.
 
 ```
 const selectProps = {
@@ -208,7 +230,8 @@ const selectProps = {
 To render the `TextInput` component, an object must be passed to the
 `textInputProps` prop. It _must_ include `labelText` and `name` properties. The
 `labelText` value won't be rendered but will be used for its `aria-label`
-attribute. Optional properties to pass include `onChange`, `placeholder`, and `value`.
+attribute. Optional properties to pass include `id`, `onChange`, `placeholder`,
+and `value`.
 
 ```
 const textInputProps = {

--- a/src/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/SearchBar/SearchBar.test.tsx
@@ -7,16 +7,16 @@ import renderer from "react-test-renderer";
 import SearchBar, { SelectProps, TextInputProps } from "./SearchBar";
 
 const optionsGroup = [
-  "Art",
-  "Bushes",
-  "Clothing",
-  "Flowers",
-  "Fossils",
-  "Fruits",
-  "Furniture",
-  "Songs",
-  "Tools",
-  "Villagers",
+  { text: "Art", value: "art" },
+  { text: "Bushes", value: "bushes" },
+  { text: "Clothing", value: "clothing" },
+  { text: "Flowers", value: "flowers" },
+  { text: "Fossils", value: "fossils" },
+  { text: "Fruits", value: "fruits" },
+  { text: "Furniture", value: "furniture" },
+  { text: "Songs", value: "songs" },
+  { text: "Tools", value: "tools" },
+  { text: "Villagers", value: "villagers" },
 ];
 const selectProps: SelectProps = {
   name: "selectName",
@@ -181,10 +181,10 @@ describe("SearchBar", () => {
     expect(selectValue).toEqual("Songs");
 
     userEvent.selectOptions(select, "Flowers");
-    expect(selectValue).toEqual("Flowers");
+    expect(selectValue).toEqual("flowers");
 
     userEvent.selectOptions(select, "Furniture");
-    expect(selectValue).toEqual("Furniture");
+    expect(selectValue).toEqual("furniture");
   });
 
   it("calls the callback function for the Button component ", () => {

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -9,6 +9,7 @@ import Select from "../Select/Select";
 import TextInput from "../TextInput/TextInput";
 
 interface BaseProps {
+  id?: string;
   labelText: string;
   name: string;
   onChange?: (
@@ -18,9 +19,14 @@ interface BaseProps {
   ) => void;
   value?: string;
 }
+interface SelectOptionsProps {
+  text: string;
+  value: string;
+}
+
 // Internal interfaces that are used only for `SearchBar` props.
 export interface SelectProps extends BaseProps {
-  optionsData: string[];
+  optionsData: SelectOptionsProps[];
   onChange?: (event: React.FormEvent) => void;
 }
 export interface TextInputProps extends BaseProps {
@@ -126,7 +132,7 @@ export const SearchBar = chakra(
     // Render the `Select` component.
     const selectElem = selectProps && (
       <Select
-        id={`searchbar-select-${id}`}
+        id={selectProps?.id || `searchbar-select-${id}`}
         labelText={selectProps?.labelText}
         name={selectProps?.name}
         onChange={selectProps?.onChange}
@@ -136,8 +142,8 @@ export const SearchBar = chakra(
         {...stateProps}
       >
         {selectProps?.optionsData.map((option) => (
-          <option key={option} value={option}>
-            {option}
+          <option key={option.value} value={option.value}>
+            {option.text}
           </option>
         ))}
       </Select>
@@ -145,7 +151,7 @@ export const SearchBar = chakra(
     // Render the `TextInput` component.
     const textInputNative = textInputProps && (
       <TextInput
-        id={`searchbar-textinput-${id}`}
+        id={textInputProps?.id || `searchbar-textinput-${id}`}
         labelText={textInputProps?.labelText}
         name={textInputProps?.name}
         onChange={textInputProps?.onChange}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -123,52 +123,52 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
             value="Songs"
           >
             <option
-              value="Art"
+              value="art"
             >
               Art
             </option>
             <option
-              value="Bushes"
+              value="bushes"
             >
               Bushes
             </option>
             <option
-              value="Clothing"
+              value="clothing"
             >
               Clothing
             </option>
             <option
-              value="Flowers"
+              value="flowers"
             >
               Flowers
             </option>
             <option
-              value="Fossils"
+              value="fossils"
             >
               Fossils
             </option>
             <option
-              value="Fruits"
+              value="fruits"
             >
               Fruits
             </option>
             <option
-              value="Furniture"
+              value="furniture"
             >
               Furniture
             </option>
             <option
-              value="Songs"
+              value="songs"
             >
               Songs
             </option>
             <option
-              value="Tools"
+              value="tools"
             >
               Tools
             </option>
             <option
-              value="Villagers"
+              value="villagers"
             >
               Villagers
             </option>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1069](https://jira.nypl.org/browse/DSD-1069)

## This PR does the following:

- Passes "text" and "value" properties for the `SearchBar`'s internal `Select` component through the `optionsData` prop.
- This is needed for `<option>` HTML elements that the `Select` must render that have different visual text labels and internal "value" attribute values.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
