### PR TITLE
DSD-1294: Update MultiSelect prop names

### DIFF
--- a/src/components/FilterBar/FilterBar.stories.tsx
+++ b/src/components/FilterBar/FilterBar.stories.tsx
@@ -139,8 +139,8 @@ export const FilterBarStory: Story<FilterBarProps> = (args) => {
             <MultiSelect
               key={multiSelect.id}
               id={multiSelect.id}
-              label={multiSelect.name}
-              variant="dialog"
+              labelText={multiSelect.name}
+              type="dialog"
               items={multiSelect.items}
               selectedItems={selectedItems}
               onChange={(e) => {
@@ -198,8 +198,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={multiSelect.id}
                 id={multiSelect.id}
-                label={multiSelect.name}
-                variant="dialog"
+                labelText={multiSelect.name}
+                type="dialog"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, multiSelect.id)}
@@ -237,8 +237,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-1`}
                 id={`${multiSelect.id}-1`}
-                label={multiSelect.name}
-                variant="dialog"
+                labelText={multiSelect.name}
+                type="dialog"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-1`)}
@@ -276,8 +276,8 @@ export const FilterBarLayoutStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-3`}
                   id={`${multiSelect.id}-3`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) => onChange(e.target.id, `${multiSelect.id}-3`)}
@@ -317,8 +317,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-2`}
                 id={`${multiSelect.id}-2`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-2`)}
@@ -357,8 +357,8 @@ export const FilterBarLayoutStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-4`}
                   id={`${multiSelect.id}-4`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) => onChange(e.target.id, `${multiSelect.id}-4`)}
@@ -399,8 +399,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-5`}
                 id={`${multiSelect.id}-5`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-5`)}
@@ -441,8 +441,8 @@ export const FilterBarLayoutStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-6`}
                   id={`${multiSelect.id}-6`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) => onChange(e.target.id, `${multiSelect.id}-6`)}
@@ -484,8 +484,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-7`}
                 id={`${multiSelect.id}-7`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-7`)}
@@ -522,8 +522,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-8`}
                 id={`${multiSelect.id}-8`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-8`)}
@@ -549,8 +549,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-9`}
                 id={`${multiSelect.id}-9`}
-                label={multiSelect.name}
-                variant="dialog"
+                labelText={multiSelect.name}
+                type="dialog"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-9`)}
@@ -586,8 +586,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-14`}
                 id={`${multiSelect.id}-14`}
-                label={multiSelect.name}
-                variant="dialog"
+                labelText={multiSelect.name}
+                type="dialog"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-14`)}
@@ -613,8 +613,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-15`}
                 id={`${multiSelect.id}-15`}
-                label={multiSelect.name}
-                variant="dialog"
+                labelText={multiSelect.name}
+                type="dialog"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-15`)}
@@ -654,8 +654,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-11`}
                 id={`${multiSelect.id}-11`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-11`)}
@@ -681,8 +681,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-12`}
                 id={`${multiSelect.id}-12`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-12`)}
@@ -721,8 +721,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-17`}
                 id={`${multiSelect.id}-17`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-17`)}
@@ -748,8 +748,8 @@ export const FilterBarLayoutStory = () => {
               <MultiSelect
                 key={`${multiSelect.id}-18`}
                 id={`${multiSelect.id}-18`}
-                label={multiSelect.name}
-                variant="listbox"
+                labelText={multiSelect.name}
+                type="listbox"
                 items={multiSelect.items}
                 selectedItems={selectedItems}
                 onChange={(e) => onChange(e.target.id, `${multiSelect.id}-18`)}
@@ -807,8 +807,8 @@ export const FilterBarRowContainerStory = () => {
                   <MultiSelect
                     key={`${multiSelect.id}-6`}
                     id={`${multiSelect.id}-6`}
-                    label={multiSelect.name}
-                    variant="listbox"
+                    labelText={multiSelect.name}
+                    type="listbox"
                     items={multiSelect.items}
                     selectedItems={selectedItems}
                     onChange={(e) =>
@@ -852,8 +852,8 @@ export const FilterBarRowContainerStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-17`}
                   id={`${multiSelect.id}-17`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) =>
@@ -881,8 +881,8 @@ export const FilterBarRowContainerStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-18`}
                   id={`${multiSelect.id}-18`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) =>
@@ -943,8 +943,8 @@ export const FilterBarColumnContainerStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-7`}
                   id={`${multiSelect.id}-7`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) => onChange(e.target.id, `${multiSelect.id}-7`)}
@@ -986,8 +986,8 @@ export const FilterBarColumnContainerStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-11`}
                   id={`${multiSelect.id}-11`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) =>
@@ -1015,8 +1015,8 @@ export const FilterBarColumnContainerStory = () => {
                 <MultiSelect
                   key={`${multiSelect.id}-12`}
                   id={`${multiSelect.id}-12`}
-                  label={multiSelect.name}
-                  variant="listbox"
+                  labelText={multiSelect.name}
+                  type="listbox"
                   items={multiSelect.items}
                   selectedItems={selectedItems}
                   onChange={(e) =>

--- a/src/components/FilterBar/FilterBar.test.tsx
+++ b/src/components/FilterBar/FilterBar.test.tsx
@@ -102,8 +102,8 @@ const FilterBarTestComponent = ({
             <MultiSelect
               key={multiSelect.id}
               id={multiSelect.id}
-              label={multiSelect.name}
-              variant="dialog"
+              labelText={multiSelect.name}
+              type="dialog"
               items={multiSelect.items}
               selectedItems={selectedItems}
               onChange={(e) => {
@@ -137,8 +137,8 @@ const MultiSelectTestGroup = (multiSelectItems) => (
       <MultiSelect
         key={multiSelectItem.id}
         id={multiSelectItem.id}
-        variant="listbox"
-        label={multiSelectItem.name}
+        type="listbox"
+        labelText={multiSelectItem.name}
         items={multiSelectItem.items}
         selectedItems={{}}
         onChange={() => null}

--- a/src/components/MultiSelect/MultiSelect.stories.mdx
+++ b/src/components/MultiSelect/MultiSelect.stories.mdx
@@ -69,8 +69,8 @@ import * as stories from "./MultiSelect.stories.tsx";
 ## Table of Contents
 
 - [Overview](#overview)
-- [Component Props for MultiSelect Listbox type](#component-props-multiselect-listbox-type)
-- [Component Props for MultiSelect Dialog type](#component-props-multiselect-dialog-type)
+- [Component Props for MultiSelect Listbox](#component-props-multiselect-listbox)
+- [Component Props for MultiSelect Dialog](#component-props-multiselect-dialog)
 - [Accessibility](#accessibility)
 - [Using the items prop](#using-the-items-prop)
 - [Controlling state using selectedItems and onChange prop](#controlling-state-using-selecteditems-and-onchange-prop)
@@ -81,9 +81,9 @@ import * as stories from "./MultiSelect.stories.tsx";
 
 <Description of={MultiSelect} />
 
-## Component Props for MultiSelect Listbox type
+## Component Props for MultiSelect Listbox
 
-The `MultiSelect` listbox type renders a non-hierarchical list of items to select from.
+The `MultiSelect` listbox renders a non-hierarchical list of items to select from.
 
 <Canvas withToolbar>
   <Story
@@ -100,9 +100,9 @@ The `MultiSelect` listbox type renders a non-hierarchical list of items to selec
 
 <ArgsTable story="MultiSelect ListBox" />
 
-## Component Props for MultiSelect Dialog type
+## Component Props for MultiSelect Dialog
 
-The `MultiSelect` dialog type allows for an optional set of child checkboxes to be passed, which makes the “parent” checkbox function as a check/uncheck all toggle.
+The `MultiSelect` dialog allows for an optional set of child checkboxes to be passed, which makes the “parent” checkbox function as a check/uncheck all toggle.
 If all of the children checkboxes are checked, the parent `isChecked` prop will be true. If only some of the child checkboxes are checked, the parent checkbox will have a `isIndeterminate` prop set to true, implying that it is not checked or unchecked.
 
 <Canvas withToolbar>
@@ -124,7 +124,7 @@ If all of the children checkboxes are checked, the parent `isChecked` prop will 
 
 ### ListBox
 
-The `MultiSelect` type `listbox` leverages `downshift.js` to assist with
+The `MultiSelect` `listbox` leverages `downshift.js` to assist with
 accessibility compliance. By using Downshift's `useSelect` hook and prop getters
 `getToggleButtonProps`, `getMenuProps`, `getItemProps` we are able to create a W3
 WAI-ARIA compliant listbox that behaves like a select element. Up and down arrow
@@ -132,7 +132,7 @@ keys are used for navigating through the `MultiSelect` options.
 
 ### Dialog
 
-The `MultiSelect` type `dialog` looks similar to the Listbox type, but because
+The `MultiSelect` `dialog` looks similar to the `MultiSelect` `listbox`, but because
 of its “clear” and “apply” buttons, it has some key functionality differences,
 and accessibility must be handled differently. When the `MultiSelect` is open,
 focus is trapped inside the dropdown menu, and the tab key is used to move through
@@ -195,7 +195,7 @@ The expected data structure is an array of objects, in the following format:
 />
 ```
 
-If choosing the `type = 'dialog'` you can also add a second level of child items, in the following format:
+If you are using `type = 'dialog'`, you can also add a second level of child items, in the following format:
 
 ```tsx
 <MultiSelect

--- a/src/components/MultiSelect/MultiSelect.stories.mdx
+++ b/src/components/MultiSelect/MultiSelect.stories.mdx
@@ -35,7 +35,7 @@ import * as stories from "./MultiSelect.stories.tsx";
       control: false,
     },
     items: { control: false },
-    label: { table: { default: "" } },
+    labelText: { table: { default: "" } },
     onApply: {
       description:
         "The action to perform for save/apply button of multiselect. <br /> `onApply: () => void;`",
@@ -49,7 +49,7 @@ import * as stories from "./MultiSelect.stories.tsx";
         "The action to perform for a mixed state checkbox (parent checkbox). <br /> `onMixedStateChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;`",
     },
     selectedItems: { control: false },
-    variant: { control: false },
+    type: { control: false },
     width: {
       description: "Value used to set the width for the MultiSelect component",
       control: "radio",
@@ -69,8 +69,8 @@ import * as stories from "./MultiSelect.stories.tsx";
 ## Table of Contents
 
 - [Overview](#overview)
-- [Component Props for MultiSelect Listbox Variant](#component-props-multiselect-listbox-variant)
-- [Component Props for MultiSelect Dialog Variant](#component-props-multiselect-dialog-variant)
+- [Component Props for MultiSelect Listbox type](#component-props-multiselect-listbox-type)
+- [Component Props for MultiSelect Dialog type](#component-props-multiselect-dialog-type)
 - [Accessibility](#accessibility)
 - [Using the items prop](#using-the-items-prop)
 - [Controlling state using selectedItems and onChange prop](#controlling-state-using-selecteditems-and-onchange-prop)
@@ -81,17 +81,17 @@ import * as stories from "./MultiSelect.stories.tsx";
 
 <Description of={MultiSelect} />
 
-## Component Props for MultiSelect Listbox Variant
+## Component Props for MultiSelect Listbox type
 
-The `MultiSelect` listbox variant renders a non-hierarchical list of items to select from.
+The `MultiSelect` listbox type renders a non-hierarchical list of items to select from.
 
 <Canvas withToolbar>
   <Story
     name="MultiSelect ListBox"
     args={{
       id: "multiselect-listbox",
-      label: "MultiSelect Listbox",
-      variant: "listbox",
+      labelText: "MultiSelect Listbox",
+      type: "listbox",
     }}
   >
     {(args) => <stories.MultiSelectListboxStory {...args} />}
@@ -100,9 +100,9 @@ The `MultiSelect` listbox variant renders a non-hierarchical list of items to se
 
 <ArgsTable story="MultiSelect ListBox" />
 
-## Component Props for MultiSelect Dialog Variant
+## Component Props for MultiSelect Dialog type
 
-The `MultiSelect` dialog variant allows for an optional set of child checkboxes to be passed, which makes the “parent” checkbox function as a check/uncheck all toggle.
+The `MultiSelect` dialog type allows for an optional set of child checkboxes to be passed, which makes the “parent” checkbox function as a check/uncheck all toggle.
 If all of the children checkboxes are checked, the parent `isChecked` prop will be true. If only some of the child checkboxes are checked, the parent checkbox will have a `isIndeterminate` prop set to true, implying that it is not checked or unchecked.
 
 <Canvas withToolbar>
@@ -110,8 +110,8 @@ If all of the children checkboxes are checked, the parent `isChecked` prop will 
     name="MultiSelect Dialog"
     args={{
       id: "multiselect-dialog",
-      label: "MultiSelect Dialog",
-      variant: "dialog",
+      labelText: "MultiSelect Dialog",
+      type: "dialog",
     }}
   >
     {(args) => <stories.MultiSelectDialogStory {...args} />}
@@ -124,7 +124,7 @@ If all of the children checkboxes are checked, the parent `isChecked` prop will 
 
 ### ListBox
 
-The `MultiSelect` variant `listbox` leverages `downshift.js` to assist with
+The `MultiSelect` type `listbox` leverages `downshift.js` to assist with
 accessibility compliance. By using Downshift's `useSelect` hook and prop getters
 `getToggleButtonProps`, `getMenuProps`, `getItemProps` we are able to create a W3
 WAI-ARIA compliant listbox that behaves like a select element. Up and down arrow
@@ -132,7 +132,7 @@ keys are used for navigating through the `MultiSelect` options.
 
 ### Dialog
 
-The `MultiSelect` variant `dialog` looks similar to the Listbox variant, but because
+The `MultiSelect` type `dialog` looks similar to the Listbox type, but because
 of its “clear” and “apply” buttons, it has some key functionality differences,
 and accessibility must be handled differently. When the `MultiSelect` is open,
 focus is trapped inside the dropdown menu, and the tab key is used to move through
@@ -143,7 +143,7 @@ package under the hood.
 NOTE: The `react-focus-lock` package renders two "focus guard" elements and one
 has a `tabindex` set to `1`, in order to perform the focus trap behavior. The
 Storybook accessibility checker [complains](https://dequeuniversity.com/rules/axe/4.4/tabindex?application=axeAPI)
-about this whenever the "dialog" variant is opened.
+about this whenever the "dialog" type is opened.
 
 While this is an accessibility issue, we explicitly want the focus trap behavior
 within the `MultiSelect`. Once the component is closed, the issue goes away. For
@@ -176,8 +176,8 @@ The expected data structure is an array of objects, in the following format:
 ```tsx
 <MultiSelect
   id="subject"
-  label="Subject Specialities"
-  variant="listbox"
+  labelText="Subject Specialities"
+  type="listbox"
   items={[
     {
       id: "art",
@@ -195,13 +195,13 @@ The expected data structure is an array of objects, in the following format:
 />
 ```
 
-If choosing the `variant = 'dialog'` you can also add a second level of child items, in the following format:
+If choosing the `type = 'dialog'` you can also add a second level of child items, in the following format:
 
 ```tsx
 <MultiSelect
   id="subject"
-  label="Subject Specialities"
-  variant="dialog"
+  labelText="Subject Specialities"
+  type="dialog"
   items={[
     {
       id: "art",
@@ -322,9 +322,9 @@ function MultiSelectControlledExample() {
   return (
     <MultiSelect
       id="subjects"
-      label="Subjects"
+      labelText="Subjects"
       items={items}
-      variant="listbox"
+      type="listbox"
       selectedItems={selectedItems}
       onChange={(selectedItem) => {
         handleChange(selectedItem.id, "subjects");

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -21,7 +21,7 @@ const items = [
   {
     id: "design",
     name: "Design",
-    // Children array will only be renderd in a "dialog" variant
+    // Children array will only be renderd in a "dialog" type
     children: [
       {
         id: "fashion",

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -29,8 +29,8 @@ const MultiSelectTestDialogComponent = ({ multiSelectId }) => {
   return (
     <MultiSelect
       id={multiSelectId}
-      label="MultiSelect Label"
-      variant="dialog"
+      labelText="MultiSelect Label"
+      type="dialog"
       items={items}
       selectedItems={selectedItems}
       onChange={(e) => onChange(e.target.id, multiSelectId)}
@@ -47,8 +47,8 @@ const MultiSelectTestListboxComponent = ({ multiSelectId }) => {
   return (
     <MultiSelect
       id={multiSelectId}
-      label="MultiSelect Label"
-      variant="listbox"
+      labelText="MultiSelect Label"
+      type="listbox"
       items={items}
       selectedItems={selectedItems}
       onChange={(selectedItem) => onChange(selectedItem.id, multiSelectId)}
@@ -62,12 +62,12 @@ describe("MultiSelect Accessibility", () => {
   let selectedTestItems;
   beforeEach(() => (selectedTestItems = {}));
 
-  it("should have no axe violations for the 'listbox' variant", async () => {
+  it("should have no axe violations for the 'listbox' type", async () => {
     const { container } = render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="multiSelect-accessibility"
-        variant="listbox"
+        labelText="multiSelect-accessibility"
+        type="listbox"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -77,12 +77,12 @@ describe("MultiSelect Accessibility", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
-  it("should have no axe violations for the 'dialog' variant", async () => {
+  it("should have no axe violations for the 'dialog' type", async () => {
     const { container } = render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="multiSelect-accessibility"
-        variant="dialog"
+        labelText="multiSelect-accessibility"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -102,8 +102,8 @@ describe("MultiSelect Dialog", () => {
     const { container } = render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Label"
-        variant="dialog"
+        labelText="MultiSelect Label"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -120,8 +120,8 @@ describe("MultiSelect Dialog", () => {
     render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Test Label"
-        variant="dialog"
+        labelText="MultiSelect Test Label"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -141,8 +141,8 @@ describe("MultiSelect Dialog", () => {
     const { rerender } = render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Test Label"
-        variant="dialog"
+        labelText="MultiSelect Test Label"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -156,8 +156,8 @@ describe("MultiSelect Dialog", () => {
     rerender(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Test Label"
-        variant="dialog"
+        labelText="MultiSelect Test Label"
+        type="dialog"
         items={items}
         isDefaultOpen={false}
         selectedItems={selectedTestItems}
@@ -174,8 +174,8 @@ describe("MultiSelect Dialog", () => {
     render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Test Label"
-        variant="dialog"
+        labelText="MultiSelect Test Label"
+        type="dialog"
         items={items}
         isDefaultOpen={true}
         selectedItems={selectedTestItems}
@@ -193,8 +193,8 @@ describe("MultiSelect Dialog", () => {
   //   const { container } = render(
   //     <MultiSelect
   //       id="multiselect-dialog-test-id"
-  //       label="MultiSelect Label"
-  //       variant="dialog"
+  //       labelText="MultiSelect Label"
+  //       type="dialog"
   //       items={items}
   //       isBlockElement={true}
   //       selectedItems={selectedTestItems}
@@ -211,8 +211,8 @@ describe("MultiSelect Dialog", () => {
     render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Label"
-        variant="dialog"
+        labelText="MultiSelect Label"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -255,8 +255,8 @@ describe("MultiSelect Dialog", () => {
     render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Label"
-        variant="dialog"
+        labelText="MultiSelect Label"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
@@ -294,8 +294,8 @@ describe("MultiSelect Dialog", () => {
     render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Label"
-        variant="dialog"
+        labelText="MultiSelect Label"
+        type="dialog"
         items={items}
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
@@ -360,8 +360,8 @@ describe("MultiSelect Dialog", () => {
     render(
       <MultiSelect
         id="multiselect-dialog-test-id"
-        label="MultiSelect Label"
-        variant="dialog"
+        labelText="MultiSelect Label"
+        type="dialog"
         items={items}
         isDefaultOpen={true}
         selectedItems={selectedTestItems}
@@ -417,8 +417,8 @@ describe("MultiSelect Dialog", () => {
       .create(
         <MultiSelect
           id="multiselect-dialog-test-id"
-          label="MultiSelect Test Label"
-          variant="dialog"
+          labelText="MultiSelect Test Label"
+          type="dialog"
           items={items}
           selectedItems={selectedTestItems}
           onChange={() => null}
@@ -432,8 +432,8 @@ describe("MultiSelect Dialog", () => {
       .create(
         <MultiSelect
           id="multiselect-dialog-test-id"
-          label="MultiSelect Test Label"
-          variant="dialog"
+          labelText="MultiSelect Test Label"
+          type="dialog"
           items={items}
           isDefaultOpen={true}
           selectedItems={selectedTestItems}
@@ -449,8 +449,8 @@ describe("MultiSelect Dialog", () => {
       .create(
         <MultiSelect
           id="multiselect-dialog-test-id"
-          label="MultiSelect Test Label"
-          variant="dialog"
+          labelText="MultiSelect Test Label"
+          type="dialog"
           items={items}
           isDefaultOpen={true}
           selectedItems={selectedTestItems}
@@ -469,8 +469,8 @@ describe("MultiSelect Dialog", () => {
       .create(
         <MultiSelect
           id="multiselect-dialog-test-id"
-          label="MultiSelect Test Label"
-          variant="dialog"
+          labelText="MultiSelect Test Label"
+          type="dialog"
           items={items}
           isDefaultOpen={true}
           selectedItems={selectedTestItems}
@@ -497,8 +497,8 @@ describe("MultiSelect Listbox", () => {
     const { container } = render(
       <MultiSelect
         id="multiselect-listbox-test-id"
-        label="MultiSelect Label"
-        variant="listbox"
+        labelText="MultiSelect Label"
+        type="listbox"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -514,8 +514,8 @@ describe("MultiSelect Listbox", () => {
     render(
       <MultiSelect
         id="multiselect-listbox-test-id"
-        label="MultiSelect Label"
-        variant="listbox"
+        labelText="MultiSelect Label"
+        type="listbox"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -533,8 +533,8 @@ describe("MultiSelect Listbox", () => {
     render(
       <MultiSelect
         id="multiselect-listbox-test-id"
-        label="MultiSelect Label"
-        variant="listbox"
+        labelText="MultiSelect Label"
+        type="listbox"
         items={items}
         isDefaultOpen={true}
         selectedItems={selectedTestItems}
@@ -552,8 +552,8 @@ describe("MultiSelect Listbox", () => {
     const { container } = render(
       <MultiSelect
         id="multiselect-listbox-test-id"
-        label="MultiSelect Label"
-        variant="listbox"
+        labelText="MultiSelect Label"
+        type="listbox"
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
@@ -597,8 +597,8 @@ describe("MultiSelect Listbox", () => {
     render(
       <MultiSelect
         id="multiselect-listbox-test-id"
-        label="MultiSelect Label"
-        variant="listbox"
+        labelText="MultiSelect Label"
+        type="listbox"
         items={items}
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
@@ -667,8 +667,8 @@ describe("MultiSelect Listbox", () => {
       .create(
         <MultiSelect
           id="multiselect-listbox-test-id"
-          label="MultiSelect Label"
-          variant="listbox"
+          labelText="MultiSelect Label"
+          type="listbox"
           items={items}
           selectedItems={selectedTestItems}
           onChange={() => null}
@@ -681,8 +681,8 @@ describe("MultiSelect Listbox", () => {
       .create(
         <MultiSelect
           id="multiselect-listbox-test-id"
-          label="MultiSelect Label"
-          variant="listbox"
+          labelText="MultiSelect Label"
+          type="listbox"
           isDefaultOpen={true}
           items={items}
           selectedItems={selectedTestItems}
@@ -699,8 +699,8 @@ describe("MultiSelect Listbox", () => {
       .create(
         <MultiSelect
           id="multiselect-listbox-test-id"
-          label="MultiSelect Label"
-          variant="listbox"
+          labelText="MultiSelect Label"
+          type="listbox"
           items={items}
           isDefaultOpen={true}
           selectedItems={selectedTestItems}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -24,12 +24,12 @@ interface MultiSelectCommonProps {
   isBlockElement?: boolean;
   /** The items to be rendered in the Multiselect as checkbox options. */
   items: MultiSelectItem[];
-  /** The label of the MultiSelect. */
-  label: string;
+  /** The labelText of the MultiSelect. */
+  labelText: string;
   /** The action to perform for clear/reset button of MultiSelect. */
   onClear?: () => void;
-  /** The variant of the MultiSelect. */
-  variant: "listbox" | "dialog";
+  /** The type of the MultiSelect. */
+  type: "listbox" | "dialog";
   /** The selected items state (items that were checked by user). */
   selectedItems: SelectedItems;
   /** Value used to set the width for the MultiSelect component. */
@@ -40,15 +40,15 @@ type DialogOnChange = (event: React.ChangeEvent<HTMLInputElement>) => void;
 
 type MultiSelectVariantsProps =
   | {
-      variant: "listbox";
+      type: "listbox";
       onApply?: never;
       /** The action to perform for downshift's onSelectedItemChange function. */
       onChange: ListboxOnChange;
-      // These are props that are never allowed on the listbox variant.
+      // These are props that are never allowed on the listbox type.
       onMixedStateChange?: never;
     }
   | {
-      variant: "dialog";
+      type: "dialog";
       /** The action to perform for save/apply button of multiselect. */
       onApply: () => void;
       /** The action to perform on the checkbox's onChange function.  */
@@ -75,13 +75,13 @@ export const MultiSelect = chakra(
         isBlockElement = false,
         isDefaultOpen = false,
         items,
-        label,
+        labelText,
         onApply,
         onChange,
         onClear,
         onMixedStateChange,
         selectedItems,
-        variant,
+        type,
         width = "default",
         ...rest
       } = props;
@@ -91,14 +91,14 @@ export const MultiSelect = chakra(
         isBlockElement,
         isDefaultOpen,
         items,
-        label,
+        labelText,
         onClear,
         selectedItems,
-        variant,
+        type,
         width,
       };
 
-      if (variant === "listbox") {
+      if (type === "listbox") {
         const listboxOnChange = onChange as ListboxOnChange;
 
         return (
@@ -111,7 +111,7 @@ export const MultiSelect = chakra(
         );
       }
 
-      if (variant === "dialog") {
+      if (type === "dialog") {
         const dialogOnChange = onChange as DialogOnChange;
 
         return (

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -24,11 +24,11 @@ interface MultiSelectCommonProps {
   isBlockElement?: boolean;
   /** The items to be rendered in the Multiselect as checkbox options. */
   items: MultiSelectItem[];
-  /** The labelText of the MultiSelect. */
+  /** The label text rendered within the MultiSelect. */
   labelText: string;
   /** The action to perform for clear/reset button of MultiSelect. */
   onClear?: () => void;
-  /** The type of the MultiSelect. */
+  /** The type of MultiSelect that will be rendered. */
   type: "listbox" | "dialog";
   /** The selected items state (items that were checked by user). */
   selectedItems: SelectedItems;

--- a/src/components/MultiSelect/MultiSelectDialog.tsx
+++ b/src/components/MultiSelect/MultiSelectDialog.tsx
@@ -29,7 +29,7 @@ export const MultiSelectDialog = chakra(
         isBlockElement,
         isDefaultOpen,
         items,
-        label,
+        labelText,
         onApply,
         onChange,
         onClear,
@@ -125,7 +125,7 @@ export const MultiSelectDialog = chakra(
             <MultiSelectMenuButton
               id={`ms-${id}-menu-button`}
               multiSelectId={id}
-              multiSelectLabel={label}
+              multiSelectLabelText={labelText}
               isOpen={isOpen}
               selectedItems={selectedItems}
               onMenuToggle={() => {

--- a/src/components/MultiSelect/MultiSelectListbox.tsx
+++ b/src/components/MultiSelect/MultiSelectListbox.tsx
@@ -16,7 +16,7 @@ type MultiSelectListboxProps = Omit<MultiSelectProps, "onChange"> & {
   onChange: (selectedItem: MultiSelectItem, id: string) => void;
 };
 
-/** MultiSelectListbox renders a non-hierarchical list of checkbox options for the `variant="listbox". It leverager downshift-js for accessiblity. */
+/** MultiSelectListbox renders a non-hierarchical list of checkbox options for the `type="listbox". It leverager downshift-js for accessiblity. */
 export const MultiSelectListbox = chakra(
   forwardRef<HTMLElement, React.PropsWithChildren<MultiSelectListboxProps>>(
     (props, ref?) => {
@@ -25,7 +25,7 @@ export const MultiSelectListbox = chakra(
         isBlockElement,
         isDefaultOpen,
         items,
-        label,
+        labelText,
         onChange,
         onClear,
         selectedItems,
@@ -71,17 +71,17 @@ export const MultiSelectListbox = chakra(
         isBlockElement,
         isOpen,
       });
-      // If a item passed to the listbox variant has children,
+      // If a item passed to the listbox type has children,
       if (items.some((item) => item.children)) {
         console.warn(
-          "NYPL Reservoir MultiSelect: Only the variant 'dialog' can render nested select items."
+          "NYPL Reservoir MultiSelect: Only the type 'dialog' can render nested select items."
         );
       }
       return (
         <Box id={id} __css={styles} {...rest}>
           <MultiSelectMenuButton
             multiSelectId={id}
-            multiSelectLabel={label}
+            multiSelectLabelText={labelText}
             isOpen={isOpen}
             selectedItems={selectedItems}
             onClear={onClear}

--- a/src/components/MultiSelect/MultiSelectMenuButton.tsx
+++ b/src/components/MultiSelect/MultiSelectMenuButton.tsx
@@ -8,8 +8,8 @@ export interface MultiSelectMenuButtonProps {
   id: string;
   /** The id of the MultiSelect using this button. */
   multiSelectId: string;
-  /** The label of the MultiSelect using this button. */
-  multiSelectLabel: string;
+  /** The labelText of the MultiSelect using this button. */
+  multiSelectLabelText: string;
   /** The open status of the MultiSelect menu. */
   isOpen: boolean;
   /** The selected items state (items that were checked by user). */
@@ -40,7 +40,7 @@ const MultiSelectMenuButton = forwardRef<
     id,
     isOpen,
     multiSelectId,
-    multiSelectLabel,
+    multiSelectLabelText,
     onClear,
     onKeyDown,
     onMenuToggle,
@@ -56,7 +56,7 @@ const MultiSelectMenuButton = forwardRef<
   if (selectedItems[multiSelectId]?.items.length > 0) {
     getSelectedItemsCount = `${selectedItems[multiSelectId].items.length}`;
     const itemPlural = getSelectedItemsCount === "1" ? "" : "s";
-    selectedItemsAriaLabel = `remove ${getSelectedItemsCount} item${itemPlural} selected from ${multiSelectLabel}`;
+    selectedItemsAriaLabel = `remove ${getSelectedItemsCount} item${itemPlural} selected from ${multiSelectLabelText}`;
   }
   const styles = useMultiStyleConfig("MultiSelectMenuButton", {
     isOpen,
@@ -87,8 +87,8 @@ const MultiSelectMenuButton = forwardRef<
         __css={styles.menuButton}
         {...rest}
       >
-        <Box as="span" title={multiSelectLabel} __css={styles.buttonLabel}>
-          {multiSelectLabel}
+        <Box as="span" title={multiSelectLabelText} __css={styles.buttonLabel}>
+          {multiSelectLabelText}
         </Box>
         <Icon id={`ms-${multiSelectId}-icon`} name={iconType} size="small" />
       </Button>

--- a/src/components/MultiSelect/MultiSelectMenuButton.tsx
+++ b/src/components/MultiSelect/MultiSelectMenuButton.tsx
@@ -8,7 +8,7 @@ export interface MultiSelectMenuButtonProps {
   id: string;
   /** The id of the MultiSelect using this button. */
   multiSelectId: string;
-  /** The labelText of the MultiSelect using this button. */
+  /** The label text rendered within the MultiSelect using this button. */
   multiSelectLabelText: string;
   /** The open status of the MultiSelect menu. */
   isOpen: boolean;

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 1`] = `
 <div
   className="css-fxdbg"
   id="multiselect-dialog-test-id"
-  variant="dialog"
+  type="dialog"
 >
   <div
     data-focus-guard={true}
@@ -119,7 +119,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 2`] = `
 <div
   className="css-fxdbg"
   id="multiselect-dialog-test-id"
-  variant="dialog"
+  type="dialog"
 >
   <div
     data-focus-guard={true}
@@ -793,7 +793,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 3`] = `
 <div
   className="css-fxdbg"
   id="multiselect-dialog-test-id"
-  variant="dialog"
+  type="dialog"
 >
   <div
     data-focus-guard={true}
@@ -1538,7 +1538,7 @@ exports[`MultiSelect Dialog should render the UI snapshot correctly 4`] = `
 <div
   className="css-fxdbg"
   id="multiselect-dialog-test-id"
-  variant="dialog"
+  type="dialog"
 >
   <div
     data-focus-guard={true}
@@ -2267,7 +2267,7 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 1`] = `
 <div
   className="css-fxdbg"
   id="multiselect-listbox-test-id"
-  variant="listbox"
+  type="listbox"
 >
   <button
     aria-expanded={false}
@@ -2339,7 +2339,7 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 2`] = `
 <div
   className="css-fxdbg"
   id="multiselect-listbox-test-id"
-  variant="listbox"
+  type="listbox"
 >
   <button
     aria-expanded={true}
@@ -2856,7 +2856,7 @@ exports[`MultiSelect Listbox Renders the UI snapshot correctly 3`] = `
 <div
   className="css-fxdbg"
   id="multiselect-listbox-test-id"
-  variant="listbox"
+  type="listbox"
 >
   <button
     aria-expanded={true}

--- a/src/components/MultiSelectGroup/MultiSelectGroup.stories.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.stories.tsx
@@ -76,8 +76,8 @@ export const MultiSelectGroupStory: Story<MultiSelectGroupProps> = (args) => {
           <MultiSelect
             key={multiSelect.id}
             id={multiSelect.id}
-            label={multiSelect.name}
-            variant="dialog"
+            labelText={multiSelect.name}
+            type="dialog"
             items={multiSelect.items}
             selectedItems={selectedItems}
             onChange={(e) => {
@@ -188,8 +188,8 @@ export const MultiSelectGroupLayoutStory: Story<MultiSelectGroupProps> = () => {
             <MultiSelect
               key={multiSelect.id}
               id={multiSelect.id}
-              label={multiSelect.name}
-              variant="dialog"
+              labelText={multiSelect.name}
+              type="dialog"
               items={multiSelect.items}
               selectedItems={selectedItems}
               onChange={(e) => {
@@ -221,8 +221,8 @@ export const MultiSelectGroupLayoutStory: Story<MultiSelectGroupProps> = () => {
             <MultiSelect
               key={`${multiSelect.id}-1`}
               id={`${multiSelect.id}-1`}
-              label={multiSelect.name}
-              variant="dialog"
+              labelText={multiSelect.name}
+              type="dialog"
               items={multiSelect.items}
               selectedItems={selectedItems}
               onChange={(e) => {
@@ -254,8 +254,8 @@ export const MultiSelectGroupLayoutStory: Story<MultiSelectGroupProps> = () => {
             <MultiSelect
               key={`${multiSelect.id}-2`}
               id={`${multiSelect.id}-2`}
-              label={multiSelect.name}
-              variant="dialog"
+              labelText={multiSelect.name}
+              type="dialog"
               items={multiSelect.items}
               selectedItems={selectedItems}
               onChange={(e) => {
@@ -287,8 +287,8 @@ export const MultiSelectGroupLayoutStory: Story<MultiSelectGroupProps> = () => {
             <MultiSelect
               key={`${multiSelect.id}-3`}
               id={`${multiSelect.id}-3`}
-              label={multiSelect.name}
-              variant="dialog"
+              labelText={multiSelect.name}
+              type="dialog"
               items={multiSelect.items}
               selectedItems={selectedItems}
               onChange={(e) => {

--- a/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
@@ -66,8 +66,8 @@ describe("MulitSelectGroup Accessibility", () => {
           <MultiSelect
             key={multiSelectItem.id}
             id={multiSelectItem.id}
-            variant="listbox"
-            label={multiSelectItem.name}
+            type="listbox"
+            labelText={multiSelectItem.name}
             items={multiSelectItem.items}
             selectedItems={{}}
             onChange={handleChangeMock}
@@ -91,8 +91,8 @@ describe("MulitSelectGroup Accessibility", () => {
           <MultiSelect
             key={multiSelectItem.id}
             id={multiSelectItem.id}
-            variant="listbox"
-            label={multiSelectItem.name}
+            type="listbox"
+            labelText={multiSelectItem.name}
             items={multiSelectItem.items}
             selectedItems={{}}
             onChange={handleChangeMock}
@@ -116,8 +116,8 @@ describe("MulitSelectGroup Accessibility", () => {
           <MultiSelect
             key={multiSelectItem.id}
             id={multiSelectItem.id}
-            variant="listbox"
-            label={multiSelectItem.name}
+            type="listbox"
+            labelText={multiSelectItem.name}
             items={multiSelectItem.items}
             selectedItems={{}}
             onChange={handleChangeMock}
@@ -142,8 +142,8 @@ describe("MulitSelectGroup Accessibility", () => {
           <MultiSelect
             key={multiSelectItem.id}
             id={multiSelectItem.id}
-            variant="listbox"
-            label={multiSelectItem.name}
+            type="listbox"
+            labelText={multiSelectItem.name}
             items={multiSelectItem.items}
             selectedItems={{}}
             onChange={handleChangeMock}
@@ -188,8 +188,8 @@ describe("MulitSelectGroup Accessibility", () => {
             <MultiSelect
               key={multiSelectItem.id}
               id={multiSelectItem.id}
-              variant="dialog"
-              label={multiSelectItem.name}
+              type="dialog"
+              labelText={multiSelectItem.name}
               items={multiSelectItem.items}
               selectedItems={{}}
               onChange={handleChangeMock}
@@ -213,8 +213,8 @@ describe("MulitSelectGroup Accessibility", () => {
             <MultiSelect
               key={multiSelectItem.id}
               id={multiSelectItem.id}
-              variant="dialog"
-              label={multiSelectItem.name}
+              type="dialog"
+              labelText={multiSelectItem.name}
               items={multiSelectItem.items}
               selectedItems={{}}
               onChange={handleChangeMock}

--- a/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
+++ b/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
     <div
       className="css-hhryjt"
       id="colors"
-      variant="dialog"
+      type="dialog"
     >
       <div
         data-focus-guard={true}
@@ -128,7 +128,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
     <div
       className="css-hhryjt"
       id="pets"
-      variant="dialog"
+      type="dialog"
     >
       <div
         data-focus-guard={true}
@@ -240,7 +240,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
     <div
       className="css-hhryjt"
       id="tools"
-      variant="dialog"
+      type="dialog"
     >
       <div
         data-focus-guard={true}
@@ -369,7 +369,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     <div
       className="css-hhryjt"
       id="colors"
-      variant="dialog"
+      type="dialog"
     >
       <div
         data-focus-guard={true}
@@ -481,7 +481,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     <div
       className="css-hhryjt"
       id="pets"
-      variant="dialog"
+      type="dialog"
     >
       <div
         data-focus-guard={true}
@@ -593,7 +593,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     <div
       className="css-hhryjt"
       id="tools"
-      variant="dialog"
+      type="dialog"
     >
       <div
         data-focus-guard={true}


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1294](https://jira.nypl.org/browse/DSD-1294)

## This PR does the following:
- Change following prop names on MutliSelect:
&ensp; - `variant` to `type`
&ensp; - `label` to `labelText`
- Change following prop names on MutliSelectMenuButton:
&ensp; - `multiSelectLabel` to `multiSelectLabelText` 
- Update Snapshot tests

## How has this been tested?

[ ] Unit tests
[ ] Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.