### PR TITLE
DSD-1342: dark mode colors for Announcement Notification

### DIFF
--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -172,7 +172,7 @@ export const Notification = chakra(
         announcement: {
           color:
             colorMode === "dark"
-              ? "ui.gray.medium"
+              ? "dark.ui.success.primary"
               : "section.research.secondary",
           name: "speakerNotes",
           title: "Notification announcement icon",

--- a/src/theme/components/notification.ts
+++ b/src/theme/components/notification.ts
@@ -101,7 +101,7 @@ const NotificationContent = {
           notificationType === "standard"
             ? "ui.status.primary"
             : notificationType === "announcement"
-            ? "ui.success.primary"
+            ? "dark.ui.success.primary"
             : "dark.ui.error.primary",
         borderLeftStyle: !isCentered ? "solid" : "none",
         borderLeftWidth: "2px",
@@ -151,7 +151,7 @@ const NotificationHeading = {
           notificationType === "standard"
             ? "ui.status.primary"
             : notificationType === "announcement"
-            ? "ui.success.primary"
+            ? "dark.ui.success.primary"
             : "dark.ui.error.primary",
         borderBottomStyle: isCentered ? "solid" : "none",
         borderBottomWidth: "2px",
@@ -167,7 +167,7 @@ const NotificationHeading = {
             notificationType === "standard"
               ? "ui.status.primary"
               : notificationType === "announcement"
-              ? "ui.success.primary"
+              ? "dark.ui.success.primary"
               : "dark.ui.error.primary",
           borderLeftStyle: !isCentered ? "solid" : "none",
           borderLeftWidth: "2px",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1342](https://jira.nypl.org/browse/DSD-1342)

## This PR does the following:

- Updates the colors used for the highlights in the `Announcement` variant of the `Notification` component.
- NOTE: Nothing was added to the CHANGELOG because this is not worth noting.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The colors used comply with WCAG contrast ratios.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
