### PR TITLE
DSD-1279: improved a11y for CheckboxGroup, MultiSelectGroup and RadioGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,23 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Updates
 
-- Updates the hex value for `ui.gray.xx-dark`, `ui.gray.xxx-dark`, `ui.gray.xxxx-dark`, `dark.ui.bg.page`, `dark.ui.bg.hover`, `dark.ui.bg.active`, `dark.ui.disabled.secondary`, `dark.ui.error.primary`, `dark.ui.error.secondary`, `dark.ui.focus`, `dark.ui.link.primary`, `dark.ui.link.secondary`, `dark.ui.status.primary`, `dark.ui.status.secondary`, `dark.ui.success.primary`, `dark.ui.success.secondary`, `dark.ui.warning.primary` and `dark.ui.warning.secondary`.
-- Updates the layout of the category `RadioGroup` to `column` for the mobie view of the `FeedbackBox` component.
-- Updates the background color for the `"iconOnly"` and `"text"` variants of the `Button` component.
-- Updates the DOM in the header of the `FeedbackBox` component to improve accessibility.
-- Updates the `Link` component to include descriptive text for screen readers in the component's `"external"` variant.
-- Updates the `HelperErrorText` component to set the `ariaLive` default value to `"polite"`.
+- Updates the hex value for `ui.gray.xx-dark`, `ui.gray.xxx-dark`,
+  `ui.gray.xxxx-dark`, `dark.ui.bg.page`, `dark.ui.bg.hover`, `dark.ui.bg.active`,
+  `dark.ui.disabled.secondary`, `dark.ui.error.primary`, `dark.ui.error.secondary`,
+  `dark.ui.focus`, `dark.ui.link.primary`, `dark.ui.link.secondary`,
+  `dark.ui.status.primary`, `dark.ui.status.secondary`, `dark.ui.success.primary`,
+  `dark.ui.success.secondary`, `dark.ui.warning.primary`
+  and `dark.ui.warning.secondary`.
+- Updates the layout of the category `RadioGroup` to `column` for the mobie
+  view of the `FeedbackBox` component.
+- Updates the background color for the `"iconOnly"` and `"text"` variants of
+  the `Button` component.
+- Updates the DOM in the header of the `FeedbackBox` component to improve
+  accessibility.
+- Updates the `Link` component to include descriptive text for screen readers
+  in the component's `"external"` variant.
+- Updates the `HelperErrorText` component to set the `ariaLive` default value
+  to `"polite"`.
 
 ### Fixes
 
@@ -34,7 +45,12 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Removes
 
-- Removes the `Link` component warning about the deprecated `button` variant. This change is temporary and will be reverted once teams are able to update their `Link`s appropriately.
+- Removes the `Link` component warning about the deprecated `button` variant.
+  This change is temporary and will be reverted once teams are able to update
+  their `Link`s appropriately.
+- Removes the `arial-label` attribute from the `CheckboxGroup` and `RadioGroup`
+  components for improved accessibility. Using the attribute is redundant with
+  the existing "screen reader only" `<legend>` element.
 
 ## 1.3.1 (December 15, 2022)
 

--- a/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
+++ b/src/components/CheckboxGroup/CheckboxGroup.stories.mdx
@@ -68,7 +68,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.1`   |
-| Latest            | `1.1.2`    |
+| Latest            | `1.4.0`    |
 
 ## Table of Contents
 

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -60,7 +60,12 @@ describe("CheckboxGroup Accessibility", () => {
   });
   it("passes axe accessibility with the legend hidden", async () => {
     const { container } = render(
-      <CheckboxGroup id="checkboxGroup" labelText="Test Label" name="test2">
+      <CheckboxGroup
+        id="checkboxGroup"
+        labelText="Test Label"
+        name="test2"
+        showLabel={false}
+      >
         <Checkbox id="checkbox2" value="2" labelText="Checkbox 2" />
         <Checkbox id="checkbox3" value="3" labelText="Checkbox 3" />
         <Checkbox id="checkbox4" value="4" labelText="Checkbox 4" />
@@ -87,14 +92,15 @@ describe("Checkbox", () => {
   });
 
   it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <CheckboxGroup id="checkboxGroup" labelText="Test Label" name="test2">
         <Checkbox id="checkbox2" value="2" labelText="Checkbox 2" />
         <Checkbox id="checkbox3" value="3" labelText="Checkbox 3" />
         <Checkbox id="checkbox4" value="4" labelText="Checkbox 4" />
       </CheckboxGroup>
     );
-    expect(screen.getByText("Test Label")).toBeVisible();
+    expect(container.querySelector("legend")).toBeVisible();
+    expect(container.querySelector("legend")).toHaveTextContent("Test Label");
 
     rerender(
       <CheckboxGroup
@@ -108,7 +114,8 @@ describe("Checkbox", () => {
         <Checkbox id="checkbox4" value="4" labelText="Checkbox 4" />
       </CheckboxGroup>
     );
-    expect(screen.getByText("Test Label")).toBeVisible();
+    expect(container.querySelector("legend")).toBeVisible();
+    expect(container.querySelector("legend")).toHaveTextContent("Test Label");
   });
 
   it("renders visible helper or error text", () => {

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -58,6 +58,16 @@ describe("CheckboxGroup Accessibility", () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
+  it("passes axe accessibility with the legend hidden", async () => {
+    const { container } = render(
+      <CheckboxGroup id="checkboxGroup" labelText="Test Label" name="test2">
+        <Checkbox id="checkbox2" value="2" labelText="Checkbox 2" />
+        <Checkbox id="checkbox3" value="3" labelText="Checkbox 3" />
+        <Checkbox id="checkbox4" value="4" labelText="Checkbox 4" />
+      </CheckboxGroup>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
 });
 
 describe("Checkbox", () => {
@@ -76,7 +86,7 @@ describe("Checkbox", () => {
     expect(screen.getByLabelText("Checkbox 4")).toBeInTheDocument();
   });
 
-  it("renders with appropriate 'aria-label' attribute and value when 'showLabel' prop is set to false", () => {
+  it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
     const { rerender } = render(
       <CheckboxGroup id="checkboxGroup" labelText="Test Label" name="test2">
         <Checkbox id="checkbox2" value="2" labelText="Checkbox 2" />
@@ -84,10 +94,7 @@ describe("Checkbox", () => {
         <Checkbox id="checkbox4" value="4" labelText="Checkbox 4" />
       </CheckboxGroup>
     );
-    expect(screen.getByTestId("checkbox-group")).not.toHaveAttribute(
-      "aria-label",
-      "Test Label"
-    );
+    expect(screen.getByText("Test Label")).toBeVisible();
 
     rerender(
       <CheckboxGroup
@@ -101,10 +108,7 @@ describe("Checkbox", () => {
         <Checkbox id="checkbox4" value="4" labelText="Checkbox 4" />
       </CheckboxGroup>
     );
-    expect(screen.getByTestId("checkbox-group")).toHaveAttribute(
-      "aria-label",
-      "Test Label"
-    );
+    expect(screen.getByText("Test Label")).toBeVisible();
   });
 
   it("renders visible helper or error text", () => {

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -158,7 +158,6 @@ export const CheckboxGroup = chakra(
             direction={[layout]}
             spacing={spacingProp}
             ref={ref}
-            aria-label={!showLabel ? labelText : undefined}
           >
             {newChildren}
           </Stack>

--- a/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -307,7 +307,6 @@ exports[`Checkbox renders the UI snapshot correctly 3`] = `
     no label
   </legend>
   <div
-    aria-label="no label"
     className="chakra-stack css-1wdv1uh"
     data-testid="checkbox-group"
     id="noLabel"

--- a/src/components/Header/components/__snapshots__/HeaderSearchForm.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/HeaderSearchForm.test.tsx.snap
@@ -154,7 +154,6 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 1`] = `
               Type of search
             </legend>
             <div
-              aria-label="Type of search"
               className="chakra-radio-group css-0"
               role="radiogroup"
             >

--- a/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { axe } from "jest-axe";
 import * as React from "react";
 import renderer from "react-test-renderer";
@@ -105,7 +105,7 @@ describe("MulitSelectGroup Accessibility", () => {
   });
   it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
     const handleChangeMock = jest.fn();
-    const { rerender } = render(
+    const { container, rerender } = render(
       <MultiSelectGroup
         id="MultiSelectGroup"
         labelText="MultiSelectGroup example"
@@ -126,7 +126,10 @@ describe("MulitSelectGroup Accessibility", () => {
         ))}
       </MultiSelectGroup>
     );
-    expect(screen.getByText("MultiSelectGroup example")).toBeVisible();
+    expect(container.querySelector("legend")).toBeVisible();
+    expect(container.querySelector("legend")).toHaveTextContent(
+      "MultiSelectGroup example"
+    );
 
     rerender(
       <MultiSelectGroup
@@ -149,7 +152,10 @@ describe("MulitSelectGroup Accessibility", () => {
         ))}
       </MultiSelectGroup>
     );
-    expect(screen.getByText("MultiSelectGroup example")).toBeVisible();
+    expect(container.querySelector("legend")).toBeVisible();
+    expect(container.querySelector("legend")).toHaveTextContent(
+      "MultiSelectGroup example"
+    );
   });
   xit("should throw warning when a non-MultiSelect component is used as a child", () => {
     const warn = jest.spyOn(console, "warn");

--- a/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
@@ -78,7 +78,32 @@ describe("MulitSelectGroup Accessibility", () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
-  it("renders with appropriate 'aria-label' attribute and value when 'showLabel' prop is set to false", () => {
+  it("passes axe accessibility with the legend hidden", async () => {
+    const handleChangeMock = jest.fn();
+    const { container } = render(
+      <MultiSelectGroup
+        id="MultiSelectGroup"
+        labelText="MultiSelectGroup example"
+        showLabel={false}
+        multiSelectWidth="default"
+      >
+        {multiSelectItems.map((multiSelectItem) => (
+          <MultiSelect
+            key={multiSelectItem.id}
+            id={multiSelectItem.id}
+            variant="listbox"
+            label={multiSelectItem.name}
+            items={multiSelectItem.items}
+            selectedItems={{}}
+            onChange={handleChangeMock}
+            onClear={() => "clear"}
+          />
+        ))}
+      </MultiSelectGroup>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+  it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
     const handleChangeMock = jest.fn();
     const { rerender } = render(
       <MultiSelectGroup
@@ -101,11 +126,7 @@ describe("MulitSelectGroup Accessibility", () => {
         ))}
       </MultiSelectGroup>
     );
-    expect(screen.getByText("MultiSelectGroup example")).toBeInTheDocument();
-    expect(screen.getByTestId("multi-select-group")).not.toHaveAttribute(
-      "aria-label",
-      "MultiSelectGroup example"
-    );
+    expect(screen.getByText("MultiSelectGroup example")).toBeVisible();
 
     rerender(
       <MultiSelectGroup
@@ -128,10 +149,7 @@ describe("MulitSelectGroup Accessibility", () => {
         ))}
       </MultiSelectGroup>
     );
-    expect(screen.getByTestId("multi-select-group")).toHaveAttribute(
-      "aria-label",
-      "MultiSelectGroup example"
-    );
+    expect(screen.getByText("MultiSelectGroup example")).toBeVisible();
   });
   xit("should throw warning when a non-MultiSelect component is used as a child", () => {
     const warn = jest.spyOn(console, "warn");

--- a/src/components/MultiSelectGroup/MultiSelectGroup.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.tsx
@@ -80,7 +80,6 @@ export const MultiSelectGroup = chakra(
           {...rest}
         >
           <Stack
-            aria-label={!showLabel ? labelText : undefined}
             className={className}
             columnGap="xs"
             data-testid="multi-select-group"

--- a/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
+++ b/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
@@ -362,7 +362,6 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     MultiSelectGroup example
   </legend>
   <div
-    aria-label="MultiSelectGroup example"
     className="chakra-stack css-10aqanz"
     data-testid="multi-select-group"
     id="MultiSelectGroup"

--- a/src/components/RadioGroup/RadioGroup.stories.mdx
+++ b/src/components/RadioGroup/RadioGroup.stories.mdx
@@ -67,7 +67,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.0`   |
-| Latest            | `1.0.2`    |
+| Latest            | `1.4.0`    |
 
 ## Table of Contents
 

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -59,6 +59,22 @@ describe("Radio Accessibility", () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
+  it("passes axe accessibility with the legend hidden", async () => {
+    const { container } = render(
+      <RadioGroup
+        id="radioGroup"
+        labelText="Test Label"
+        name="test3"
+        helperText="This is the helper text for the full group."
+        invalidText="This is the error text :("
+      >
+        <Radio id="radio2" value="2" labelText="Radio 2" />
+        <Radio id="radio3" value="3" labelText="Radio 3" />
+        <Radio id="radio4" value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
 });
 
 describe("Radio Button", () => {
@@ -77,8 +93,22 @@ describe("Radio Button", () => {
     expect(screen.getByText("Radio 4")).toBeInTheDocument();
   });
 
-  it("renders with appropriate 'aria-label' attribute and value when 'showLabel' prop is set to false", () => {
-    render(
+  it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
+    const { rerender } = render(
+      <RadioGroup
+        id="radioGroup"
+        labelText="Test Label"
+        name="test2"
+        showLabel={true}
+      >
+        <Radio id="radio2" value="2" labelText="Radio 2" />
+        <Radio id="radio3" value="3" labelText="Radio 3" />
+        <Radio id="radio4" value="4" labelText="Radio 4" />
+      </RadioGroup>
+    );
+    expect(screen.getByText("Test Label")).toBeVisible();
+
+    rerender(
       <RadioGroup
         id="radioGroup"
         labelText="Test Label"
@@ -90,10 +120,7 @@ describe("Radio Button", () => {
         <Radio id="radio4" value="4" labelText="Radio 4" />
       </RadioGroup>
     );
-    expect(screen.getByRole("radiogroup")).toHaveAttribute(
-      "aria-label",
-      "Test Label"
-    );
+    expect(screen.getByText("Test Label")).toBeVisible();
   });
 
   it("renders visible helper or error text", () => {

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -94,7 +94,7 @@ describe("Radio Button", () => {
   });
 
   it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
-    const { rerender } = render(
+    const { container, rerender } = render(
       <RadioGroup
         id="radioGroup"
         labelText="Test Label"
@@ -106,7 +106,8 @@ describe("Radio Button", () => {
         <Radio id="radio4" value="4" labelText="Radio 4" />
       </RadioGroup>
     );
-    expect(screen.getByText("Test Label")).toBeVisible();
+    expect(container.querySelector("legend")).toBeVisible();
+    expect(container.querySelector("legend")).toHaveTextContent("Test Label");
 
     rerender(
       <RadioGroup
@@ -120,7 +121,8 @@ describe("Radio Button", () => {
         <Radio id="radio4" value="4" labelText="Radio 4" />
       </RadioGroup>
     );
-    expect(screen.getByText("Test Label")).toBeVisible();
+    expect(container.querySelector("legend")).toBeVisible();
+    expect(container.querySelector("legend")).toHaveTextContent("Test Label");
   });
 
   it("renders visible helper or error text", () => {

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -94,7 +94,6 @@ export const RadioGroup = chakra(
       const styles = useMultiStyleConfig("RadioGroup", { isFullWidth });
       // Props for the `ChakraRadioGroup` component.
       const radioGroupProps = {
-        "aria-label": !showLabel ? labelText : undefined,
         name,
         onChange: (selected: string) => {
           setValue(selected);

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -273,7 +273,6 @@ exports[`Radio Button renders the UI snapshot correctly 3`] = `
     no label
   </legend>
   <div
-    aria-label="no label"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1279](https://jira.nypl.org/browse/DSD-1279)

## This PR does the following:

- Removes the `arial-label` attribute from the `CheckboxGroup`, `MultiSelectGroup` and `RadioGroup`  components for improved accessibility. Using the attribute is redundant with  the existing "screen reader only" `<legend>` element.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Using the `aria-label` attribute on the noted components is redundant with  the existing "screen reader only" `<legend>` element that is also implemented in those components.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
