### PR TITLE
DSD-1077: Fixing the layout of the image in the Hero 'fiftyfifty' variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates border color in the `Description` variant of the `List` component.
 - Updates how options are passed to the `SearchBar` component for its internal `Select` component.
 - Updates how style props are passed to the `Link` component when using with third-party libraries, such as React Router.
-- Updates the layout of the `Image` in the `Hero` "secondary" variant for mobile and desktop.
+- Updates the layout of the `Image` in the `Hero` "secondary" and "fiftyFifty" variants for mobile and desktop.
 
 ## 1.0.6 (July 21, 2022)
 

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -160,7 +160,10 @@ the [All Variations](#all-variations) section.
         <Hero
           {...args}
           heroType={args.heroType}
-          imageProps={args.imageProps}
+          imageProps={{
+            ...args.imageProps,
+            src: "https://placeimg.com/1200/400/animals",
+          }}
           subHeaderText={otherSubHeaderText}
         />
       ))

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -200,18 +200,22 @@ const fiftyFifty = {
       lg: "unset",
     },
   },
-  img: {
+  imgWrapper: {
     marginBottom: {
       base: "s",
       lg: "unset",
     },
     marginEnd: {
+      base: "-15px",
       lg: "s",
     },
+    marginStart: {
+      base: "-15px",
+    },
     maxWidth: {
-      base: "fit-content",
       lg: "50%",
     },
+    width: "auto",
   },
 };
 const Hero = {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1077](url)

## This PR does the following:

- Fixes the layout of the image in the "fiftyfifty" `Hero` variant.

## How has this been tested?

Locally in Storybook for mobile and desktop views.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
