### PR TITLE
Updates Tooltip component and test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates how content in the `Table` component is aligned.
 - Updates the `Button` styles in the `Header`, `Notification`, `SearchBar`, and
   `Tabs` components based on the new `size` prop.
+- Updates the `content` prop of the `Tooltip` component to accept number values.
 
 ### Removals
 

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -159,7 +159,7 @@ describe("Tooltip", () => {
     );
   });
 
-  it("logs a warning if `content` is not a string, Icon, or Image", () => {
+  it("logs a warning if `content` is not a string, number, Icon, or Image", () => {
     const warn = jest.spyOn(console, "warn");
     render(
       <Tooltip content={<Button id="warn-button">Should warn</Button>}>
@@ -168,7 +168,7 @@ describe("Tooltip", () => {
     );
 
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Tooltip: Pass in a string, DS Icon, or DS Image into the 'content' prop."
+      "NYPL Reservoir Tooltip: Pass in a string, number, DS Icon, or DS Image into the 'content' prop."
     );
   });
 });

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -12,7 +12,7 @@ export interface TooltipProps {
   /** Any child node passed to the component. */
   children: React.ReactNode;
   /** Value used to populate the tooltip content. */
-  content: string | React.ReactNode;
+  content: string | number | React.ReactNode;
   /** A class name for the Tooltip parent div. */
   className?: string;
   /** ID that other components can cross reference for accessibility purposes. */
@@ -35,13 +35,13 @@ export const Tooltip = chakra(
       ...rest
     } = props;
 
-    if (typeof content !== "string") {
+    if (typeof content !== "string" && typeof content !== "number") {
       React.Children.map(
         content as React.ReactNode,
         (contentChild: React.ReactElement) => {
           if (contentChild.type !== Icon || contentChild.type !== Image) {
             console.warn(
-              "NYPL Reservoir Tooltip: Pass in a string, DS Icon, or DS Image into the 'content' prop."
+              "NYPL Reservoir Tooltip: Pass in a string, number, DS Icon, or DS Image into the 'content' prop."
             );
           }
         }


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1116](https://jira.nypl.org/browse/DSD-1116).

## This PR does the following:

- Updates the `content` prop of the `Tooltip` component to accept number values (and not log a warning if a number is passed)

## How has this been tested?

- Unit test
- In Storybook

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
