### PR TITLE
DSD-1189: TextInput focus on input element when clear button is clicked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Adds
 
-- Adds an `isClearable` prop to the `TextInput` component. When set to `true`, a close `Button` component will render that will clear any text value in the input field.
+- Adds an `isClearable` prop to the `TextInput` component. When set to `true`, a close `Button` component will render on top of the input element. Once clicked, any text value in the input field will be cleared and focus will return to the input element.
 
 ### Updates
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -129,6 +129,9 @@ Internally, a `Label` is associated with the `<input>` element. When `showLabel`
 is set to false, the `<input>` element's `aria-label` attribute is set to the
 required `labelText` value.
 
+When the `isClearable` prop is set to `true`, a button is rendered to clear the
+input value. Once clicked, focus will be set to the input element.
+
 When the `type` prop is set to `"textarea"`, the `<textarea>` element
 is rendered instead of the `<input>` element. This element follows all the same
 accessibility rules described above.

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -129,8 +129,10 @@ Internally, a `Label` is associated with the `<input>` element. When `showLabel`
 is set to false, the `<input>` element's `aria-label` attribute is set to the
 required `labelText` value.
 
-When the `isClearable` prop is set to `true`, a button is rendered to clear the
-input value. Once clicked, focus will be set to the input element.
+When the `isClearable` prop is set to `true`, as text is added to the input
+field a close button is rendered to clear the input value. Once the close button
+is clicked, the input value will be cleared, the close button will become hidden,
+and focus will be set to the input element.
 
 When the `type` prop is set to `"textarea"`, the `<textarea>` element
 is rendered instead of the `<input>` element. This element follows all the same

--- a/src/components/TextInput/TextInput.test.tsx
+++ b/src/components/TextInput/TextInput.test.tsx
@@ -284,6 +284,36 @@ describe("TextInput", () => {
     expect(clearButton).not.toBeInTheDocument();
   });
 
+  it("returns focus to the input field when the `clear` button is clicked", () => {
+    const onChangeSpy = jest.fn();
+
+    utils.rerender(
+      <TextInput
+        id="inputID-attributes"
+        isClearable
+        labelText="Input Label"
+        maxLength={10}
+        onChange={onChangeSpy}
+        placeholder="Input Placeholder"
+        type="text"
+      />
+    );
+    let inputElement = screen.getByRole("textbox");
+    let clearButton;
+
+    // Type some value
+    userEvent.type(inputElement, "text value");
+    clearButton = screen.queryByRole("button");
+    expect(clearButton).toBeInTheDocument();
+
+    // Click on the clear button
+    userEvent.click(clearButton);
+
+    // The text should no longer be in the input field.
+    expect(inputElement).toHaveValue("");
+    expect(inputElement).toHaveFocus();
+  });
+
   it("logs a warning for the number type when the min prop is greater than the max prop", () => {
     const warn = jest.spyOn(console, "warn");
     render(

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -2,9 +2,10 @@ import {
   chakra,
   Input as ChakraInput,
   Textarea as ChakraTextarea,
+  useMergeRefs,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef, useEffect, useState } from "react";
+import React, { forwardRef, useEffect, useRef, useState } from "react";
 
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import Label from "../Label/Label";
@@ -146,6 +147,10 @@ export const TextInput = chakra(
         ...rest
       } = props;
       const [finalValue, setFinalValue] = useState<string>(value || "");
+      const closedRef = useRef<HTMLInputElement>();
+      const mergedRefs = useMergeRefs(closedRef, ref);
+      // If a ref is not passed, then merging refs won't work.
+      const finalRef = ref ? mergedRefs : closedRef;
       const styles = useMultiStyleConfig("TextInput", {
         showLabel,
         variant: textInputType,
@@ -173,6 +178,11 @@ export const TextInput = chakra(
         name: "TextInput",
         showLabel,
       });
+      const onClearClick = () => {
+        setFinalValue("");
+        // Set focus back to the input element.
+        (finalRef as any).current.focus();
+      };
       let finalIsInvalid = isInvalid;
       let fieldOutput;
       let clearButtonOutput;
@@ -216,7 +226,7 @@ export const TextInput = chakra(
             "aria-hidden": isHidden,
             name,
             onChange: internalOnChange,
-            ref,
+            ref: finalRef,
           }
         : {
             "aria-required": isRequired,
@@ -233,7 +243,7 @@ export const TextInput = chakra(
             onClick,
             onFocus,
             placeholder,
-            ref,
+            ref: finalRef,
             // The `step` attribute is useful for the number type.
             step: type === "number" ? step : null,
             ...ariaAttributes,
@@ -244,12 +254,12 @@ export const TextInput = chakra(
       if (!isTextArea) {
         options = { type, value: finalValue, ...options } as any;
         fieldOutput = <ChakraInput {...options} __css={styles.input} />;
-        if (isClearable) {
+        if (isClearable && !isHidden) {
           clearButtonOutput = (
             <Button
               buttonType="text"
               id={`${id}-clear-btn`}
-              onClick={() => setFinalValue("")}
+              onClick={onClearClick}
               sx={styles.clearButton}
             >
               <Icon color="ui.black" name="close" size="medium" />


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1189](https://jira.nypl.org/browse/DSD-1189)

## This PR does the following:

- Focuses back on the input element when the clear button is clicked.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- This is better for a11y because the focus is not gone once the button is clicked.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
