### PR TITLE
DSD-1188: Remove button deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Removes
 
-- Removes the `Button` component's warning about the `link` variant being deprecated.
+- Removes the `Button` component's warning about the `link` variant being deprecated. This change is intended to be temporary.
 
 ## 1.2.1 (October 27, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Removes
 
-- Removes the `Button` component's warning about the `link` variant being deprecated. This change is intended to be temporary.
+- Removes the `Button` component warning about the deprecated `link` variant. This change is temporary and will be reverted once teams are able to update their `Button`s appropriately.
 
 ## 1.2.1 (October 27, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Fixes the sizing of the `errorFilled` and `errorOutline` icons in the `Icon` component.
 - Adds new props to Chakra's `ToolTip` to more forcefully close the DS `ToolTip`. New props include `closeDelay`, `closeOnClick`, `closeOnEsc`, and `closeOnMouseDown`.
 
+### Removes
+
+- Removes the `Button` component's warning about the `link` variant being deprecated.
+
 ## 1.2.1 (October 27, 2022)
 
 ### Adds

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -68,12 +68,6 @@ export const Button = chakra(
         );
       }
 
-      if (buttonType === "link") {
-        console.warn(
-          "NYPL Reservoir Button: The 'link' value for the 'buttonType' prop has been deprecated."
-        );
-      }
-
       React.Children.map(
         children as JSX.Element,
         (child: React.ReactElement) => {


### PR DESCRIPTION
Fixes JIRA ticket [OE-1188](https://jira.nypl.org/browse/DSD-1188).

## This PR does the following:

- Removes the `Button` component's warning about the `link` variant being deprecated.

## How has this been tested?

- In Storybook.

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
