### PR TITLE
DSD-1109: Dark mode nav category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `dark mode` color mode support for the `Heading` and `List` components.
 - Adds `dark mode` color mode support for the `Footer`, `Header`, `HorizontalRule` and `Table` components.
 - Adds `dark mode` color mode support for the `Notification`, `ProgressIndicator`, and `SkeletonLoader` components.
+- Adds `dark mode` color mode support for the `Breadcrumbs`, `Link Types`, and `Pagination` components.
+- Adds `brand` as a `breadcrumbsType` to the `Breadcrumbs` component.
 
 ### Updates
 

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -12,6 +12,7 @@ import Icon from "../Icons/Icon";
 export type BreadcrumbsTypes =
   | "blogs"
   | "booksAndMore"
+  | "brand"
   | "education"
   | "locations"
   | "research"

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -132,6 +132,9 @@ export const Pagination = chakra(
         ? {
             color: "ui.black",
             pointerEvent: "none",
+            _dark: {
+              color: "dark.ui.typography.body",
+            },
           }
         : {};
       const allAttrs = {

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="css-1eo4rk2"
+        className="css-u4fxc5"
         href="page=1"
         id="firstPage-1"
         rel={null}
@@ -203,7 +203,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-current="page"
         aria-label="Page 10"
-        className="css-1eo4rk2"
+        className="css-u4fxc5"
         href="page=10"
         id="lastPage-10"
         rel={null}
@@ -272,7 +272,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-current="page"
         aria-label="Page 5"
-        className="css-1eo4rk2"
+        className="css-u4fxc5"
         href="page=5"
         id="middlePage-5"
         rel={null}
@@ -341,7 +341,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="css-1eo4rk2"
+        className="css-u4fxc5"
         href="page=1"
         id="chakra-1"
         rel={null}
@@ -450,7 +450,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="css-1eo4rk2"
+        className="css-u4fxc5"
         href="page=1"
         id="props-1"
         rel={null}

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -20,8 +20,17 @@ const booksAndMore = {
     bg: "dark.section.books-and-more.secondary",
   },
 };
+const brand = {
+  bg: "brand.secondary",
+  _dark: {
+    bg: "dark.brand.secondary",
+  },
+};
 const education = {
   bg: "section.education.secondary",
+  _dark: {
+    bg: "dark.section.education.secondary",
+  },
 };
 const locations = {
   bg: "section.locations.primary",
@@ -103,6 +112,7 @@ const Breadcrumb = {
   variants: {
     blogs,
     booksAndMore,
+    brand,
     education,
     locations,
     research,

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -2,6 +2,9 @@
 const blogs = {
   bg: "section.blogs.secondary",
   color: "ui.black",
+  _dark: {
+    bg: "dark.section.blogs.secondary",
+  },
   a: {
     _hover: {
       color: "ui.gray.x-dark",
@@ -13,18 +16,30 @@ const blogs = {
 };
 const booksAndMore = {
   bg: "section.books-and-more.secondary",
+  _dark: {
+    bg: "dark.section.books-and-more.secondary",
+  },
 };
 const education = {
   bg: "section.education.secondary",
 };
 const locations = {
   bg: "section.locations.primary",
+  _dark: {
+    bg: "dark.section.locations.primary",
+  },
 };
 const research = {
   bg: "section.research.secondary",
+  _dark: {
+    bg: "dark.section.research.secondary",
+  },
 };
 const whatsOn = {
   bg: "section.whats-on.secondary",
+  _dark: {
+    bg: "dark.section.whats-on.secondary",
+  },
 };
 
 const Breadcrumb = {
@@ -35,6 +50,10 @@ const Breadcrumb = {
     fontWeight: "breadcrumbs.default",
     paddingBottom: "xs",
     paddingTop: "xs",
+    _dark: {
+      bg: "dark.ui.bg.hover",
+      color: "dark.ui.typography.heading",
+    },
     ol: {
       alignItems: { base: "center", md: "unset" },
       display: { base: "flex", md: "block" },

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -1,6 +1,9 @@
 export const baseLinkStyles = {
   color: "ui.link.primary",
   textDecoration: "underline",
+  _dark: {
+    color: "dark.ui.link.primary",
+  },
   _hover: {
     color: "ui.link.secondary",
   },

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -6,6 +6,9 @@ export const baseLinkStyles = {
   },
   _hover: {
     color: "ui.link.secondary",
+    _dark: {
+      color: "dark.ui.link.secondary",
+    },
   },
 };
 
@@ -24,10 +27,6 @@ const variants = {
       textDecoration: "none",
       fill: "currentColor",
     },
-    _hover: {
-      color: "ui.link.secondary",
-      textDecoration: "underline",
-    },
   },
   button: {
     width: "100px",
@@ -42,10 +41,18 @@ const variants = {
     textDecoration: "none",
     fontWeight: "button.default",
     bg: "ui.link.primary",
+    _dark: {
+      color: "ui.white",
+      bg: "dark.ui.link.primary",
+    },
     _hover: {
       color: "ui.white",
       bg: "ui.link.secondary",
       textDecoration: "none",
+      _dark: {
+        color: "ui.white",
+        bg: "dark.ui.link.secondary",
+      },
     },
   },
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -85,9 +85,13 @@ export const getAriaAttrs = ({
 
 /** Convert a hex color value to an rgb or rgba value */
 export const hexToRGB = (hex: string, alpha: number) => {
-  const r = parseInt(hex.slice(1, 3), 16),
-    g = parseInt(hex.slice(3, 5), 16),
-    b = parseInt(hex.slice(5, 7), 16);
+  const shortHex = hex.length === 4;
+  const rSlice = shortHex ? hex.slice(1, 2).repeat(2) : hex.slice(1, 3),
+    gSlice = shortHex ? hex.slice(2, 3).repeat(2) : hex.slice(3, 5),
+    bSlice = shortHex ? hex.slice(3, 4).repeat(2) : hex.slice(5, 7);
+  const r = parseInt(rSlice, 16),
+    g = parseInt(gSlice, 16),
+    b = parseInt(bSlice, 16);
   const rgb = `${r}, ${g}, ${b}`;
   return alpha ? `rgba(${rgb},${alpha})` : `rgb(${rgb})`;
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1109](https://jira.nypl.org/browse/DSD-1109).

## This PR does the following:

- Adds `dark mode` color mode support for the `Breadcrumbs`, `Link Types`, and `Pagination` components.
- Adds `brand` as a `breadcrumbsType` to the `Breadcrumbs` component.

## This PR does _not_:

- Include `dark mode` color mode support for the `AlphabetFilter,` because it has not yet been merged into develop.
- Include the styling for "Mid page (before numbers shift)" in the `Pagination` component as seen [here](https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=10766%3A1031). This is because I don't believe it is currently present in light mode either. @bigfishdesign13 to check on this and let me know if it should be added in both scenarios.

## How has this been tested?

- Locally in Storybook.

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
