### PR TITLE
DSD-1187: updated spacing for tertiary variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `Icon` and `Logo` documentation to include size values in px.
+- Updates the spacing within the `tertiary` variant of the `Hero` component.
 
 ### Fixes
 

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -58,7 +58,7 @@ export const imageProps = {
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.2.0`    |
-| Latest            | `1.2.1`    |
+| Latest            | `1.2.2`    |
 
 ## Table of Contents
 

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -121,10 +121,10 @@ const tertiary = {
     display: "flex",
     flexFlow: "column nowrap",
     px: "inset.default",
-    py: {base: "inset.default", xl: "inset.wide"},
+    py: { base: "inset.default", xl: "inset.wide" },
     p: {
       marginBottom: "0",
-      marginTop: {base: "xxs", xl: "xs"},
+      marginTop: { base: "xxs", xl: "xs" },
     },
   },
   heading: {

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -120,10 +120,11 @@ const tertiary = {
     color: "ui.white",
     display: "flex",
     flexFlow: "column nowrap",
-    padding: "inset.default",
+    px: "inset.default",
+    py: {base: "inset.default", xl: "inset.wide"},
     p: {
       marginBottom: "0",
-      marginTop: "s",
+      marginTop: {base: "xxs", xl: "xs"},
     },
   },
   heading: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1187](https://jira.nypl.org/browse/DSD-1187)

## This PR does the following:

- Updates the spacing within the `tertiary` variant of the `Hero` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
