### PR TITLE
DSD-1143: hamburger icon color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `hamburger` SVG for the `Icon` component to allow for color assignments.
+
 ## 1.1.2 (September 29, 2022)
 
 ### Adds

--- a/icons/svg/utility-hamburger.svg
+++ b/icons/svg/utility-hamburger.svg
@@ -1,5 +1,5 @@
 <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-    <line fill-rule="evenodd" clip-rule="evenodd" x1="4" y1="16.9375" x2="20" y2="16.9375" stroke="black" stroke-width="2" stroke-linecap="round"/>
-    <line fill-rule="evenodd" clip-rule="evenodd" x1="4" y1="11.9375" x2="20" y2="11.9375" stroke="black" stroke-width="2" stroke-linecap="round"/>
-    <line fill-rule="evenodd" clip-rule="evenodd" x1="4" y1="6.9375" x2="20" y2="6.9375" stroke="black" stroke-width="2" stroke-linecap="round"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M3 17C3 16.4477 3.44772 16 4 16H20C20.5523 16 21 16.4477 21 17C21 17.5523 20.5523 18 20 18H4C3.44772 18 3 17.5523 3 17Z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M3 12C3 11.4477 3.44772 11 4 11H20C20.5523 11 21 11.4477 21 12C21 12.5523 20.5523 13 20 13H4C3.44772 13 3 12.5523 3 12Z"/>
+    <path fill-rule="evenodd" clip-rule="evenodd" d="M3 7C3 6.44772 3.44772 6 4 6H20C20.5523 6 21 6.44772 21 7C21 7.55228 20.5523 8 20 8H4C3.44772 8 3 7.55228 3 7Z"/>
 </svg>

--- a/src/components/Icons/Icon.stories.mdx
+++ b/src/components/Icons/Icon.stories.mdx
@@ -78,7 +78,7 @@ import { getCategory } from "../../utils/componentCategories";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.0.6`    |
+| Latest            | `1.2.0`    |
 
 ## Table of Contents
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1143](https://jira.nypl.org/browse/DSD-1143)

## This PR does the following:

- Updates the `hamburger` SVG for the `Icon` component to allow for color assignments.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
