### PR TITLE
DSD-1318: image height for Hero campaign and 5050

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `Hero` component so that the height of the image in the "campaign" and "fiftyFifty" variants will grow and shrink based on the text content.
+
 ## 1.5.0 (March 16, 2023)
 
 ### Adds

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -7,6 +7,7 @@ import {
 } from "@storybook/addon-docs";
 import { withDesign } from "storybook-addon-designs";
 
+import { Stack } from "@chakra-ui/react";
 import Heading from "../Heading/Heading";
 import Hero, { heroSecondaryTypes } from "./Hero";
 import SimpleGrid from "../Grid/SimpleGrid";
@@ -48,6 +49,23 @@ export const secondarySubHeaderText = (
 );
 export const otherSubHeaderText =
   "With 92 locations across the Bronx, Manhattan, and Staten Island, The New York Public Library is an essential part of neighborhoods across the city. Visit us today.";
+export const otherSubHeaderTextLong = (
+  <>
+    <Heading level="two" noSpace>
+      Subheading
+    </Heading>
+    <Text size="caption">Lorem Parturient Bibendum Aenean Cras</Text>
+    <Heading level="three">Subheading</Heading>
+    <Text noSpace>
+      Donec ullamcorper nulla non metus auctor fringilla. Cras mattis
+      consectetur purus sit amet fermentum. Nulla vitae elit libero, a pharetra
+      augue. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+      Aenean lacinia bibendum nulla sed consectetur. Vestibulum id ligula porta
+      felis euismod semper. Donec sed odio dui. Nullam quis risus eget urna
+      mollis ornare vel eu leo.
+    </Text>
+  </>
+);
 export const imageProps = {
   alt: "Image example",
   src: "https://placeimg.com/800/400/animals",
@@ -55,10 +73,10 @@ export const imageProps = {
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -196,13 +214,13 @@ heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
 ```
 
 <Canvas>
-  <DSProvider>
+  <Story name="All Variantions">
     <Hero
       backgroundImageSrc="https://placeimg.com/1600/800/arch"
       heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
       heroType="primary"
     />
-  </DSProvider>
+  </Story>
 </Canvas>
 
 ### Secondary
@@ -293,13 +311,35 @@ subHeaderText={otherSubHeaderText}
 
 <Canvas>
   <DSProvider>
-    <Hero
-      backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
-      heroType="campaign"
-      heading={<Heading level="one" id="campaign-hero" text="Hero Campaign" />}
-      imageProps={imageProps}
-      subHeaderText={otherSubHeaderText}
-    />
+    <Stack spacing="l">
+      <div>
+        <Heading
+          id="campaign-stabdard"
+          text="Campaign Hero at Default Height"
+        />
+        <Hero
+          backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+          heroType="campaign"
+          heading={
+            <Heading level="one" id="campaign-hero" text="Hero Campaign" />
+          }
+          imageProps={imageProps}
+          subHeaderText={otherSubHeaderText}
+        />
+      </div>
+      <div>
+        <Heading id="campaign-stabdard" text="Campaign Hero with Long Text" />
+        <Hero
+          backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+          heroType="campaign"
+          heading={
+            <Heading level="one" id="campaign-hero" text="Hero Campaign" />
+          }
+          imageProps={imageProps}
+          subHeaderText={otherSubHeaderTextLong}
+        />
+      </div>
+    </Stack>
   </DSProvider>
 </Canvas>
 
@@ -316,11 +356,27 @@ subHeaderText={otherSubHeaderText}
 
 <Canvas>
   <DSProvider>
-    <Hero
-      heroType="fiftyFifty"
-      imageProps={imageProps}
-      subHeaderText={otherSubHeaderText}
-    />
+    <Stack>
+      <div>
+        <Heading
+          id="campaign-stabdard"
+          text="FiftyFifty Hero at Default Height"
+        />
+        <Hero
+          heroType="fiftyFifty"
+          imageProps={imageProps}
+          subHeaderText={otherSubHeaderText}
+        />
+      </div>
+      <div>
+        <Heading id="campaign-stabdard" text="FiftyFifty Hero with Long Text" />
+        <Hero
+          heroType="fiftyFifty"
+          imageProps={imageProps}
+          subHeaderText={otherSubHeaderTextLong}
+        />
+      </div>
+    </Stack>
   </DSProvider>
 </Canvas>
 

--- a/src/components/Hero/Hero.stories.mdx
+++ b/src/components/Hero/Hero.stories.mdx
@@ -214,7 +214,7 @@ heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
 ```
 
 <Canvas>
-  <Story name="All Variantions">
+  <Story name="All Variations">
     <Hero
       backgroundImageSrc="https://placeimg.com/1600/800/arch"
       heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
@@ -272,8 +272,8 @@ subHeaderText={otherSubHeaderText}
       heading={
         <Heading
           level="one"
-          id="tertiary-hero"
-          text="Hero Tertiary with Sub-Header"
+          id="tertiary-hero-subheading"
+          text="Hero Tertiary with Sub-Heading"
         />
       }
       heroType="tertiary"
@@ -285,7 +285,7 @@ subHeaderText={otherSubHeaderText}
         <Heading
           level="one"
           id="tertiary-hero"
-          text="Hero Tertiary without Sub-Header text"
+          text="Hero Tertiary without Sub-Heading text"
         />
       }
       heroType="tertiary"
@@ -314,26 +314,37 @@ subHeaderText={otherSubHeaderText}
     <Stack spacing="l">
       <div>
         <Heading
-          id="campaign-stabdard"
+          id="campaign-hero-default"
           text="Campaign Hero at Default Height"
         />
         <Hero
           backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
           heroType="campaign"
           heading={
-            <Heading level="one" id="campaign-hero" text="Hero Campaign" />
+            <Heading
+              level="one"
+              id="campaign-hero-default-heading"
+              text="Hero Campaign"
+            />
           }
           imageProps={imageProps}
           subHeaderText={otherSubHeaderText}
         />
       </div>
       <div>
-        <Heading id="campaign-stabdard" text="Campaign Hero with Long Text" />
+        <Heading
+          id="campaign-hero-long-text"
+          text="Campaign Hero with Long Text"
+        />
         <Hero
           backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
           heroType="campaign"
           heading={
-            <Heading level="one" id="campaign-hero" text="Hero Campaign" />
+            <Heading
+              level="one"
+              id="campaign-hero-long-text-heading"
+              text="Hero Campaign"
+            />
           }
           imageProps={imageProps}
           subHeaderText={otherSubHeaderTextLong}
@@ -356,10 +367,10 @@ subHeaderText={otherSubHeaderText}
 
 <Canvas>
   <DSProvider>
-    <Stack>
+    <Stack spacing="l">
       <div>
         <Heading
-          id="campaign-stabdard"
+          id="fiftyfifty-default"
           text="FiftyFifty Hero at Default Height"
         />
         <Hero
@@ -369,7 +380,10 @@ subHeaderText={otherSubHeaderText}
         />
       </div>
       <div>
-        <Heading id="campaign-stabdard" text="FiftyFifty Hero with Long Text" />
+        <Heading
+          id="fiftyfifty-long-text"
+          text="FiftyFifty Hero with Long Text"
+        />
         <Hero
           heroType="fiftyFifty"
           imageProps={imageProps}

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -160,7 +160,14 @@ export const Hero = chakra(
       const childrenToRender =
         heroType === "campaign" ? (
           <>
-            <Image alt={imageProps.alt} src={imageProps.src} />
+            <Box
+              __css={styles.imgWrapper}
+              style={{
+                backgroundImage: `url(${imageProps.src})`,
+              }}
+            >
+              <Image alt={imageProps.alt} src={imageProps.src} />
+            </Box>
             <Box __css={styles.interior}>
               {finalHeading}
               {subHeaderText}
@@ -169,7 +176,15 @@ export const Hero = chakra(
         ) : (
           <>
             {heroType !== "primary" && heroType !== "tertiary" && (
-              <Box __css={styles.imgWrapper}>
+              <Box
+                __css={styles.imgWrapper}
+                style={{
+                  backgroundImage:
+                    heroType === "fiftyFifty"
+                      ? `url(${imageProps.src})`
+                      : undefined,
+                }}
+              >
                 <Image alt={imageProps.alt} src={imageProps.src} />
               </Box>
             )}

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -161,8 +161,8 @@ export const Hero = chakra(
         heroType === "campaign" ? (
           <>
             <Box
-              __css={styles.imgWrapper}
-              style={{
+              __css={{
+                ...styles.imgWrapper,
                 backgroundImage: `url(${imageProps.src})`,
               }}
             >
@@ -177,8 +177,8 @@ export const Hero = chakra(
           <>
             {heroType !== "primary" && heroType !== "tertiary" && (
               <Box
-                __css={styles.imgWrapper}
-                style={{
+                __css={{
+                  ...styles.imgWrapper,
                   backgroundImage:
                     heroType === "fiftyFifty"
                       ? `url(${imageProps.src})`

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -50,11 +50,6 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
   >
     <div
       className="css-0"
-      style={
-        Object {
-          "backgroundImage": undefined,
-        }
-      }
     >
       <div
         className="css-0"
@@ -95,11 +90,6 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
   >
     <div
       className="css-0"
-      style={
-        Object {
-          "backgroundImage": undefined,
-        }
-      }
     >
       <div
         className="css-0"
@@ -140,11 +130,6 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
   >
     <div
       className="css-0"
-      style={
-        Object {
-          "backgroundImage": undefined,
-        }
-      }
     >
       <div
         className="css-0"
@@ -185,11 +170,6 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
   >
     <div
       className="css-0"
-      style={
-        Object {
-          "backgroundImage": undefined,
-        }
-      }
     >
       <div
         className="css-0"
@@ -230,11 +210,6 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
   >
     <div
       className="css-0"
-      style={
-        Object {
-          "backgroundImage": undefined,
-        }
-      }
     >
       <div
         className="css-0"
@@ -317,12 +292,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
     }
   >
     <div
-      className="css-0"
-      style={
-        Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
-        }
-      }
+      className="css-mswi6j"
     >
       <div
         className="css-0"
@@ -371,12 +341,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
     }
   >
     <div
-      className="css-0"
-      style={
-        Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
-        }
-      }
+      className="css-mswi6j"
     >
       <div
         className="css-0"

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -50,6 +50,11 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
       <div
         className="css-0"
@@ -90,6 +95,11 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
       <div
         className="css-0"
@@ -130,6 +140,11 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
       <div
         className="css-0"
@@ -170,6 +185,11 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
       <div
         className="css-0"
@@ -210,6 +230,11 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
       <div
         className="css-0"
@@ -293,12 +318,21 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
-      <img
-        alt="Image example"
+      <div
         className="css-0"
-        src="https://placeimg.com/800/400/animals"
-      />
+      >
+        <img
+          alt="Image example"
+          className="css-0"
+          src="https://placeimg.com/800/400/animals"
+        />
+      </div>
     </div>
     <div
       className="css-0"
@@ -338,6 +372,11 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
   >
     <div
       className="css-0"
+      style={
+        Object {
+          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+        }
+      }
     >
       <div
         className="css-0"

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
       className="css-0"
       style={
         Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+          "backgroundImage": undefined,
         }
       }
     >
@@ -97,7 +97,7 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
       className="css-0"
       style={
         Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+          "backgroundImage": undefined,
         }
       }
     >
@@ -142,7 +142,7 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
       className="css-0"
       style={
         Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+          "backgroundImage": undefined,
         }
       }
     >
@@ -187,7 +187,7 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
       className="css-0"
       style={
         Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+          "backgroundImage": undefined,
         }
       }
     >
@@ -232,7 +232,7 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
       className="css-0"
       style={
         Object {
-          "backgroundImage": "url(https://placeimg.com/800/400/animals)",
+          "backgroundImage": undefined,
         }
       }
     >

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -199,9 +199,7 @@ const campaign = {
     color: "inherit",
     display: "inline-block",
   },
-  img: {
-    ...screenreaderOnly(),
-  },
+  img: screenreaderOnly(),
   imgWrapper: {
     backgroundPosition: "center",
     backgroundSize: "cover",
@@ -243,9 +241,7 @@ const fiftyFifty = {
       lg: "50%",
     },
   },
-  img: {
-    ...screenreaderOnly(),
-  },
+  img: screenreaderOnly(),
   bodyText: {
     alignSelf: "center",
     maxWidth: { md: "960px" },

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -1,4 +1,5 @@
 import { wrapperStyles } from "./global";
+import { screenreaderOnly } from "./globalMixins";
 
 // Used for all "secondary" variants.
 const secondaryBase = {
@@ -176,13 +177,13 @@ const campaign = {
   },
   position: "relative",
   content: {
-    alignItems: "center",
+    alignItems: "stretch",
     bg: "ui.black",
     color: "ui.white",
     display: "flex",
     flexFlow: {
       base: "column nowrap",
-      md: "row nowrap",
+      lg: "row nowrap",
     },
     minHeight: "320px",
     flex: { md: "0 0 90%" },
@@ -199,56 +200,63 @@ const campaign = {
     display: "inline-block",
   },
   img: {
-    flex: {
-      base: "1 1 100%",
-      md: "0 0 50%",
+    ...screenreaderOnly(),
+  },
+  imgWrapper: {
+    backgroundPosition: "center",
+    backgroundSize: "cover",
+    minHeight: "230px",
+    width: {
+      base: "100%",
+      lg: "50%",
     },
-    minWidth: "0", // https://github.com/philipwalton/flexbugs/issues/41
-    objectFit: "cover",
-    width: "100%",
-    height: { md: "320px" },
   },
   interior: {
-    flex: {
-      base: "0 0 100%",
-      md: "0 0 50%",
-    },
-    padding: "inset.wide",
+    alignSelf: "center",
     maxWidth: { md: "960px" },
+    padding: {
+      base: "inset.default",
+      md: "inset.wide",
+    },
+    width: {
+      base: "100%",
+      lg: "50%",
+    },
   },
 };
 const fiftyFifty = {
   content: {
     ...wrapperStyles,
-    alignItems: "center",
+    alignItems: "stretch",
     display: "flex",
     flexFlow: {
       base: "column nowrap",
       lg: "row nowrap",
     },
-    paddingBottom: "s",
-    paddingEnd: "s",
-    paddingStart: "s",
-    padding: {
-      lg: "unset",
-    },
   },
   imgWrapper: {
-    marginBottom: {
-      base: "s",
-      lg: "unset",
-    },
-    marginEnd: {
-      base: "-15px",
-      lg: "s",
-    },
-    marginStart: {
-      base: "-15px",
-    },
-    maxWidth: {
+    backgroundPosition: "center",
+    backgroundSize: "cover",
+    minHeight: "160px",
+    width: {
+      base: "100%",
       lg: "50%",
     },
-    width: "auto",
+  },
+  img: {
+    ...screenreaderOnly(),
+  },
+  bodyText: {
+    alignSelf: "center",
+    maxWidth: { md: "960px" },
+    padding: {
+      base: "inset.default",
+      md: "inset.wide",
+    },
+    width: {
+      base: "100%",
+      lg: "50%",
+    },
   },
 };
 const Hero = {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1318](https://jira.nypl.org/browse/DSD-1318)

## This PR does the following:

- Updates the `Hero` component so that the height of the image in the "campaign" and "fiftyFifty" variants will grow and shrink based on the text content.
- NOTE: I am using an unconventional method to get the formatting that I wanted.  The actual image for campaing and 5050 is set to `screenreader only` and the image is then set as the background image for the image container.  I checked with Clare on this and there are no a11y concerns.  It gets the job done.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
