### PR TITLE
DSD-1112: dark mode support for Typography components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `dark mode` support for `background-color` and `color` global styles.
 - Adds `dark mode` color mode support for the `HelperErrorText` and `StatusBadge` components.
+- Adds `dark mode` color mode support for the `Heading` and `List` components.
 
 ## 1.1.0 (Ausut 30, 2022)
 

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -73,6 +73,9 @@ const Heading = {
       : isLowercase
       ? "lowercase"
       : null,
+    _dark: {
+      color: "dark.ui.typography.heading",
+    },
   }),
   // Available variants:
   // h1, h2, h3, h4, h5, h6,

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -37,6 +37,11 @@ export const baseUnorderedStyles = (noStyling = false) => ({
       marginStart: "-1rem",
       width: "1rem",
     },
+    _dark: {
+      _before: {
+        color: "dark.ui.bg.active",
+      },
+    },
   },
 });
 export const baseSectionDescriptionStyles = {
@@ -45,9 +50,15 @@ export const baseSectionDescriptionStyles = {
   paddingStart: "0",
   h2: {
     borderTop: "3px solid",
-    borderColor: "ui.gray.medium",
+    borderColor: "ui.border.default",
     margin: "0",
     padding: "var(--nypl-space-xs) 0 0",
+    _dark: {
+      borderColor: "dark.ui.border.default",
+    },
+  },
+  _dark: {
+    borderColor: "dark.ui.border.default",
   },
 };
 export const baseDescriptionStyles = {
@@ -60,18 +71,25 @@ export const baseDescriptionStyles = {
   },
   dt: {
     borderTop: "1px solid",
-    borderColor: "ui.gray.light-cool",
+    borderColor: "ui.border.default",
     fontWeight: "label.default",
     paddingBottom: { base: "0", md: "s" },
     paddingTop: "s",
     paddingEnd: { md: "table.column" },
+    _dark: {
+      borderColor: "dark.ui.border.default",
+      color: "dark.ui.typography.heading",
+    },
   },
   dd: {
     margin: "0",
     paddingBottom: "s",
     borderTop: { base: "none", md: "1px solid" },
-    borderColor: { md: "ui.gray.light-cool" },
+    borderColor: { md: "ui.border.default" },
     paddingTop: { md: "s" },
+    _dark: {
+      borderColor: { md: "dark.ui.border.default" },
+    },
   },
 };
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1112](https://jira.nypl.org/browse/DSD-1112)

## This PR does the following:

- Adds `dark mode` color mode support for the `Heading` and `List` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The dark mode updates are implemented using the NYPL WCAG compliant `dark` color palette.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
