### PR TITLE
DSD-1075: MultiSelect accessibility fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@nypl/design-system-react-components",
-      "version": "1.0.6",
+      "version": "1.0.7",
       "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/react": ">=1.8.5 <=1.8.8",

--- a/src/components/MultiSelect/MultiSelect.stories.mdx
+++ b/src/components/MultiSelect/MultiSelect.stories.mdx
@@ -122,17 +122,51 @@ If all of the children checkboxes are checked, the parent `isChecked` prop will 
 
 ## Accessibility
 
-The `MultiSelect` variant `listbox` leverages `downshift.js` to assist with accessibility compliance.
-By using Downshift's `useSelect` hook and prop getters `getToggleButtonProps`, `getMenuProps`, `getItemProps` we are able to create a W3 WAI-ARIA compliant listbox that behaves like a select element. Up and down arrow keys are used for navigating through the `MultiSelect` options.
+### ListBox
 
-The MultiSelect variant `dialog` looks similar to the Listbox variant, but because of its “clear” and “apply” buttons, it has some key functionality differences, and accessibility must be handled differently. When the multiselect is open, focus is trapped inside the dropdown menu, and the tab key is used to move through the checkboxes and buttons inside the dialog modal.
+The `MultiSelect` variant `listbox` leverages `downshift.js` to assist with
+accessibility compliance. By using Downshift's `useSelect` hook and prop getters
+`getToggleButtonProps`, `getMenuProps`, `getItemProps` we are able to create a W3
+WAI-ARIA compliant listbox that behaves like a select element. Up and down arrow
+keys are used for navigating through the `MultiSelect` options.
+
+### Dialog
+
+The `MultiSelect` variant `dialog` looks similar to the Listbox variant, but because
+of its “clear” and “apply” buttons, it has some key functionality differences,
+and accessibility must be handled differently. When the `MultiSelect` is open,
+focus is trapped inside the dropdown menu, and the tab key is used to move through
+the checkboxes and buttons inside the dialog modal. The focus trap is performed
+through Chakra's `@chakra-ui/focus-lock` package which uses the `react-focus-lock`
+package under the hood.
+
+NOTE: The `react-focus-lock` package renders two "focus guard" elements and one
+has a `tabindex` set to `1`, in order to perform the focus trap behavior. The
+Storybook accessibility checker [complains](https://dequeuniversity.com/rules/axe/4.4/tabindex?application=axeAPI)
+about this whenever the "dialog" variant is opened.
+
+While this is an accessibility issue, we explicitly want the focus trap behavior
+within the `MultiSelect`. Once the component is closed, the issue goes away. For
+the moment, we will continue to use Chakra's implementation of the `react-focus-lock`
+package.
+
+### Selected Items Count Button
+
+When items are selected in a `MultiSelect`, a button with the count of the selected
+items will display above the main `MultiSelect` button. This count button is
+rendered _after_ the main button but visualy displays above the main button. This
+is performed to prevent the accessibility issue where nested interactive control
+elements are not properly accessible by screen readers.
 
 Resources:
 
 - [downshift.js documentation](https://www.downshift-js.com/)
-- [Reservoir Checkbox Component](http://localhost:6006/?path=/docs/components-form-elements-checkbox--checkbox#accessibility)
+- [Reservoir Checkbox Component](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/components-form-elements-checkbox--checkbox#accessibility)
 - [W3C WAI Listbox Example](https://www.w3.org/TR/2017/WD-wai-aria-practices-1.1-20170628/examples/listbox/listbox.html)
 - [W3C WAI on using ARIA role=dialog](https://www.w3.org/WAI/GL/wiki/Using_ARIA_role%3Ddialog_to_implement_a_modal_dialog_box)
+- [Chakra focus-lock npm](https://www.npmjs.com/package/@chakra-ui/focus-lock)
+- [react-focus-lock npm](https://www.npmjs.com/package/react-focus-lock)
+- [Deque University - Nested interactive controls are not announced by screen readers](https://dequeuniversity.com/rules/axe/4.4/nested-interactive)
 
 ## Using the items prop
 
@@ -312,4 +346,4 @@ of a concern and general ease of use is prefered.
 The hook returns an object containing all the props and state needed to handle the selectedItems.
 That includes the functions `onChange`, `onClear`, `onMixedStateChange` for handling any changes to the selection of items and the current state of the selection: `selectedItems`.
 
-<!-- Find the full documentation under [useMultiSelect](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/hooks-usemultiselect--page) -->
+Find the full documentation under [useMultiSelect](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/hooks-usemultiselect--page).

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -402,9 +402,8 @@ describe("MultiSelect Dialog", () => {
     userEvent.click(countButton);
     // Count button disapeared
     expect(countButton).not.toBeInTheDocument();
-    // @TODO prevent menu toggle on count button click
-    // // Open menu
-    // userEvent.click(screen.getByRole("button", { name: /MultiSelect Label/i }));
+    // Open menu
+    userEvent.click(screen.getByRole("button", { name: /MultiSelect Label/i }));
     // Previously selected elements should not be selected
     expect(screen.getByLabelText("Dogs")).not.toBeChecked();
     expect(screen.getByLabelText("Colors")).not.toBeChecked();
@@ -654,9 +653,8 @@ describe("MultiSelect Listbox", () => {
     userEvent.click(countButton);
     // Count button disapeared
     expect(countButton).not.toBeInTheDocument();
-    // @TODO prevent menu toggle on count button click
-    // // Open menu
-    // userEvent.click(screen.getByRole("button", { name: /MultiSelect Label/i }));
+    // Open menu
+    userEvent.click(screen.getByRole("button", { name: /MultiSelect Label/i }));
     // Previously selected elements should not be selected
     expect(screen.getByLabelText("Dogs")).not.toBeChecked();
     expect(screen.getByLabelText("Colors")).not.toBeChecked();

--- a/src/components/MultiSelect/MultiSelectMenuButton.tsx
+++ b/src/components/MultiSelect/MultiSelectMenuButton.tsx
@@ -52,8 +52,11 @@ const MultiSelectMenuButton = forwardRef<
 
   // Sets the selected items count on the menu button.
   let getSelectedItemsCount;
+  let selectedItemsAriaLabel;
   if (selectedItems[multiSelectId]?.items.length > 0) {
     getSelectedItemsCount = `${selectedItems[multiSelectId].items.length}`;
+    const itemPlural = getSelectedItemsCount === "1" ? "" : "s";
+    selectedItemsAriaLabel = `${getSelectedItemsCount} item${itemPlural} selected`;
   }
   const styles = useMultiStyleConfig("MultiSelectMenuButton", {
     isOpen,
@@ -92,7 +95,7 @@ const MultiSelectMenuButton = forwardRef<
       {getSelectedItemsCount && (
         <Box
           animation={growAnimation}
-          aria-label={`${getSelectedItemsCount} items selected`}
+          aria-label={selectedItemsAriaLabel}
           as="span"
           onClick={onClear}
           onKeyPress={onKeyPress}

--- a/src/components/MultiSelect/MultiSelectMenuButton.tsx
+++ b/src/components/MultiSelect/MultiSelectMenuButton.tsx
@@ -24,6 +24,14 @@ const grow = keyframes`
   from {width: 22px; opacity: 0; }
   to {width: 46px; opacity: 1;}
 `;
+
+/**
+ * The toggle button component used to open and close the `MultiSelect` menu.
+ * A second button is rendered above the main button that displays the current
+ * number of selected items. Clicking on the second button will clear all
+ * the selected items and the main button's close event will not be fired
+ * (as expected).
+ */
 const MultiSelectMenuButton = forwardRef<
   HTMLButtonElement,
   MultiSelectMenuButtonProps
@@ -39,7 +47,6 @@ const MultiSelectMenuButton = forwardRef<
     selectedItems,
     ...rest
   } = props;
-  const styles = useMultiStyleConfig("MultiSelectMenuButton", { isOpen });
   const iconType = isOpen ? "minus" : "plus";
   const growAnimation = `${grow} 150ms ease-out`;
 
@@ -48,6 +55,10 @@ const MultiSelectMenuButton = forwardRef<
   if (selectedItems[multiSelectId]?.items.length > 0) {
     getSelectedItemsCount = `${selectedItems[multiSelectId].items.length}`;
   }
+  const styles = useMultiStyleConfig("MultiSelectMenuButton", {
+    isOpen,
+    hasSelectedItems: getSelectedItemsCount,
+  });
   // We need this for our "fake" button inside the main menu button.
   function onKeyPress(e) {
     const enterOrSpace =
@@ -64,17 +75,24 @@ const MultiSelectMenuButton = forwardRef<
   }
 
   return (
-    <Button
-      buttonType="secondary"
-      id={id}
-      onClick={onMenuToggle}
-      ref={ref}
-      __css={styles.menuButton}
-      {...rest}
-    >
+    <>
+      <Button
+        buttonType="secondary"
+        id={id}
+        onClick={onMenuToggle}
+        ref={ref}
+        __css={styles.menuButton}
+        {...rest}
+      >
+        <Box as="span" title={multiSelectLabel} __css={styles.buttonLabel}>
+          {multiSelectLabel}
+        </Box>
+        <Icon id={`ms-${multiSelectId}-icon`} name={iconType} size="small" />
+      </Button>
       {getSelectedItemsCount && (
         <Box
           animation={growAnimation}
+          aria-label={`${getSelectedItemsCount} items selected`}
           as="span"
           onClick={onClear}
           onKeyPress={onKeyPress}
@@ -94,16 +112,7 @@ const MultiSelectMenuButton = forwardRef<
           />
         </Box>
       )}
-      <Box as="span" title={multiSelectLabel} __css={styles.buttonLabel}>
-        {multiSelectLabel}
-      </Box>
-      <Icon
-        id={`ms-${multiSelectId}-icon`}
-        name={iconType}
-        size="small"
-        __css={styles.toggleIcon}
-      />
-    </Button>
+    </>
   );
 });
 

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -840,51 +840,6 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 3`] = `
       type="button"
     >
       <span
-        className="css-1hgz0t9"
-        onClick={[Function]}
-        onKeyPress={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="css-i6dzq1"
-        >
-          1
-        </span>
-        <svg
-          aria-hidden={true}
-          className="chakra-icon css-h7dq2k"
-          focusable={false}
-          id="ms-multiselect-dialog-test-id-selected-items-count-icon"
-          role="img"
-          title="close icon"
-          viewBox="0 0 24 24"
-        >
-          <g
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <path
-              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-              fill="none"
-              strokeLinecap="round"
-            />
-            <path
-              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-              fill="currentColor"
-              strokeLinecap="round"
-            />
-            <circle
-              cx="12"
-              cy="12"
-              fill="none"
-              r="11.25"
-              strokeMiterlimit="10"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
         className="css-0"
         title="MultiSelect Test Label"
       >
@@ -923,6 +878,52 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 3`] = `
         </g>
       </svg>
     </button>
+    <span
+      aria-label="1 items selected"
+      className="css-1hgz0t9"
+      onClick={[Function]}
+      onKeyPress={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <span
+        className="css-i6dzq1"
+      >
+        1
+      </span>
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-h7dq2k"
+        focusable={false}
+        id="ms-multiselect-dialog-test-id-selected-items-count-icon"
+        role="img"
+        title="close icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
+    </span>
     <div
       aria-labelledby="ms-multiselect-dialog-test-id-menu-button"
       aria-modal={true}
@@ -1585,51 +1586,6 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 4`] = `
       type="button"
     >
       <span
-        className="css-1hgz0t9"
-        onClick={[Function]}
-        onKeyPress={[Function]}
-        role="button"
-        tabIndex={0}
-      >
-        <span
-          className="css-i6dzq1"
-        >
-          2
-        </span>
-        <svg
-          aria-hidden={true}
-          className="chakra-icon css-h7dq2k"
-          focusable={false}
-          id="ms-multiselect-dialog-test-id-selected-items-count-icon"
-          role="img"
-          title="close icon"
-          viewBox="0 0 24 24"
-        >
-          <g
-            stroke="currentColor"
-            strokeWidth="1.5"
-          >
-            <path
-              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-              fill="none"
-              strokeLinecap="round"
-            />
-            <path
-              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-              fill="currentColor"
-              strokeLinecap="round"
-            />
-            <circle
-              cx="12"
-              cy="12"
-              fill="none"
-              r="11.25"
-              strokeMiterlimit="10"
-            />
-          </g>
-        </svg>
-      </span>
-      <span
         className="css-0"
         title="MultiSelect Test Label"
       >
@@ -1668,6 +1624,52 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 4`] = `
         </g>
       </svg>
     </button>
+    <span
+      aria-label="2 items selected"
+      className="css-1hgz0t9"
+      onClick={[Function]}
+      onKeyPress={[Function]}
+      role="button"
+      tabIndex={0}
+    >
+      <span
+        className="css-i6dzq1"
+      >
+        2
+      </span>
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-h7dq2k"
+        focusable={false}
+        id="ms-multiselect-dialog-test-id-selected-items-count-icon"
+        role="img"
+        title="close icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
+    </span>
     <div
       aria-labelledby="ms-multiselect-dialog-test-id-menu-button"
       aria-modal={true}
@@ -2873,51 +2875,6 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 3`] = `
     type="button"
   >
     <span
-      className="css-1hgz0t9"
-      onClick={[Function]}
-      onKeyPress={[Function]}
-      role="button"
-      tabIndex={0}
-    >
-      <span
-        className="css-i6dzq1"
-      >
-        2
-      </span>
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-h7dq2k"
-        focusable={false}
-        id="ms-multiselect-listbox-test-id-selected-items-count-icon"
-        role="img"
-        title="close icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
-        >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-    </span>
-    <span
       className="css-0"
       title="MultiSelect Label"
     >
@@ -2956,6 +2913,52 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 3`] = `
       </g>
     </svg>
   </button>
+  <span
+    aria-label="2 items selected"
+    className="css-1hgz0t9"
+    onClick={[Function]}
+    onKeyPress={[Function]}
+    role="button"
+    tabIndex={0}
+  >
+    <span
+      className="css-i6dzq1"
+    >
+      2
+    </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-h7dq2k"
+      focusable={false}
+      id="ms-multiselect-listbox-test-id-selected-items-count-icon"
+      role="img"
+      title="close icon"
+      viewBox="0 0 24 24"
+    >
+      <g
+        stroke="currentColor"
+        strokeWidth="1.5"
+      >
+        <path
+          d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+          fill="none"
+          strokeLinecap="round"
+        />
+        <path
+          d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+          fill="currentColor"
+          strokeLinecap="round"
+        />
+        <circle
+          cx="12"
+          cy="12"
+          fill="none"
+          r="11.25"
+          strokeMiterlimit="10"
+        />
+      </g>
+    </svg>
+  </span>
   <div
     className="css-0"
   >

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -879,7 +879,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 3`] = `
       </svg>
     </button>
     <span
-      aria-label="1 items selected"
+      aria-label="1 item selected"
       className="css-1hgz0t9"
       onClick={[Function]}
       onKeyPress={[Function]}

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -14,6 +14,7 @@ const MultiSelectMenuButton = {
       textAlign: "left",
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
+      transition: "margin 150ms ease-out",
     },
     menuButton: {
       alignItems: "center",

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -5,10 +5,11 @@ const MultiSelectMenuButton = {
     "selectedItemsCountButton",
     "toggleIcon",
   ],
-  baseStyle: ({ isOpen = false }) => ({
+  baseStyle: ({ hasSelectedItems = false, isOpen = false }) => ({
     buttonLabel: {
       justifyContent: "flex-start",
       overflow: "hidden",
+      marginLeft: hasSelectedItems ? "50px" : "0",
       marginRight: "l",
       textAlign: "left",
       textOverflow: "ellipsis",
@@ -20,7 +21,7 @@ const MultiSelectMenuButton = {
       borderBottomLeftRadius: isOpen ? "0" : "button.default",
       borderBottomRightRadius: isOpen ? "0" : "button.default",
       borderColor: isOpen ? "ui.gray.dark" : "ui.gray.medium",
-      justifyContent: "flex-start",
+      justifyContent: "space-between",
       width: "100%",
       _hover: {
         backgroundColor: isOpen ? "ui.gray.x-light-cool" : "ui.white",
@@ -40,7 +41,10 @@ const MultiSelectMenuButton = {
       flexShrink: 0,
       fontSize: "text.tag",
       justifyContent: "flex-end",
+      left: "15px",
       marginRight: "xs",
+      position: "absolute",
+      top: "10px",
       width: "46px",
       _hover: {
         borderColor: "ui.gray.dark",
@@ -51,7 +55,6 @@ const MultiSelectMenuButton = {
         marginTop: "0",
       },
     },
-    toggleIcon: { position: "absolute", right: "s" },
   }),
 };
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1075](https://jira.nypl.org/browse/DSD-1075)

## This PR does the following:

### Issue 1

This fixes the accessibility issue `"Interactive controls must not be nested"` found by axe when items are selected: the selected count button that renders inside the `MultiSelectMenuButton` is the issue. When using VoiceOver on a Mac, I was able to focus on both the menu button and the selected count button and VoiceOver read _both_ buttons correctly. So, on an n=1 test case, it worked for me. I did not test on other machines with other screenreaders so I do think it's still an issue.

The proposed update is going from

```jsx
<button ...>
  <span role="button">
    <span>2</span><svg>
  </span>
  <span>title</title>
  <svg>
</button>
```

to 

```jsx
<>
  <button ...>
    <span>title</title>
    <svg>
  </button>
  <span role="button">
    <span>2</span><svg>
  </span>
</>
```

The selected count button now renders _after_ the main button but is still visually displayed above the main menu button. This also helps prevent click events from the selected count button from bubbling up to the main button (as noted in two unit tests).

An `aria-label` was also added so that screen readers now read the button with context. Before, it use to say something like "2 MultiSelect Listbox" when it read the entire button which can be confusing. It also just read "2" for the selected count button itself.

<img width="424" alt="Screen Shot 2022-08-08 at 2 15 13 PM" src="https://user-images.githubusercontent.com/1280564/183485752-1199ca8f-e3a3-4b4e-a791-99e38c4d3c2a.png">

With the update:

<img width="708" alt="Screen Shot 2022-08-08 at 12 43 53 PM" src="https://user-images.githubusercontent.com/1280564/183485787-49a288ad-6702-4f5a-ab56-0ab84c7b385c.png">

### Issue 2

The second issue is `"Elements should not have tabindex greater than zero”`. This occurs for the "dialog" variant when it is opened and is caused by the `react-focus-lock` usage (which is used by Chakra's `focus-lock` implementation). I think in this case we can proceed and say that we _know_ this is an issue and a limitation, but also part of expected behavior we want to implement. While is not directly an issue we implemented, it's caused by something we use that implements a behavior we want. Typically, someone would write a VPAT document to list this issue but I'm not sure who would do it in this case or that is the right approach.

For now, let's list this down in the Storybook doc as something we know is an issue but doesn't affect component or app usage when it is rendered. It is only and issue when it is opened but something we can live with since we _want_ to trap focus within the component and the rest of the page is irrelevant.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Yeah, fixes one and explicitly lists down an issue we will have to proceed with until a better solution appears in the near (?) future.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
