### PR TITLE
DSD-1154: dark mode support for new components in v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `brand` as a `breadcrumbsType` to the `Breadcrumbs` component.
 - Adds `dark` color mode support for the `ALphabetFilter`, `AudioPlayer`, and `TagSet` components.
 
+### Updates
+
+- Updates the hex value for `dark.ui.error.primary`.
+
 ## 1.2.1 (October 27, 2022)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Adds
 
-- Adds the `"buttonPrimary"`, `"buttonSecondary"`, `"buttonPill"`, `"buttonCallout"`, `"buttonNoBrand"`, `"buttonDisabled"` variants for the the `Link` component, set through the `type` prop.
 - Adds `dark` color mode support for `background-color` and `color` global styles.
 - Adds `dark` color mode support for the `HelperErrorText` and `StatusBadge` components.
 - Adds `dark` color mode support for the `Card` and `Hero` components.
@@ -20,6 +19,13 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `dark` color mode support for the `Breadcrumbs`, `Link Types`, and `Pagination` components.
 - Adds `dark` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.
 - Adds `brand` as a `breadcrumbsType` to the `Breadcrumbs` component.
+- Adds `dark` color mode support for the `ALphabetFilter`, `AudioPlayer`, and `TagSet` components.
+
+## 1.2.1 (October 27, 2022)
+
+### Adds
+
+- Adds the `"buttonPrimary"`, `"buttonSecondary"`, `"buttonPill"`, `"buttonCallout"`, `"buttonNoBrand"`, `"buttonDisabled"` variants for the the `Link` component, set through the `type` prop.
 
 ### Deprecates
 

--- a/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
@@ -39,7 +39,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `1.2.0`    |
-| Latest            | `1.2.0`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/components/AlphabetFilter/AlphabetFilter.tsx
+++ b/src/components/AlphabetFilter/AlphabetFilter.tsx
@@ -1,5 +1,11 @@
 import React, { forwardRef, useRef, useState } from "react";
-import { Box, chakra, Flex, useMultiStyleConfig } from "@chakra-ui/react";
+import {
+  Box,
+  chakra,
+  Flex,
+  useColorModeValue,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
 import { Button } from "../Button/Button";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 
@@ -97,6 +103,12 @@ export const AlphabetFilter = chakra(
       onClick && onClick(clickedLetter);
     };
 
+    // Set the color of the border of the selected letter based on the color mode.
+    const selectedLetterBorderColor = useColorModeValue(
+      "ui.gray.dark",
+      "ui.gray.medium"
+    );
+
     const getButtonElement = (item) => {
       const isSelectedLetter =
         selectedLetter === item.value && item.value !== "showAll";
@@ -109,7 +121,7 @@ export const AlphabetFilter = chakra(
         ? {
             ...styles.button,
             border: "1px solid",
-            borderColor: "ui.border.hover",
+            borderColor: selectedLetterBorderColor,
           }
         : {
             ...styles.button,

--- a/src/components/AudioPlayer/AudioPlayer.stories.mdx
+++ b/src/components/AudioPlayer/AudioPlayer.stories.mdx
@@ -35,7 +35,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `1.2.0`    |
-| Latest            | `1.2.0`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/components/TagSet/TagSet.stories.mdx
+++ b/src/components/TagSet/TagSet.stories.mdx
@@ -44,7 +44,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `1.2.0`    |
-| Latest            | `1.2.1`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/components/TagSet/TagSetFilter.tsx
+++ b/src/components/TagSet/TagSetFilter.tsx
@@ -1,4 +1,8 @@
-import { chakra, useMultiStyleConfig } from "@chakra-ui/react";
+import {
+  chakra,
+  useColorModeValue,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
 import React, { useEffect } from "react";
 
 import Button from "../Button/Button";
@@ -37,6 +41,13 @@ export const TagSetFilter = chakra((props: TagSetFilterProps) => {
   const finalOnClick = (tagLabel: string) => {
     onClick && onClick(tagLabel);
   };
+
+  // Set element colors based on color mode
+  const dismissButtonColor = useColorModeValue(
+    "ui.gray.x-dark",
+    "dark.ui.typography.body"
+  );
+  const iconColor = useColorModeValue("ui.black", "dark.ui.typography.body");
 
   // This expects that the consuming app passes in a new set of data
   // whenever the current list of tags needs to be updated.
@@ -77,6 +88,7 @@ export const TagSetFilter = chakra((props: TagSetFilterProps) => {
               {!isDismissible && tagSet.iconName ? (
                 <Icon
                   align="left"
+                  color={iconColor}
                   data-testid="ts-icon"
                   name={tagSet.iconName}
                   size="small"
@@ -89,7 +101,7 @@ export const TagSetFilter = chakra((props: TagSetFilterProps) => {
                   align="right"
                   name="close"
                   size="small"
-                  color="ui.gray.x-dark"
+                  color={dismissButtonColor}
                   width="12px"
                 />
               ) : null}

--- a/src/components/TagSet/__snapshots__/TagSet.test.tsx.snap
+++ b/src/components/TagSet/__snapshots__/TagSet.test.tsx.snap
@@ -706,7 +706,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"
@@ -748,7 +748,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"
@@ -790,7 +790,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"
@@ -832,7 +832,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"
@@ -874,7 +874,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"
@@ -916,7 +916,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"
@@ -958,7 +958,7 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   >
     <svg
       aria-hidden={true}
-      className="chakra-icon css-1grhd2q"
+      className="chakra-icon css-q3eg3a"
       data-testid="ts-icon"
       focusable={false}
       role="img"

--- a/src/components/VideoPlayer/VideoPlayer.stories.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.stories.mdx
@@ -43,7 +43,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.23.2`   |
-| Latest            | `1.0.6`    |
+| Latest            | `1.3.0`    |
 
 ## Table of Contents
 

--- a/src/theme/components/audioPlayer.ts
+++ b/src/theme/components/audioPlayer.ts
@@ -2,7 +2,14 @@ const AudioPlayer = {
   baseStyle: {
     invalid: {
       backgroundColor: "ui.bg.default",
+      border: "1px solid",
+      borderColor: "ui.border.default",
       padding: "s",
+      _dark: {
+        bg: "dark.ui.bg.default",
+        border: "1px solid",
+        borderColor: "dark.ui.border.default",
+      },
     },
   },
 };

--- a/src/theme/components/tagSet.ts
+++ b/src/theme/components/tagSet.ts
@@ -6,9 +6,9 @@ const TagSetFilter = {
     display: "flex",
     alignItems: "center",
     justifyContent: "center",
-    bg: "ui.gray.x-light-cool",
+    bg: "ui.bg.default",
     border: "1px solid",
-    borderColor: "ui.gray.medium",
+    borderColor: "ui.border.default",
     borderRadius: "pill",
     color: "ui.black",
     cursor: isDismissible ? "pointer" : "auto",
@@ -26,13 +26,28 @@ const TagSetFilter = {
       whiteSpace: "nowrap",
     },
     _hover: {
-      bg: isDismissible ? "ui.gray.light-cool" : "ui.gray.x-light-cool",
+      bg: isDismissible ? "ui.bg.hover" : "ui.bg.default",
+      borderColor: isDismissible ? "ui.border.hover" : "ui.border.default",
+    },
+    _dark: {
+      bg: "dark.ui.bg.default",
+      borderColor: "dark.ui.border.default",
+      color: "dark.ui.typography.body",
+      _hover: {
+        bg: isDismissible ? "dark.ui.bg.hover" : "dark.ui.bg.default",
+        borderColor: isDismissible
+          ? "dark.ui.border.hover"
+          : "dark.ui.border.default",
+      },
     },
     clearAll: {
       color: "ui.black",
       height: { base: "32px", md: "22px" },
       fontSize: "text.tag",
       minHeight: "22px",
+      _dark: {
+        color: "dark.ui.typography.heading",
+      },
     },
   }),
 };
@@ -82,6 +97,29 @@ const TagSetExplore = {
       },
       "> span": {
         color: "ui.white",
+      },
+    },
+    _dark: {
+      bg: "dark.ui.bg.default",
+      borderColor: "dark.ui.link.primary",
+      color: "dark.ui.link.primary",
+      a: {
+        color: "dark.ui.link.primary",
+      },
+      svg: {
+        fill: "dark.ui.link.primary",
+      },
+      _hover: {
+        bg: "dark.ui.link.primary",
+        a: {
+          color: "ui.gray.xxx-dark",
+        },
+        svg: {
+          fill: "ui.gray.xxx-dark",
+        },
+        "> span": {
+          color: "ui.gray.xxx-dark",
+        },
       },
     },
   },

--- a/src/theme/components/videoPlayer.ts
+++ b/src/theme/components/videoPlayer.ts
@@ -12,8 +12,15 @@ const square = {
 
 const invalid = {
   backgroundColor: "ui.gray.light-cool",
+  border: "1px solid",
+  borderColor: "ui.border.default",
   height: "auto",
   padding: "s",
+  _dark: {
+    bg: "dark.ui.bg.default",
+    border: "1px solid",
+    borderColor: "dark.ui.border.default",
+  },
 };
 
 const VideoPlayer = {

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -208,7 +208,7 @@ const colors: Colors = {
         secondary: grayxxDark,
       },
       error: {
-        primary: "#E1454C",
+        primary: "#DC4850",
         secondary: "#F67C82",
       },
       focus: "#5181D4",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1154](https://jira.nypl.org/browse/DSD-1154)

## This PR does the following:

- Adds `dark` color mode support for the `AlphabetFilter`, `AudioPlayer`, and `TagSet` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- locally in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Color updates have been completed with WCAG compliant color palette

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
