### PR TITLE
DSD-1303: Fix Slider onChangeEnd with value prop issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Updates the `Slider` component's `currentValue` state to use the `useStateWithDependencies` hook.
+
 ## 1.4.1 (February 9, 2023)
 
 ### Adds

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -75,10 +75,10 @@ import DSProvider from "../../theme/provider";
 
 # Slider
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `1.4.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.4`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -388,6 +388,7 @@ describe("Slider", () => {
           invalidText="Component error text :("
           labelText="Label"
           onChangeEnd={onChangeEnd}
+          value={currentValue}
         />
       );
 
@@ -935,12 +936,12 @@ describe("Slider", () => {
     render(
       <Slider
         id="rangeSlider"
-        defaultValue={[25, 75]}
         helperText="Component helper text."
         invalidText="Component error text :("
         labelText="Label"
         isRangeSlider
         onChangeEnd={onChangeEnd}
+        value={currentValue}
       />
     );
 
@@ -948,7 +949,7 @@ describe("Slider", () => {
     fireEvent.change(inputs[0], {
       target: { value: "42" },
     });
-    expect(currentValue).toEqual([42, 75]);
+    expect(currentValue).toEqual([42, 100]);
 
     fireEvent.change(inputs[1], {
       target: { value: "84" },

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -11,7 +11,8 @@ import {
   SliderTrack as ChakraSliderTrack,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef, useEffect } from "react";
+import React, { forwardRef } from "react";
+import useStateWithDependencies from "../../hooks/useStateWithDependencies";
 
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
@@ -103,7 +104,14 @@ export const Slider = chakra(
         showRequiredLabel = true,
         showValues = true,
         step = 1,
-        value,
+        // For the RangeSlider, if the defaultValue is not an array, then we set
+        // the defaultValue to an array with the min and max values.
+        // We need to set the default value correctly for both types of sliders.
+        value = isRangeSlider
+          ? typeof defaultValue === "number"
+            ? [min, max]
+            : defaultValue
+          : defaultValue,
         ...rest
       } = props;
 
@@ -117,31 +125,7 @@ export const Slider = chakra(
           "NYPL Reservoir Slider: Both `onChange` and `onChangeEnd` props were passed."
         );
       }
-      // For the RangeSlider, if the defaultValue is not an array, then we set
-      // the defaultValue to an array with the min and max values.
-      const rangeSliderDefault =
-        typeof defaultValue === "number" ? [min, max] : defaultValue;
-      // We need to set the default value correctly for both types of sliders.
-      const finalDevaultValue = isRangeSlider
-        ? rangeSliderDefault
-        : defaultValue;
-      const [currentValue, setCurrentValue] =
-        React.useState<typeof defaultValue>(finalDevaultValue);
-
-      // If the value(s) needs to be updated programmatically,
-      // listen to the `value` prop.
-      useEffect(() => {
-        if (value) {
-          if (typeof value === "number" && value !== currentValue) {
-            setCurrentValue(value);
-          } else if (
-            value[0] !== currentValue[0] ||
-            value[1] !== currentValue[1]
-          ) {
-            setCurrentValue(value);
-          }
-        }
-      }, [value, currentValue]);
+      const [currentValue, setCurrentValue] = useStateWithDependencies(value);
 
       let finalIsInvalid = isInvalid;
       // In the Range Slider, if the first value is bigger than the second value,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1303](https://jira.nypl.org/browse/DSD-1303)

## This PR does the following:

- Replaces `useEffect` with the `useStateWithDependencies` hook to update the `currentValue` state.

## How has this been tested?

Locally on Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
