### PR TITLE
DSD-1166:  Improve a11y for AlphabetFilter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `AlphabetFilter` component by adding `aria-label=“Filter by letter"` attribute
+  and removing the `role` attribute on the `<nav>` element.
+- Updates `AlphabetFilter` border color for the `active letter` indicator from
+  `ui.gray.medium` to `ui.gray.dark`.
+
 ## 1.2.0 (October 17, 2022)
 
 ### Adds

--- a/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
@@ -100,6 +100,11 @@ The `AlphabetFilter` component is accessible via keyboard. The color contrast be
 foreground color and background color is 4.5:1. If text size is 200%, the
 button scales with text so there is no overlap.
 
+Only one `AlphabetFilter` component should be rendered on a page. This is because only one HTML
+`<nav>` element with an aria-label attribute value of "Alphabet Filter" should be rendered on a
+page. The DS `AlphabetFilter` component renders this HTML landmark, so only one component must
+be rendered on a page.
+
 Resources:
 
 - [MDN aria-current](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-current)

--- a/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
@@ -101,7 +101,7 @@ foreground color and background color is 4.5:1. If text size is 200%, the
 button scales with text so there is no overlap.
 
 Only one `AlphabetFilter` component should be rendered on a page. This is because only one HTML
-`<nav>` element with an aria-label attribute value of "Alphabet Filter" should be rendered on a
+`<nav>` element with an `aria-label` attribute value of `"Filter by letter"` should be rendered on a
 page. The DS `AlphabetFilter` component renders this HTML landmark, so only one component must
 be rendered on a page.
 

--- a/src/components/AlphabetFilter/AlphabetFilter.test.tsx
+++ b/src/components/AlphabetFilter/AlphabetFilter.test.tsx
@@ -85,6 +85,14 @@ describe("AlphabetFilter", () => {
     expect(buttons[2]).toBeDisabled();
   });
 
+  it("should have correct aria-label", () => {
+    const { container } = render(
+      <AlphabetFilter id="alphabet-filter-id" onClick={onClick} />
+    );
+    const navLabel = container.querySelector("nav").getAttribute("aria-label");
+    expect(navLabel).toEqual("Filter by letter");
+  });
+
   it("should have corresponding aria-labels for each button", () => {
     render(<AlphabetFilter onClick={onClick} id="alphabet-filter-id" />);
     const buttons = screen.getAllByRole("button");

--- a/src/components/AlphabetFilter/AlphabetFilter.tsx
+++ b/src/components/AlphabetFilter/AlphabetFilter.tsx
@@ -109,7 +109,7 @@ export const AlphabetFilter = chakra(
         ? {
             ...styles.button,
             border: "1px solid",
-            borderColor: "ui.border.default",
+            borderColor: "ui.border.hover",
           }
         : {
             ...styles.button,
@@ -143,7 +143,7 @@ export const AlphabetFilter = chakra(
     };
 
     return (
-      <Box as="nav" role="navigation" ref={ref}>
+      <Box as="nav" ref={ref} aria-label="Filter by letter">
         <ComponentWrapper
           id={id}
           className={className}

--- a/src/components/AlphabetFilter/__snapshots__/AlphabetFilter.test.tsx.snap
+++ b/src/components/AlphabetFilter/__snapshots__/AlphabetFilter.test.tsx.snap
@@ -2,8 +2,8 @@
 
 exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
 <nav
+  aria-label="Filter by letter"
   className="css-0"
-  role="navigation"
 >
   <div
     className="css-1u8qly9"
@@ -299,8 +299,8 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
 
 exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
 <nav
+  aria-label="Filter by letter"
   className="css-0"
-  role="navigation"
 >
   <div
     className="css-1u8qly9"
@@ -624,8 +624,8 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
 
 exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
 <nav
+  aria-label="Filter by letter"
   className="css-0"
-  role="navigation"
 >
   <div
     className="css-1u8qly9"
@@ -927,8 +927,8 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
 
 exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
 <nav
+  aria-label="Filter by letter"
   className="css-0"
-  role="navigation"
 >
   <div
     className="css-1u8qly9"
@@ -1229,8 +1229,8 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
 
 exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
 <nav
+  aria-label="Filter by letter"
   className="css-0"
-  role="navigation"
 >
   <div
     className="css-2bbtg1"
@@ -1526,8 +1526,8 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
 
 exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
 <nav
+  aria-label="Filter by letter"
   className="css-0"
-  role="navigation"
 >
   <div
     className="css-1u8qly9"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1166](https://jira.nypl.org/browse/DSD-1166)

## This PR does the following:

- Remove the `role` attribute from the <nav> element used to compose the `AlphabetFilter` component.
- Add `aria-label=“Filter by letter"` attribute on the <nav> element used to compose the `AlphabetFilter` component
- Change the border color for the `active letter` indicator from `ui.gray.medium` to `ui.gray.dark`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- Unit test and locally on Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
