### PR TITLE
DSD-46: [Addendum] Adding TemplateContentBottom and updating the Template DOM structure

### DIFF
--- a/src/components/Template/Template.stories.mdx
+++ b/src/components/Template/Template.stories.mdx
@@ -28,14 +28,15 @@ import SkipNavigation from "../SkipNavigation/SkipNavigation";
 import {
   Template,
   TemplateAboveHeader,
-  TemplateHeader,
+  TemplateAppContainer,
   TemplateBreakout,
   TemplateContent,
-  TemplateContentTop,
+  TemplateContentBottom,
   TemplateContentPrimary,
   TemplateContentSidebar,
+  TemplateContentTop,
   TemplateFooter,
-  TemplateAppContainer,
+  TemplateHeader,
 } from "./Template";
 import TextInput from "../TextInput/TextInput";
 import { getCategory } from "../../utils/componentCategories";
@@ -90,15 +91,15 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
 
 <TemplateAppContainer
   aboveHeader={<Placeholder variant="short">Above Header</Placeholder>}
-  header={<Placeholder variant="short">NYPL Header</Placeholder>}
+  header={<Placeholder variant="short">Header</Placeholder>}
   breakout={
     <>
       <Placeholder variant="short">Breadcrumbs</Placeholder>
-      <Placeholder variant="short">Hero</Placeholder>
+      <Placeholder>Hero</Placeholder>
     </>
   }
   sidebar="left"
-  contentTop={<Placeholder>Content Top</Placeholder>}
+  contentTop={<Placeholder variant="short">Content Top</Placeholder>}
   contentSidebar={<Placeholder>Left Sidebar</Placeholder>}
   contentPrimary={
     <>
@@ -106,7 +107,8 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
       <Placeholder variant="short">More Content</Placeholder>
     </>
   }
-  footer={<Placeholder variant="short">Footer</Placeholder>}
+  contentBottom={<Placeholder variant="short">Content Bottom</Placeholder>}
+  footer={<Placeholder>Footer</Placeholder>}
   renderSkipNavigation={true}
 />;
 ```
@@ -121,24 +123,25 @@ import { TemplateAppContainer } from "@nypl/design-system-react-components";
       breakout: (
         <>
           <Placeholder variant="short">Breadcrumbs</Placeholder>
-          <Placeholder variant="short">Hero</Placeholder>
+          <Placeholder>Hero</Placeholder>
         </>
       ),
+      contentBottom: <Placeholder variant="short">Content Bottom</Placeholder>,
+      contentId: "mainContent",
       contentPrimary: (
         <>
           <Placeholder>Main Content</Placeholder>
           <Placeholder variant="short">More Content</Placeholder>
         </>
       ),
-      contentId: "mainContent",
       contentSidebar: <Placeholder>Left Sidebar</Placeholder>,
-      contentTop: <Placeholder>Content Top</Placeholder>,
-      footer: <Placeholder variant="short">Footer</Placeholder>,
-      header: <Placeholder variant="short">NYPL Header</Placeholder>,
-      sidebar: "left",
+      contentTop: <Placeholder variant="short">Content Top</Placeholder>,
+      footer: <Placeholder>Footer</Placeholder>,
+      header: <Placeholder variant="short">Header</Placeholder>,
       renderFooterElement: true,
       renderHeaderElement: true,
       renderSkipNavigation: true,
+      sidebar: "left",
     }}
     argTypes={{
       aboveHeader: { control: false },
@@ -179,7 +182,7 @@ accessibility violation.
 The `TemplateAppContainer` component renders a full DOM and one of the children
 is the `main` HTML element with a default "id" of `"mainContent"`. This should
 be used as the anchor element that the skip navigation link points to. If your
-application is using the current NYPL Header, it already contains the skip
+application is using the current Header, it already contains the skip
 navigation feature but make sure it is pointing to the correct anchor element.
 
 If you are using a custom header component or you need to use the Reservoir
@@ -205,7 +208,7 @@ using the `TemplateAppContainer` component and passing down children component
 as props as needed.
 
 Note: If you need to render the `SkipNavigation` component, you need to explicitly
-render it immediately before the `TemplateAboveHeader` component. This is done
+render it immediately before the `Template` component. This is done
 automatically in the `TemplateAppContainer` component.
 
 Note: All components that go above the main content `TemplateContent` component
@@ -217,44 +220,49 @@ Basic "template" components structure:
 import {
   Template,
   TemplateAboveHeader,
-  TemplateHeader,
   TemplateBreakout,
   TemplateContent,
-  TemplateContentTop,
+  TemplateContentBottom,
   TemplateContentPrimary,
   TemplateContentSidebar,
+  TemplateContentTop,
   TemplateFooter,
+  TemplateHeader,
 } from "@nypl/design-system-react-components";
 
 
-<Template>
-  <Box>
-    <SkipNavigation />
-    <TemplateAboveHeader>
-      // ...
-    </TemplateAboveHeader>
-    <TemplateHeader>
-      // ...
-      <TemplateBreakout>
+<>
+  <SkipNavigation />
+  <Template>
+    <TemplateBreakout>
+      <TemplateAboveHeader>
         // ...
-      </TemplateBreakout>
-    </TemplateHeader>
-  </Box>
+      </TemplateAboveHeader>
+      <TemplateHeader>
+        // ...
+        // ...
+      </TemplateHeader>
+    </TemplateBreakout>
 
-  <TemplateContent sidebar="...">
-    <TemplateContentTop>
+    <TemplateContent sidebar="...">
+      <TemplateContentTop>
+        // ...
+      </TemplateContentTop>
+
+      <TemplateContentPrimary>
+        // ...
+      </TemplateContentPrimary>
+
+      <TemplateContentBottom>
+        // ...
+      </TemplateContentBottom>
+    </TemplateContent>
+
+    <TemplateFooter>
       // ...
-    </TemplateContentTop>
-
-    <TemplateContentPrimary>
-      // ...
-    </TemplateContentPrimary>
-  </TemplateContent>
-
-  <TemplateFooter>
-    // ...
-  </TemplateFooter>
-</Template>
+    </TemplateFooter>
+  </Template>
+</>
 ```
 
 ## Template Children Component Props
@@ -268,6 +276,7 @@ import {
     argTypes={{
       aboveHeader: { table: { disable: true } },
       breakout: { table: { disable: true } },
+      contentBottom: { table: { disable: true } },
       contentId: { table: { disable: true } },
       contentPrimary: { table: { disable: true } },
       contentSidebar: { table: { disable: true } },
@@ -278,43 +287,46 @@ import {
     }}
   >
     {(args) => (
-      <Template>
-        <Box>
-          <SkipNavigation />
-          <TemplateAboveHeader>
-            <Placeholder variant="short">Above Header</Placeholder>
-          </TemplateAboveHeader>
-          <TemplateHeader>
-            <Placeholder variant="short">NYPL Header</Placeholder>
-            <TemplateBreakout>
+      <>
+        <SkipNavigation />
+        <Template>
+          <TemplateBreakout>
+            <TemplateAboveHeader>
+              <Placeholder variant="short">Above Header</Placeholder>
+            </TemplateAboveHeader>
+            <TemplateHeader>
+              <Placeholder variant="short">Header</Placeholder>
               <Placeholder variant="short">Breadcrumbs</Placeholder>
-              <Placeholder variant="short">Hero</Placeholder>
-            </TemplateBreakout>
-          </TemplateHeader>
-        </Box>
-        <TemplateContent sidebar={args.sidebar}>
-          <TemplateContentTop>
-            <Placeholder>Content Top</Placeholder>
-          </TemplateContentTop>
-          {args.sidebar === "left" && (
-            <TemplateContentSidebar>
-              <Placeholder>Left Sidebar</Placeholder>
-            </TemplateContentSidebar>
-          )}
-          <TemplateContentPrimary>
-            <Placeholder>Main Content</Placeholder>
-            <Placeholder variant="short">More Content</Placeholder>
-          </TemplateContentPrimary>
-          {args.sidebar === "right" && (
-            <TemplateContentSidebar>
-              <Placeholder>Right Sidebar</Placeholder>
-            </TemplateContentSidebar>
-          )}
-        </TemplateContent>
-        <TemplateFooter>
-          <Placeholder variant="short">Footer</Placeholder>
-        </TemplateFooter>
-      </Template>
+              <Placeholder>Hero</Placeholder>
+            </TemplateHeader>
+          </TemplateBreakout>
+          <TemplateContent sidebar={args.sidebar}>
+            <TemplateContentTop>
+              <Placeholder variant="short">Content Top</Placeholder>
+            </TemplateContentTop>
+            {args.sidebar === "left" && (
+              <TemplateContentSidebar>
+                <Placeholder>Left Sidebar</Placeholder>
+              </TemplateContentSidebar>
+            )}
+            <TemplateContentPrimary>
+              <Placeholder>Main Content</Placeholder>
+              <Placeholder variant="short">More Content</Placeholder>
+            </TemplateContentPrimary>
+            {args.sidebar === "right" && (
+              <TemplateContentSidebar>
+                <Placeholder>Right Sidebar</Placeholder>
+              </TemplateContentSidebar>
+            )}
+            <TemplateContentBottom>
+              <Placeholder variant="short">Content Bottom</Placeholder>
+            </TemplateContentBottom>
+          </TemplateContent>
+          <TemplateFooter>
+            <Placeholder>Footer</Placeholder>
+          </TemplateFooter>
+        </Template>
+      </>
     )}
   </Story>
 </Canvas>
@@ -323,7 +335,7 @@ import {
 
 ### Template Components
 
-The components consist of:
+The components consist of, listed in DOM structure order:
 
 - `Template`
 - `TemplateAboveHeader`
@@ -333,6 +345,7 @@ The components consist of:
 - `TemplateContentTop`
 - `TemplateContentPrimary`
 - `TemplateContentSidebar`
+- `TemplateContentBottom`
 - `TemplateFooter`
 
 #### Template
@@ -345,15 +358,27 @@ The components consist of:
 
 <Description of={Template} />
 
+#### TemplateBreakout
+
+```
+<Template>
+  <TemplateBreakout>
+    // ...
+  </TemplateBreakout>
+</Template>
+```
+
+<Description of={TemplateBreakout} />
+
 #### TemplateAboveHeader
 
 ```
 <Template>
-  <Box>
+  <TemplateBreakout>
     <TemplateAboveHeader>
       // ...
     </TemplateAboveHeader>
-  </Box>
+  </TemplateBreakout>
 </Template>
 ```
 
@@ -363,46 +388,29 @@ The components consist of:
 
 ```
 <Template>
-  <Box>
+  <TemplateBreakout>
     <TemplateAboveHeader>
       // ...
     </TemplateAboveHeader>
     <TemplateHeader>
       // ...
     </TemplateHeader>
-  </Box>
+  </TemplateBreakout>
 </Template>
 ```
 
 <Description of={TemplateHeader} />
 
-#### TemplateBreakout
-
-```
-<Template>
-  <Box>
-    <TemplateAboveHeader>
-      // ...
-    </TemplateAboveHeader>
-    <TemplateHeader>
-      <TemplateBreakout>
-        // ...
-      </TemplateBreakout>
-    </TemplateHeader>
-  </Box>
-</Template>
-```
-
-<Description of={TemplateBreakout} />
-
 #### TemplateContent
 
 ```
 <Template>
-  <Box>
-    <TemplateHeader>...</TemplateHeader>
-  </Box>
-  <TemplateContent id="mainContent" sidebar="left">
+  <TemplateBreakout>
+    <TemplateHeader>
+      // ...
+    </TemplateHeader>
+  </TemplateBreakout>
+  <TemplateContent id="mainContent">
     // ...
   </TemplateContent>
 </Template>
@@ -414,16 +422,18 @@ The components consist of:
 
 ```
 <Template>
-  <Box>
+  <TemplateBreakout>
     <TemplateAboveHeader>
       // ...
     </TemplateAboveHeader>
-    <TemplateHeader>...</TemplateHeader>
-  </Box>
+    <TemplateHeader>
+      // ...
+    </TemplateHeader>
+  </TemplateBreakout>
   <TemplateContent>
     <TemplateContentTop>
       // ...
-    </TemplateContent>
+    </TemplateContentTop>
   </TemplateContent>
 </Template>
 ```
@@ -434,10 +444,14 @@ The components consist of:
 
 ```
 <Template>
-  <TemplateAboveHeader>
-    // ...
-  </TemplateAboveHeader>
-  <TemplateHeader>...</TemplateHeader>
+  <TemplateBreakout>
+    <TemplateAboveHeader>
+      // ...
+    </TemplateAboveHeader>
+    <TemplateHeader>
+      // ...
+    </TemplateHeader>
+  </TemplateBreakout>
   <TemplateContent>
     <TemplateContentPrimary>
       // ...
@@ -452,12 +466,14 @@ The components consist of:
 
 ```
 <Template>
-  <Box>
+  <TemplateBreakout>
     <TemplateAboveHeader>
       // ...
     </TemplateAboveHeader>
-    <TemplateHeader>...</TemplateHeader>
-  </Box>
+    <TemplateHeader>
+      // ...
+    </TemplateHeader>
+  <TemplateBreakout>
   <TemplateContent sidebar="right">
     <TemplateContentPrimary>
       // ...
@@ -469,12 +485,14 @@ The components consist of:
 </Template>
 
 <Template>
-  <Box>
+  <TemplateBreakout>
     <TemplateAboveHeader>
       // ...
     </TemplateAboveHeader>
-    <TemplateHeader>...</TemplateHeader>
-  </Box>
+    <TemplateHeader>
+      // ...
+    </TemplateHeader>
+  </TemplateBreakout>
   <TemplateContent sidebar="left">
     <TemplateContentSidebar>
       // LEFT SIDEBAR
@@ -488,18 +506,46 @@ The components consist of:
 
 <Description of={TemplateContentSidebar} />
 
-#### TemplateFooter
+#### TemplateContentBottom
 
 ```
 <Template>
-  <Box>
+  <TemplateBreakout>
     <TemplateAboveHeader>
       // ...
     </TemplateAboveHeader>
     <TemplateHeader>
       // ...
     </TemplateHeader>
-  </Box>
+  </TemplateBreakout>
+  <TemplateContent>
+    <TemplateContentTop>
+      // ...
+    </TemplateContentTop>
+    <TemplateContentPrimary>
+      // ...
+    </TemplateContentPrimary>
+    <TemplateContentBottom>
+      // ...
+    </TemplateContentBottom>
+  </TemplateContent>
+</Template>
+```
+
+<Description of={TemplateContentBottom} />
+
+#### TemplateFooter
+
+```
+<Template>
+  <TemplateBreakout>
+    <TemplateAboveHeader>
+      // ...
+    </TemplateAboveHeader>
+    <TemplateHeader>
+      // ...
+    </TemplateHeader>
+  </TemplateBreakout>
   <TemplateContent sidebar="right">
     //...
   </TemplateContent>
@@ -558,28 +604,28 @@ This is best viewed in the Storybook "Canvas" and not "Docs" section.
 
 <Canvas>
   <Story name="Full Example with Template Children Components">
-    <Template>
-      <Box>
-        <SkipNavigation />
-        <TemplateAboveHeader>
-          <Notification
-            noMargin
-            notificationHeading="Standard Notification"
-            notificationContent={
-              <>
-                This is an "announcement" Notification with a heading. Cras
-                mattis consectetur purus sit amet fermentum. Maecenas faucibus
-                mollis interdum. Morbi leo risus, porta ac consectetur ac,
-                vestibulum at eros. Cum sociis natoque penatibus et magnis dis
-                parturient montes, nascetur ridiculus mus. Vivamus sagittis
-                lacus vel augue laoreet rutrum faucibus dolor auctor.
-              </>
-            }
-            showIcon={false}
-          />
-        </TemplateAboveHeader>
-        <TemplateHeader>
-          <TemplateBreakout>
+    <>
+      <SkipNavigation />
+      <Template>
+        <TemplateBreakout>
+          <TemplateAboveHeader>
+            <Notification
+              noMargin
+              notificationHeading="Standard Notification"
+              notificationContent={
+                <>
+                  This is an "announcement" Notification with a heading. Cras
+                  mattis consectetur purus sit amet fermentum. Maecenas faucibus
+                  mollis interdum. Morbi leo risus, porta ac consectetur ac,
+                  vestibulum at eros. Cum sociis natoque penatibus et magnis dis
+                  parturient montes, nascetur ridiculus mus. Vivamus sagittis
+                  lacus vel augue laoreet rutrum faucibus dolor auctor.
+                </>
+              }
+              showIcon={false}
+            />
+          </TemplateAboveHeader>
+          <TemplateHeader>
             <Breadcrumbs
               breadcrumbsData={[
                 { url: "#", text: "Home" },
@@ -600,122 +646,130 @@ This is best viewed in the Storybook "Canvas" and not "Docs" section.
               }}
               subHeaderText={otherSubHeaderText}
             />
-          </TemplateBreakout>
-        </TemplateHeader>
-      </Box>
-      <TemplateContent sidebar="right">
-        <TemplateContentTop>
-          <Notification
-            notificationType="announcement"
-            notificationHeading="Announcement Notification"
-            notificationContent={
-              <>
-                This is an "announcement" Notification with a heading. Cras
-                mattis consectetur purus sit amet fermentum. Maecenas faucibus
-                mollis interdum. Morbi leo risus, porta ac consectetur ac,
-                vestibulum at eros. Cum sociis natoque penatibus et magnis dis
-                parturient montes, nascetur ridiculus mus. Vivamus sagittis
-                lacus vel augue laoreet rutrum faucibus dolor auctor.
-              </>
-            }
-          />
-        </TemplateContentTop>
-        <TemplateContentPrimary>
-          <p>This is the main content!</p>
-          <Accordion accordionData={faqContent} />
-          <HorizontalRule />
-          <p>Fill out the form!</p>
-          <Form action="/end/point" id="form1">
-            <FormField>
-              <TextInput
-                helperText="Make sure to complete this field."
-                id="username"
-                labelText="Username"
-                required
-              />
-            </FormField>
-            <FormField>
-              <TextInput
-                helperText="Make sure to complete this field."
-                id="password"
-                labelText="Password"
-                required
-              />
-            </FormField>
-            <FormRow>
+          </TemplateHeader>
+        </TemplateBreakout>
+        <TemplateContent sidebar="right">
+          <TemplateContentTop>
+            <Notification
+              notificationType="announcement"
+              notificationHeading="Announcement Notification"
+              notificationContent={
+                <>
+                  This is an "announcement" Notification with a heading. Cras
+                  mattis consectetur purus sit amet fermentum. Maecenas faucibus
+                  mollis interdum. Morbi leo risus, porta ac consectetur ac,
+                  vestibulum at eros. Cum sociis natoque penatibus et magnis dis
+                  parturient montes, nascetur ridiculus mus. Vivamus sagittis
+                  lacus vel augue laoreet rutrum faucibus dolor auctor.
+                </>
+              }
+            />
+          </TemplateContentTop>
+          <TemplateContentPrimary>
+            <p>This is the main content!</p>
+            <Accordion accordionData={faqContent} />
+            <HorizontalRule />
+            <p>Fill out the form!</p>
+            <Form action="/end/point" id="form1">
               <FormField>
                 <TextInput
-                  id="phone-field"
-                  labelText="Phone Field"
-                  type="tel"
+                  helperText="Make sure to complete this field."
+                  id="username"
+                  labelText="Username"
+                  required
                 />
               </FormField>
               <FormField>
-                <TextInput id="url-field" labelText="URL Field" type="url" />
+                <TextInput
+                  helperText="Make sure to complete this field."
+                  id="password"
+                  labelText="Password"
+                  required
+                />
               </FormField>
+              <FormRow>
+                <FormField>
+                  <TextInput
+                    id="phone-field"
+                    labelText="Phone Field"
+                    type="tel"
+                  />
+                </FormField>
+                <FormField>
+                  <TextInput id="url-field" labelText="URL Field" type="url" />
+                </FormField>
+                <FormField>
+                  <TextInput id="age-field" labelText="Age" type="number" />
+                </FormField>
+              </FormRow>
               <FormField>
-                <TextInput id="age-field" labelText="Age" type="number" />
+                <Button id="submit">Submit</Button>
               </FormField>
-            </FormRow>
-            <FormField>
-              <Button id="submit">Submit</Button>
-            </FormField>
-          </Form>
-        </TemplateContentPrimary>
-        <TemplateContentSidebar>
-          <p>Sidebar information in a `Card` component.</p>
+            </Form>
+          </TemplateContentPrimary>
+          <TemplateContentSidebar>
+            <p>Sidebar information in a `Card` component.</p>
+            <Card
+              imageProps={{
+                alt: "Alt text",
+                aspectRatio: "square",
+                size: "small",
+                src: "https://placeimg.com/400/200/animals",
+              }}
+              isCentered
+            >
+              <CardHeading id="heading1">Small Animal Image</CardHeading>
+              <CardHeading level="three" id="heading2">
+                Animal info
+              </CardHeading>
+              <CardContent>
+                Vestibulum id ligula porta felis euismod semper. Nulla vitae
+                elit libero, a pharetra augue.
+              </CardContent>
+            </Card>
+          </TemplateContentSidebar>
+          <TemplateContentBottom>
+            <Notification
+              noMargin
+              notificationHeading="Standard Notification"
+              notificationContent={<>This is an the bottom content area!</>}
+              showIcon={false}
+            />
+          </TemplateContentBottom>
+        </TemplateContent>
+        <TemplateFooter>
           <Card
+            id="custom-card"
             imageProps={{
               alt: "Alt text",
-              aspectRatio: "square",
-              size: "small",
-              src: "https://placeimg.com/400/200/animals",
+              aspectRatio: "sixteenByNine",
+              src: "https://cdn-d8.nypl.org/s3fs-public/2020-05/NYPL_MainFacadeRev2Cam2.png",
             }}
-            isCentered
+            layout="row"
+            backgroundColor="#616161"
+            foregroundColor="#FFF"
           >
-            <CardHeading id="heading1">Small Animal Image</CardHeading>
-            <CardHeading level="three" id="heading2">
-              Animal info
-            </CardHeading>
+            <CardHeading id="heading1-footer">Footer</CardHeading>
             <CardContent>
-              Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
-              libero, a pharetra augue.
+              <p>This is an example footer using the `Card` component.</p>
+              <p>
+                © The New York Public Library, 2021 The New York Public Library
+                is a 501(c)(3) | EIN 13-1887440
+              </p>
             </CardContent>
+            <CardActions>
+              <Link color="#FFF" href="#" textDecoration="underline">
+                Facebook
+              </Link>
+              ,<Link color="#FFF" href="#" textDecoration="underline">
+                Instagram
+              </Link>,<Link color="#FFF" href="#" textDecoration="underline">
+                Twitter
+              </Link>
+            </CardActions>
           </Card>
-        </TemplateContentSidebar>
-      </TemplateContent>
-      <TemplateFooter>
-        <Card
-          id="custom-card"
-          imageProps={{
-            alt: "Alt text",
-            aspectRatio: "sixteenByNine",
-            src: "https://cdn-d8.nypl.org/s3fs-public/2020-05/NYPL_MainFacadeRev2Cam2.png",
-          }}
-          layout="horizontal"
-          backgroundColor="#616161"
-          foregroundColor="#FFF"
-        >
-          <CardHeading id="heading1-footer">Footer</CardHeading>
-          <CardContent>
-            <p>This is an example footer using the `Card` component.</p>
-            <p>
-              © The New York Public Library, 2021 The New York Public Library is
-              a 501(c)(3) | EIN 13-1887440
-            </p>
-          </CardContent>
-          <CardActions>
-            <Link color="#FFF" href="#" textDecoration="underline">
-              Facebook
-            </Link>
-            ,<Link color="#FFF" href="#" textDecoration="underline">
-              Instagram
-            </Link>,<Link color="#FFF" href="#" textDecoration="underline">
-              Twitter
-            </Link>
-          </CardActions>
-        </Card>
-      </TemplateFooter>
-    </Template>
+        </TemplateFooter>
+      </Template>
+    </>
   </Story>
 </Canvas>

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -35,6 +35,8 @@ export interface TemplateAppContainerProps
   /** ID used for the `main` HTML element. Defaults to "mainContent". Useful
    * anchor for the application skip navigation. */
   contentId?: string;
+  /** DOM that will be rendered in the `TemplateContentBottom` component section. */
+  contentBottom?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateContentPrimary` component section. */
   contentPrimary?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateContentSidebar` component section. */
@@ -116,12 +118,14 @@ const TemplateHeader = ({
 };
 
 /**
- * This optional component should be used inside the `TemplateHeader` component.
- * This is meant to render its children from edge to edge and is most useful
- * for the `Breadcrumbs` and `Hero` components, and other banner-like components.
+ * This component should be used inside the `Template` component to contain both
+ * the `TemplateAboveHeader` and `TemplateHeader` components. This is meant to
+ * render its children from edge to edge and is most useful for the headers,
+ * `Breadcrumbs`, and `Hero` components or other banner-like components.
  */
 const TemplateBreakout = (props: React.PropsWithChildren<TemplateProps>) => {
-  return <Box>{props.children}</Box>;
+  const styles = useStyleConfig("TemplateBreakout", {});
+  return <Box __css={styles}>{props.children}</Box>;
 };
 
 /**
@@ -173,7 +177,20 @@ const TemplateContent = (
  * above the primary component and the sidebar component (if any).
  */
 const TemplateContentTop = (props: React.PropsWithChildren<TemplateProps>) => {
-  const styles = useStyleConfig("TemplateContentTop", {});
+  const styles = useStyleConfig("TemplateContentTopBottom", {});
+  return <Box __css={styles}>{props.children}</Box>;
+};
+
+/**
+ * This optional component must be used inside the `TemplateContent` component
+ * and after the `TemplateContentPrimary` or `TemplateContentSidebar` component.
+ * This renders content in the main width of the container and should always
+ * render below the primary component and the sidebar component (if any).
+ */
+const TemplateContentBottom = (
+  props: React.PropsWithChildren<TemplateProps>
+) => {
+  const styles = useStyleConfig("TemplateContentTopBottom", {});
   return <Box __css={styles}>{props.children}</Box>;
 };
 
@@ -266,6 +283,7 @@ export const TemplateAppContainer = chakra(
       aboveHeader,
       breakout,
       contentId = "mainContent",
+      contentBottom,
       contentPrimary,
       contentSidebar,
       contentTop,
@@ -280,47 +298,51 @@ export const TemplateAppContainer = chakra(
     const aboveHeaderElem = aboveHeader && (
       <TemplateAboveHeader>{aboveHeader}</TemplateAboveHeader>
     );
-    const breakoutElem = breakout && (
-      <TemplateBreakout>{breakout}</TemplateBreakout>
-    );
     const contentTopElem = contentTop && (
       <TemplateContentTop>{contentTop}</TemplateContentTop>
     );
     const contentPrimaryElem = contentPrimary && (
       <TemplateContentPrimary>{contentPrimary}</TemplateContentPrimary>
     );
+    const contentBottomElem = contentBottom && (
+      <TemplateContentBottom>{contentBottom}</TemplateContentBottom>
+    );
     const contentSidebarElem = contentSidebar && (
       <TemplateContentSidebar>{contentSidebar}</TemplateContentSidebar>
     );
     return (
-      <Template ref={ref} {...rest}>
-        <Box>
-          {renderSkipNavigation ? <SkipNavigation /> : null}
-          {aboveHeaderElem}
-          {(header || breakoutElem) && (
-            <TemplateHeader renderHeaderElement={renderHeaderElement}>
-              {header}
-              {breakoutElem}
-            </TemplateHeader>
+      <>
+        {renderSkipNavigation ? <SkipNavigation /> : null}
+        <Template ref={ref} {...rest}>
+          <TemplateBreakout>
+            {aboveHeaderElem}
+            {(header || breakout) && (
+              <TemplateHeader renderHeaderElement={renderHeaderElement}>
+                {header}
+                {breakout}
+              </TemplateHeader>
+            )}
+          </TemplateBreakout>
+          {/* Note that setting `sidebar` as a prop here affects the
+          TemplateContentSidebar and TemplateContentPrimary components. */}
+          <TemplateContent id={contentId} sidebar={sidebar}>
+            {contentTopElem}
+
+            {sidebar === "left" && contentSidebarElem}
+
+            {contentPrimaryElem}
+
+            {sidebar === "right" && contentSidebarElem}
+
+            {contentBottomElem}
+          </TemplateContent>
+          {footer && (
+            <TemplateFooter renderFooterElement={renderFooterElement}>
+              {footer}
+            </TemplateFooter>
           )}
-        </Box>
-        {/* Note that setting `sidebar` as a prop here affects the
-       TemplateContentSidebar and TemplateContentPrimary components. */}
-        <TemplateContent id={contentId} sidebar={sidebar}>
-          {contentTopElem}
-
-          {sidebar === "left" && contentSidebarElem}
-
-          {contentPrimaryElem}
-
-          {sidebar === "right" && contentSidebarElem}
-        </TemplateContent>
-        {footer && (
-          <TemplateFooter renderFooterElement={renderFooterElement}>
-            {footer}
-          </TemplateFooter>
-        )}
-      </Template>
+        </Template>
+      </>
     );
   })
 );
@@ -328,12 +350,13 @@ export const TemplateAppContainer = chakra(
 export {
   Template,
   TemplateAboveHeader,
-  TemplateHeader,
   TemplateBreakout,
   TemplateContent,
-  TemplateContentTop,
+  TemplateContentBottom,
   TemplateContentPrimary,
   TemplateContentSidebar,
+  TemplateContentTop,
   TemplateFooter,
+  TemplateHeader,
 };
 export default TemplateAppContainer;

--- a/src/components/Template/__snapshots__/Template.test.tsx.snap
+++ b/src/components/Template/__snapshots__/Template.test.tsx.snap
@@ -110,18 +110,14 @@ exports[`Template components renders the UI snapshot correctly 2`] = `
         NYPL Header
       </div>
       <div
-        className="css-0"
+        className="placeholder placeholder--short"
       >
-        <div
-          className="placeholder placeholder--short"
-        >
-          Breadcrumbs
-        </div>
-        <div
-          className="placeholder placeholder--short"
-        >
-          Hero
-        </div>
+        Breadcrumbs
+      </div>
+      <div
+        className="placeholder placeholder--short"
+      >
+        Hero
       </div>
     </header>
   </div>
@@ -199,18 +195,14 @@ exports[`Template components renders the UI snapshot correctly 3`] = `
         NYPL Header
       </div>
       <div
-        className="css-0"
+        className="placeholder placeholder--short"
       >
-        <div
-          className="placeholder placeholder--short"
-        >
-          Breadcrumbs
-        </div>
-        <div
-          className="placeholder placeholder--short"
-        >
-          Hero
-        </div>
+        Breadcrumbs
+      </div>
+      <div
+        className="placeholder placeholder--short"
+      >
+        Hero
       </div>
     </header>
   </div>
@@ -289,18 +281,14 @@ exports[`Template components renders the UI snapshot correctly 4`] = `
         NYPL Header
       </div>
       <div
-        className="css-0"
+        className="placeholder placeholder--short"
       >
-        <div
-          className="placeholder placeholder--short"
-        >
-          Breadcrumbs
-        </div>
-        <div
-          className="placeholder placeholder--short"
-        >
-          Hero
-        </div>
+        Breadcrumbs
+      </div>
+      <div
+        className="placeholder placeholder--short"
+      >
+        Hero
       </div>
     </header>
   </div>

--- a/src/theme/components/skipNavigation.ts
+++ b/src/theme/components/skipNavigation.ts
@@ -14,12 +14,11 @@ const SkipNavigation = {
       width: "1px",
       // Only display when the user focuses on the links.
       _focus: {
-        border: "1px solid var(—nypl-colors-ui-gray-dark)",
         height: "auto",
-        left: "2rem",
-        padding:
-          "var(--nypl-space-inset-extranarrow) var(--nypl-space-inset-narrow)",
-        top: "3rem",
+        left: "1rem",
+        paddingX: "inset.extranarrow",
+        paddingY: "inset.extranarrow",
+        top: "1rem",
         width: "auto",
       },
     },

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -2,13 +2,6 @@
  * Grid layout based on https://www.joshwcomeau.com/css/full-bleed/
  */
 
-const breakout = {
-  width: "100%",
-  // This could be "1 / 4" and it would mean the same. This is
-  // "future-proof" the grid column assignment to the last column.
-  gridColumn: "1 / -1",
-};
-
 const Template = {
   baseStyle: {
     boxSizing: "border-box",
@@ -18,10 +11,6 @@ const Template = {
       1fr
       min(1280px, 100%)
       1fr`,
-    // Set all elements to start on the second 1280px grid column.
-    "> *": {
-      gridColumn: "2",
-    },
     rowGap: "grid.l",
   },
   sizes: {},
@@ -30,10 +19,18 @@ const Template = {
 // Elements that need to breakout will span outside
 // the center 1280px grid column.
 const TemplateBreakout = {
-  baseStyle: breakout,
+  baseStyle: {
+    width: "100%",
+    // This could be "1 / 4" and it would mean the same. This is
+    // "future-proof" the grid column assignment to the last column.
+    gridColumn: "1 / -1",
+  },
 };
 const TemplateContent = {
   baseStyle: {
+    // Set this element to start on the second 1280px grid column.
+    gridColumn: "2",
+    // But this element also contains its own grid system within.
     display: "grid",
     gridTemplateColumns: "1fr",
     paddingY: 0,
@@ -51,7 +48,7 @@ const TemplateContent = {
     },
   },
 };
-const TemplateContentTop = {
+const TemplateContentTopBottom = {
   baseStyle: {
     gridColumn: { base: "1", md: "1 / span 2" },
     height: "100%",
@@ -81,7 +78,7 @@ export default {
   Template,
   TemplateBreakout,
   TemplateContent,
-  TemplateContentTop,
+  TemplateContentTopBottom,
   TemplateContentPrimary,
   TemplateContentSidebar,
 };


### PR DESCRIPTION
This is in addition to PR #1098 .

## This PR does the following:

- Fixes an issue found in the original PR but adds more to the `Template` components. Specifically, it adds a `TemplateContentBottom` component and also updates how the `TemplateBreakout` component is used. It also moves the `SkipNavigation` component _outside_ of the `Template` component but still renders it as part of the `TemplateAppContainer` component. All of this is more of a proposal so that's why it's a separate PR. It's not fully complete but if you think it's fine, I'll merge it and then update the main PR with more comments.

## How has this been tested?

Locally and in Turbine. All template pages render as expected.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
