### PR TITLE
DSD-1339: Fixing keyboard controls state update issue in the range Slider variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Removes the `Slider` component's internal state update function (`setCurrentValue`) from Chakra's own `RangeSlider` component's `onChangeEnd` prop function. This fixes an issue where both Chakra's `onChange` and `onChangeEnd` prop functions were being called regardless of whether they were passed to the DS `Slider` component or not. Since Chakra's `onChange` function will always be called, the internal state function is kept. This ensures that there is no multiple calls or loop of state update calls when using keyboard controls to change the range slider's value.
+
 ## 1.5.0 (March 16, 2023)
 
 ### Adds

--- a/src/components/Slider/Slider.stories.mdx
+++ b/src/components/Slider/Slider.stories.mdx
@@ -78,7 +78,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.4`   |
-| Latest            | `1.5.0`    |
+| Latest            | `prelease` |
 
 ## Table of Contents
 

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -167,7 +167,6 @@ export const Slider = chakra(
           onChange && onChange(val);
         },
         onChangeEnd: (val) => {
-          setCurrentValue(val);
           onChangeEnd && onChangeEnd(val);
         },
         step,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1339](https://jira.nypl.org/browse/DSD-1339)

## This PR does the following:

- Fixes an issue where keyboard controls used in the range `Slider` loops updating the internal state. This happened because both `onChange` and `onChangeEnd` props in Chakra's `RangeSlider` component get called. This is _not_ the problem. The problem occurs because we passed the `setCurrentValue` function to both prop functions and when both get called, the internal state tries to update. This is what caused the state update loop that causes the page to slow down or crash.
- The `setCurrentValue` function is removed from the `onChangeEnd` prop function but is kept in the `onChange` prop function. For the cases where a user wants to only use the `onChangeEnd` function, this change does not affect the original implementation. This is because Chakra will still call the `onChange` function, it just won't call our own internal `onChange` function since `onChangeEnd` was passed.

## How has this been tested?

In Storybook. Any of the range `Slider`s can be used to test. Just focus on either the first or second slider thumb and use keyboard controls to update the value.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A the Slider still works as expected, or better, with keyboard controls.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
