### PR TITLE
DSD-1185: docs for button sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `Icon` and `Logo` documentation to include size values in px.
+- Updates the `Buttons Style Guide` to extend the information about button sizes.
 
 ### Fixes
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -435,6 +435,18 @@ export const buttonData = [
       No Brand
     </Button>,
   ],
+  [
+    "link (deprecated)",
+    <Button buttonType="link" id="l-small" size="small">
+      Link
+    </Button>,
+    <Button buttonType="link" id="l-medium" size="medium">
+      Link
+    </Button>,
+    <Button buttonType="link" id="l-large" size="large">
+      Link
+    </Button>,
+  ],
 ];
 
 <Canvas>
@@ -445,6 +457,16 @@ export const buttonData = [
       showRowDividers
       tableData={buttonData}
       useRowHeaders
+      sx={{
+        tbody: {
+          th: {
+            verticalAlign: "middle",
+          },
+          td: {
+            verticalAlign: "middle",
+          },
+        },
+      }}
     />
   </DSProvider>
 </Canvas>

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -133,10 +133,10 @@ that can be rendered.
 - `"primary"` is used for actions that move the user forward. This is the default.
 - `"secondary"` is used for actions that move the user back, such as cancellations.
 - `"text"` is used for equally weighted actions in a text based list.
-- `"pill"` is used for equally weighted actions within cards and always in a set.
 - `"callout"` is used for call to action text such as "Donate".
 - `"noBrand"` is a variant used when there is no brand and will display the
   background color as black.
+- `"pill"` is used for equally weighted actions within cards and always in a set.
 - `"link"` has been deprecated and should not be used.
 
 When one and only one `Icon` component is passed inside a `Button` component with
@@ -325,14 +325,14 @@ The variations modified by the `buttonType` prop:
       <Button buttonType="text" id="text-btn">
         Text
       </Button>
-      <Button buttonType="pill" id="pill-btn">
-        Pill
-      </Button>
       <Button buttonType="callout" id="callout-btn">
         Callout
       </Button>
       <Button buttonType="noBrand" id="nobrand-btn">
         No Brand
+      </Button>
+      <Button buttonType="pill" id="pill-btn">
+        Pill
       </Button>
       <Button buttonType="link" id="link-btn">
         Link (deprecated)
@@ -400,18 +400,6 @@ export const buttonData = [
     </Button>,
   ],
   [
-    "pill",
-    <Button buttonType="pill" id="pill-small" size="small">
-      Pill
-    </Button>,
-    <Button buttonType="pill" id="pill-medium" size="medium">
-      Pill
-    </Button>,
-    <Button buttonType="pill" id="pill-large" size="large">
-      Pill
-    </Button>,
-  ],
-  [
     "callout",
     <Button buttonType="callout" id="c-small" size="small">
       Callout
@@ -433,6 +421,18 @@ export const buttonData = [
     </Button>,
     <Button buttonType="noBrand" id="nb-large" size="large">
       No Brand
+    </Button>,
+  ],
+  [
+    "pill",
+    <Button buttonType="pill" id="pill-small" size="small">
+      Pill
+    </Button>,
+    <Button buttonType="pill" id="pill-medium" size="medium">
+      Pill
+    </Button>,
+    <Button buttonType="pill" id="pill-large" size="large">
+      Pill
     </Button>,
   ],
   [

--- a/src/components/StyleGuide/Buttons.stories.mdx
+++ b/src/components/StyleGuide/Buttons.stories.mdx
@@ -101,14 +101,14 @@ component.
       <Button buttonType="text" id="text">
         Text
       </Button>
-      <Button buttonType="pill" id="pill">
-        Pill
-      </Button>
       <Button buttonType="callout" id="callout">
         Callout
       </Button>
       <Button buttonType="noBrand" id="noBrand">
         NoBrand
+      </Button>
+      <Button buttonType="pill" id="pill">
+        Pill
       </Button>
       <Button buttonType="link" id="link">
         Link (deprecated)
@@ -133,12 +133,6 @@ component.
 - used for equally weighted actions
 - Visual Treatment: plain text only without an underline
 
-### Pill
-
-- used for equally weighted actions
-- should only be used for buttons that are displayed in a set (i.e. never use for a singleton button)
-- Visual Treatment: rounded, outlined
-
 ### Callout
 
 - used for call to actions such as donation buttons
@@ -148,6 +142,20 @@ component.
 
 - used in cases where there is no brand color
 - Visual Treatment: rectangular, filled with a black background
+
+### Pill
+
+- used for equally weighted actions
+- should only be used for buttons that are displayed in a set (i.e. never use for a singleton button)
+- Visual Treatment: rounded, outlined
+
+### Link (deprecated)
+
+The `link` variant has been deprecated for accessibility reasons. From a visual
+standpoint, an underlined link has the expected functionality of navigating to
+a new page within the current site. If we are true to semantic coding, buttons
+will not be used for this same type of navigational functionality and styling 
+a button to mimic the look of a standard link could cause unnecessary confusion.
 
 ## Button Sizes
 

--- a/src/components/StyleGuide/Buttons.stories.mdx
+++ b/src/components/StyleGuide/Buttons.stories.mdx
@@ -91,24 +91,27 @@ component.
 
 <Canvas>
   <DSProvider>
-    <ButtonGroup>
+    <ButtonGroup alignItems="center">
       <Button buttonType="primary" id="primary">
-        Primary Button
+        Primary
       </Button>
       <Button buttonType="secondary" id="secondary">
-        Secondary Button
+        Secondary
       </Button>
       <Button buttonType="text" id="text">
-        Text Button
+        Text
       </Button>
       <Button buttonType="pill" id="pill">
-        Pill Button
+        Pill
       </Button>
       <Button buttonType="callout" id="callout">
-        Callout Button
+        CalloutButton
       </Button>
       <Button buttonType="noBrand" id="noBrand">
-        NoBrand Button
+        NoBrand
+      </Button>
+      <Button buttonType="link" id="link">
+        Link (deprecated)
       </Button>
     </ButtonGroup>
   </DSProvider>
@@ -153,13 +156,15 @@ The `size` prop should be used to render various sizes of the button component:
 
 ### Small
 
-- Even though the `"small"` size is available, we recommend to use the `"medium"`
-  or `"large"` sizes.
-- Use cases: TBD
+- **IMPORTAN:** Even though the `"small"` size is available, it is recommended
+  to use the `"medium"` or `"large"` sizes.
+- This is a reduced button size.
+- This size can be used when space is limited or when the action is of lesser 
+  significance.
 
 <Canvas>
   <DSProvider>
-    <ButtonGroup>
+    <ButtonGroup alignItems="center">
       <Button buttonType="primary" id="small-primary" size="small">
         Primary
       </Button>
@@ -178,17 +183,22 @@ The `size` prop should be used to render various sizes of the button component:
       <Button buttonType="pill" id="small-pill" size="small">
         Pill
       </Button>
+      <Button buttonType="link" id="small-link" size="small">
+        Link (deprecated)
+      </Button>
     </ButtonGroup>
   </DSProvider>
 </Canvas>
 
 ### Medium
 
-- This is the default button size and this size should be used whenever possible.
+- This is the default button size.
+- This button size should be used unless there is a very compelling reason to
+  use one of the other sizes.
 
 <Canvas>
   <DSProvider>
-    <ButtonGroup>
+    <ButtonGroup alignItems="center">
       <Button buttonType="primary" id="medium-primary" size="medium">
         Primary
       </Button>
@@ -207,17 +217,22 @@ The `size` prop should be used to render various sizes of the button component:
       <Button buttonType="pill" id="medium-pill" size="medium">
         Pill
       </Button>
+      <Button buttonType="link" id="medium-link" size="medium">
+        Link (deprecated)
+      </Button>
     </ButtonGroup>
   </DSProvider>
 </Canvas>
 
 ### Large
 
-- Use cases: TBD
+- This is an enlarged button size.
+- This size can be used to bring prominence to a button that needs to have a major impact.
+- **Use large buttons sparingly.** Layouts should generally have only one large button.
 
 <Canvas>
   <DSProvider>
-    <ButtonGroup>
+    <ButtonGroup alignItems="center">
       <Button buttonType="primary" id="large-primary" size="large">
         Primary
       </Button>
@@ -235,6 +250,9 @@ The `size` prop should be used to render various sizes of the button component:
       </Button>
       <Button buttonType="pill" id="large-pill" size="large">
         Pill
+      </Button>
+      <Button buttonType="link" id="large-link" size="large">
+        Link (deprecated)
       </Button>
     </ButtonGroup>
   </DSProvider>

--- a/src/components/StyleGuide/Buttons.stories.mdx
+++ b/src/components/StyleGuide/Buttons.stories.mdx
@@ -228,7 +228,7 @@ The `size` prop should be used to render various sizes of the button component:
 
 - This is an enlarged button size.
 - This size can be used to bring prominence to a button that needs to have a major impact.
-- **IMPORTANT:** Use large buttons sparingly. Layouts should generally have only one large button.
+- **IMPORTANT:** Use the `"large"` size sparingly. Layouts should generally have only one `"large"` button.
 
 <Canvas>
   <DSProvider>

--- a/src/components/StyleGuide/Buttons.stories.mdx
+++ b/src/components/StyleGuide/Buttons.stories.mdx
@@ -105,7 +105,7 @@ component.
         Pill
       </Button>
       <Button buttonType="callout" id="callout">
-        CalloutButton
+        Callout
       </Button>
       <Button buttonType="noBrand" id="noBrand">
         NoBrand
@@ -156,11 +156,11 @@ The `size` prop should be used to render various sizes of the button component:
 
 ### Small
 
-- **IMPORTAN:** Even though the `"small"` size is available, it is recommended
-  to use the `"medium"` or `"large"` sizes.
 - This is a reduced button size.
-- This size can be used when space is limited or when the action is of lesser 
+- This size can be used when space is limited or when the action is of lesser
   significance.
+- **IMPORTANT:** Even though the `"small"` size is available, it is recommended
+  to use the `"medium"` or `"large"` sizes.
 
 <Canvas>
   <DSProvider>
@@ -228,7 +228,7 @@ The `size` prop should be used to render various sizes of the button component:
 
 - This is an enlarged button size.
 - This size can be used to bring prominence to a button that needs to have a major impact.
-- **Use large buttons sparingly.** Layouts should generally have only one large button.
+- **IMPORTANT:** Use large buttons sparingly. Layouts should generally have only one large button.
 
 <Canvas>
   <DSProvider>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1185](https://jira.nypl.org/browse/DSD-1185)

## This PR does the following:

- Updates the `Buttons Style Guide` to extend the information about button sizes.
- Also cleaned up a few things in the `Button` story.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
