### PR TITLE
DSD-1216: dark mode BG color for Image

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "analyze": "size-limit --why",
     "generate-sass-resources": "gulp",
     "storybook": "start-storybook -p 6006 -s ./.storybook/public",
-    "build-storybook:v1": "npm run prebuild:storybook && build-storybook -c .storybook -o ./reservoir/v1",
+    "build-storybook:v1": "npm run prebuild:storybook && NODE_OPTIONS=--openssl-legacy-provider build-storybook -c .storybook -o ./reservoir/v1",
     "prebuild:storybook": "npm run test:generate-output"
   },
   "lint-staged": {

--- a/src/theme/components/image.ts
+++ b/src/theme/components/image.ts
@@ -89,8 +89,11 @@ const CustomImage = {
       width: "100%",
       ...imageSizes[size],
       img: {
-        backgroundColor: "ui.gray.x-light-cool",
+        backgroundColor: "ui.bg.default",
         marginBottom: "xxs",
+        _dark: {
+          backgroundColor: "dark.ui.bg.default",
+        },
       },
     },
     figcaption: {
@@ -99,12 +102,15 @@ const CustomImage = {
     },
     img: {
       display: "block",
-      backgroundColor: "ui.gray.x-light-cool",
+      backgroundColor: "ui.bg.default",
       boxSizing: "border-box",
       objectFit: "cover",
       position: "relative",
       width: "100%",
       ...imageSizes[size],
+      _dark: {
+        backgroundColor: "dark.ui.bg.default",
+      },
     },
     captionWrappers: {
       marginTop: "xxs",
@@ -125,13 +131,16 @@ const CustomImageWrapper = {
       ...imageRatios[ratio],
     },
     img: {
-      backgroundColor: "ui.gray.x-light-cool",
+      backgroundColor: "ui.bg.default",
       height: "100%",
       left: "0",
       maxWidth: "100%",
       position: "absolute",
       top: "0",
       width: "100%",
+      _dark: {
+        backgroundColor: "dark.ui.bg.default",
+      },
     },
   }),
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1216](https://jira.nypl.org/browse/DSD-1216)

## This PR does the following:

- Adds an appropriate `dark mode` background color for the `Image` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
