### PR TITLE
DSD-1180: Adding isClearable to the SearchBar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds an `isClearable` prop to the `TextInput` component. When set to `true`, a close `Button` component will render that will clear any text value in the input field.
+- Adds the `isClearable` property to the `textInputProps` prop object in the `SearchBar` component. This allows the `isClearable` prop to be passed to the `TextInput` component to render the close `Button` component.
 
 ### Updates
 

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -60,7 +60,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.1.2`    |
+| Latest            | `1.2.2`    |
 
 ## Table of Contents
 
@@ -230,11 +230,12 @@ const selectProps = {
 To render the `TextInput` component, an object must be passed to the
 `textInputProps` prop. It _must_ include `labelText` and `name` properties. The
 `labelText` value won't be rendered but will be used for its `aria-label`
-attribute. Optional properties to pass include `id`, `onChange`, `placeholder`,
-and `value`.
+attribute. Optional properties to pass include `id`, `isClearable`, `onChange`,
+`placeholder`, and `value`.
 
 ```
 const textInputProps = {
+  isClearable: true,
   labelText: "Item Search",
   name: "textInputName",
   onChange: (event) => {
@@ -252,6 +253,29 @@ const textInputProps = {
   // ...
 />
 ```
+
+#### isClearable
+
+Set the `isClearable` property in the `textInputProps` prop to `true` to render
+a button that clears the input value. The behavior for this feature is
+documented in the TextInput component's [isClearable Button](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/components-form-elements-textinput--text-input-with-controls#isclearable-button)
+section.
+
+<Canvas>
+  <DSProvider>
+    <SearchBar
+      descriptionText="Begin typing for the clear button to appear. Once clicked, the value in the text input field will be cleared."
+      id="textInput-isClearable"
+      onSubmit={() => {}}
+      textInputProps={{
+        isClearable: true,
+        labelText: "Item Search",
+        name: "textInputName",
+        placeholder: "Item Search",
+      }}
+    />
+  </DSProvider>
+</Canvas>
 
 ### Custom Input Component
 

--- a/src/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/SearchBar/SearchBar.test.tsx
@@ -48,6 +48,24 @@ describe("SearchBar Accessibility", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
+  it("passes axe accessibility test with `clear` button", async () => {
+    const { container } = render(
+      <SearchBar
+        helperText={helperText}
+        id="id"
+        invalidText={invalidText}
+        labelText={labelText}
+        onSubmit={jest.fn()}
+        textInputProps={{
+          isClearable: true,
+          value: "input value",
+          ...textInputProps,
+        }}
+      />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
   it("passes axe accessibility test with a Select component", async () => {
     const { container } = render(
       <SearchBar
@@ -160,6 +178,44 @@ describe("SearchBar", () => {
 
     // Seven times for every letter in the search string
     expect(textInputProps.onChange).toHaveBeenCalledTimes(7);
+  });
+
+  it("renders a `clear` button and clears the input field when clicked", () => {
+    render(
+      <SearchBar
+        helperText={helperText}
+        id="id"
+        labelText={labelText}
+        onSubmit={jest.fn()}
+        textInputProps={{
+          isClearable: true,
+          ...textInputProps,
+        }}
+      />
+    );
+    // The `labelText` value is "Item Search".
+    let clearButton = screen.queryByRole("button", {
+      name: "Clear Item Search",
+    });
+
+    // Renders when `isClearable` is true and the input has a value.
+    expect(clearButton).not.toBeInTheDocument();
+
+    // Type some value
+    userEvent.type(screen.getByRole("textbox"), "text value");
+
+    expect(screen.getByRole("textbox")).toHaveValue("text value");
+    clearButton = screen.queryByRole("button", {
+      name: "Clear Item Search",
+    });
+    expect(clearButton).toBeInTheDocument();
+
+    // Click on the clear button
+    userEvent.click(clearButton);
+    // The text should no longer be in the input field.
+    expect(screen.getByRole("textbox")).toHaveValue("");
+    // The clear button does not render.
+    expect(clearButton).not.toBeInTheDocument();
   });
 
   it("calls the Select onChange callback function", () => {
@@ -315,6 +371,20 @@ describe("SearchBar", () => {
         />
       )
       .toJSON();
+    const withClearButton = renderer
+      .create(
+        <SearchBar
+          helperText={helperText}
+          id="withClearButton"
+          labelText={labelText}
+          onSubmit={jest.fn()}
+          textInputProps={{
+            isClearable: true,
+            ...textInputProps,
+          }}
+        />
+      )
+      .toJSON();
     const invalidState = renderer
       .create(
         <SearchBar
@@ -422,6 +492,7 @@ describe("SearchBar", () => {
     expect(basic).toMatchSnapshot();
     expect(withSelect).toMatchSnapshot();
     expect(withoutHelperText).toMatchSnapshot();
+    expect(withClearButton).toMatchSnapshot();
     expect(invalidState).toMatchSnapshot();
     expect(disabledState).toMatchSnapshot();
     expect(requiredState).toMatchSnapshot();

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -30,6 +30,7 @@ export interface SelectProps extends BaseProps {
   onChange?: (event: React.FormEvent) => void;
 }
 export interface TextInputProps extends BaseProps {
+  isClearable?: boolean;
   placeholder?: string;
 }
 
@@ -152,6 +153,7 @@ export const SearchBar = chakra(
     const textInputNative = textInputProps && (
       <TextInput
         id={textInputProps?.id || `searchbar-textinput-${id}`}
+        isClearable={textInputProps?.isClearable}
         labelText={textInputProps?.labelText}
         name={textInputProps?.name}
         onChange={textInputProps?.onChange}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -375,6 +375,94 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
 exports[`SearchBar renders the UI snapshot correctly 4`] = `
 <div
   className="css-1xdhyk6"
+  id="withClearButton-wrapper"
+>
+  <form
+    aria-label="SearchBar label - Search for items in Animal Crossing New Horizons"
+    className="css-1xdhyk6"
+    id="searchbar-form-withClearButton"
+    onSubmit={[MockFunction]}
+    role="search"
+  >
+    <div
+      className="css-1u8qly9"
+      id="searchbar-textinput-withClearButton-wrapper"
+    >
+      <input
+        aria-label="Item Search"
+        className="chakra-input css-0"
+        disabled={false}
+        id="searchbar-textinput-withClearButton"
+        name="textInputName"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        placeholder="Item Search "
+        required={false}
+        step={null}
+        type="text"
+        value=""
+      />
+      
+    </div>
+    <button
+      className="chakra-button css-r60hgy"
+      id="searchbar-button-withClearButton"
+      type="submit"
+    >
+      <svg
+        aria-hidden={true}
+        className="chakra-icon css-1grhd2q"
+        focusable={false}
+        id="searchbar-icon-withClearButton"
+        role="img"
+        title="search icon"
+        viewBox="0 0 24 24"
+      >
+        <g
+          stroke="currentColor"
+          strokeWidth="1.5"
+        >
+          <path
+            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+            fill="none"
+            strokeLinecap="round"
+          />
+          <path
+            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+            fill="currentColor"
+            strokeLinecap="round"
+          />
+          <circle
+            cx="12"
+            cy="12"
+            fill="none"
+            r="11.25"
+            strokeMiterlimit="10"
+          />
+        </g>
+      </svg>
+      Search
+    </button>
+  </form>
+  <div
+    aria-atomic={true}
+    aria-live="off"
+    className="css-1xdhyk6"
+    dangerouslySetInnerHTML={
+      Object {
+        "__html": "Search for items in Animal Crossing New Horizons",
+      }
+    }
+    data-isinvalid={false}
+    id="withClearButton-helperText"
+  />
+</div>
+`;
+
+exports[`SearchBar renders the UI snapshot correctly 5`] = `
+<div
+  className="css-1xdhyk6"
   id="invalidState-wrapper"
 >
   <form
@@ -448,7 +536,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 5`] = `
+exports[`SearchBar renders the UI snapshot correctly 6`] = `
 <div
   className="css-1xdhyk6"
   id="disabledState-wrapper"
@@ -525,7 +613,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 6`] = `
+exports[`SearchBar renders the UI snapshot correctly 7`] = `
 <div
   className="css-1xdhyk6"
   id="requiredState-wrapper"
@@ -603,7 +691,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 7`] = `
+exports[`SearchBar renders the UI snapshot correctly 8`] = `
 <div
   className="css-1xdhyk6"
   id="noBrandButtonType-wrapper"
@@ -681,7 +769,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 8`] = `
+exports[`SearchBar renders the UI snapshot correctly 9`] = `
 <div
   className="css-1xdhyk6"
   id="withHeading-wrapper"
@@ -742,7 +830,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 9`] = `
+exports[`SearchBar renders the UI snapshot correctly 10`] = `
 <div
   className="css-1xdhyk6"
   id="withDescription-wrapper"
@@ -802,7 +890,7 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 10`] = `
+exports[`SearchBar renders the UI snapshot correctly 11`] = `
 <div
   className="css-1xdhyk6"
   id="withHeadingAndDescription-wrapper"
@@ -868,7 +956,7 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 11`] = `
+exports[`SearchBar renders the UI snapshot correctly 12`] = `
 <div
   className="css-1xdhyk6"
   id="chakra-wrapper"
@@ -956,7 +1044,7 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
 </div>
 `;
 
-exports[`SearchBar renders the UI snapshot correctly 12`] = `
+exports[`SearchBar renders the UI snapshot correctly 13`] = `
 <div
   className="css-1xdhyk6"
   data-testid="props"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1180](https://jira.nypl.org/browse/DSD-1180)

## This PR does the following:

- Passes the `isClearable` prop to the `textInputProps` object prop in the `SearchBar` component.

## How has this been tested?

Locally in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
