### PR TITLE
DSD-1298: dark mode for v1.4.0 components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `dark` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.
 - Adds `dark` color mode support for the `AlphabetFilter`, `AudioPlayer`, and `TagSet` components.
 - Adds `dark` color mode support for the `FeedbackBox` and `StyledList` components.
+- Adds `dark` color mode support for the `FilterBar`, `Modal` and `MultiSelect` components.
 
 ## 1.4.1 (February 9, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `dark` color mode support for the `Accordion`, `Modal`, `Tabs`, and `Tooltip` components.
 - Adds `dark` color mode support for the `AlphabetFilter`, `AudioPlayer`, and `TagSet` components.
 - Adds `dark` color mode support for the `FeedbackBox` and `StyledList` components.
-- Adds `dark` color mode support for the `FilterBar`, `Modal` and `MultiSelect` components.
+- Adds `dark` color mode support for the `FilterBar` and `MultiSelect` components.
 
 ## 1.4.1 (February 9, 2023)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20526,6 +20526,29 @@
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+          "dev": true
+        }
       }
     },
     "react-autosuggest": {

--- a/src/components/FilterBar/FilterBar.tsx
+++ b/src/components/FilterBar/FilterBar.tsx
@@ -246,7 +246,7 @@ export const FilterBar = chakra(
                     Filter Criteria
                   </ModalHeader>
                   <ModalCloseButton sx={styles.modalCloseButton} />
-                  <ModalBody>{newChildren}</ModalBody>
+                  <ModalBody sx={styles.modalBody}>{newChildren}</ModalBody>
                   <ModalFooter sx={styles.modalFooter}>
                     <ButtonGroup layout="row" buttonWidth="full">
                       <Button

--- a/src/components/MultiSelect/MultiSelect.stories.mdx
+++ b/src/components/MultiSelect/MultiSelect.stories.mdx
@@ -61,10 +61,10 @@ import * as stories from "./MultiSelect.stories.tsx";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `1.4.0`    |
+| Component Version | DS Version        |
+| ----------------- | ----------------- |
+| Added             | `1.4.0`           |
+| Latest            | `DarkModeVersion` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -84,6 +84,7 @@ export const MultiSelectListboxStory: Story<MultiSelectProps> = (args) => {
   return (
     <MultiSelect
       {...args}
+      isDefaultOpen
       items={items}
       selectedItems={selectedItems}
       onChange={(selectedItem) => {

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -16,7 +16,7 @@ import DSProvider from "../../theme/provider";
   title={getCategory("TextInput")}
   component={TextInput}
   decorators={[withDesign]}
-  parameters={{https://github.com/NYPL/nypl-design-system/pull/1137/conflict?name=src%252Fcomponents%252FTextInput%252FTextInput.stories.mdx&ancestor_oid=4e64f4d5ac327c092247f43cef563cd111b2eba9&base_oid=18657f129e8a84e8b5dba19629daab900adca055&head_oid=f563417ec7a35ada4ac395b9431d54be572f60f7
+  parameters={{
     design: {
       type: "figma",
       url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=11895%3A547",

--- a/src/theme/components/filterBar.ts
+++ b/src/theme/components/filterBar.ts
@@ -24,21 +24,21 @@ const FilterBar = {
     modalBody: {
       _dark: {
         background: "dark.ui.bg.page",
-      }
+      },
     },
     modalHeader: {
       bg: "ui.bg.default",
       _dark: {
         background: "dark.ui.bg.default",
-        borderBottom:"1px solid",
+        borderBottom: "1px solid",
         borderColor: "dark.ui.border.default",
-      }
+      },
     },
     modalFooter: {
       bg: "ui.bg.default",
       _dark: {
         background: "dark.ui.bg.default",
-        borderTop:"1px solid",
+        borderTop: "1px solid",
         borderColor: "dark.ui.border.default",
         color: "dark.ui.typography.heading",
       },

--- a/src/theme/components/filterBar.ts
+++ b/src/theme/components/filterBar.ts
@@ -12,6 +12,7 @@ export const filterBarWidth = {
 
 const FilterBar = {
   parts: [
+    "modalBody",
     "modalHeader",
     "modalFooter",
     "modalCloseButton",
@@ -20,11 +21,27 @@ const FilterBar = {
   ],
   baseStyle: ({ width }) => ({
     width: "full",
+    modalBody: {
+      _dark: {
+        background: "dark.ui.bg.page",
+      }
+    },
     modalHeader: {
-      bg: "ui.gray.x-light-cool",
+      bg: "ui.bg.default",
+      _dark: {
+        background: "dark.ui.bg.default",
+        borderBottom:"1px solid",
+        borderColor: "dark.ui.border.default",
+      }
     },
     modalFooter: {
-      bg: "ui.gray.x-light-cool",
+      bg: "ui.bg.default",
+      _dark: {
+        background: "dark.ui.bg.default",
+        borderTop:"1px solid",
+        borderColor: "dark.ui.border.default",
+        color: "dark.ui.typography.heading",
+      },
     },
     modalCloseButton: {
       mt: "8px",

--- a/src/theme/components/multiSelect.ts
+++ b/src/theme/components/multiSelect.ts
@@ -90,6 +90,19 @@ const MultiSelect = {
           },
         },
       },
+      _dark: {
+        background: "dark.ui.bg.default",
+        borderColor: "dark.ui.border.hover",
+        ul: {
+          li: {
+            div: {
+              _hover: {
+                bg: "dark.ui.bg.hover",
+              },
+            },
+          },
+        },
+      },
     },
     menu: {
       paddingX: "xs",

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -79,17 +79,13 @@ const MultiSelectMenuButton = {
       },
       _dark: {
         backgroundColor: "dark.ui.bg.hover",
-        borderColor: isOpen
-          ? "dark.ui.border.hover"
-          : "dark.ui.border.default",
+        borderColor: isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
         svg: {
           fill: "dark.ui.typography.heading",
         },
         _hover: {
-          borderColor: isOpen
-          ? "ui.white"
-          : "dark.ui.border.hover",
-        }
+          borderColor: isOpen ? "ui.white" : "dark.ui.border.hover",
+        },
       },
     },
   }),

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -10,7 +10,7 @@ const GetStyles = (props) => {
     ),
     borderColor: useColorModeValue(
       isOpen ? "ui.border.hover" : "ui.border.default",
-      isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
+      isOpen ? "dark.ui.border.hover" : "dark.ui.border.default"
     ),
   };
 };

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -23,7 +23,7 @@ const MultiSelectMenuButton = {
       backgroundColor: isOpen ? "ui.bg.active" : "ui.white",
       borderBottomLeftRadius: isOpen ? "0" : "button.default",
       borderBottomRightRadius: isOpen ? "0" : "button.default",
-      borderColor: isOpen ? "ui.gray.dark" : "ui.gray.medium",
+      borderColor: isOpen ? "ui.border.hover" : "ui.border.default",
       borderRadius: "button.default",
       borderWidth: "1px",
       fontSize: "button.default",
@@ -39,6 +39,19 @@ const MultiSelectMenuButton = {
       },
       svg: {
         marginTop: "0",
+      },
+      _dark: {
+        backgroundColor: isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default",
+        borderBottomLeftRadius: isOpen ? "0" : "button.default",
+        borderBottomRightRadius: isOpen ? "0" : "button.default",
+        borderColor: isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
+        svg: {
+          fill: "dark.ui.typography.heading",
+        },
+        _hover: {
+          backgroundColor: isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default",
+          borderColor: "dark.ui.border.hover",
+        },
       },
     },
     selectedItemsCountButton: {
@@ -63,6 +76,20 @@ const MultiSelectMenuButton = {
         marginLeft: "xxs",
         marginRight: "6px",
         marginTop: "0",
+      },
+      _dark: {
+        backgroundColor: "dark.ui.bg.hover",
+        borderColor: isOpen
+          ? "dark.ui.border.hover"
+          : "dark.ui.border.default",
+        svg: {
+          fill: "dark.ui.typography.heading",
+        },
+        _hover: {
+          borderColor: isOpen
+          ? "ui.white"
+          : "dark.ui.border.hover",
+        }
       },
     },
   }),

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -1,4 +1,19 @@
 import { defaultElementSizes } from "./global";
+import { useColorModeValue } from "@chakra-ui/react";
+
+const GetStyles = (props) => {
+  const { isOpen } = props;
+  return {
+    bgColor: useColorModeValue(
+      isOpen ? "ui.bg.active" : "ui.white",
+      isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default"
+    ),
+    borderColor: useColorModeValue(
+      isOpen ? "ui.border.hover" : "ui.border.default",
+      isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
+    ),
+  };
+};
 
 const MultiSelectMenuButton = {
   parts: [
@@ -20,10 +35,12 @@ const MultiSelectMenuButton = {
     },
     menuButton: {
       alignItems: "center",
-      backgroundColor: isOpen ? "ui.bg.active" : "ui.white",
+      // backgroundColor: isOpen ? "ui.bg.active" : "ui.white",
+      backgroundColor: GetStyles(isOpen).bgColor,
       borderBottomLeftRadius: isOpen ? "0" : "button.default",
       borderBottomRightRadius: isOpen ? "0" : "button.default",
-      borderColor: isOpen ? "ui.border.hover" : "ui.border.default",
+      // borderColor: isOpen ? "ui.border.hover" : "ui.border.default",
+      borderColor: GetStyles(isOpen).borderColor,
       borderRadius: "button.default",
       borderWidth: "1px",
       fontSize: "button.default",
@@ -41,10 +58,10 @@ const MultiSelectMenuButton = {
         marginTop: "0",
       },
       _dark: {
-        backgroundColor: isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default",
+        // backgroundColor: isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default",
         borderBottomLeftRadius: isOpen ? "0" : "button.default",
         borderBottomRightRadius: isOpen ? "0" : "button.default",
-        borderColor: isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
+        // borderColor: isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
         svg: {
           fill: "dark.ui.typography.heading",
         },

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -1,19 +1,4 @@
 import { defaultElementSizes } from "./global";
-import { useColorModeValue } from "@chakra-ui/react";
-
-const GetStyles = (props) => {
-  const { isOpen } = props;
-  return {
-    bgColor: useColorModeValue(
-      isOpen ? "ui.bg.active" : "ui.white",
-      isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default"
-    ),
-    borderColor: useColorModeValue(
-      isOpen ? "ui.border.hover" : "ui.border.default",
-      isOpen ? "dark.ui.border.hover" : "dark.ui.border.default"
-    ),
-  };
-};
 
 const MultiSelectMenuButton = {
   parts: [
@@ -35,12 +20,10 @@ const MultiSelectMenuButton = {
     },
     menuButton: {
       alignItems: "center",
-      // backgroundColor: isOpen ? "ui.bg.active" : "ui.white",
-      backgroundColor: GetStyles(isOpen).bgColor,
+      backgroundColor: isOpen ? "ui.bg.active" : "ui.white",
       borderBottomLeftRadius: isOpen ? "0" : "button.default",
       borderBottomRightRadius: isOpen ? "0" : "button.default",
-      // borderColor: isOpen ? "ui.border.hover" : "ui.border.default",
-      borderColor: GetStyles(isOpen).borderColor,
+      borderColor: isOpen ? "ui.border.hover" : "ui.border.default",
       borderRadius: "button.default",
       borderWidth: "1px",
       fontSize: "button.default",
@@ -58,10 +41,10 @@ const MultiSelectMenuButton = {
         marginTop: "0",
       },
       _dark: {
-        // backgroundColor: isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default",
+        backgroundColor: isOpen ? "dark.ui.bg.active" : "dark.ui.bg.default",
         borderBottomLeftRadius: isOpen ? "0" : "button.default",
         borderBottomRightRadius: isOpen ? "0" : "button.default",
-        // borderColor: isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
+        borderColor: isOpen ? "dark.ui.border.hover" : "dark.ui.border.default",
         svg: {
           fill: "dark.ui.typography.heading",
         },

--- a/src/theme/components/skeletonLoader.ts
+++ b/src/theme/components/skeletonLoader.ts
@@ -17,7 +17,7 @@ const borderRules = {
   padding: "s",
   _dark: {
     borderColor: "ui.gray.xx-dark",
-  }
+  },
 };
 const imagePaddingBottomStyles = {
   landscape: "50%",

--- a/src/theme/components/skeletonLoader.ts
+++ b/src/theme/components/skeletonLoader.ts
@@ -13,8 +13,11 @@ const element = {
 };
 const borderRules = {
   border: "1px solid",
-  borderColor: "ui.gray.light-cool",
+  borderColor: "ui.gray.x-light-cool",
   padding: "s",
+  _dark: {
+    borderColor: "ui.gray.xx-dark",
+  }
 };
 const imagePaddingBottomStyles = {
   landscape: "50%",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1298](https://jira.nypl.org/browse/DSD-1298)

## This PR does the following:

- Adds `dark` color mode support for the `FilterBar` and `MultiSelect` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->
- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.
