### PR TITLE
Removes default background color in storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -39,7 +39,6 @@ export const parameters = {
   // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
   actions: { argTypesRegex: "^on.*" },
   backgrounds: {
-    default: "Light mode page background",
     values: [
       { name: "Light mode page background", value: "#FFFFFF" },
       { name: "Light mode default background", value: "#F5F5F5" },

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Link` component's `onClick` event type.
 - Makes small, clarifying update to `Color Mode` story in Storybook.
 - Updates background color values available in Storybook.
+- Removes default background color in Storybook so Chakra dark mode toggle isn't overridden.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,7 +46,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Link` component's `onClick` event type.
 - Makes small, clarifying update to `Color Mode` story in Storybook.
 - Updates background color values available in Storybook.
-- Removes default background color in Storybook so Chakra dark mode toggle isn't overridden.
 
 ### Fixes
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1119](https://jira.nypl.org/browse/DSD-1119) (update to previously merged PR).

## This PR does the following:

- Removes the default background color in Storybook so that the Chakra dark mode toggle works and isn't overridden.

## How has this been tested?

- Locally, in Storybook.

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
