### PR TITLE
DSD-1115: remove Tooltip drop shadow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds the `text` variant in the `Button` component.
 
+### Updates
+
+- Updates the  `Tooltip` component to remove the dropshadow effect.
+
 ### Fixes
 
 - Fixes a bug where the `defaultValue` for a `TextInput` component was not being passed correctly to the Chakra input element.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Updates
 
-- Updates the  `Tooltip` component to remove the dropshadow effect.
+- Updates the `Tooltip` component to remove the dropshadow effect.
 
 ### Fixes
 

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -48,7 +48,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `1.1.0`    |
-| Latest            | `1.1.0`    |
+| Latest            | `1.1.2`    |
 
 ## Table of Contents
 

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -6,6 +6,7 @@ const Tooltip = {
   baseStyle: {
     [$bg.variable]: "colors.ui.gray.xx-dark",
     borderRadius: "4px",
+    boxShadow: "none",
     color: "ui.white",
     fontSize: "text.tag",
     marginBottom: "xxs",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1115](https://jira.nypl.org/browse/DSD-1115)

## This PR does the following:

- Updates the `Tooltip` component to remove the dropshadow effect.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
