### PR TITLE
DSD-1090: Update colormode story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Fixes the styling for the `Image` component in the `Hero` "secondary" variant.
 
+### Updates
+
+- Makes small, clarifying update to `Color Mode` story in Storybook.
+
 ## 1.0.8 (August 11, 2022)
 
 ### Adds

--- a/src/components/StyleGuide/ColorMode.stories.mdx
+++ b/src/components/StyleGuide/ColorMode.stories.mdx
@@ -58,6 +58,9 @@ will return an object with the following properties:
 - `colorMode` is the current color mode of the application as "light" or "dark".
 - `toggleColorMode` is a function that can be used to toggle the color mode.
 
+Note that the `useColorMode` hook must be used inside of the `DSProvider`. If you
+call it outside of the provider, `colorMode` will return a value of `undefined`.
+
 ```tsx
 import { Button, useColorMode } from "@nypl/design-system-react-components";
 

--- a/src/components/StyleGuide/ColorMode.stories.mdx
+++ b/src/components/StyleGuide/ColorMode.stories.mdx
@@ -58,8 +58,8 @@ will return an object with the following properties:
 - `colorMode` is the current color mode of the application as "light" or "dark".
 - `toggleColorMode` is a function that can be used to toggle the color mode.
 
-Note that the `useColorMode` hook must be used inside of the `DSProvider`. If you
-call it outside of the provider, `colorMode` will return a value of `undefined`.
+Note that the `useColorMode` hook must be used inside of the `DSProvider`. If
+called outside of the provider, the value of `colorMode` will be `undefined`.
 
 ```tsx
 import { Button, useColorMode } from "@nypl/design-system-react-components";


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1090](https://jira.nypl.org/browse/DSD-1090).

## This PR does the following:

- Makes a small, clarifying update to the story for `Color Mode` around where to use the `useColorMode` hook (a problem I ran into when trying to implement the hook in Turbine).

## How has this been tested?

- No need to test Storybook text updates, but arguably the principle was tested while implementing `useColorMode` in Turbine.

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
