### PR TITLE
DSD-1283: arial-label for Total Items Selected button

### DIFF
--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -394,7 +394,7 @@ describe("MultiSelect Dialog", () => {
     // Check for the count of selectedItems
     expect(countButton).toHaveTextContent("3");
     // Close menu
-    userEvent.click(screen.getByRole("button", { name: /MultiSelect Label/i }));
+    userEvent.click(screen.getByRole("button", { name: "MultiSelect Label" }));
     // Count button is still present
     expect(countButton).toHaveTextContent("3");
     // Click count button
@@ -646,7 +646,9 @@ describe("MultiSelect Listbox", () => {
     // Check for the count of selectedItems
     expect(countButton).toHaveTextContent("2");
     // Close menu
-    userEvent.click(screen.getByRole("button", { name: /MultiSelect Label/i }));
+    userEvent.click(
+      screen.getByRole("button", { name: "Colors MultiSelect Label" })
+    );
     // Count button is still present
     expect(countButton).toHaveTextContent("2");
     // Click count button

--- a/src/components/MultiSelect/MultiSelectMenuButton.tsx
+++ b/src/components/MultiSelect/MultiSelectMenuButton.tsx
@@ -56,7 +56,7 @@ const MultiSelectMenuButton = forwardRef<
   if (selectedItems[multiSelectId]?.items.length > 0) {
     getSelectedItemsCount = `${selectedItems[multiSelectId].items.length}`;
     const itemPlural = getSelectedItemsCount === "1" ? "" : "s";
-    selectedItemsAriaLabel = `${getSelectedItemsCount} item${itemPlural} selected`;
+    selectedItemsAriaLabel = `remove ${getSelectedItemsCount} item${itemPlural} selected from ${multiSelectLabel}`;
   }
   const styles = useMultiStyleConfig("MultiSelectMenuButton", {
     isOpen,
@@ -112,6 +112,7 @@ const MultiSelectMenuButton = forwardRef<
             marginLeft="xs"
             name="close"
             size="xsmall"
+            title="Remove selected items"
           />
         </Box>
       )}

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -876,7 +876,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 3`] = `
       </svg>
     </button>
     <span
-      aria-label="1 item selected"
+      aria-label="remove 1 item selected from MultiSelect Test Label"
       className="css-1hgz0t9"
       onClick={[Function]}
       onKeyPress={[Function]}
@@ -894,7 +894,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 3`] = `
         focusable={false}
         id="ms-multiselect-dialog-test-id-selected-items-count-icon"
         role="img"
-        title="close icon"
+        title="Remove selected items"
         viewBox="0 0 24 24"
       >
         <g
@@ -1621,7 +1621,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 4`] = `
       </svg>
     </button>
     <span
-      aria-label="2 items selected"
+      aria-label="remove 2 items selected from MultiSelect Test Label"
       className="css-1hgz0t9"
       onClick={[Function]}
       onKeyPress={[Function]}
@@ -1639,7 +1639,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 4`] = `
         focusable={false}
         id="ms-multiselect-dialog-test-id-selected-items-count-icon"
         role="img"
-        title="close icon"
+        title="Remove selected items"
         viewBox="0 0 24 24"
       >
         <g
@@ -2907,7 +2907,7 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 3`] = `
     </svg>
   </button>
   <span
-    aria-label="2 items selected"
+    aria-label="remove 2 items selected from MultiSelect Label"
     className="css-1hgz0t9"
     onClick={[Function]}
     onKeyPress={[Function]}
@@ -2925,7 +2925,7 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 3`] = `
       focusable={false}
       id="ms-multiselect-listbox-test-id-selected-items-count-icon"
       role="img"
-      title="close icon"
+      title="Remove selected items"
       viewBox="0 0 24 24"
     >
       <g


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1283](https://jira.nypl.org/browse/DSD-1283)

## This PR does the following:

- Updates the arial-label for the `Total Items Selected` button
- There is no CHANGELOG update associated with this change because this is continued development of the new `MultiSelect` component.
- **NOTE:** Some of the tests are failing, but I am not sure why.  The tests are failing due to the changes made on line 59 in `MultiSelectMenuButton.tsx`.  Specifically, the tests are fialing when the `multiSelectLabel` variable is used.  When that variable is added to the value for `selectedItemsAriaLabel`, the tests fail.  When that variable is not used on line 59, all tests pass.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
