### PR TITLE
DSD-1113: warning message for deprecated variant

### DIFF
--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -325,6 +325,9 @@ The variations modified by the `buttonType` prop:
       <Button buttonType="noBrand" id="nobrand-btn">
         No Brand
       </Button>
+      <Button buttonType="link" id="link-btn">
+        Link (deprecated)
+      </Button>
     </ButtonGroup>
   </DSProvider>
 </Canvas>

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -64,6 +64,12 @@ export const Button = chakra(
         );
       }
 
+      if (buttonType === "link") {
+        console.warn(
+          "NYPL Reservoir Button: The 'link' value for the 'buttonType' prop has been deprecated."
+        );
+      }
+
       React.Children.map(
         children as JSX.Element,
         (child: React.ReactElement) => {

--- a/src/components/Header/components/HeaderLoginButton.tsx
+++ b/src/components/Header/components/HeaderLoginButton.tsx
@@ -64,7 +64,7 @@ const HeaderLoginButton = chakra(
         <FocusLock isDisabled={!isOpen}>
           <Button
             aria-label={desktopButtonLabel}
-            buttonType="link"
+            buttonType="text"
             id="loginButton"
             onClick={() => {
               gaUtils.trackEvent(gaAction, gaLabel);

--- a/src/components/Header/components/HeaderMobileNavButton.tsx
+++ b/src/components/Header/components/HeaderMobileNavButton.tsx
@@ -26,7 +26,7 @@ const HeaderMobileNavButton = chakra(() => {
           aria-haspopup="true"
           aria-label={isOpen ? "Close Navigation" : "Open Navigation"}
           aria-expanded={isOpen ? true : null}
-          buttonType="link"
+          buttonType="text"
           id="mobileNav-btn"
           onClick={() => {
             gaUtils.trackEvent("Click", "Mobile mobileMenu");

--- a/src/components/Header/components/HeaderSearchButton.tsx
+++ b/src/components/Header/components/HeaderSearchButton.tsx
@@ -39,7 +39,7 @@ const HeaderSearchButton = chakra(
             aria-haspopup="true"
             aria-label={labelText}
             aria-expanded={isOpen ? true : null}
-            buttonType="link"
+            buttonType="text"
             id="searchButton"
             onClick={() => {
               gaUtils.trackEvent(gaAction, gaLabel);

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -163,7 +163,7 @@ export const Notification = chakra(
     const dismissibleButton = dismissible && (
       <Button
         aria-label="Close the notification"
-        buttonType="link"
+        buttonType="text"
         id={`${id}-notification-dismissible-button`}
         onClick={handleClose}
         __css={styles.dismissibleButton}

--- a/src/theme/components/header/headerSearchButton.ts
+++ b/src/theme/components/header/headerSearchButton.ts
@@ -10,6 +10,7 @@ const HeaderSearchButton = {
     fontWeight: "medium",
     minHeight: { md: "40px" },
     minWidth: { md: "80px" },
+    px: "0",
     textDecoration: "none",
     span: {
       alignItems: "center",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1113](https://jira.nypl.org/browse/DSD-1113)

## This PR does the following:

- Added a warning message related to the use of the deprecated `link` variant.
- Updated any DS components that were using the deprecated `link` variant to now use the `text` variant.  Only one component required additional CSS changes.
- Nothing was added to the CHANGELOG for this update, as this should have been included in the original pull request for DSD-1113.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
