### PR TITLE
DSD-1325: secondary button background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `Button` component to use a transparent background for the default
+  state of the "secondary" variant.
+
 ## 1.5.0 (March 16, 2023)
 
 ### Adds

--- a/src/components/Button/Button.stories.mdx
+++ b/src/components/Button/Button.stories.mdx
@@ -107,10 +107,10 @@ export const iconNames = [
 
 # Button
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -93,7 +93,6 @@ export const primary = ({ buttonSize = "medium" }) => ({
   },
 });
 export const secondary = ({ buttonSize = "medium" }) => ({
-  bg: "ui.white",
   border: "1px solid",
   borderColor: "ui.link.primary",
   color: "ui.link.primary",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1325](https://jira.nypl.org/browse/DSD-1325)

## This PR does the following:

- Updates the `Button` component to use a transparent background for the default state of the "secondary" variant.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
