### PR TITLE
DSD-1172: broken TOC link on Card story

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes an invalid TOC link on the `Card` component Storybook page.
+
 ## 1.2.1 (October 27, 2022)
 
 ### Adds

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -90,7 +90,7 @@ import DSProvider from "../../theme/provider";
 - [Card with Right Side CardActions](#card-with-right-side-cardactions)
 - [Cards in a Grid](#cards-in-a-grid)
 - [Cards in a Stack](#cards-in-a-stack)
-- [Card Without Images](#card-without-images)
+- [Cards Without Images](#cards-without-images)
 
 ## Overview
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1172](https://jira.nypl.org/browse/DSD-1172)

## This PR does the following:

- Fixes an invalid TOC link on the `Card` component Storybook page.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- locally in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
