### PR TITLE
DSD-1072: Hero secondary image layout alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the layout of the `Image` in the `Hero` "secondary" variant for mobile and desktop.
+
 ## 1.0.6 (July 21, 2022)
 
 ### Adds

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -112,7 +112,7 @@ the [All Variations](#all-variations) section.
       foregroundColor: undefined,
       heading: undefined,
       heroType: "primary",
-      imageProps: undefined,
+      imageProps,
       locationDetails: undefined,
       subHeaderText: undefined,
     }}

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -58,7 +58,7 @@ export const imageProps = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.2.0`    |
-| Latest            | `1.0.6`    |
+| Latest            | `1.0.7`    |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -169,7 +169,11 @@ export const Hero = chakra(
         ) : (
           <>
             {heroType !== "primary" && heroType !== "tertiary" && (
-              <Image alt={imageProps.alt} src={imageProps.src} />
+              <Image
+                alt={imageProps.alt}
+                src={imageProps.src}
+                __css={styles.imgWrapper}
+              />
             )}
             {finalHeading}
             {heroType === "tertiary" && subHeaderText ? (

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -66,7 +66,7 @@ export const imageBlockStyles = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.6`    |
-| Latest            | `1.0.6`    |
+| Latest            | `1.0.7`    |
 
 ## Table of Contents
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -194,7 +194,7 @@ export const Image = chakra(
     );
 
     return (
-      <Box ref={finalRefs}>
+      <Box ref={finalRefs} {...rest}>
         {caption || credit ? (
           <Box
             as="figure"
@@ -212,7 +212,8 @@ export const Image = chakra(
         )}
       </Box>
     );
-  })
+  }),
+  { shouldForwardProp: () => true }
 );
 
 export default Image;

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -326,7 +326,7 @@ exports[`Image Renders the UI snapshot correctly 18`] = `
 
 exports[`Image Renders the UI snapshot correctly 19`] = `
 <div
-  className="css-0"
+  className="css-qvgr6z"
 >
   <img
     alt=""
@@ -339,6 +339,7 @@ exports[`Image Renders the UI snapshot correctly 19`] = `
 exports[`Image Renders the UI snapshot correctly 20`] = `
 <div
   className="css-0"
+  data-testid="image"
 >
   <img
     alt=""

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -12,12 +12,14 @@ const secondaryBase = {
       base: "column nowrap",
       md: "row wrap",
     },
+  },
+  imgWrapper: {
+    flex: {
+      base: "1 1 100%",
+      md: "0 0 250px",
+    },
+    order: { md: "3" },
     img: {
-      flex: {
-        base: "1 1 100%",
-        md: "0 0 250px",
-      },
-      order: { md: "3" },
       height: "150px",
       minWidth: "0", // https://github.com/philipwalton/flexbugs/issues/41
       objectFit: "cover",
@@ -35,7 +37,6 @@ const secondaryBase = {
 // Used for all "secondary" variants' heading component.
 const secondaryHeadingBase = {
   marginBottom: "0",
-  bg: "ui.black",
   color: "ui.white",
   flex: "1 1 100%",
   marginTop: "0",
@@ -44,7 +45,6 @@ const secondaryHeadingBase = {
   zIndex: "0",
   order: { md: "1" },
   _before: {
-    bg: "ui.black",
     content: `""`,
     height: "100%",
     left: "-2000px",
@@ -55,7 +55,7 @@ const secondaryHeadingBase = {
 };
 // Get all the styles for the specific Secondary variant but
 // update the background color.
-const getSecondaryVariantStyles = (bgColor: string) => ({
+const getSecondaryVariantStyles = (bgColor: string = "ui.black") => ({
   ...secondaryBase,
   heading: {
     ...secondaryHeadingBase,
@@ -100,12 +100,7 @@ const primary = {
     },
   },
 };
-const secondary = {
-  ...secondaryBase,
-  heading: {
-    ...secondaryHeadingBase,
-  },
-};
+const secondary = getSecondaryVariantStyles();
 const secondaryBooksAndMore = getSecondaryVariantStyles(
   "section.books-and-more.primary"
 );

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -14,11 +14,13 @@ const secondaryBase = {
     },
   },
   imgWrapper: {
+    marginEnd: { base: "calc(-50vw + 50%)", md: "0" },
+    marginStart: { base: "calc(-50vw + 50%)", md: "0" },
     flex: {
       base: "1 1 100%",
       md: "0 0 250px",
     },
-    order: { md: "3" },
+    order: { base: "2", md: "3" },
     img: {
       height: "150px",
       minWidth: "0", // https://github.com/philipwalton/flexbugs/issues/41
@@ -31,7 +33,7 @@ const secondaryBase = {
     paddingEnd: { md: "inset.default" },
     paddingTop: "inset.default",
     flex: { md: "1 1 50%" },
-    order: { md: "2" },
+    order: { base: "3", md: "2" },
   },
 };
 // Used for all "secondary" variants' heading component.
@@ -43,7 +45,7 @@ const secondaryHeadingBase = {
   paddingBottom: "xxs",
   position: "relative",
   zIndex: "0",
-  order: { md: "1" },
+  order: "1",
   _before: {
     content: `""`,
     height: "100%",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1072](https://jira.nypl.org/browse/DSD-1072)

## This PR does the following:

- Updates how the image in the `Hero` component is aligned.
- The `Image` component now _always_ renders a wrapper `div` element and it wasn't taken into account when used in the `Hero` component.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
