### PR TITLE
DSD-1199: custom viewport options for Storybook

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -37,38 +37,38 @@ addDecorator((StoryFn) => (
 // Custom viewport options
 const customViewports = {
   sm: {
-    name: 'sm (320px)',
+    name: "sm (320px)",
     styles: {
-      width: '320px',
-      height: '568px',
+      width: "320px",
+      height: "568px",
     },
   },
   md: {
-    name: 'md (600px)',
+    name: "md (600px)",
     styles: {
-      width: '600px',
-      height: '800px',
+      width: "600px",
+      height: "800px",
     },
   },
   lg: {
-    name: 'lg (960px)',
+    name: "lg (960px)",
     styles: {
-      width: '960px',
-      height: '800px',
+      width: "960px",
+      height: "800px",
     },
   },
   xl: {
-    name: 'xl (1280px)',
+    name: "xl (1280px)",
     styles: {
-      width: '1280px',
-      height: '1080px',
+      width: "1280px",
+      height: "1080px",
     },
   },
   "2xl": {
-    name: '2xl (1536px)',
+    name: "2xl (1536px)",
     styles: {
-      width: '1536px',
-      height: '1080px',
+      width: "1536px",
+      height: "1080px",
     },
   },
 };

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -34,6 +34,45 @@ addDecorator((StoryFn) => (
   </div>
 ));
 
+// Custom viewport options
+const customViewports = {
+  sm: {
+    name: 'sm (320px)',
+    styles: {
+      width: '320px',
+      height: '568px',
+    },
+  },
+  md: {
+    name: 'md (600px)',
+    styles: {
+      width: '600px',
+      height: '800px',
+    },
+  },
+  lg: {
+    name: 'lg (960px)',
+    styles: {
+      width: '960px',
+      height: '800px',
+    },
+  },
+  xl: {
+    name: 'xl (1280px)',
+    styles: {
+      width: '1280px',
+      height: '1080px',
+    },
+  },
+  "2xl": {
+    name: '2xl (1536px)',
+    styles: {
+      width: '1536px',
+      height: '1080px',
+    },
+  },
+};
+
 // https://storybook.js.org/docs/react/writing-stories/parameters#global-parameters
 export const parameters = {
   // https://storybook.js.org/docs/react/essentials/actions#automatically-matching-args
@@ -45,4 +84,6 @@ export const parameters = {
   // Allows all props' descriptions and default values to show in
   // Storybook's canvas addon bar.
   controls: { expanded: true },
+  // Sets custom viewport options for testing under the Canvas view
+  viewport: { viewports: customViewports },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Icon` and `Logo` documentation to include size values in px.
 - Updates the spacing within the `tertiary` variant of the `Hero` component.
 - Updates the `Buttons Style Guide` to extend the information about button sizes.
+- Updates the `viewport` options in Storybook to align with the Reservoir breakpoints.
 
 ### Fixes
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "analyze": "size-limit --why",
     "generate-sass-resources": "gulp",
     "storybook": "start-storybook -p 6006 -s ./.storybook/public",
-    "build-storybook:v1": "npm run prebuild:storybook && build-storybook -c .storybook -o ./reservoir/v1",
+    "build-storybook:v1": "npm run prebuild:storybook && NODE_OPTIONS=--openssl-legacy-provider build-storybook -c .storybook -o ./reservoir/v1",
     "prebuild:storybook": "npm run test:generate-output"
   },
   "lint-staged": {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1199](https://jira.nypl.org/browse/DSD-1199)

## This PR does the following:

- Updates the `viewport` options in Storybook to align with the Reservoir breakpoints.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
