### PR TITLE
DSD-1104: dark mode support for Basic Elements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `dark mode` support for `background-color` and `color` global styles.
 - Adds `dark mode` color mode support for the `HelperErrorText` and `StatusBadge` components.
+- Adds `dark mode` color mode support for the `Card` and `Hero` components.
 
 ## 1.1.0 (Ausut 30, 2022)
 

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -75,7 +75,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `1.0.6`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/components/HelperErrorText/HelperErrorText.stories.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.mdx
@@ -46,7 +46,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `1.0.6`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -58,7 +58,7 @@ export const imageProps = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.2.0`    |
-| Latest            | `1.0.7`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/components/StatusBadge/StatusBadge.stories.mdx
+++ b/src/components/StatusBadge/StatusBadge.stories.mdx
@@ -40,7 +40,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.18.7`   |
-| Latest            | `1.0.6`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -92,7 +92,10 @@ const Card = {
     const baseBorderStyles = isBordered
       ? {
           border: "1px solid",
-          borderColor: "ui.gray.medium",
+          borderColor: "ui.border.default",
+          _dark: {
+            borderColor: "dark.ui.border.default",
+          }
         }
       : {};
     const bodyPadding = getBodyPaddingStyles({
@@ -130,7 +133,10 @@ const Card = {
       },
       heading: {
         marginBottom: "xs",
-        a: mainActionLink ? { color: "ui.black" } : null,
+        a: mainActionLink ? { color: "ui.typography.heading" } : null,
+        _dark: {
+          a: mainActionLink ? { color: "dark.ui.typography.heading" } : null,
+        }
       },
       ...baseBorderStyles,
       ...layoutStyles,
@@ -175,7 +181,10 @@ const CardActions = {
       ...topBorderStyles,
       ...bottomBorderStyles,
       justifyContent,
-      borderColor: "ui.gray.medium",
+      borderColor: "ui.border.default",
+      _dark: {
+        borderColor: "dark.ui.border.default",
+      }
     };
   },
 };

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -95,7 +95,7 @@ const Card = {
           borderColor: "ui.border.default",
           _dark: {
             borderColor: "dark.ui.border.default",
-          }
+          },
         }
       : {};
     const bodyPadding = getBodyPaddingStyles({
@@ -136,7 +136,7 @@ const Card = {
         a: mainActionLink ? { color: "ui.typography.heading" } : null,
         _dark: {
           a: mainActionLink ? { color: "dark.ui.typography.heading" } : null,
-        }
+        },
       },
       ...baseBorderStyles,
       ...layoutStyles,
@@ -184,7 +184,7 @@ const CardActions = {
       borderColor: "ui.border.default",
       _dark: {
         borderColor: "dark.ui.border.default",
-      }
+      },
     };
   },
 };

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -54,20 +54,36 @@ const secondaryHeadingBase = {
     width: "4000px",
     zIndex: "-1",
   },
+  _dark: {
+    color: "dark.ui.typography.heading",
+  },
 };
+
 // Get all the styles for the specific Secondary variant but
 // update the background color.
-const getSecondaryVariantStyles = (bgColor: string = "ui.black") => ({
-  ...secondaryBase,
-  heading: {
-    ...secondaryHeadingBase,
-    bg: bgColor,
-    _before: {
-      ...secondaryHeadingBase["_before"],
-      bg: bgColor,
+const getSecondaryVariantStyles = (bgColor: string = "") => {
+  const finalBgColor = {
+    light: bgColor ? bgColor : "ui.black",
+    dark: bgColor ? `dark.${bgColor}` : "dark.ui.bg.active",
+  };
+  return {
+    ...secondaryBase,
+    heading: {
+      ...secondaryHeadingBase,
+      // bg: finalBgColor.light,
+      _before: {
+        ...secondaryHeadingBase["_before"],
+        bg: finalBgColor.light,
+      },
+      _dark: {
+        // bg: finalBgColor.dark,
+        _before: {
+          bg: finalBgColor.dark,
+        },
+      },
     },
-  },
-});
+  };
+};
 // Variant styling
 const primary = {
   alignItems: "center",
@@ -100,6 +116,10 @@ const primary = {
     bodyText: {
       marginBottom: "0",
     },
+    _dark: {
+      bg: "dark.ui.bg.default",
+      color: "dark.ui.typography.body",
+    },
   },
 };
 const secondary = getSecondaryVariantStyles();
@@ -123,6 +143,9 @@ const tertiary = {
       marginBottom: "0",
       marginTop: "s",
     },
+    _dark: {
+      color: "dark.ui.typography.body",
+    },
   },
   heading: {
     marginBottom: "0",
@@ -132,6 +155,9 @@ const tertiary = {
   },
   p: {
     marginBottom: "0",
+  },
+  _dark: {
+    bg: "dark.ui.bg.hover",
   },
 };
 const campaign = {
@@ -160,6 +186,10 @@ const campaign = {
     maxWidth: { md: "1280px" },
     position: { md: "relative" },
     top: { md: "xxl" },
+    _dark: {
+      bg: "dark.ui.bg.default",
+      color: "dark.ui.typography.body",
+    },
   },
   a: {
     color: "inherit",
@@ -221,6 +251,9 @@ const fiftyFifty = {
 const Hero = {
   baseStyle: {
     bg: "ui.gray.x-light-cool",
+    _dark: {
+      bg: "dark.ui.bg.default",
+    },
   },
   // Available variants:
   variants: {

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -70,13 +70,11 @@ const getSecondaryVariantStyles = (bgColor: string = "") => {
     ...secondaryBase,
     heading: {
       ...secondaryHeadingBase,
-      // bg: finalBgColor.light,
       _before: {
         ...secondaryHeadingBase["_before"],
         bg: finalBgColor.light,
       },
       _dark: {
-        // bg: finalBgColor.dark,
         _before: {
           bg: finalBgColor.dark,
         },

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -1,4 +1,5 @@
 import { Colors } from "@chakra-ui/react";
+import { hexToRGB } from "../../utils/utils";
 
 /**
  * All colors can be found in Storybook:
@@ -33,9 +34,94 @@ const grayxLightCool = "#F5F5F5";
 const grayxxLightCool = "#FAFAFA";
 const brandPrimary = "#C60917";
 const brandSecondary = "#760000";
+const blogsPrimary = grayLightCool;
+const blogsSecondary = grayMedium;
+const educationPrimary = "#1D62E6";
+const educationSecondary = "#2540A4";
+const researchPrimary = "#00838A";
+const researchSecondary = "#006166";
+const researchLibraryLpa = "#005D53";
+const researchLibrarySchomburg = "#A03E31";
+const researchLibrarySchwartzman = brandSecondary;
+const whatsOnPrimary = "#242424";
+const whatsOnSecondary = black;
+
 const brandObj = {
-  primary: brandPrimary,
-  secondary: brandSecondary,
+  light: {
+    primary: brandPrimary,
+    secondary: brandSecondary,
+  },
+  dark: {
+    primary: hexToRGB(brandPrimary, 0.2),
+    secondary: hexToRGB(brandSecondary, 0.2),
+  },
+};
+
+const blogsObj = {
+  light: {
+    primary: blogsPrimary,
+    secondary: blogsSecondary,
+  },
+  dark: {
+    primary: hexToRGB(blogsPrimary, 0.2),
+    secondary: hexToRGB(blogsSecondary, 0.2),
+  },
+};
+
+const booksAndMoreObj = {
+  light: brandObj.light,
+  dark: brandObj.dark,
+};
+
+const educationObj = {
+  light: {
+    primary: educationPrimary,
+    secondary: educationSecondary,
+  },
+  dark: {
+    primary: hexToRGB(educationPrimary, 0.2),
+    secondary: hexToRGB(educationSecondary, 0.2),
+  },
+};
+
+const locationsObj = {
+  light: brandObj.light,
+  dark: brandObj.dark,
+};
+
+const researchObj = {
+  light: {
+    primary: researchPrimary,
+    secondary: researchSecondary,
+  },
+  dark: {
+    primary: hexToRGB(researchPrimary, 0.2),
+    secondary: hexToRGB(researchSecondary, 0.2),
+  },
+};
+
+const researchLibraryObj = {
+  light: {
+    lpa: researchLibraryLpa,
+    schomburg: researchLibrarySchomburg,
+    schwatzman: researchLibrarySchwartzman,
+  },
+  dark: {
+    lpa: hexToRGB(researchLibraryLpa, 0.2),
+    schomburg: hexToRGB(researchLibrarySchomburg, 0.2),
+    schwatzman: hexToRGB(researchLibrarySchwartzman, 0.2),
+  },
+};
+
+const whatsOnObj = {
+  light: {
+    primary: whatsOnPrimary,
+    secondary: whatsOnSecondary,
+  },
+  dark: {
+    primary: hexToRGB(grayLightCool, 0.2),
+    secondary: hexToRGB(white, 0.05),
+  },
 };
 
 const colors: Colors = {
@@ -103,8 +189,17 @@ const colors: Colors = {
     },
   },
 
-  // dark mode ui fills
+  // dark mode fills
   dark: {
+    section: {
+      blogs: blogsObj.dark,
+      "books-and-more": booksAndMoreObj.dark,
+      education: educationObj.dark,
+      locations: locationsObj.dark,
+      research: researchObj.dark,
+      "research-library": researchLibraryObj.dark,
+      "whats-on": whatsOnObj.dark,
+    },
     ui: {
       /// State and link utilities
       disabled: {
@@ -152,49 +247,33 @@ const colors: Colors = {
   },
 
   /** Brand fills are the NYPL primary and secondary colors. */
-  brand: brandObj,
+  brand: brandObj.light,
 
   /** Brand fills for sections on NYPL pages. */
   section: {
     /** Blogs is used for the Blogs section. */
-    blogs: {
-      primary: grayLightCool,
-      secondary: grayMedium,
-    },
+    blogs: blogsObj.light,
 
     /** Books and More is used for the Catalog, Staff Picks, Recommendations,
      * New Arrivals, and E-Book Central. */
-    "books-and-more": brandObj,
+    "books-and-more": booksAndMoreObj.light,
 
     /** Education is used for the Education section front and associated
      * sub-sections. */
-    education: {
-      primary: "#1D62E6",
-      secondary: "#2540A4",
-    },
+    education: educationObj.light,
 
     /** Locations is used for Location Finder and all branch pages with
      * the exceptions of some research libraries. */
-    locations: brandObj,
+    locations: locationsObj.light,
 
     /** Research is used for the Research Catalog and SCC. */
-    research: {
-      primary: "#00838A",
-      secondary: "#006166",
-    },
+    research: researchObj.light,
 
     /** Research libraries with specific brand colors to adhere to. */
-    "research-library": {
-      lpa: "#005D53",
-      schomburg: "#A03E31",
-      schwartzman: brandSecondary,
-    },
+    "research-library": researchLibraryObj.light,
 
     /** What's On is used for Exhibitions & Events. */
-    "whats-on": {
-      primary: "#242424",
-      secondary: black,
-    },
+    "whats-on": whatsOnObj.light,
   },
 
   /**

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -83,15 +83,11 @@ export const getAriaAttrs = ({
   return ariaAttributes;
 };
 
-/** Convert a hax color value to an rgb or rgba value */
+/** Convert a hex color value to an rgb or rgba value */
 export const hexToRGB = (hex: string, alpha: number) => {
   const r = parseInt(hex.slice(1, 3), 16),
     g = parseInt(hex.slice(3, 5), 16),
     b = parseInt(hex.slice(5, 7), 16);
-
-  if (alpha) {
-    return "rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")";
-  } else {
-    return "rgb(" + r + ", " + g + ", " + b + ")";
-  }
+  const rgb = `${r}, ${g}, ${b}`;
+  return alpha ? `rgba(${rgb},${alpha})` : `rgb(${rgb})`;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -82,3 +82,16 @@ export const getAriaAttrs = ({
 
   return ariaAttributes;
 };
+
+/** Convert a hax color value to an rgb or rgba value */
+export const hexToRGB = (hex: string, alpha: number) => {
+  const r = parseInt(hex.slice(1, 3), 16),
+    g = parseInt(hex.slice(3, 5), 16),
+    b = parseInt(hex.slice(5, 7), 16);
+
+  if (alpha) {
+    return "rgba(" + r + ", " + g + ", " + b + ", " + alpha + ")";
+  } else {
+    return "rgb(" + r + ", " + g + ", " + b + ")";
+  }
+};


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1104](https://jira.nypl.org/browse/DSD-1104)

## This PR does the following:

- Adds `dark mode` color mode support for the `Card` and `Hero` components.
- Corrects the `Latest Version` number for the `HelperErrorText` and `StatusBadge` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The dark mode updates are implemented using the NYPL WCAG compliant `dark` color palette.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
