### PR TITLE
DSD-1043: TOC styles for Style Guide pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the style of the TOC on the `Style Guide` pages to match the style of the TOC on the component pages.
+
 ## 1.0.7 (July 29, 2022)
 
 ### Updates

--- a/src/components/StyleGuide/Bidirectionality.stories.mdx
+++ b/src/components/StyleGuide/Bidirectionality.stories.mdx
@@ -15,14 +15,14 @@ import DSProvider from "../../theme/provider";
 
 # Bidirectionality
 
-| Table of Contents                                                            |
-| ---------------------------------------------------------------------------- |
-| 1. [Terms](#terms)                                                           |
-| 2. [General Information](#general-information)                               |
-| 3. [Terms](#terms)                                                           |
-| 4. [Reservoir Birectionality Goal](#reservoir-bidirectionality-goal)         |
-| 5. [Reservoir Component Implementation](#reservoir-component-implementation) |
-| 6. [Application Implementation](#application-implementation)                 |
+## Table of Contents
+
+- [Terms](#terms)
+- [General Information](#general-information)
+- [Terms](#terms)
+- [Reservoir Birectionality Goal](#reservoir-bidirectionality-goal)
+- [Reservoir Component Implementation](#reservoir-component-implementation)
+- [Application Implementation](#application-implementation)
 
 ## Terms
 

--- a/src/components/StyleGuide/Breakpoints.stories.mdx
+++ b/src/components/StyleGuide/Breakpoints.stories.mdx
@@ -58,4 +58,4 @@ For additional spacing information, please refer to the Figma Main file.
 
 <!-- hack to make sure correct styles are used on the page -->
 
-<DSProvider></DSProvider>
+<DSProvider />

--- a/src/components/StyleGuide/Breakpoints.stories.mdx
+++ b/src/components/StyleGuide/Breakpoints.stories.mdx
@@ -1,17 +1,19 @@
-import { Meta } from "@storybook/addon-docs";
+import { Box } from "@chakra-ui/react";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
-import Heading from "../Heading/Heading";
+import List from "../List/List";
 import { getCategory } from "../../utils/componentCategories";
+import DSProvider from "../../theme/provider";
 
 <Meta title={getCategory("Breakpoints")} />
 
 # Breakpoints
 
-| Table of Contents                              |
-| ---------------------------------------------- |
-| 1. [General Information](#general-information) |
-| 2. [CSS Variables](#css-variables)             |
-| 3. [Figma Reference](#figma-reference)         |
+## Table of Contents
+
+- [General Information](#general-information)
+- [CSS Variables](#css-variables)
+- [Figma Reference](#figma-reference)
 
 ## General Information
 
@@ -53,3 +55,7 @@ $nypl-max-width: $nypl-breakpoint-xl;
 For additional spacing information, please refer to the Figma Main file.
 
 - https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=17983%3A60146
+
+<!-- hack to make sure correct styles are used on the page -->
+
+<DSProvider></DSProvider>

--- a/src/components/StyleGuide/Buttons.stories.mdx
+++ b/src/components/StyleGuide/Buttons.stories.mdx
@@ -1,3 +1,4 @@
+import { Box } from "@chakra-ui/react";
 import { Canvas, Meta } from "@storybook/addon-docs";
 
 import Button from "../Button/Button";
@@ -10,14 +11,14 @@ import DSProvider from "../../theme/provider";
 
 # Buttons
 
-| Table of Contents                              |
-| ---------------------------------------------- |
-| 1. [General Information](#general-information) |
-| 2. [Guidelines](#guidelines)                   |
-| 3. [Button Groups](#button-groups)             |
-| 4. [Button Types](#button-types)               |
-| 5. [Patterns](#patterns)                       |
-| 6. [Figma Reference](#figma-reference)         |
+## Table of Contents
+
+- [General Information](#general-information)
+- [Guidelines](#guidelines)
+- [Button Groups](#button-groups)
+- [Button Types](#button-types)
+- [Patterns](#patterns)
+- [Figma Reference](#figma-reference)
 
 ## General Information
 

--- a/src/components/StyleGuide/ColorMode.stories.mdx
+++ b/src/components/StyleGuide/ColorMode.stories.mdx
@@ -1,3 +1,4 @@
+import { Box } from "@chakra-ui/react";
 import { Canvas, Meta } from "@storybook/addon-docs";
 
 import { getCategory } from "../../utils/componentCategories";
@@ -7,12 +8,12 @@ import DSProvider from "../../theme/provider";
 
 # Color Mode
 
-| Table of Contents                                                                        |
-| ---------------------------------------------------------------------------------------- |
-| 1. [General Information](#general-information)                                           |
-| 2. [Accessibility Guidelines](#accessibility-guidelines)                                 |
-| 3. [Toggling Color Mode](#toggling-color-mode)                                           |
-| 4. [Using Local Storage to Manage Color Mode](#using-local-storage-to-manage-color-mode) |
+## Table of Contents
+
+- [General Information](#general-information)
+- [Accessibility Guidelines](#accessibility-guidelines)
+- [Toggling Color Mode](#toggling-color-mode)
+- [Using Local Storage to Manage Color Mode](#using-local-storage-to-manage-color-mode)
 
 ## General Information
 
@@ -202,3 +203,7 @@ export function getServerSideProps({ req }: any) {
   };
 }
 ```
+
+<!-- hack to make sure correct styles are used on the page -->
+
+<DSProvider></DSProvider>

--- a/src/components/StyleGuide/ColorMode.stories.mdx
+++ b/src/components/StyleGuide/ColorMode.stories.mdx
@@ -206,4 +206,4 @@ export function getServerSideProps({ req }: any) {
 
 <!-- hack to make sure correct styles are used on the page -->
 
-<DSProvider></DSProvider>
+<DSProvider />

--- a/src/components/StyleGuide/DesignTokens.stories.mdx
+++ b/src/components/StyleGuide/DesignTokens.stories.mdx
@@ -196,4 +196,4 @@ section in the Style Guide available in the DS Storybook.
 
 <!-- hack to make sure correct styles are used on the page -->
 
-<DSProvider></DSProvider>
+<DSProvider />

--- a/src/components/StyleGuide/DesignTokens.stories.mdx
+++ b/src/components/StyleGuide/DesignTokens.stories.mdx
@@ -1,19 +1,21 @@
-import { Meta } from "@storybook/addon-docs";
+import { Box } from "@chakra-ui/react";
+import { Canvas, Meta } from "@storybook/addon-docs";
 
 import { getCategory } from "../../utils/componentCategories";
+import DSProvider from "../../theme/provider";
 
 <Meta title={getCategory("Design Tokens")} />
 
 # Design Tokens
 
-| Table of Contents                                                                              |
-| ---------------------------------------------------------------------------------------------- |
-| 1. [What are Design Tokens?](#what-are-design-tokens)                                          |
-| 2. [Why Use Design Tokens?](#why-use-design-tokens)                                            |
-| 3. [How to Use the Reservoir Design Tokens](#figma-reference)                                  |
-| 4. [Using Reservoir Design Tokens in CSS](#using-reservoir-design-tokens-in-css)               |
-| 5. [Using Reservoir Design Tokens in Javascript](#using-reservoir-design-tokens-in-javascript) |
-| 6. [Reservoir Design Token Categories](#reservoir-design-token-categories)                     |
+## Table of Contents
+
+- [What are Design Tokens?](#what-are-design-tokens)
+- [Why Use Design Tokens?](#why-use-design-tokens)
+- [How to Use the Reservoir Design Tokens](#figma-reference)
+- [Using Reservoir Design Tokens in CSS](#using-reservoir-design-tokens-in-css)
+- [Using Reservoir Design Tokens in Javascript](#using-reservoir-design-tokens-in-javascript)
+- [Reservoir Design Token Categories](#reservoir-design-token-categories)
 
 ## What are Design Tokens?
 
@@ -191,3 +193,7 @@ The DS design tokens are broken into the following categories:
 
 For details related to a specific category, please refer to the corresponding
 section in the Style Guide available in the DS Storybook.
+
+<!-- hack to make sure correct styles are used on the page -->
+
+<DSProvider></DSProvider>

--- a/src/components/StyleGuide/Forms.stories.mdx
+++ b/src/components/StyleGuide/Forms.stories.mdx
@@ -3,18 +3,19 @@ import { Meta } from "@storybook/addon-docs";
 import Card from "../Card/Card";
 import List from "../List/List";
 import { getCategory } from "../../utils/componentCategories";
+import DSProvider from "../../theme/provider";
 
 <Meta title={getCategory("Forms")} />
 
 # Forms
 
-| Table of Contents                                  |
-| -------------------------------------------------- |
-| 1. [General Information](#general-information)     |
-| 2. [Form Input Components](#form-input-components) |
-| 3. [Input Labelling](#input-labelling)             |
-| 4. [Input States](#input-states)                   |
-| 5. [Figma Reference](#figma-reference)             |
+## Table of Contents
+
+- [General Information](#general-information)
+- [Form Input Components](#form-input-components)
+- [Input Labelling](#input-labelling)
+- [Input States](#input-states)
+- [Figma Reference](#figma-reference)
 
 ## General Information
 
@@ -92,3 +93,7 @@ All form input fields offer styling for the following states:
 For additional spacing information, please refer to the Figma Main file.
 
 - [General Forms Page](https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/?node-id=10734%3A2768)
+
+<!-- hack to make sure correct styles are used on the page -->
+
+<DSProvider></DSProvider>

--- a/src/components/StyleGuide/Forms.stories.mdx
+++ b/src/components/StyleGuide/Forms.stories.mdx
@@ -96,4 +96,4 @@ For additional spacing information, please refer to the Figma Main file.
 
 <!-- hack to make sure correct styles are used on the page -->
 
-<DSProvider></DSProvider>
+<DSProvider />

--- a/src/components/StyleGuide/Iconography.stories.mdx
+++ b/src/components/StyleGuide/Iconography.stories.mdx
@@ -9,14 +9,14 @@ import DSProvider from "../../theme/provider";
 
 # Iconography
 
-| Table of Contents                              |
-| ---------------------------------------------- |
-| 1. [General Information](#general-information) |
-| 2. [Icon Examples](#icon-examples)             |
-| 3. [Icon Sizes](#icon-sizes)                   |
-| 4. [Icon Colors](#icon-colors)                 |
-| 5. [Development Notes](#development-notes)     |
-| 6. [Figma Reference](#figma-reference)         |
+## Table of Contents
+
+- [General Information](#general-information)
+- [Icon Examples](#icon-examples)
+- [Icon Sizes](#icon-sizes)
+- [Icon Colors](#icon-colors)
+- [Development Notes](#development-notes)
+- [Figma Reference](#figma-reference)
 
 ## General Information
 

--- a/src/components/StyleGuide/Spacing.stories.mdx
+++ b/src/components/StyleGuide/Spacing.stories.mdx
@@ -9,15 +9,15 @@ import DSProvider from "../../theme/provider";
 
 # Spacing
 
-| Table of Contents                                    |
-| ---------------------------------------------------- |
-| 1. [General Information](#general-information)       |
-| 2. [Default Spacing Values](#default-spacing-values) |
-| 3. [Page Section Spacing](#page-section-spacing)     |
-| 4. [Grid Spacing](#grid-spacing)                     |
-| 5. [Form Spacing](#form-spacing)                     |
-| 6. [Tabular Data Spacing](#tabular-data-spacing)     |
-| 7. [Figma Reference](#figma-reference)               |
+## Table of Contents
+
+- [General Information](#general-information)
+- [Default Spacing Values](#default-spacing-values)
+- [Page Section Spacing](#page-section-spacing)
+- [Grid Spacing](#grid-spacing)
+- [Form Spacing](#form-spacing)
+- [Tabular Data Spacing](#tabular-data-spacing)
+- [Figma Reference](#figma-reference)
 
 ## General Information
 

--- a/src/components/StyleGuide/Typography.stories.mdx
+++ b/src/components/StyleGuide/Typography.stories.mdx
@@ -10,18 +10,18 @@ import DSProvider from "../../theme/provider";
 
 # Typography
 
-| Table of Contents                              |
-| ---------------------------------------------- |
-| 1. [General Information](#general-information) |
-| 2. [Heading Component](#heading-component)     |
-| 3. [Text Component](#text-component)           |
-| 4. [Font Family](#font-family)                 |
-| 5. [Font Color](#font-color)                   |
-| 6. [Font Weight](#font-weight)                 |
-| 7. [Font Sizes](#font-sizes)                   |
-| 8. [Text Case](#text-case)                     |
-| 9. [Character Count](#character-count)         |
-| 10. [Figma Reference](#figma-reference)        |
+## Table of Contents
+
+- [General Information](#general-information)
+- [Heading Component](#heading-component)
+- [Text Component](#text-component)
+- [Font Family](#font-family)
+- [Font Color](#font-color)
+- [Font Weight](#font-weight)
+- [Font Sizes](#font-sizes)
+- [Text Case](#text-case)
+- [Character Count](#character-count)
+- [Figma Reference](#figma-reference)
 
 ## General Information
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1043](https://jira.nypl.org/browse/DSD-1043)

## This PR does the following:

- Updates the style of the TOC on the `Style Guide` pages to match the style of the TOC on the component pages.
- Adds `<DSProvder />` to the bottom of docs pages that previously did not include the  `<DSProvder>` tag.  This fixes a text styling problem.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
