### PR TITLE
DSD-1238: remove deprecation warning from Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the hex value for `ui.gray.xx-dark`, `ui.gray.xxx-dark`, `ui.gray.xxxx-dark`, `dark.ui.bg.page`, `dark.ui.bg.hover`, `dark.ui.bg.active`, `dark.ui.disabled.secondary`, `dark.ui.error.primary`, `dark.ui.error.secondary`, `dark.ui.focus`, `dark.ui.link.primary`, `dark.ui.link.secondary`, `dark.ui.status.primary`, `dark.ui.status.secondary`, `dark.ui.success.primary`, `dark.ui.success.secondary`, `dark.ui.warning.primary` and `dark.ui.warning.secondary`.
 
+### Removes
+
+- Removes the `Link` component warning about the deprecated `button` variant. This change is temporary and will be reverted once teams are able to update their `Link`s appropriately.
+
 ## 1.3.1 (December 15, 2022)
 
 ### Adds

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -114,18 +114,19 @@ describe("Link", () => {
     );
   });
 
-  it("logs a deprecated warning if 'button' `type` passed", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      <Link href="#test" type="button">
-        Test
-      </Link>
-    );
-
-    expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir Link: The "button" type is deprecated. Instead, use either "buttonPrimary", "buttonSecondary", "buttonPill", "buttonCallout", "buttonNoBrand", or "buttonDisabled".`
-    );
-  });
+  /** This deprecation warning is temporarily being removed, but it will be
+   * reinstated once teams are able to update their `Link`s appropriately. */
+  // it("logs a deprecated warning if 'button' `type` passed", () => {
+  //   const warn = jest.spyOn(console, "warn");
+  //   render(
+  //     <Link href="#test" type="button">
+  //       Test
+  //     </Link>
+  //   );
+  //   expect(warn).toHaveBeenCalledWith(
+  //     `NYPL Reservoir Link: The "button" type is deprecated. Instead, use either "buttonPrimary", "buttonSecondary", "buttonPill", "buttonCallout", "buttonNoBrand", or "buttonDisabled".`
+  //   );
+  // });
 
   it("renders the UI snapshot correctly", () => {
     const standard = renderer

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -139,11 +139,13 @@ export const Link = chakra(
     ) {
       variant = "moreLink";
     } else if (type.includes("button")) {
-      if (type === "button") {
-        console.warn(
-          `NYPL Reservoir Link: The "button" type is deprecated. Instead, use either "buttonPrimary", "buttonSecondary", "buttonPill", "buttonCallout", "buttonNoBrand", or "buttonDisabled".`
-        );
-      }
+      /** This deprecation warning is temporarily being removed, but it will be
+       * reinstated once teams are able to update their `Link`s appropriately. */
+      // if (type === "button") {
+      //   console.warn(
+      //     `NYPL Reservoir Link: The "button" type is deprecated. Instead, use either "buttonPrimary", "buttonSecondary", "buttonPill", "buttonCallout", "buttonNoBrand", or "buttonDisabled".`
+      //   );
+      // }
       variant = type;
     }
     const style = useStyleConfig("Link", { variant });


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1238](https://jira.nypl.org/browse/DSD-1238)

## This PR does the following:

- Removes the `Link` component warning about the deprecated `button` variant. This change is temporary and will be reverted once teams are able to update their `Link`s appropriately.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
