### PR TITLE
DSD-1227: dark mode for v1.3.0 components

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -81,8 +81,12 @@ export const parameters = {
     values: [
       { name: "Light mode page background", value: "#FFFFFF" },
       { name: "Light mode default background", value: "#F5F5F5" },
-      { name: "Dark mode page background", value: "#121212" },
-      { name: "Dark mode default background", value: "#191919" },
+      { name: "Light mode hover background", value: "#E9E9E9" },
+      { name: "Light mode active background", value: "#BDBDBD" },
+      { name: "Dark mode page background", value: "#191919" },
+      { name: "Dark mode default background", value: "#252525" },
+      { name: "Dark mode hover background", value: "#2E2E2E" },
+      { name: "Dark mode active background", value: "#424242" },
     ],
   },
   // Load the Reservoir's Chakra-based theme.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds `dark` color mode support for `background-color` and `color` global styles.
+- Adds `dark` color mode support for the `HelperErrorText` and `StatusBadge` components.
+- Adds `dark` color mode support for the `Button`, `Checkbox`, `DatePicker`, `ProgressIndicator`, `Radio`, `SearchBar`, `Select`, `Slider` and `Toggle` components.
+- Adds `dark` color mode support for the `Card` and `Hero` components.
+- Adds `dark` color mode support for the `Heading` and `List` components.
+- Adds `dark` color mode support for the `Footer`, `Header`, `HorizontalRule` and `Table` components.
+- Adds `dark` color mode support for the `Notification`, `ProgressIndicator`, and `SkeletonLoader` components.
+- Adds `dark` color mode support for the `Breadcrumbs`, `Link Types`, and `Pagination` components.
+- Adds `dark` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.
+- Adds `dark` color mode support for the `AlphabetFilter`, `AudioPlayer`, and `TagSet` components.
+- Adds `dark` color mode support for the `FeedbackBox` and `StyledList` components.
+
 ## 1.3.0 (December 8, 2022)
 
 This release is exactly the same as the `1.3.0-rc` release candidate published on December 2, 2022. The `rc` release was reviewed and validated.
@@ -59,16 +73,7 @@ This release is exactly the same as the `1.3.0-rc` release candidate published o
 
 ### Adds
 
-- Adds `dark` color mode support for `background-color` and `color` global styles.
-- Adds `dark` color mode support for the `HelperErrorText` and `StatusBadge` components.
-- Adds `dark` color mode support for the `Card` and `Hero` components.
-- Adds `dark` color mode support for the `Heading` and `List` components.
-- Adds `dark` color mode support for the `Footer`, `Header`, `HorizontalRule` and `Table` components.
-- Adds `dark` color mode support for the `Notification`, `ProgressIndicator`, and `SkeletonLoader` components.
-- Adds `dark` color mode support for the `Breadcrumbs`, `Link Types`, and `Pagination` components.
-- Adds `dark` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.
 - Adds `brand` as a `breadcrumbsType` to the `Breadcrumbs` component.
-- Adds `dark` color mode support for the `ALphabetFilter`, `AudioPlayer`, and `TagSet` components.
 
 ### Updates
 

--- a/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.stories.mdx
@@ -36,10 +36,10 @@ import DSProvider from "../../theme/provider";
 
 # AlphabetFilter
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.2.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/AudioPlayer/AudioPlayer.stories.mdx
+++ b/src/components/AudioPlayer/AudioPlayer.stories.mdx
@@ -32,10 +32,10 @@ import DSProvider from "../../theme/provider";
 
 # Audio Player
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.2.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -107,10 +107,10 @@ export const iconNames = [
 
 # Button
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.0.4`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Card/Card.stories.mdx
+++ b/src/components/Card/Card.stories.mdx
@@ -72,10 +72,10 @@ import DSProvider from "../../theme/provider";
 
 # Card
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.24.0`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Checkbox/Checkbox.stories.mdx
+++ b/src/components/Checkbox/Checkbox.stories.mdx
@@ -54,10 +54,10 @@ import DSProvider from "../../theme/provider";
 
 # Checkbox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.1.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/DatePicker/DatePicker.stories.mdx
+++ b/src/components/DatePicker/DatePicker.stories.mdx
@@ -68,10 +68,10 @@ const currentYear = new Date().getFullYear();
 
 # DatePicker
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.24.0`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/FeedbackBox.stories.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.stories.mdx
@@ -39,10 +39,10 @@ import { getCategory } from "../../utils/componentCategories";
 
 # FeedbackBox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.3.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.3.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -7,6 +7,7 @@ import {
   DrawerHeader,
   DrawerOverlay,
   Spacer,
+  useColorModeValue,
   useDisclosure,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
@@ -128,6 +129,7 @@ export const FeedbackBox = chakra(
       const minHeightWithCategory = "345px";
       const minHeightWithEmail = "385px";
       const minHeightWithCategoryAndEmail = "455px";
+      const iconColor = useColorModeValue(null, "dark.ui.typography.body");
       let drawerMinHeight = initMinHeight;
       const closeAndResetForm = () => {
         finalOnClose();
@@ -150,6 +152,7 @@ export const FeedbackBox = chakra(
             noMargin
             notificationContent={notificationText}
             showIcon={false}
+            p="0"
             sx={{
               // The padding of the Notification is smaller than
               // the initial one.
@@ -375,7 +378,11 @@ export const FeedbackBox = chakra(
                         textAlign="center"
                         ref={focusRef}
                       >
-                        <Icon name="actionCheckCircleFilled" size="large" />
+                        <Icon
+                          color={iconColor}
+                          name="actionCheckCircleFilled"
+                          size="large"
+                        />
                         <Text fontWeight="medium">
                           Thank you for submitting your feedback.
                         </Text>

--- a/src/components/Fieldset/Fieldset.stories.mdx
+++ b/src/components/Fieldset/Fieldset.stories.mdx
@@ -36,10 +36,10 @@ import DSProvider from "../../theme/provider";
 
 # Fieldset
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.3`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.25.3`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Footer/Footer.stories.mdx
+++ b/src/components/Footer/Footer.stories.mdx
@@ -26,10 +26,10 @@ import DSProvider from "../../theme/provider";
 
 # Footer
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.1.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.1.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Header/Header.stories.mdx
+++ b/src/components/Header/Header.stories.mdx
@@ -22,10 +22,10 @@ import { getCategory } from "../../utils/componentCategories";
 
 # Header
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.1.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.1.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/HelperErrorText/HelperErrorText.stories.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.mdx
@@ -43,10 +43,10 @@ import DSProvider from "../../theme/provider";
 
 # HelperErrorText
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.0.10`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -55,10 +55,10 @@ export const imageProps = {
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.2.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/HorizontalRule/HorizontalRule.stories.mdx
+++ b/src/components/HorizontalRule/HorizontalRule.stories.mdx
@@ -30,10 +30,10 @@ import { getCategory } from "../../utils/componentCategories";
 
 # Horizontal Rule
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.0`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.23.0`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Icons/Icon.stories.mdx
+++ b/src/components/Icons/Icon.stories.mdx
@@ -61,10 +61,10 @@ import { getIconNames } from "./IconNames";
 
 # Icon
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.0.4`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Label/Label.stories.mdx
+++ b/src/components/Label/Label.stories.mdx
@@ -28,10 +28,10 @@ import { getCategory } from "../../utils/componentCategories";
 
 # Label
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.0.10`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Notification/Notification.stories.mdx
+++ b/src/components/Notification/Notification.stories.mdx
@@ -46,10 +46,10 @@ import DSProvider from "../../theme/provider";
 
 # Notification
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.23.2`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/ProgressIndicator/ProgressIndicator.stories.mdx
+++ b/src/components/ProgressIndicator/ProgressIndicator.stories.mdx
@@ -49,10 +49,10 @@ import DSProvider from "../../theme/provider";
 
 # ProgressIndicator
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.25.4`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Radio/Radio.stories.mdx
+++ b/src/components/Radio/Radio.stories.mdx
@@ -50,10 +50,10 @@ import DSProvider from "../../theme/provider";
 
 # Radio
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.22.0`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.22.0`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -57,10 +57,10 @@ import DSProvider from "../../theme/provider";
 
 # SearchBar
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.0.4`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Select/Select.stories.mdx
+++ b/src/components/Select/Select.stories.mdx
@@ -63,10 +63,10 @@ import DSProvider from "../../theme/provider";
 
 # Select
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.7.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/SkeletonLoader/SkeletonLoader.stories.mdx
+++ b/src/components/SkeletonLoader/SkeletonLoader.stories.mdx
@@ -45,10 +45,10 @@ import { getCategory } from "../../utils/componentCategories";
 
 # SkeletonLoader
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.17.3`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.17.3`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -74,10 +74,10 @@ import DSProvider from "../../theme/provider";
 
 # Slider
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.25.4`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/StatusBadge/StatusBadge.stories.mdx
+++ b/src/components/StatusBadge/StatusBadge.stories.mdx
@@ -37,10 +37,10 @@ import DSProvider from "../../theme/provider";
 
 # StatusBadge
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.18.7`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.18.7`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/StyledList/StyledList.stories.mdx
+++ b/src/components/StyledList/StyledList.stories.mdx
@@ -35,10 +35,10 @@ import DSProvider from "../../theme/provider";
 
 # StyledList
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.3.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.3.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Table/Table.stories.mdx
+++ b/src/components/Table/Table.stories.mdx
@@ -35,10 +35,10 @@ import { getCategory } from "../../utils/componentCategories";
 
 # Table
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.9`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.25.9`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/TagSet/TagSet.stories.mdx
+++ b/src/components/TagSet/TagSet.stories.mdx
@@ -41,10 +41,10 @@ import DSProvider from "../../theme/provider";
 
 # TagSet
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.2.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -50,10 +50,10 @@ import DSProvider from "../../theme/provider";
 
 # TextInput
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.22.0`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.22.0`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/Toggle/Toggle.stories.mdx
+++ b/src/components/Toggle/Toggle.stories.mdx
@@ -42,10 +42,10 @@ import DSProvider from "../../theme/provider";
 
 # Toggle
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.8`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.25.8`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/VideoPlayer/VideoPlayer.stories.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.stories.mdx
@@ -40,10 +40,10 @@ import DSProvider from "../../theme/provider";
 
 # Video Player
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `1.3.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `0.23.2`          |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/theme/components/feedbackBox.ts
+++ b/src/theme/components/feedbackBox.ts
@@ -12,10 +12,21 @@ const FeedbackBox = {
     closeButton: {
       p: "0",
       span: screenreaderOnly(),
+      _dark: {
+        svg: {
+          fill: "dark.ui.typography.heading",
+        },
+      },
     },
     drawerBody: {
+      borderLeft: { base: undefined, md: "1px solid" },
+      borderColor: "ui.border.default",
       paddingTop: "m",
       paddingBottom: "m",
+      _dark: {
+        background: "dark.ui.bg.page",
+        borderColor: "dark.ui.border.default",
+      },
     },
     drawerContent: {
       marginStart: "auto",
@@ -25,6 +36,8 @@ const FeedbackBox = {
       alignItems: "baseline",
       background: "ui.gray.light-cool",
       borderBottomWidth: "1px",
+      borderLeftWidth: { base: undefined, md: "1px" },
+      borderTopWidth: "1px",
       display: "flex",
       fontSize: "text.default",
       px: "m",
@@ -32,6 +45,9 @@ const FeedbackBox = {
       paddingBottom: "xs",
       p: {
         marginBottom: "0",
+      },
+      _dark: {
+        background: "dark.ui.bg.hover",
       },
     },
     openButton: {

--- a/src/theme/components/styledList.ts
+++ b/src/theme/components/styledList.ts
@@ -18,6 +18,11 @@ const StyledList = {
         my: "xs",
         px: "xs",
       },
+      _dark: {
+        li: {
+          borderColor: "dark.ui.border.default",
+        }
+      }
     },
   },
 };

--- a/src/theme/components/styledList.ts
+++ b/src/theme/components/styledList.ts
@@ -21,8 +21,8 @@ const StyledList = {
       _dark: {
         li: {
           borderColor: "dark.ui.border.default",
-        }
-      }
+        },
+      },
     },
   },
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1227](https://jira.nypl.org/browse/DSD-1227)

## This PR does the following:

- Adds `dark` color mode support for the `FeedbackBox` and `StyledList` components.
- Changes `Latest` version number for all updated component to `DarkModeVersion` placeholder text. The placeholder text can be updated once we settle on a release for these updates.
- Adds more background color options for Storybook.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Using approved dark mode color palette.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
