### PR TITLE
DSD-1212: updated md (mobile) breakpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds additional color options to `Icon` component.
 - Adds reusable iconColors and iconNames arrays/types for DRYer, easier-to-update code.
 
+## Updates
+
+- Updates the `md` breakpoint to `"37.5em"`, which is equal to `"600px"`.
+
 ### Fixes
 
 - Adds Node environment variable to npm script that Vercel uses to build the site. This patches an error from webpack not building correctly.

--- a/src/theme/foundations/breakpoints.ts
+++ b/src/theme/foundations/breakpoints.ts
@@ -7,7 +7,7 @@ import { createBreakpoints } from "@chakra-ui/theme-tools";
  * Chakra Value |     DS Variable           | EM/PX value
  * ------------------------------------------------------
  *      sm      | --nypl-breakpoint-small   | 20em/320px
- *      md      | --nypl-breakpoint-medium  | 38em/600px
+ *      md      | --nypl-breakpoint-medium  | 37.5em/600px
  *      lg      | --nypl-breakpoint-large   | 60em/960px
  *      xl      | --nypl-breakpoint-xl      | 80em/1280px
  *     2xl      |        N/A                | 96em/1536px
@@ -17,7 +17,7 @@ import { createBreakpoints } from "@chakra-ui/theme-tools";
  */
 export default createBreakpoints({
   sm: "20em",
-  md: "38em",
+  md: "37.5em",
   lg: "60em",
   xl: "80em",
   "2xl": "96em",


### PR DESCRIPTION
Fixes JIRA ticket DSD-1212

## This PR does the following:

- Updates the `md` breakpoint to `"37.5em"`, which is equal to `"600px"`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
