### PR TITLE
DSD-1142: Accordion always render content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates whehter the content inside of an `Accordion` is always rendered through the `isAlwaysRendered` prop.
+
 ## 1.1.1 (September 19, 2022)
 
 ### Adds

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -10,7 +10,10 @@ import { withDesign } from "storybook-addon-designs";
 
 import Accordion from "./Accordion";
 import Card, { CardHeading, CardContent } from "../Card/Card";
+import Checkbox from "../Checkbox/Checkbox";
+import CheckboxGroup from "../CheckboxGroup/CheckboxGroup";
 import { getCategory } from "../../utils/componentCategories";
+import DSProvider from "../../theme/provider";
 
 <Meta
   title={getCategory("Accordion")}
@@ -27,6 +30,7 @@ import { getCategory } from "../../utils/componentCategories";
     accordionData: { control: false },
     id: { control: false },
     isDefaultOpen: { table: { defaultValue: { summary: false } } },
+    isAlwaysRendered: { table: { defaultValue: { summary: false } } },
     panelMaxHeight: { control: { type: "text" } },
   }}
 />
@@ -36,7 +40,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.1.0`    |
-| Latest            | `1.0.8`    |
+| Latest            | `1.1.2`    |
 
 ## Table of Contents
 
@@ -138,6 +142,7 @@ export const accordionData = [
       accordionData: accordionData,
       id: "accordion-id",
       isDefaultOpen: false,
+      isAlwaysRendered: false,
       panelMaxHeight: undefined,
     }}
   >
@@ -391,4 +396,43 @@ Example with multiple paragraphs
   <Story name="panelMaxHeight Example With Long Text">
     <Accordion accordionData={accordionTextData} panelMaxHeight="100px" />
   </Story>
+</Canvas>
+
+## Always Render the Accordion Content
+
+export const AccordionAlwaysRender = () => {
+  const onChange = (data) => {
+    console.log(data);
+  };
+  const accordionData = [
+    {
+      accordionType: "default",
+      label: "Subjects",
+      panel: (
+        <CheckboxGroup
+          id="controlled-example"
+          labelText="Checkbox Group"
+          name="CheckboxExample"
+          defaultValue={["2"]}
+          onChange={onChange}
+        >
+          <Checkbox value="2" labelText="Checkbox 2" />
+          <Checkbox value="3" labelText="Checkbox 3" />
+          <Checkbox value="4" labelText="Checkbox 4" />
+        </CheckboxGroup>
+      ),
+    },
+  ];
+  return (
+    <>
+      <Accordion accordionData={accordionData} />
+      <Accordion accordionData={accordionData} isAlwaysRendered />
+    </>
+  );
+};
+
+<Canvas>
+  <DSProvider>
+    <AccordionAlwaysRender />
+  </DSProvider>
 </Canvas>

--- a/src/components/Accordion/Accordion.stories.mdx
+++ b/src/components/Accordion/Accordion.stories.mdx
@@ -1,3 +1,4 @@
+import { VStack } from "@chakra-ui/react";
 import {
   ArgsTable,
   Canvas,
@@ -12,6 +13,7 @@ import Accordion from "./Accordion";
 import Card, { CardHeading, CardContent } from "../Card/Card";
 import Checkbox from "../Checkbox/Checkbox";
 import CheckboxGroup from "../CheckboxGroup/CheckboxGroup";
+import Heading from "../Heading/Heading";
 import { getCategory } from "../../utils/componentCategories";
 import DSProvider from "../../theme/provider";
 
@@ -400,34 +402,51 @@ Example with multiple paragraphs
 
 ## Always Render the Accordion Content
 
+By default, the content in an `Accordion` is only rendered when it is opened. When
+it is closed, the content gets removed from the DOM. This is an intentional
+optimization. However, there will be occasions when you want to always render the
+content inside an `Accordion` whether it's opened or closed. Use the
+`isAlwaysRendered` prop to always render the `Accordion`'s content.
+
+In the following examples, the first `Accordion` has the default behavior where
+the content is removed when it is closed. The second `Accordion` always renders
+its content. This is important in this scenario because we want to keep the state
+of the content when it is closed. Click on subjects inside both `Accordion`s and
+toggle them closed and opened to see the difference.
+
 export const AccordionAlwaysRender = () => {
   const onChange = (data) => {
     console.log(data);
   };
-  const accordionData = [
+  const accordionData = (key) => [
     {
       accordionType: "default",
       label: "Subjects",
       panel: (
         <CheckboxGroup
-          id="controlled-example"
-          labelText="Checkbox Group"
-          name="CheckboxExample"
-          defaultValue={["2"]}
+          id="accordion-checkbox-example"
+          labelText="Subjects"
+          name={`accordionExample${key}`}
+          showLabel={false}
+          defaultValue={["music"]}
           onChange={onChange}
         >
-          <Checkbox value="2" labelText="Checkbox 2" />
-          <Checkbox value="3" labelText="Checkbox 3" />
-          <Checkbox value="4" labelText="Checkbox 4" />
+          <Checkbox value="art" labelText="Art" />
+          <Checkbox value="chemistry" labelText="Chemistry" />
+          <Checkbox value="history" labelText="History" />
+          <Checkbox value="music" labelText="Music" />
+          <Checkbox value="science" labelText="Science" />
         </CheckboxGroup>
       ),
     },
   ];
   return (
-    <>
-      <Accordion accordionData={accordionData} />
-      <Accordion accordionData={accordionData} isAlwaysRendered />
-    </>
+    <VStack align="stretch" spacing="s">
+      <Heading level="three">Accordion panel is removed when closed</Heading>
+      <Accordion accordionData={accordionData(0)} />
+      <Heading level="three">Accordion panel is always rendered</Heading>
+      <Accordion accordionData={accordionData(1)} isAlwaysRendered />
+    </VStack>
   );
 };
 

--- a/src/components/Accordion/Accordion.test.tsx
+++ b/src/components/Accordion/Accordion.test.tsx
@@ -28,6 +28,27 @@ describe("Accordion Accessibility", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
+  it("passes axe accessibility test for one item when it is always rendered", async () => {
+    const { container } = render(
+      <Accordion
+        accordionData={[
+          {
+            label: "Tom Nook",
+            panel: (
+              <p>
+                Tom Nook, <b>known in Japan as Tanukichi</b>, is a fictional
+                character in the Animal Crossing series who operates the village
+                store.
+              </p>
+            ),
+          },
+        ]}
+        isAlwaysRendered
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
   it("passes axe accessibility test for multiple items", async () => {
     const { container } = render(
       <Accordion
@@ -122,6 +143,17 @@ describe("Accordion", () => {
 
     accordionPanelContent = screen.queryByText(/known in Japan as Tanukichi/i);
     expect(accordionLabel).toHaveAttribute("aria-expanded", "true");
+    expect(accordionPanelContent).toBeInTheDocument();
+  });
+
+  it("always renders its content when isAlwaysRendered is true", () => {
+    render(<Accordion accordionData={[accordionData[0]]} isAlwaysRendered />);
+
+    const accordionLabel = screen.getByRole("button", { name: "Tom Nook" });
+    let accordionPanelContent = screen.queryByText(
+      /known in Japan as Tanukichi/i
+    );
+    expect(accordionLabel).toHaveAttribute("aria-expanded", "false");
     expect(accordionPanelContent).toBeInTheDocument();
   });
 

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -52,8 +52,8 @@ const getIcon = (isExpanded = false, index: number, id: string) => {
 const getElementsFromData = (
   data: AccordionDataProps[] = [],
   id: string,
-  panelMaxHeight: string,
-  isAlwaysRendered: boolean = false
+  isAlwaysRendered: boolean = false,
+  panelMaxHeight: string
 ) => {
   const colorMap = {
     default: "ui.white",
@@ -167,8 +167,8 @@ export const Accordion = chakra(
         {getElementsFromData(
           accordionData,
           id,
-          panelMaxHeight,
-          isAlwaysRendered
+          isAlwaysRendered,
+          panelMaxHeight
         )}
       </ChakraAccordion>
     );

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -23,6 +23,9 @@ export interface AccordionProps {
   id?: string;
   /** Whether the accordion is open by default only on its initial rendering */
   isDefaultOpen?: boolean;
+  /** Whether the contents of the Accordion should always be rendered.
+   *  Useful for form-components. `false` by default. */
+  isAlwaysRendered?: boolean;
   /** Sets max height of accordion panel. This value should be entered with the
    * formatting of a CSS height attribute (ex. 100px, 8rem). If height of content
    * within accordion panel is greater than height set by panelMaxHeight, a
@@ -49,7 +52,8 @@ const getIcon = (isExpanded = false, index: number, id: string) => {
 const getElementsFromData = (
   data: AccordionDataProps[] = [],
   id: string,
-  panelMaxHeight: string
+  panelMaxHeight: string,
+  isAlwaysRendered: boolean = false
 ) => {
   const colorMap = {
     default: "ui.white",
@@ -125,7 +129,7 @@ const getElementsFromData = (
                 </Box>
                 {getIcon(isExpanded, index, id)}
               </AccordionButton>
-              {isExpanded && panel}
+              {(isAlwaysRendered || isExpanded) && panel}
             </>
           );
         }}
@@ -144,6 +148,7 @@ export const Accordion = chakra(
       accordionData,
       id,
       isDefaultOpen = false,
+      isAlwaysRendered = false,
       panelMaxHeight,
       ...rest
     } = props;
@@ -159,7 +164,12 @@ export const Accordion = chakra(
         ref={ref}
         {...rest}
       >
-        {getElementsFromData(accordionData, id, panelMaxHeight)}
+        {getElementsFromData(
+          accordionData,
+          id,
+          panelMaxHeight,
+          isAlwaysRendered
+        )}
       </ChakraAccordion>
     );
   })


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1142](https://jira.nypl.org/browse/DSD-1142)

## This PR does the following:

- Adds a prop to always render content inside of an `Accordion`.
- This came up in MLN where checkboxes were checked, the `Accordion` closed, and then when it was opened again, the checked status was gone. For form-components, we want to always render the content so the state can persist when the `Accordion` is closed and opened.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
