### PR TITLE
[DSD-1153] Adds background styles to Hero component variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates background styles for `Hero` component's `primary` and `campaign` variants.
+
 ## 1.2.0 (October 17, 2022)
 
 ### Adds

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -58,7 +58,7 @@ export const imageProps = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.2.0`    |
-| Latest            | `1.0.7`    |
+| Latest            | `1.2.1`    |
 
 ## Table of Contents
 

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -71,6 +71,8 @@ const getSecondaryVariantStyles = (bgColor: string = "ui.black") => ({
 // Variant styling
 const primary = {
   alignItems: "center",
+  backgroundSize: "cover",
+  backgroundPosition: "center",
   display: "flex",
   flexFlow: {
     base: "column nowrap",
@@ -136,6 +138,8 @@ const tertiary = {
 };
 const campaign = {
   alignItems: "center",
+  backgroundSize: "cover",
+  backgroundPosition: "center",
   display: "flex",
   justifyContent: "center",
   marginBottom: ["0", "0", "xxl"],


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1153](https://jira.nypl.org/browse/DSD-1153).

## This PR does the following:

- Updates background styles for `Hero` component's `primary` and `campaign` variants.

## How has this been tested?

- Locally, in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
