### PR TITLE
DSD-1347: dark mode styles for Primary Hero bg image

### DIFF
--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -117,7 +117,7 @@ const primary = {
       marginBottom: "0",
     },
     _dark: {
-      bg: "dark.ui.bg.default",
+      bgColor: "dark.ui.bg.default",
       color: "dark.ui.typography.body",
     },
   },
@@ -253,9 +253,9 @@ const fiftyFifty = {
 };
 const Hero = {
   baseStyle: {
-    bg: "ui.gray.x-light-cool",
+    bgColor: "ui.gray.x-light-cool",
     _dark: {
-      bg: "dark.ui.bg.default",
+      bgColor: "dark.ui.bg.default",
     },
   },
   // Available variants:


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1347](https://jira.nypl.org/browse/DSD-1347)

## This PR does the following:

- Updates dark mode styles for background image in "primary" variant of the `Hero` component.
- NOTE: Nothing was added to the CHANGELOG because this is not worth noting. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
