### PR TITLE
DSD-1354: dark mode colors on FilterBar story page

### DIFF
--- a/src/components/FilterBar/FilterBar.stories.mdx
+++ b/src/components/FilterBar/FilterBar.stories.mdx
@@ -142,6 +142,9 @@ The `FilterBar` component will often be rendered within a UI container with
 `background-color` and `padding` styles applied. This treatment can easily be
 accomplished using the `Box` component with inline styles.
 
+If a consuming app supports dark mode, styles for both light and dark mode will
+be required for the UI container element.
+
 **Note:** Future DS updates may provide a standalone component to implement a
 UI container similar to what is used in these example.
 
@@ -154,7 +157,9 @@ UI container similar to what is used in these example.
 </Canvas>
 
 ```jsx
-// Container for row layout
+/* LIGHT MODE ONLY */
+
+// Add container for row layout
 <Box bg="ui.bg.default" p="inset.wide">
   <FilterBar
     layout="row"
@@ -163,6 +168,29 @@ UI container similar to what is used in these example.
     // MultiSelect and MultiSelectGroup components...
   </FilterBar>
 </Box>
+```
+
+```jsx
+/* DARK MODE SUPPORT */
+
+// Import useColorModeValue hook
+import { useColorModeValue } from "@nypl/design-system-react-components";
+
+// Use hook to set values for light and dark mode
+const containerBgColor = useColorModeValue(
+  "ui.bg.default",
+  "dark.ui.bg.default"
+);
+
+// Add container for row layout
+<Box bg={containerBgColor} p="inset.wide">
+  <FilterBar
+    layout="row"
+    // ...
+  >
+    // MultiSelect and MultiSelectGroup components...
+  </FilterBar>
+</Box>;
 ```
 
 ### Column Layout
@@ -174,7 +202,9 @@ UI container similar to what is used in these example.
 </Canvas>
 
 ```jsx
-// Container for column layout
+/* LIGHT MODE ONLY */
+
+// Add container for column layout
 <Box bg="ui.bg.default" p="inset.default">
   <FilterBar
     layout="column"
@@ -183,6 +213,29 @@ UI container similar to what is used in these example.
     // MultiSelect and MultiSelectGroup components...
   </FilterBar>
 </Box>
+```
+
+```jsx
+/* DARK MODE SUPPORT */
+
+// Import useColorModeValue hook
+import { useColorModeValue } from "@nypl/design-system-react-components";
+
+// Use hook to set values for light and dark mode
+const containerBgColor = useColorModeValue(
+  "ui.bg.default",
+  "dark.ui.bg.default"
+);
+
+// Add container for column layout
+<Box bg={containerBgColor} p="inset.default">
+  <FilterBar
+    layout="column"
+    // ...
+  >
+    // MultiSelect and MultiSelectGroup components...
+  </FilterBar>
+</Box>;
 ```
 
 ## `useFilterBar` hook

--- a/src/components/FilterBar/FilterBar.stories.tsx
+++ b/src/components/FilterBar/FilterBar.stories.tsx
@@ -1,7 +1,7 @@
 import { action } from "@storybook/addon-actions";
 import React from "react";
 import { Story } from "@storybook/react/types-6-0";
-import { Box, VStack } from "@chakra-ui/react";
+import { Box, useColorModeValue, VStack } from "@chakra-ui/react";
 
 import FilterBar, { FilterBarProps } from "./FilterBar";
 import MultiSelect from "../MultiSelect/MultiSelect";
@@ -780,9 +780,13 @@ export const FilterBarRowContainerStory = () => {
     isModalOpen,
     onToggle,
   } = useFilterBar();
+  const containerBgColor = useColorModeValue(
+    "ui.bg.default",
+    "dark.ui.bg.default"
+  );
   return (
     <VStack align="stretch" spacing="l" key="filter-bar-row-container-story">
-      <Box bg="ui.bg.default" p="inset.wide">
+      <Box bg={containerBgColor} p="inset.wide">
         <FilterBar
           key="row-with-buttons"
           id="row-with-buttons"
@@ -829,7 +833,7 @@ export const FilterBarRowContainerStory = () => {
           </MultiSelectGroup>
         </FilterBar>
       </Box>
-      <Box bg="ui.bg.default" p="inset.wide">
+      <Box bg={containerBgColor} p="inset.wide">
         <FilterBar
           key="row-multiple-multiselect-groups-buttons"
           id="row-multiple-multiselect-groups-buttons"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1354](https://jira.nypl.org/browse/DSD-1345)

## This PR does the following:

- Adds dark mode colors for UI Containers on `FilterBar` story page.
- NOTE: Nothing was added to the CHANGELOG because this is not worth noting.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
