### PR TITLE
DSD-1230: SR-only descriptive text for Link component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the hex value for `ui.gray.xx-dark`, `ui.gray.xxx-dark`, `ui.gray.xxxx-dark`, `dark.ui.bg.page`, `dark.ui.bg.hover`, `dark.ui.bg.active`, `dark.ui.disabled.secondary`, `dark.ui.error.primary`, `dark.ui.error.secondary`, `dark.ui.focus`, `dark.ui.link.primary`, `dark.ui.link.secondary`, `dark.ui.status.primary`, `dark.ui.status.secondary`, `dark.ui.success.primary`, `dark.ui.success.secondary`, `dark.ui.warning.primary` and `dark.ui.warning.secondary`.
 - Updates the layout of the category `RadioGroup` to `column` for the mobie view of the `FeedbackBox` component.
+- Updates the `Link` component to include descriptive text for screen readers in the component's `"external"` variant.
 
 ### Fixes
 

--- a/src/components/Link/Link.stories.mdx
+++ b/src/components/Link/Link.stories.mdx
@@ -39,7 +39,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.2.1`    |
+| Latest            | `1.4.0`    |
 
 ## Table of Contents
 
@@ -78,10 +78,22 @@ The `Link` component should be used for navigation. If an `onClick` user
 interface action is required, a `Button` component should be used instead. The
 `Link` component renders an `<a>` element with the `href` attribute.
 
+The `"external"` variant of the `Link` component includes `"screen reader only"`
+descriptive text to clarify that the link will open in a new tab/window.
+
+<Canvas>
+  <DSProvider>
+    <Link type="external" href="https://nypl.org">
+      NYPL Website
+    </Link>
+  </DSProvider>
+</Canvas>
+
 Resources:
 
 - [W3C WAI Link Examples](https://www.w3.org/TR/wai-aria-practices-1.1/examples/link/link.html)
 - [Yale Usability & Web Accessibility Links](https://usability.yale.edu/web-accessibility/articles/links)
+- [WebAIM: Invisible Content Just for Screen Reader Users](https://webaim.org/techniques/css/invisiblecontent/)
 
 ## Links With Icons
 

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -1,4 +1,4 @@
-import { Box, chakra, useStyleConfig } from "@chakra-ui/react";
+import { Box, chakra, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 import Icon from "../Icons/Icon";
@@ -79,11 +79,17 @@ function getWithDirectionIcon(
   );
 }
 
-function getExternalExtraElements(children: JSX.Element, linkId: string) {
+function getExternalExtraElements(
+  children: JSX.Element,
+  linkId: string,
+  styles: object
+) {
   const iconId = `${linkId}-icon`;
-  const icon = (
+  const extraElements = (
     <>
-      <span>This link opens in a new window</span>
+      <Box as="span" __css={styles}>
+        This link opens in a new window
+      </Box>
       <Icon
         align={"right"}
         className="more-link"
@@ -98,7 +104,7 @@ function getExternalExtraElements(children: JSX.Element, linkId: string) {
   return (
     <>
       {children}
-      {icon}
+      {extraElements}
     </>
   );
 }
@@ -150,7 +156,7 @@ export const Link = chakra(
       }
       variant = type;
     }
-    const style = useStyleConfig("Link", { variant });
+    const styles = useMultiStyleConfig("Link", { variant });
     const rel = type === "external" ? "nofollow" : null;
     const target = type === "external" ? "_blank" : null;
     // Render with specific direction arrows if the type is
@@ -160,7 +166,7 @@ export const Link = chakra(
       ((type === "forwards" || type === "backwards") &&
         getWithDirectionIcon(children as JSX.Element, type, id)) ||
       (type === "external" &&
-        getExternalExtraElements(children as JSX.Element, id)) ||
+        getExternalExtraElements(children as JSX.Element, id, styles.srOnly)) ||
       children;
 
     if (!href) {
@@ -175,7 +181,7 @@ export const Link = chakra(
       const childrenToClone: any = children[0] ? children[0] : children;
       const childProps = childrenToClone.props;
       return (
-        <Box as="span" __css={style} {...rest}>
+        <Box as="span" __css={styles} {...rest}>
           {React.cloneElement(
             childrenToClone,
             {
@@ -200,7 +206,7 @@ export const Link = chakra(
           onClick={onClick}
           target={target}
           {...linkProps}
-          __css={style}
+          __css={styles}
         >
           {newChildren}
         </Box>

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -79,16 +79,20 @@ function getWithDirectionIcon(
   );
 }
 
-function getExternalIcon(children: JSX.Element, linkId: string) {
+function getExternalExtraElements(children: JSX.Element, linkId: string) {
   const iconId = `${linkId}-icon`;
   const icon = (
-    <Icon
-      align={"right"}
-      className="more-link"
-      id={iconId}
-      name="actionLaunch"
-      size="medium"
-    />
+    <>
+      <span>This link opens in a new window</span>
+      <Icon
+        align={"right"}
+        className="more-link"
+        id={iconId}
+        name="actionLaunch"
+        size="medium"
+        title="External link"
+      />
+    </>
   );
 
   return (
@@ -155,7 +159,8 @@ export const Link = chakra(
     const newChildren =
       ((type === "forwards" || type === "backwards") &&
         getWithDirectionIcon(children as JSX.Element, type, id)) ||
-      (type === "external" && getExternalIcon(children as JSX.Element, id)) ||
+      (type === "external" &&
+        getExternalExtraElements(children as JSX.Element, id)) ||
       children;
 
     if (!href) {

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -109,7 +109,9 @@ exports[`Link renders the UI snapshot correctly 4`] = `
   target="_blank"
 >
   External
-  <span>
+  <span
+    className="css-0"
+  >
     This link opens in a new window
   </span>
   <svg

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -109,13 +109,16 @@ exports[`Link renders the UI snapshot correctly 4`] = `
   target="_blank"
 >
   External
+  <span>
+    This link opens in a new window
+  </span>
   <svg
     aria-hidden={true}
     className="chakra-icon more-link css-1grhd2q"
     focusable={false}
     id="external-link-icon"
     role="img"
-    title="actionLaunch icon"
+    title="External link"
     viewBox="0 0 24 24"
   >
     <g

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -6,6 +6,7 @@ import {
   primary,
   secondary,
 } from "./button";
+import { screenreaderOnly } from "./globalMixins";
 
 export const baseLinkStyles = {
   color: "ui.link.primary",
@@ -101,13 +102,16 @@ const variants = {
 const Link = {
   baseStyle: {
     ...baseLinkStyles,
-    // This is needed for custom anchor elements or link components
-    // that are passed as children to the `Link` component.
+    /** This is needed for custom anchor elements or link components
+     * that are passed as children to the `Link` component. */
     a: {
       _hover: {
         color: "ui.link.secondary",
       },
     },
+    /** The span element will handle descriptive text added to aid
+     * screen readers. */
+    span: screenreaderOnly(),
   },
   variants,
 };

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -100,6 +100,7 @@ const variants = {
   },
 };
 const Link = {
+  parts: ["srOnly"],
   baseStyle: {
     ...baseLinkStyles,
     /** This is needed for custom anchor elements or link components
@@ -109,9 +110,9 @@ const Link = {
         color: "ui.link.secondary",
       },
     },
-    /** The span element will handle descriptive text added to aid
+    /** The element will handle descriptive text added to aid
      * screen readers. */
-    span: screenreaderOnly(),
+    srOnly: screenreaderOnly(),
   },
   variants,
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1230](https://jira.nypl.org/browse/DSD-1230)

## This PR does the following:

- Updates the `Link` component to include descriptive text for screen readers in the component's `"external"` variant.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The addition of the new descriptive text is for screen readers only.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
