### PR TITLE
DSD-1124: Fixing placement of links in the Footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the padding and placement of the links in the `Footer` component.
+
 ## 1.1.1 (September 19, 2022)
 
 ### Adds

--- a/src/theme/components/footer.ts
+++ b/src/theme/components/footer.ts
@@ -23,7 +23,7 @@ const Footer = {
       fontSize: { base: "14px", md: "13px", lg: "14px" },
       fontWeight: { lg: "400" },
       lineHeight: { base: "18px", md: "23px", lg: "30px" },
-      marginRight: { xl: "70px" },
+      marginRight: { xl: "100px" },
       order: { base: "2", md: "1", xl: "2" },
       textAlign: { base: "right", md: "left" },
       width: { base: "100%", md: "auto" },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1124](https://jira.nypl.org/browse/DSD-1124)

## This PR does the following:

- Updates the placement of the sitewide links in the `Footer` to better align with the production footer on nypl.org.

<img width="1589" alt="Screen Shot 2022-09-21 at 10 27 55 AM" src="https://user-images.githubusercontent.com/1280564/191533616-9da03ee0-4dc0-44ba-a038-733d5a2e0a81.png">

- Note: there is a visual difference in the DS `Footer` at the 1280px breakpoint due to the differences in breakpoint values. This is visually different but we should stay with the new DS breakpoints rather than use the older breakpoints.

The bottom is the DS `Footer`.
<img width="1282" alt="Screen Shot 2022-09-21 at 10 27 34 AM" src="https://user-images.githubusercontent.com/1280564/191533684-d2b79e5a-7b76-4ad8-9f62-82d3ff014439.png">


## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
