### PR TITLE
DSD-1091: Passing props in the Image component to the correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates how HTML attributes are passed down in the `Image` component to the HTML `img` element.
+
 ## 1.0.7 (July 29, 2022)
 
 ### Updates

--- a/src/components/Image/Image.stories.mdx
+++ b/src/components/Image/Image.stories.mdx
@@ -11,6 +11,7 @@ import { withDesign } from "storybook-addon-designs";
 import Heading from "../Heading/Heading";
 import Image from "./Image";
 import SimpleGrid from "../Grid/SimpleGrid";
+import Text from "../Text/Text";
 import { getCategory } from "../../utils/componentCategories";
 
 export const imageBlockStyles = {
@@ -66,7 +67,7 @@ export const imageBlockStyles = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.6`    |
-| Latest            | `1.0.7`    |
+| Latest            | `1.0.9`    |
 
 ## Table of Contents
 
@@ -77,6 +78,7 @@ export const imageBlockStyles = {
 - [Image Sizes](#image-sizes)
 - [Image Aspect Ratios](#image-aspect-ratios)
 - [Image Types](#image-types)
+- [Image HTML Attributes](#image-html-attributes)
 - [Lazy Loading](#lazy-loading)
 
 ## Overview
@@ -330,6 +332,45 @@ in an element with a fixed width value.
       </div>
     </SimpleGrid>
   </Story>
+</Canvas>
+
+## Image HTML Attributes
+
+The `Image` component accepts HTML image attributes. If needed, you can pass
+functions such as `onLoad` and `onError` or attributes such as `srcset`.
+
+For both examples below, open the browser's console to see the log messages. In
+the first example below, when the image is finished loading, the `onLoad`
+function callback is called. The image's dimensions are logged. In the second
+example, there is an (intentional) error with the image's URL. This will trigger
+the `onError` function callback.
+
+<Canvas>
+  <VStack align="start">
+    <Box>
+      <Text>Image with `onLoad` function</Text>
+      <Image
+        alt="Alt text"
+        src="https://placeimg.com/400/400/animals"
+        onLoad={({ target }) => {
+          console.log("Image 1 loaded and `onLoad` called.");
+          console.log(
+            "Image 1 dimensions:",
+            target.offsetHeight,
+            target.offsetWidth
+          );
+        }}
+      />
+    </Box>
+    <Box>
+      <Text>Image with `onError` function</Text>
+      <Image
+        alt="Broken image with bad url"
+        src="https://placeimcom/400/400/animals"
+        onError={() => console.warn("Image 2 error! Called through `onError`.")}
+      />
+    </Box>
+  </VStack>
 </Canvas>
 
 ## Lazy Loading

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -5,7 +5,7 @@ import {
   useMergeRefs,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef } from "react";
+import React, { forwardRef, ImgHTMLAttributes } from "react";
 import { useInView } from "react-intersection-observer";
 
 export type ImageRatios =
@@ -26,7 +26,7 @@ export type ImageSizes =
   | "large";
 export type ImageTypes = "default" | "circle";
 // Used for components that have an `imageProps` prop.
-export interface ComponentImageProps {
+export interface ComponentImageProps extends Partial<HTMLImageElement> {
   /** String value used to populate the `alt` attribute of the internal `Image`
    * component's `img` element. @NOTE if an image is used, this value must be passed. */
   alt?: string;
@@ -61,7 +61,9 @@ interface ImageWrapperProps {
   size?: ImageSizes;
 }
 
-export interface ImageProps extends ImageWrapperProps {
+export interface ImageProps
+  extends ImageWrapperProps,
+    ImgHTMLAttributes<HTMLImageElement> {
   /** Optionally pass in additional Chakra-based styles only for the figure. */
   additionalFigureStyles?: { [key: string]: any };
   /** Optionally pass in additional Chakra-based styles only for the image. */
@@ -177,6 +179,7 @@ export const Image = chakra(
         loading={isLazy ? "lazy" : undefined}
         {...srcProp}
         __css={{ ...styles.img, ...additionalImageStyles }}
+        {...rest}
       />
     );
     const finalImage = useImageWrapper ? (
@@ -194,12 +197,11 @@ export const Image = chakra(
     );
 
     return (
-      <Box ref={finalRefs} {...rest}>
+      <Box ref={finalRefs}>
         {caption || credit ? (
           <Box
             as="figure"
             __css={{ ...styles.figure, ...additionalFigureStyles }}
-            {...rest}
           >
             {finalImage}
             <Box as="figcaption" __css={styles.figcaption}>

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -326,11 +326,11 @@ exports[`Image Renders the UI snapshot correctly 18`] = `
 
 exports[`Image Renders the UI snapshot correctly 19`] = `
 <div
-  className="css-qvgr6z"
+  className="css-0"
 >
   <img
     alt=""
-    className="css-0"
+    className="css-qvgr6z"
     src="test.png"
   />
 </div>
@@ -339,11 +339,11 @@ exports[`Image Renders the UI snapshot correctly 19`] = `
 exports[`Image Renders the UI snapshot correctly 20`] = `
 <div
   className="css-0"
-  data-testid="image"
 >
   <img
     alt=""
     className="css-0"
+    data-testid="image"
     src="test.png"
   />
 </div>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1091](https://jira.nypl.org/browse/DSD-1091)

## This PR does the following:

- Correctly passes down HTML `img` attributes in the `Image` component to the `img` element.
- This came up in MLN where error checking was being performed in the `Image` component by checking its width and height. An `onLoad` callback function was passed but it was being passed to the wrapper `div` element and not the `img` element itself. Therefore, the width and height captured was wrong since it was from the `div` element and not the `img`.
- This PR passes down the `...rest` props to the `img` element.
- More work needs to be done to better delineate styling props for the wrappers and props for the `img` element itself, since we include different style props for the potential wrappers and figure elements. But, this can wait for another PR.

## How has this been tested?

Locally in Storybook.
It's difficult to unit test because images are not loaded in jest.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
