### PR TITLE
DSD-1242: remove aria-live from HelpErerrorText

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Fixes spacing and alignment issues in the `FeedbackBox` component.
 - Fixes the width of the Privacy Policy link in the `FeedbackBox` component.
 
+### Deprecates
+
+- Deprecates the `ariaLive` prop in the `HelperErrorText` component.
+
 ## 1.3.1 (December 15, 2022)
 
 ### Adds

--- a/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
+++ b/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
   </p>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -596,7 +596,6 @@ exports[`Checkbox renders the UI snapshot correctly 4`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
+++ b/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 1`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -66,7 +65,6 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 3`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="polite"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -379,7 +379,6 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
               />
               <div
                 aria-atomic={true}
-                aria-live="polite"
                 className="css-1xdhyk6"
                 dangerouslySetInnerHTML={
                   Object {
@@ -435,7 +434,6 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
               />
               <div
                 aria-atomic={true}
-                aria-live="polite"
                 className="css-1xdhyk6"
                 dangerouslySetInnerHTML={
                   Object {
@@ -452,7 +450,6 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
     </div>
     <div
       aria-atomic={true}
-      aria-live="off"
       className="css-1xdhyk6"
       dangerouslySetInnerHTML={
         Object {
@@ -571,7 +568,6 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
     </div>
     <div
       aria-atomic={true}
-      aria-live="off"
       className="css-1xdhyk6"
       dangerouslySetInnerHTML={
         Object {
@@ -779,7 +775,6 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
           />
           <div
             aria-atomic={true}
-            aria-live="polite"
             className="css-1xdhyk6"
             dangerouslySetInnerHTML={
               Object {
@@ -842,7 +837,6 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
           />
           <div
             aria-atomic={true}
-            aria-live="off"
             className="css-1xdhyk6"
             dangerouslySetInnerHTML={
               Object {
@@ -905,7 +899,6 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
           />
           <div
             aria-atomic={true}
-            aria-live="off"
             className="css-1xdhyk6"
             dangerouslySetInnerHTML={
               Object {
@@ -969,7 +962,6 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
           />
           <div
             aria-atomic={true}
-            aria-live="off"
             className="css-1xdhyk6"
             dangerouslySetInnerHTML={
               Object {

--- a/src/components/HelperErrorText/HelperErrorText.stories.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.mdx
@@ -30,9 +30,6 @@ import DSProvider from "../../theme/provider";
       control: false,
       table: { defaultValue: { summary: true } },
     },
-    ariaLive: {
-      table: { defaultValue: { summary: "undefined" } },
-    },
     children: { table: { disable: true } },
     className: { control: false },
     id: { control: false },
@@ -68,7 +65,7 @@ import DSProvider from "../../theme/provider";
     name="HelperErrorText with Controls"
     args={{
       ariaAtomic: undefined,
-      ariaLive: "polite",
+      ariaLive: undefined,
       className: undefined,
       id: "helperErrorText-id",
       isInvalid: false,
@@ -89,9 +86,17 @@ import DSProvider from "../../theme/provider";
 ## Accessibility
 
 In the Reservoir Design System (DS), the `HelperErrorText` component is always
-associated with a related element by using the `aria-describedby` attribute in
-the associated element. In this way, the content of the `HelperErrorText` is
-made available to screenreaders.
+used as a child component when composing more complex components. In the case
+of form components, the `HelperErrorText` component is associated with a
+related input field by using the `aria-describedby` attribute in the
+associated element. In this way, the content of the `HelperErrorText` component
+is made available to screenreaders.
+
+The example below is rendered using the `TextInput` component. The `TextInput`
+component uses the `HelperErrorText` component to render the red
+`"This is error text :("` below the input field and that text element is
+referenced with the `aria-describedby` attribute on the HTML input element.
+This type of association is handled automatically by all DS `Form Elements` components.
 
 <Canvas>
   <Story

--- a/src/components/HelperErrorText/HelperErrorText.stories.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.mdx
@@ -10,6 +10,7 @@ import { withDesign } from "storybook-addon-designs";
 import HelperErrorText from "./HelperErrorText";
 import Link from "../Link/Link";
 import Text from "../Text/Text";
+import TextInput from "../TextInput/TextInput";
 import { getCategory } from "../../utils/componentCategories";
 import DSProvider from "../../theme/provider";
 
@@ -30,7 +31,7 @@ import DSProvider from "../../theme/provider";
       table: { defaultValue: { summary: true } },
     },
     ariaLive: {
-      table: { defaultValue: { summary: "polite" } },
+      table: { defaultValue: { summary: "undefined" } },
     },
     children: { table: { disable: true } },
     className: { control: false },
@@ -46,7 +47,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `1.0.6`    |
+| Latest            | `1.4.0`    |
 
 ## Table of Contents
 
@@ -87,10 +88,27 @@ import DSProvider from "../../theme/provider";
 
 ## Accessibility
 
-In the "invalid" state when `isInvalid` is set to true, the text passed to the
-`invalidText` prop will be presented to screen readers be default. If you need
-to turn this off, set the `ariaLive` prop to `"off"`. This is used in DS "form"
-components for invalid form submissions or incorrect values entered.
+In the Reservoir Design System (DS), the `HelperErrorText` component is always
+associated with a related element by using the `aria-describedby` attribute in
+the associated element. In this way, the content of the `HelperErrorText` is
+made available to screenreaders.
+
+<Canvas>
+  <Story
+    name="Text Input with HelperErrorText"
+    args={{
+      helperText: "Choose wisely.",
+      id: "textInput-id",
+      invalidText: "This is error text :(",
+      isInvalid: true,
+      labelText: "What is your favorite color?",
+      name: "textInput-name",
+      placeholder: "e.g. blue, green, etc.",
+    }}
+  >
+    {(args) => <TextInput {...args} />}
+  </Story>
+</Canvas>
 
 ### ariaAtomic
 
@@ -100,6 +118,10 @@ technologies. When it is set to `false`, only additionals or removals will be
 read by assistive technologies.
 
 ### ariaLive
+
+IMPORTANT: The `ariaLive` prop has been deprecated. Due to how the `HelperErrorText`
+component is used within the DS, this prop was found to be unnecessary and it will
+eventually be removed.
 
 The `ariaLive` prop sets the `aria-live` attribute; `"polite"` is set by default
 in the "invalid" state and `"off"` otherwise. This sets the priority of when the
@@ -128,6 +150,7 @@ should be announced immediately.
 
 Resources:
 
+- [MDN aria-describedby Attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-describedby)
 - [MDN ARIA live regions](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions)
 - [W3C WAI-ARIA 1.1 - aria-live (property)](https://www.w3.org/TR/wai-aria-1.1/#aria-live)
 - [W3C ARIA19: Using ARIA role=alert or Live Regions to Identify Errors](https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html)

--- a/src/components/HelperErrorText/HelperErrorText.test.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.test.tsx
@@ -39,10 +39,14 @@ describe("HelperErrorText", () => {
     expect(screen.getByText("Text")).toHaveAttribute("data-isinvalid", "true");
   });
 
-  it("has aria-live and aria-atomic attributes when errored", () => {
+  it("has aria-atomic attributes when errored", () => {
     render(<HelperErrorText isInvalid text="Text" />);
-    expect(screen.getByText("Text")).toHaveAttribute("aria-live", "polite");
     expect(screen.getByText("Text")).toHaveAttribute("aria-atomic");
+  });
+
+  it("has aria-live attributes when ariaLive prop is passed", () => {
+    render(<HelperErrorText ariaLive="polite" text="Text" />);
+    expect(screen.getByText("Text")).toHaveAttribute("aria-live", "polite");
   });
 
   it("accepts an aria-atomic value of false", () => {

--- a/src/components/HelperErrorText/HelperErrorText.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.tsx
@@ -43,7 +43,7 @@ export const HelperErrorText = chakra(
       const styles = useStyleConfig("HelperErrorText", { isInvalid });
       const props = {
         "aria-atomic": ariaAtomic,
-        "aria-live": ariaLive ? ariaLive : undefined,
+        "aria-live": ariaLive,
         className,
         "data-isinvalid": isInvalid,
         id,

--- a/src/components/HelperErrorText/HelperErrorText.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.tsx
@@ -1,20 +1,16 @@
 import { Box, chakra, useStyleConfig } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
-export type AriaLiveValues = "assertive" | "off" | "polite";
+export type AriaLiveValues = "assertive" | "off" | "polite" | undefined;
 export type HelperErrorTextType = string | JSX.Element;
 
 interface HelperErrorTextProps {
-  /** Aria attribute. When true, assistive technologies will
-   * read the entire DOM element. When false, only changes (additionals or
-   * removals) will be read. True by default. */
+  /** Aria attribute. When true, assistive technologies will read the entire 
+   * DOM element. When false, only changes (additionals or removals) will be 
+   * read. True by default. */
   ariaAtomic?: boolean;
-  /** Aria attribute used in the invalid state to read error text by default.
-   * This indicates the priority of the text and when it should be presented to
-   * users using screen readers; "off" indicates that the content should not be
-   * presented, "polite" that it will be announced at the next available time
-   * slot, and "assertive" that it should be announced immediately. This is set
-   * to "off" by default and to "polite" by when `isInvalid` is true. */
+  /** DEPRECATED: The `ariaLive` prop was found to be unnecessary. The prop 
+   * has been deprecated and it will eventually be removed. */
   ariaLive?: AriaLiveValues;
   /** Additional className to add. */
   className?: string;
@@ -34,7 +30,7 @@ export const HelperErrorText = chakra(
     (
       {
         ariaAtomic = true,
-        ariaLive = "polite",
+        ariaLive = undefined,
         className = "",
         id,
         isInvalid = false,
@@ -44,11 +40,10 @@ export const HelperErrorText = chakra(
       ref?
     ) => {
       // Only announce the text in the invalid state.
-      const announceAriaLive = isInvalid;
       const styles = useStyleConfig("HelperErrorText", { isInvalid });
       const props = {
         "aria-atomic": ariaAtomic,
-        "aria-live": announceAriaLive ? ariaLive : "off",
+        "aria-live": ariaLive ? ariaLive : undefined,
         className,
         "data-isinvalid": isInvalid,
         id,

--- a/src/components/HelperErrorText/HelperErrorText.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.tsx
@@ -5,11 +5,11 @@ export type AriaLiveValues = "assertive" | "off" | "polite" | undefined;
 export type HelperErrorTextType = string | JSX.Element;
 
 interface HelperErrorTextProps {
-  /** Aria attribute. When true, assistive technologies will read the entire 
-   * DOM element. When false, only changes (additionals or removals) will be 
+  /** Aria attribute. When true, assistive technologies will read the entire
+   * DOM element. When false, only changes (additionals or removals) will be
    * read. True by default. */
   ariaAtomic?: boolean;
-  /** DEPRECATED: The `ariaLive` prop was found to be unnecessary. The prop 
+  /** DEPRECATED: The `ariaLive` prop was found to be unnecessary. The prop
    * has been deprecated and it will eventually be removed. */
   ariaLive?: AriaLiveValues;
   /** Additional className to add. */

--- a/src/components/HelperErrorText/__snapshots__/HelperErrorText.test.tsx.snap
+++ b/src/components/HelperErrorText/__snapshots__/HelperErrorText.test.tsx.snap
@@ -3,7 +3,6 @@
 exports[`HelperErrorText Renders the UI snapshot correctly 1`] = `
 <div
   aria-atomic={true}
-  aria-live="off"
   className="css-1xdhyk6"
   dangerouslySetInnerHTML={
     Object {
@@ -18,7 +17,6 @@ exports[`HelperErrorText Renders the UI snapshot correctly 1`] = `
 exports[`HelperErrorText Renders the UI snapshot correctly 2`] = `
 <div
   aria-atomic={true}
-  aria-live="polite"
   className="css-1xdhyk6"
   dangerouslySetInnerHTML={
     Object {
@@ -33,7 +31,6 @@ exports[`HelperErrorText Renders the UI snapshot correctly 2`] = `
 exports[`HelperErrorText Renders the UI snapshot correctly 3`] = `
 <div
   aria-atomic={true}
-  aria-live="polite"
   className="css-1xdhyk6"
   dangerouslySetInnerHTML={
     Object {
@@ -48,7 +45,6 @@ exports[`HelperErrorText Renders the UI snapshot correctly 3`] = `
 exports[`HelperErrorText Renders the UI snapshot correctly 4`] = `
 <div
   aria-atomic={true}
-  aria-live="polite"
   className="css-1xdhyk6"
   data-isinvalid={true}
   id="invalid"
@@ -64,7 +60,6 @@ exports[`HelperErrorText Renders the UI snapshot correctly 4`] = `
 exports[`HelperErrorText Renders the UI snapshot correctly 5`] = `
 <div
   aria-atomic={true}
-  aria-live="off"
   className="css-10g9ftz"
   dangerouslySetInnerHTML={
     Object {
@@ -79,7 +74,6 @@ exports[`HelperErrorText Renders the UI snapshot correctly 5`] = `
 exports[`HelperErrorText Renders the UI snapshot correctly 6`] = `
 <div
   aria-atomic={true}
-  aria-live="off"
   className="css-1xdhyk6"
   dangerouslySetInnerHTML={
     Object {

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -528,7 +528,6 @@ exports[`Radio Button renders the UI snapshot correctly 4`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -75,7 +75,6 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
   </form>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -283,7 +282,6 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
   </form>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -447,7 +445,6 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
   </form>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1031,7 +1028,6 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
   </form>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1120,7 +1116,6 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
   </form>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/Select/__snapshots__/Select.test.tsx.snap
+++ b/src/components/Select/__snapshots__/Select.test.tsx.snap
@@ -287,7 +287,6 @@ exports[`Select Renders the UI snapshot correctly 3`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="polite"
     className="css-bl03f5"
     dangerouslySetInnerHTML={
       Object {
@@ -395,7 +394,6 @@ exports[`Select Renders the UI snapshot correctly 4`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-bl03f5"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -162,7 +162,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -339,7 +338,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="polite"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -519,7 +517,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -696,7 +693,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -977,7 +973,6 @@ exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1214,7 +1209,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1346,7 +1340,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="polite"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1481,7 +1474,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1614,7 +1606,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -1827,7 +1818,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 6`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -2040,7 +2030,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -2172,7 +2161,6 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
   </div>
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -173,7 +173,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
   />
   <div
     aria-atomic={true}
-    aria-live="off"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {
@@ -219,7 +218,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
   />
   <div
     aria-atomic={true}
-    aria-live="polite"
     className="css-1xdhyk6"
     dangerouslySetInnerHTML={
       Object {

--- a/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
+++ b/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
@@ -61,7 +61,6 @@ exports[`VideoPlayer renders the UI snapshot correctly 2`] = `
     </div>
     <div
       aria-atomic={true}
-      aria-live="off"
       className="css-1xdhyk6"
       dangerouslySetInnerHTML={
         Object {
@@ -109,7 +108,6 @@ exports[`VideoPlayer renders the UI snapshot correctly 3`] = `
     </div>
     <div
       aria-atomic={true}
-      aria-live="off"
       className="css-1xdhyk6"
       dangerouslySetInnerHTML={
         Object {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1242](https://jira.nypl.org/browse/DSD-1242)

## This PR does the following:

- Deprecates the `ariaLive` prop in the `HelperErrorText` component.
- The Jira ticket requests that the `ariaLive` prop be removed, but that would produce a breaking change.  In light of that, the `ariaLive` prop has been deprecated and the logic in the `HelperErrorText` component was updated to omit the `aria-live` attribute unless the `ariaLive` prop was explicitly passed.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Due to how the `HelperErrorText` component is used within the DS, the `ariaLive` prop was found to be unnecessary.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
