### PR TITLE
DSD-1113: text variant for Button component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,17 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `text` variant in the `Button` component.
+
 ### Fixes
 
 - Fixes a bug where the `defaultValue` for a `TextInput` component was not being passed correctly to the Chakra input element.
+
+### Deprecates
+
+- Deprecates the `link` variant in the `Button` component.
 
 ## 1.1.0 (Ausut 30, 2022)
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -109,7 +109,7 @@ export const iconNames = [
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.0.6`    |
+| Latest            | `1.1.1`    |
 
 ## Table of Contents
 
@@ -130,11 +130,12 @@ that can be rendered.
 
 - `"primary"` is used for actions that move the user forward. This is the default.
 - `"secondary"` is used for actions that move the user back, such as cancellations.
-- `"callout"` is used for call to action text such as "Donate".
+- `"text"` is used for equally weighted actions in a text based list.
 - `"pill"` is used for equally weighted actions within cards and always in a set.
-- `"link"` is used for equally weighted actions in a text based list.
+- `"callout"` is used for call to action text such as "Donate".
 - `"noBrand"` is a variant used when there is no brand and will display the
   background color as black.
+- `"link"` has been deprecated and should not be used.
 
 When one and only one `Icon` component is passed inside a `Button` component with
 no text, it will automatically be configured to use the `"iconOnly"` type.
@@ -308,21 +309,21 @@ The variations modified by the `buttonType` prop:
 <Canvas>
   <DSProvider>
     <ButtonGroup>
-      <Button id="primary-btn">primary</Button>
+      <Button id="primary-btn">Primary</Button>
       <Button buttonType="secondary" id="secondary-btn">
-        secondary
+        Secondary
       </Button>
-      <Button buttonType="callout" id="callout-btn">
-        callout
+      <Button buttonType="text" id="text-btn">
+        Text
       </Button>
       <Button buttonType="pill" id="pill-btn">
-        pill
+        Pill
       </Button>
-      <Button buttonType="link" id="link-btn">
-        link
+      <Button buttonType="callout" id="callout-btn">
+        Callout
       </Button>
       <Button buttonType="noBrand" id="nobrand-btn">
-        noBrand
+        No Brand
       </Button>
     </ButtonGroup>
   </DSProvider>

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -140,10 +140,10 @@ describe("Button Snapshot", () => {
         </Button>
       )
       .toJSON();
-    const link = renderer
+    const text = renderer
       .create(
-        <Button id="button" onClick={jest.fn()} buttonType="link">
-          Link
+        <Button id="button" onClick={jest.fn()} buttonType="text">
+          Text
         </Button>
       )
       .toJSON();
@@ -173,7 +173,7 @@ describe("Button Snapshot", () => {
     expect(secondary).toMatchSnapshot();
     expect(callout).toMatchSnapshot();
     expect(pill).toMatchSnapshot();
-    expect(link).toMatchSnapshot();
+    expect(text).toMatchSnapshot();
     expect(noBrand).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -11,10 +11,11 @@ export type ButtonElementType = "submit" | "button" | "reset";
 export type ButtonTypes =
   | "primary"
   | "secondary"
+  | "text"
   | "callout"
   | "pill"
-  | "link"
-  | "noBrand";
+  | "noBrand"
+  | "link";
 
 interface ButtonProps {
   /** The button variation to render based on the `ButtonTypes` type.*/

--- a/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`Button Snapshot Renders the UI snapshot correctly 6`] = `
   onClick={[MockFunction]}
   type="button"
 >
-  Link
+  Text
 </button>
 `;
 

--- a/src/components/StyleGuide/Buttons.stories.mdx
+++ b/src/components/StyleGuide/Buttons.stories.mdx
@@ -96,14 +96,14 @@ component.
       <Button buttonType="secondary" id="secondary">
         Secondary Button
       </Button>
-      <Button buttonType="callout" id="callout">
-        Callout Button
+      <Button buttonType="text" id="text">
+        Text Button
       </Button>
       <Button buttonType="pill" id="pill">
         Pill Button
       </Button>
-      <Button buttonType="link" id="link">
-        Link Button
+      <Button buttonType="callout" id="callout">
+        Callout Button
       </Button>
       <Button buttonType="noBrand" id="noBrand">
         NoBrand Button
@@ -120,13 +120,13 @@ component.
 ### Secondary
 
 - used for actions that move the user back, such as a form cancel button
-- often paired with a Primary button
+- often paired with a `Primary` button
 - Visual Treatment: rectangular, outlined
 
-### Callout
+### Text
 
-- used for call to actions such as donation buttons
-- Visual Treatment: rectangular, NYPL red background
+- used for equally weighted actions
+- Visual Treatment: plain text only without an underline
 
 ### Pill
 
@@ -134,10 +134,10 @@ component.
 - should only be used for buttons that are displayed in a set (i.e. never use for a singleton button)
 - Visual Treatment: rounded, outlined
 
-### Link
+### Callout
 
-- used for equally weighted actions
-- Visual Treatment: text link with underline
+- used for call to actions such as donation buttons
+- Visual Treatment: rectangular, NYPL red background
 
 ### NoBrand
 

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -7,6 +7,7 @@ const baseStyle = {
   display: "flex",
   cursor: "pointer",
   color: "ui.white",
+  fontWeight: "button.default",
   height: "10",
   justifyContent: "center",
   lineHeight: "1.5",
@@ -16,7 +17,6 @@ const baseStyle = {
   px: "inset.default",
   textDecoration: "none",
   wordWrap: "normal",
-  fontWeight: "button.default",
   svg: {
     fill: "currentColor",
   },
@@ -29,17 +29,17 @@ const baseStyle = {
   _disabled: {
     bg: "ui.gray.light-cool",
     color: "ui.gray.dark",
-    pointerEvents: "none",
     opacity: "1",
+    pointerEvents: "none",
   },
 };
 // Styles for different visual variants:
 // primary, secondary, link, pill, iconOnly, callout, searchbar, noBrand
 const primary = {
   bg: "ui.link.primary",
-  minWidth: "none",
   height: "none",
   fontSize: "button.default",
+  minWidth: "none",
 };
 const secondary = {
   bg: "ui.white",
@@ -57,9 +57,21 @@ const secondary = {
 };
 const link = {
   bg: "transparent",
-  lineHeight: "2.5",
   color: "ui.link.primary",
+  lineHeight: "2.5",
   textDecoration: "underline",
+  _disabled: {
+    bg: "transparent",
+  },
+  _hover: {
+    bg: "transparent",
+    color: "ui.link.secondary",
+  },
+};
+const text = {
+  bg: "transparent",
+  color: "ui.link.primary",
+  fontSize: "button.default",
   _disabled: {
     bg: "transparent",
   },
@@ -72,11 +84,11 @@ const pill = {
   bg: "ui.white",
   border: "1px solid",
   borderColor: "ui.gray.light-cool",
-  color: "inherit",
   borderRadius: "pill",
+  color: "inherit",
+  fontSize: "button.default",
   py: "inset.narrow",
   px: "inset.wide",
-  fontSize: "button.default",
   _hover: {
     bg: "ui.gray.xx-light-cool",
     borderColor: "ui.gray.medium",
@@ -122,6 +134,7 @@ const Button = {
   variants: {
     primary,
     secondary,
+    text,
     link,
     pill,
     iconOnly,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1113](https://jira.nypl.org/browse/DSD-1113)

## This PR does the following:

- Adds the `text` variant in the `Button` component.
- Deprecates the `link` variant in the `Button` component.
- Updates the Button Style Guide to include the new `text` variant and to remove the deprecated `link` variant.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
