### PR TITLE
DSD-1110: dark mode for overlays and switchers category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `dark mode` color mode support for the `Footer`, `Header`, `HorizontalRule` and `Table` components.
 - Adds `dark mode` color mode support for the `Notification`, `ProgressIndicator`, and `SkeletonLoader` components.
 - Adds `dark mode` color mode support for the `Breadcrumbs`, `Link Types`, and `Pagination` components.
+- Adds `dark mode` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.
 - Adds `brand` as a `breadcrumbsType` to the `Breadcrumbs` component.
 
 ### Updates

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -136,23 +136,15 @@ const getElementsFromData = (
                 }}
                 _dark={{
                   _expanded: {
-                    bg:
-                      !content.accordionType ||
-                      content.accordionType === "default"
-                        ? "dark.ui.bg.active"
-                        : "dark.ui.bg.default",
+                    bg: "dark.ui.bg.active",
                   },
                   bg: "dark.ui.bg.default",
                   color: "dark.ui.typography.heading",
-                  borderLeft:
-                    !content.accordionType ||
-                    content.accordionType === "default"
-                      ? "1px solid"
-                      : "4px solid",
+                  borderLeft: "4px solid",
                   borderLeftColor:
                     !content.accordionType ||
                     content.accordionType === "default"
-                      ? "dark.ui.border.default"
+                      ? "dark.ui.border.hover"
                       : bgColorByAccordionType,
                 }}
               >

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -5,6 +5,7 @@ import {
   AccordionPanel,
   Box,
   chakra,
+  useColorMode,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
@@ -34,10 +35,20 @@ export interface AccordionProps {
  * Get the minus or plus icon depending on whether the accordion
  * is open or closed.
  */
-const getIcon = (isExpanded = false, index: number, id: string) => {
+const getIcon = (
+  isExpanded = false,
+  index: number,
+  id: string,
+  iconColor: string
+) => {
   const iconName = isExpanded ? "minus" : "plus";
   return (
-    <Icon id={`accordion-${id}-icon-${index}`} name={iconName} size="small" />
+    <Icon
+      id={`accordion-${id}-icon-${index}`}
+      name={iconName}
+      size="small"
+      color={iconColor}
+    />
   );
 };
 
@@ -49,13 +60,20 @@ const getIcon = (isExpanded = false, index: number, id: string) => {
 const getElementsFromData = (
   data: AccordionDataProps[] = [],
   id: string,
-  panelMaxHeight: string
+  panelMaxHeight: string,
+  isDarkMode: boolean
 ) => {
-  const colorMap = {
-    default: "ui.white",
-    warning: "ui.status.primary",
-    error: "ui.status.secondary",
-  };
+  const colorMap = isDarkMode
+    ? {
+        default: "ui.white",
+        warning: "ui.status.primary",
+        error: "dark.ui.error.primary",
+      }
+    : {
+        default: "ui.white",
+        warning: "ui.status.primary",
+        error: "ui.status.secondary",
+      };
   // For FAQ-style multiple accordions, the button should be bigger.
   // Otherwise, use the default.
   const multipleFontSize = data?.length > 1 ? "text.default" : "text.caption";
@@ -92,7 +110,9 @@ const getElementsFromData = (
             <>
               <AccordionButton
                 id={`${id}-button-${index}`}
-                borderColor="ui.gray.medium"
+                borderColor={
+                  isDarkMode ? "dark.ui.border.default" : "ui.gray.medium"
+                }
                 padding={multiplePadding}
                 bg={
                   !content.accordionType
@@ -114,6 +134,27 @@ const getElementsFromData = (
                       : bgColorByAccordionType,
                   borderColor: "ui.gray.dark",
                 }}
+                _dark={{
+                  _expanded: {
+                    bg:
+                      !content.accordionType ||
+                      content.accordionType === "default"
+                        ? "dark.ui.bg.active"
+                        : "dark.ui.bg.default",
+                  },
+                  bg: "dark.ui.bg.default",
+                  color: "dark.ui.typography.heading",
+                  borderLeft:
+                    !content.accordionType ||
+                    content.accordionType === "default"
+                      ? "1px solid"
+                      : "4px solid",
+                  borderLeftColor:
+                    !content.accordionType ||
+                    content.accordionType === "default"
+                      ? "dark.ui.border.default"
+                      : bgColorByAccordionType,
+                }}
               >
                 <Box
                   as="span"
@@ -123,7 +164,12 @@ const getElementsFromData = (
                 >
                   {content.label}
                 </Box>
-                {getIcon(isExpanded, index, id)}
+                {getIcon(
+                  isExpanded,
+                  index,
+                  id,
+                  isDarkMode ? "dark.ui.typography.heading" : "ui.black"
+                )}
               </AccordionButton>
               {isExpanded && panel}
             </>
@@ -148,6 +194,7 @@ export const Accordion = chakra(
       ...rest
     } = props;
 
+    const isDarkMode = useColorMode().colorMode === "dark";
     // Pass `0` to open the first accordion in the 0-index based array.
     const openFirstAccordion = isDefaultOpen ? [0] : undefined;
 
@@ -159,7 +206,7 @@ export const Accordion = chakra(
         ref={ref}
         {...rest}
       >
-        {getElementsFromData(accordionData, id, panelMaxHeight)}
+        {getElementsFromData(accordionData, id, panelMaxHeight, isDarkMode)}
       </ChakraAccordion>
     );
   })

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1610qd6"
+      className="chakra-accordion__button css-1qa7iva"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -72,7 +72,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1610qd6"
+      className="chakra-accordion__button css-1qa7iva"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -133,7 +133,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1610qd6"
+      className="chakra-accordion__button css-1qa7iva"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -195,7 +195,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1610qd6"
+      className="chakra-accordion__button css-1qa7iva"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -256,7 +256,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1610qd6"
+      className="chakra-accordion__button css-1qa7iva"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -317,7 +317,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-jq69br"
+      className="chakra-accordion__button css-wztri9"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -378,7 +378,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1gfo82t"
+      className="chakra-accordion__button css-17kfyub"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1c6323r"
+      className="chakra-accordion__button css-1610qd6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -26,7 +26,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"
@@ -72,7 +72,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1c6323r"
+      className="chakra-accordion__button css-1610qd6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -87,7 +87,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"
@@ -133,7 +133,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1c6323r"
+      className="chakra-accordion__button css-1610qd6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -148,7 +148,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"
@@ -195,7 +195,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1c6323r"
+      className="chakra-accordion__button css-1610qd6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -210,7 +210,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"
@@ -256,7 +256,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1c6323r"
+      className="chakra-accordion__button css-1610qd6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -271,7 +271,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"
@@ -317,7 +317,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1c8csqn"
+      className="chakra-accordion__button css-jq69br"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -332,7 +332,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"
@@ -378,7 +378,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1lty5mh"
+      className="chakra-accordion__button css-1gfo82t"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -393,7 +393,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
       </span>
       <svg
         aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
+        className="chakra-icon css-q3eg3a"
         focusable={false}
         id="accordion-accordian-icon-0"
         role="img"

--- a/src/theme/components/accordion.ts
+++ b/src/theme/components/accordion.ts
@@ -1,16 +1,30 @@
 const containerStyles = {
   border: "none",
   width: "100%",
+  _dark: {
+    bg: "dark.ui.bg.default",
+    color: "dark.ui.typography.heading",
+    borderColor: "dark.ui.border.default",
+  },
 };
 const buttonStyles = {
   borderWidth: "1px",
   fontWeight: "medium",
+  _dark: {
+    bg: "dark.ui.bg.default",
+    color: "dark.ui.typography.heading",
+  },
 };
 const panelStyles = {
   padding: "s",
   borderLeftWidth: "1px",
   borderRightWidth: "1px",
   borderBottomWidth: "1px",
+  _dark: {
+    bg: "dark.ui.bg.default",
+    color: "dark.ui.typography.body",
+    borderColor: "dark.ui.border.default",
+  },
 };
 
 const Accordion = {

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -1,0 +1,30 @@
+const Modal = {
+  parts: [
+    "header",
+    "overlay",
+    "dialogContainer",
+    "dialog",
+    "closeButton",
+    "body",
+    "footer",
+  ],
+  baseStyle: {
+    dialog: {
+      _dark: {
+        bg: "dark.ui.bg.default",
+      },
+    },
+    header: {
+      _dark: {
+        color: "dark.ui.typography.heading",
+      },
+    },
+    body: {
+      _dark: {
+        color: "dark.ui.typography.body",
+      },
+    },
+  },
+};
+
+export default Modal;

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -2,7 +2,6 @@ const tablist = {
   borderColor: "ui.black",
 };
 const tab = {
-  color: "black !important",
   paddingInlineStart: "s",
   paddingStart: "s",
   background: "transparent",
@@ -38,9 +37,25 @@ const tab = {
   _focus: {
     boxShadow: "0",
   },
+  _dark: {
+    color: "dark.ui.typography.heading",
+    bg: "dark.ui.bg.default",
+    border: "0",
+    borderBottom: "1px solid",
+    borderBottomColor: "dark.ui.border.hover",
+    _hover: {
+      bg: "dark.ui.bg.hover",
+    },
+    _selected: {
+      color: "dark.ui.typography.heading",
+      bg: "dark.ui.bg.active",
+    },
+  },
 };
 // Only display the previous/next arrow buttons on mobile.
 const buttonArrows = {
+  bg: "transparent",
+  color: "black",
   border: "0",
   borderRadius: "0",
   display: {
@@ -56,6 +71,20 @@ const buttonArrows = {
   pos: "absolute",
   transition: "0.6s ease",
   zIndex: "9999",
+  _hover: {
+    bg: "unset",
+    color: "unset",
+    borderColor: "unset",
+  },
+  _disabled: {
+    color: "ui.disabled.primary",
+  },
+  _dark: {
+    color: "dark.ui.typography.heading",
+    _disabled: {
+      color: "dark.ui.disabled.primary",
+    },
+  },
 };
 const tablistWrapper = {
   display: "flex",
@@ -72,6 +101,9 @@ const tablistWrapper = {
   paddingEnd: { base: "4px", md: "0" },
   paddingTop: { base: "4px", md: "0" },
   position: "relative",
+  _dark: {
+    borderColor: "dark.ui.border.hover",
+  },
 };
 const tabpanels = {
   paddingTop: "2px",
@@ -103,6 +135,9 @@ const CustomTabs = {
     tablistWrapper,
     tabpanels,
     carouselParent,
+  },
+  defaultProps: {
+    colorScheme: "ui.black",
   },
 };
 

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -39,8 +39,7 @@ const tab = {
   },
   _dark: {
     color: "dark.ui.typography.heading",
-    bg: "dark.ui.bg.default",
-    border: "0",
+    border: "1px solid transparent",
     borderBottom: "1px solid",
     borderBottomColor: "dark.ui.border.hover",
     _hover: {
@@ -48,7 +47,9 @@ const tab = {
     },
     _selected: {
       color: "dark.ui.typography.heading",
+      border: "0",
       bg: "dark.ui.bg.active",
+      borderBottom: "3px solid",
     },
   },
 };

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -13,6 +13,9 @@ const Tooltip = {
     maxWidth: "240px",
     px: "s",
     py: "xs",
+    _dark: {
+      [$bg.variable]: "colors.ui.gray.x-dark",
+    },
   },
 };
 

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -41,6 +41,7 @@ import Label from "./components/label";
 import Link from "./components/link";
 import List from "./components/list";
 import Logo from "./components/logo";
+import Modal from "./components/modal";
 import NotificationStyles from "./components/notification";
 import Pagination from "./components/pagination";
 import ProgressIndicator from "./components/progressIndicator";
@@ -126,6 +127,7 @@ const theme = extendTheme({
     Link,
     List,
     Logo,
+    Modal,
     ...NotificationStyles,
     Pagination,
     ProgressIndicator,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1110](https://jira.nypl.org/browse/DSD-1110)
## This PR does the following:

- Adds `dark mode` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
