### PR TITLE
DSD-1146: Allow CheckboxGroup to update programmatically

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `value` prop to the `CheckboxGroup` component to programmatically
+  update the values of the `Checkbox`es within it.
+
 ### Updates
 
 - Updates the colors for the `secondary` and `iconOnly` variants of the `Button` component.

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -469,18 +469,21 @@ const onSubmit = () => {
 ### Programmatically Update
 
 Within the `CheckboxGroup`, individual `Checkbox`es can be updated programmatically
-through the `value` prop. Like the `defaultValue` prop, the `value` prop also
-accepts an array of strings.
+through the `value` prop. Similar to the `defaultValue` prop, the `value` prop
+also accepts an array of strings.
 
 When passing selected values through the `value` prop, the consuming app is now
 controlling the state of the values. By default, the `CheckboxGroup` component
 returns the value(s) checked to the consuming app through the `onChange` callback.
-Note that the `defaultValue` prop is not necessary unless if there are values
-that should be checked when the component first renders.
+Note that the `defaultValue` prop is not necessary unless there are values that
+should be checked when the component first renders.
 
 In the following example, the `CheckboxGroup` component works as expected, but
 now there are three (3) additional buttons that can update the selected checkboxes
-within the `CheckboxGroup` component.
+within the `CheckboxGroup` component. Open the browser's console to see the
+`onChange` callback being called _only_ when checkboxes are checked or unchecked.
+Clicking on a button does not trigger the `onChange` callback but does update
+the values.
 
 ```jsx
 export function CheckboxGroupValuesUpdateExample() {
@@ -492,7 +495,7 @@ export function CheckboxGroupValuesUpdateExample() {
     setValue(["math", "music", "magic"]);
   };
   const onClick3 = () => {
-    setValue(["physics", "science", "chemisty"]);
+    setValue(["physics", "science", "chemistry"]);
   };
   const onChange = (data) => {
     setValue(data);
@@ -509,7 +512,7 @@ export function CheckboxGroupValuesUpdateExample() {
           "math", "music", "magic"
         </Button>
         <Button id="btn3" onClick={onClick3}>
-          "physics", "science", "chemisty"
+          "physics", "science", "chemistry"
         </Button>
       </ButtonGroup>
       <CheckboxGroup
@@ -542,7 +545,7 @@ export function CheckboxGroupValuesUpdateExample() {
     setValue(["math", "music", "magic"]);
   };
   const onClick3 = () => {
-    setValue(["physics", "science", "chemisty"]);
+    setValue(["physics", "science", "chemistry"]);
   };
   const onChange = (data) => {
     setValue(data);
@@ -559,7 +562,7 @@ export function CheckboxGroupValuesUpdateExample() {
           "math", "music", "magic"
         </Button>
         <Button id="btn3" onClick={onClick3}>
-          "physics", "science", "chemisty"
+          "physics", "science", "chemistry"
         </Button>
       </ButtonGroup>
       <CheckboxGroup

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -1,4 +1,4 @@
-import { Flex, Spacer } from "@chakra-ui/react";
+import { Flex, Spacer, VStack } from "@chakra-ui/react";
 import {
   ArgsTable,
   Canvas,
@@ -6,8 +6,11 @@ import {
   Meta,
   Story,
 } from "@storybook/addon-docs";
+import { useState } from "react";
 import { withDesign } from "storybook-addon-designs";
 
+import { Button } from "../Button/Button";
+import { ButtonGroup } from "../ButtonGroup/ButtonGroup";
 import Checkbox from "../Checkbox/Checkbox";
 import CheckboxGroup from "./CheckboxGroup";
 import { getCategory } from "../../utils/componentCategories";
@@ -56,6 +59,7 @@ import DSProvider from "../../theme/provider";
     showRequiredLabel: {
       table: { defaultValue: { summary: true } },
     },
+    value: { control: false },
   }}
 />
 
@@ -64,7 +68,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.1`   |
-| Latest            | `1.0.2`    |
+| Latest            | `1.1.2`    |
 
 ## Table of Contents
 
@@ -78,6 +82,7 @@ import DSProvider from "../../theme/provider";
 - [With JSX Element labels](#with-jsx-element-labels)
 - [Indeterminate Example](#indeterminate-example)
 - [Getting Checkbox Input Values](#getting-checkbox-input-values)
+- [Programmatically Update](#programmatically-update)
 
 ## Overview
 
@@ -460,3 +465,125 @@ const onSubmit = () => {
   const CheckboxGroupValue = CheckboxGroupRef.current.value;
 };
 ```
+
+### Programmatically Update
+
+Within the `CheckboxGroup`, individual `Checkbox`es can be updated programmatically
+through the `value` prop. Like the `defaultValue` prop, the `value` prop also
+accepts an array of strings.
+
+When passing selected values through the `value` prop, the consuming app is now
+controlling the state of the values. By default, the `CheckboxGroup` component
+returns the value(s) checked to the consuming app through the `onChange` callback.
+Note that the `defaultValue` prop is not necessary unless if there are values
+that should be checked when the component first renders.
+
+In the following example, the `CheckboxGroup` component works as expected, but
+now there are three (3) additional buttons that can update the selected checkboxes
+within the `CheckboxGroup` component.
+
+```jsx
+export function CheckboxGroupValuesUpdateExample() {
+  const [value, setValue] = useState([]);
+  const onClick1 = () => {
+    setValue(["art", "science", "math"]);
+  };
+  const onClick2 = () => {
+    setValue(["math", "music", "magic"]);
+  };
+  const onClick3 = () => {
+    setValue(["physics", "science", "chemisty"]);
+  };
+  const onChange = (data) => {
+    setValue(data);
+    console.log("Selected values:", data);
+  };
+  return (
+    <VStack align="stretch" spacing="m">
+      <span>Set values to:</span>
+      <ButtonGroup>
+        <Button id="btn1" onClick={onClick1}>
+          "art", "science", "math"
+        </Button>
+        <Button id="btn2" onClick={onClick2}>
+          "math", "music", "magic"
+        </Button>
+        <Button id="btn3" onClick={onClick3}>
+          "physics", "science", "chemisty"
+        </Button>
+      </ButtonGroup>
+      <CheckboxGroup
+        id="programmatically-update-example"
+        labelText="Course Selection"
+        name="courseSelection"
+        onChange={onChange}
+        value={value}
+      >
+        <Checkbox id="art" labelText="Art" value="art" />
+        <Checkbox id="chemistry" labelText="Chemistry" value="chemistry" />
+        <Checkbox id="english" labelText="English" value="english" />
+        <Checkbox id="magic" labelText="Magic" value="magic" />
+        <Checkbox id="math" labelText="Math" value="math" />
+        <Checkbox id="music" labelText="Music" value="music" />
+        <Checkbox id="physics" labelText="Physics" value="physics" />
+        <Checkbox id="science" labelText="Science" value="science" />
+      </CheckboxGroup>
+    </VStack>
+  );
+}
+```
+
+export function CheckboxGroupValuesUpdateExample() {
+  const [value, setValue] = useState([]);
+  const onClick1 = () => {
+    setValue(["art", "science", "math"]);
+  };
+  const onClick2 = () => {
+    setValue(["math", "music", "magic"]);
+  };
+  const onClick3 = () => {
+    setValue(["physics", "science", "chemisty"]);
+  };
+  const onChange = (data) => {
+    setValue(data);
+    console.log("Selected values:", data);
+  };
+  return (
+    <VStack align="stretch" spacing="m">
+      <span>Set values to:</span>
+      <ButtonGroup>
+        <Button id="btn1" onClick={onClick1}>
+          "art", "science", "math"
+        </Button>
+        <Button id="btn2" onClick={onClick2}>
+          "math", "music", "magic"
+        </Button>
+        <Button id="btn3" onClick={onClick3}>
+          "physics", "science", "chemisty"
+        </Button>
+      </ButtonGroup>
+      <CheckboxGroup
+        id="programmatically-update-example"
+        labelText="Course Selection"
+        name="courseSelection"
+        onChange={onChange}
+        value={value}
+      >
+        <Checkbox id="art" labelText="Art" value="art" />
+        <Checkbox id="chemistry" labelText="Chemistry" value="chemistry" />
+        <Checkbox id="english" labelText="English" value="english" />
+        <Checkbox id="magic" labelText="Magic" value="magic" />
+        <Checkbox id="math" labelText="Math" value="math" />
+        <Checkbox id="music" labelText="Music" value="music" />
+        <Checkbox id="physics" labelText="Physics" value="physics" />
+        <Checkbox id="science" labelText="Science" value="science" />
+      </CheckboxGroup>
+    </VStack>
+  );
+}
+
+<Canvas>
+  <DSProvider>
+    <CheckboxGroupValuesUpdateExample />
+  </DSProvider>
+</Canvas>

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -2,7 +2,7 @@ import { Flex, Spacer } from "@chakra-ui/react";
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { axe } from "jest-axe";
-import * as React from "react";
+import React from "react";
 import renderer from "react-test-renderer";
 
 import CheckboxGroup from "./CheckboxGroup";
@@ -291,6 +291,38 @@ describe("Checkbox", () => {
     expect(warn).toHaveBeenCalledWith(
       "NYPL Reservoir CheckboxGroup: This component's required `id` prop was not passed."
     );
+  });
+
+  it("updates the selected checkboxes programmatically through the `value` prop", () => {
+    const value = ["physics", "english", "math"];
+    render(
+      <CheckboxGroup
+        id="programmatically-update-example"
+        labelText="Course Selection"
+        name="courseSelection"
+        value={value}
+      >
+        <Checkbox id="art" labelText="Art" value="art" />
+        <Checkbox id="chemistry" labelText="Chemistry" value="chemistry" />
+        <Checkbox id="english" labelText="English" value="english" />
+        <Checkbox id="magic" labelText="Magic" value="magic" />
+        <Checkbox id="math" labelText="Math" value="math" />
+        <Checkbox id="music" labelText="Music" value="music" />
+        <Checkbox id="physics" labelText="Physics" value="physics" />
+        <Checkbox id="science" labelText="Science" value="science" />
+      </CheckboxGroup>
+    );
+    const checkboxes = screen.getAllByRole("checkbox");
+
+    // Only "physics", "english", and "math" are checked
+    expect(checkboxes[0]).not.toHaveAttribute("checked");
+    expect(checkboxes[1]).not.toHaveAttribute("checked");
+    expect(checkboxes[2]).toHaveAttribute("checked");
+    expect(checkboxes[3]).not.toHaveAttribute("checked");
+    expect(checkboxes[4]).toHaveAttribute("checked");
+    expect(checkboxes[5]).not.toHaveAttribute("checked");
+    expect(checkboxes[6]).toHaveAttribute("checked");
+    expect(checkboxes[7]).not.toHaveAttribute("checked");
   });
 
   it("renders the UI snapshot correctly", () => {

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -51,6 +51,8 @@ export interface CheckboxGroupProps {
   /** Whether or not to display the "(Required)" text in the label text.
    * True by default. */
   showRequiredLabel?: boolean;
+  /** The values to programmatically update the selected `Checkbox`es. */
+  value?: string[];
 }
 
 const noop = () => {};
@@ -80,6 +82,7 @@ export const CheckboxGroup = chakra(
       showHelperInvalidText = true,
       showLabel = true,
       showRequiredLabel = true,
+      value,
       ...rest
     } = props;
     const footnote = isInvalid ? invalidText : helperText;
@@ -96,12 +99,15 @@ export const CheckboxGroup = chakra(
           }
         : {};
 
+    if (value) {
+      checkboxProps["value"] = value;
+    }
+
     if (!id) {
       console.warn(
         "NYPL Reservoir CheckboxGroup: This component's required `id` prop was not passed."
       );
     }
-
     // Go through the Checkbox children and update them as needed.
     React.Children.map(
       children as JSX.Element,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1146](https://jira.nypl.org/browse/DSD-1146)

## This PR does the following:

- Allows the `CheckboxGroup` to programmatically update its internal `Checkbox`es through the `value` prop.
- This issue came up in the MLN app.

## How has this been tested?

Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
