### PR TITLE
DSD-1384 - Add defaultValue to TextInputProps and pass into TextInput component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the `Button` component to use a transparent background for the default state of the "secondary" variant.
 - Updates the `Hero` component so that the height of the image in the "campaign" and "fiftyFifty" variants will grow and shrink based on the text content.
+- Adds `defaultValue` as a prop to `textInputProps` in the `SearchBar` component.
 
 ### Removes
 

--- a/src/components/SearchBar/SearchBar.stories.mdx
+++ b/src/components/SearchBar/SearchBar.stories.mdx
@@ -230,12 +230,13 @@ const selectProps = {
 To render the `TextInput` component, an object must be passed to the
 `textInputProps` prop. It _must_ include `labelText` and `name` properties. The
 `labelText` value won't be rendered but will be used for its `aria-label`
-attribute. Optional properties to pass include `id`, `isClearable`,
+attribute. Optional properties to pass include `defaultValue`, `id`, `isClearable`,
 `isClearableCallback`, `max`, `maxLength`, `min`, `onChange`, `pattern`,
 `placeholder`, and `value`.
 
 ```
 const textInputProps = {
+  defaultValue: "Horizon",
   isClearable: true,
   isClearableCallback: () => {},
   labelText: "Item Search",

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -31,6 +31,7 @@ export type TextInputProps = Pick<InitialInputProps, "labelText" | "name"> &
   Partial<
     Pick<
       InitialInputProps,
+      | "defaultValue"
       | "id"
       | "isClearable"
       | "isClearableCallback"
@@ -162,6 +163,7 @@ export const SearchBar = chakra(
     // Render the `TextInput` component.
     const textInputNative = textInputProps && (
       <TextInput
+        defaultValue={textInputProps?.defaultValue}
         id={textInputProps?.id || `searchbar-textinput-${id}`}
         isClearable={textInputProps?.isClearable}
         isClearableCallback={textInputProps?.isClearableCallback}


### PR DESCRIPTION
Fixes JIRA ticket DSD-1384

## This PR does the following:

- It allows defaultValue to be passed into SearchBar's rendered TextInput component via its textInputProps prop.
- This needs to be added to have the textInput re-render when the value is empty (necessary for https://jira.nypl.org/browse/SCC-3423)