### PR TITLE
DSD-1346: hover state colors for Breadcrumbs in dark mode

### DIFF
--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -7,7 +7,12 @@ const blogs = {
   },
   a: {
     _hover: {
-      color: "ui.gray.x-dark",
+      color: "ui.gray.xx-dark",
+    },
+    _dark: {
+      _hover: {
+        color: "dark.ui.typography.heading",
+      },
     },
   },
   svg: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1346](https://jira.nypl.org/browse/DSD-1346)

## This PR does the following:

- Updates the color used for link hover state in the "blogs" variant of the `Breadcrumbs` component.
- NOTE: Nothing was added to the CHANGELOG because this is not worth noting.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
