### PR TITLE
DSD-1338 POC: testing new tooltip to wrap around form elements

### DIFF
--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -53,6 +53,7 @@ export interface CheckboxProps extends CheckboxIconProps {
   showLabel?: boolean;
   /** Populates the value of the input */
   value?: string;
+  tooltipLabelText?: any;
 }
 
 function CheckboxIcon(props: CheckboxIconProps) {
@@ -89,6 +90,7 @@ export const Checkbox = chakra(
       showHelperInvalidText = true,
       showLabel = true,
       value,
+      tooltipLabelText,
       ...rest
     } = props;
     const styles = useMultiStyleConfig("Checkbox", {});
@@ -117,6 +119,7 @@ export const Checkbox = chakra(
         invalidText={invalidText}
         isInvalid={isInvalid}
         showHelperInvalidText={showHelperInvalidText}
+        tooltipLabelText={tooltipLabelText}
         {...rest}
       >
         <ChakraCheckbox

--- a/src/components/ComponentWrapper/ComponentWrapper.tsx
+++ b/src/components/ComponentWrapper/ComponentWrapper.tsx
@@ -6,6 +6,8 @@ import HelperErrorText, {
   HelperErrorTextType,
 } from "../HelperErrorText/HelperErrorText";
 import Text from "../Text/Text";
+import Tooltip from "../Tooltip/Tooltip";
+
 export interface ComponentWrapperProps {
   /** The UI elements that will be wrapped by this component */
   children: React.ReactNode;
@@ -28,6 +30,7 @@ export interface ComponentWrapperProps {
   isInvalid?: boolean;
   /** Offers the ability to hide the helper/invalid text. */
   showHelperInvalidText?: boolean;
+  tooltipLabelText?: any;
 }
 
 export const ComponentWrapper = chakra(
@@ -44,6 +47,7 @@ export const ComponentWrapper = chakra(
         invalidText,
         isInvalid = false,
         showHelperInvalidText = true,
+        tooltipLabelText,
         ...rest
       } = props;
       const hasChildren = !!children;
@@ -68,7 +72,11 @@ export const ComponentWrapper = chakra(
         >
           {headingText && <Heading id={`${id}-heading`} text={headingText} />}
           {descriptionText && <Text>{descriptionText}</Text>}
-          {children}
+          {tooltipLabelText ? (
+            <Tooltip content={tooltipLabelText}>{children}</Tooltip>
+          ) : (
+            <>{children}</>
+          )}
           <HelperErrorText
             id={`${id}-helperText`}
             isInvalid={isInvalid}

--- a/src/components/Radio/Radio.tsx
+++ b/src/components/Radio/Radio.tsx
@@ -10,6 +10,7 @@ import React, { forwardRef } from "react";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
 import { getAriaAttrs } from "../../utils/utils";
+import Tooltip from "../Tooltip/Tooltip";
 
 export interface RadioProps {
   /** Additional class name. */
@@ -49,6 +50,7 @@ export interface RadioProps {
   showLabel?: boolean;
   /** Populates the value of the input. */
   value?: string;
+  tooltipLabelText?: any;
 }
 
 export const Radio = chakra(
@@ -68,6 +70,7 @@ export const Radio = chakra(
       showHelperInvalidText = true,
       showLabel = true,
       value,
+      tooltipLabelText,
       ...rest
     } = props;
     const styles = useMultiStyleConfig("Radio", { showLabel });
@@ -101,25 +104,49 @@ export const Radio = chakra(
         sx={wrapperStyles}
         {...rest}
       >
-        <ChakraRadio
-          className={className}
-          id={id}
-          isChecked={isChecked}
-          isDisabled={isDisabled}
-          isInvalid={isInvalid}
-          isRequired={isRequired}
-          name={name}
-          onChange={onChange}
-          ref={ref}
-          value={value}
-          alignItems="flex-start"
-          sx={styles}
-          {...ariaAttributes}
-        >
-          <Box as="span" __css={showLabel ? {} : styles.hiddenLabel}>
-            {labelText}
-          </Box>
-        </ChakraRadio>
+        {tooltipLabelText ? (
+          <Tooltip content={tooltipLabelText}>
+            <ChakraRadio
+              className={className}
+              id={id}
+              isChecked={isChecked}
+              isDisabled={isDisabled}
+              isInvalid={isInvalid}
+              isRequired={isRequired}
+              name={name}
+              onChange={onChange}
+              ref={ref}
+              value={value}
+              alignItems="flex-start"
+              sx={styles}
+              {...ariaAttributes}
+            >
+              <Box as="span" __css={showLabel ? {} : styles.hiddenLabel}>
+                {labelText}
+              </Box>
+            </ChakraRadio>
+          </Tooltip>
+        ) : (
+          <ChakraRadio
+            className={className}
+            id={id}
+            isChecked={isChecked}
+            isDisabled={isDisabled}
+            isInvalid={isInvalid}
+            isRequired={isRequired}
+            name={name}
+            onChange={onChange}
+            ref={ref}
+            value={value}
+            alignItems="flex-start"
+            sx={styles}
+            {...ariaAttributes}
+          >
+            <Box as="span" __css={showLabel ? {} : styles.hiddenLabel}>
+              {labelText}
+            </Box>
+          </ChakraRadio>
+        )}
       </ComponentWrapper>
     );
   })

--- a/src/components/Toggle/Toggle.tsx
+++ b/src/components/Toggle/Toggle.tsx
@@ -10,6 +10,7 @@ import React, { forwardRef } from "react";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
 import { getAriaAttrs } from "../../utils/utils";
+import Tooltip from "../Tooltip/Tooltip";
 
 export type ToggleSizes = "default" | "small";
 export interface ToggleProps {
@@ -44,6 +45,7 @@ export interface ToggleProps {
   onChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** The size of the Toggle. Defaults to "large". */
   size?: ToggleSizes;
+  tooltipLabelText?: any;
 }
 
 export const onChangeDefault = () => {
@@ -68,6 +70,7 @@ export const Toggle = chakra(
       name,
       onChange = onChangeDefault,
       size = "default",
+      tooltipLabelText,
       ...rest
     } = props;
     const styles = useMultiStyleConfig("Toggle", { isDisabled, size });
@@ -97,28 +100,55 @@ export const Toggle = chakra(
         {...rest}
       >
         <Box __css={styles}>
-          <Switch
-            id={id}
-            isDisabled={isDisabled}
-            isInvalid={isInvalid}
-            isRequired={isRequired}
-            name={name || "default"}
-            ref={ref}
-            size={size === "default" ? "lg" : "sm"}
-            lineHeight="1.5"
-            {...(isChecked !== undefined
-              ? {
-                  isChecked,
-                  onChange,
-                }
-              : {
-                  defaultChecked,
-                })}
-            {...ariaAttributes}
-            __css={switchStyles}
-          >
-            {labelText}
-          </Switch>
+          {tooltipLabelText ? (
+            <Tooltip content={tooltipLabelText}>
+              <Switch
+                id={id}
+                isDisabled={isDisabled}
+                isInvalid={isInvalid}
+                isRequired={isRequired}
+                name={name || "default"}
+                ref={ref}
+                size={size === "default" ? "lg" : "sm"}
+                lineHeight="1.5"
+                {...(isChecked !== undefined
+                  ? {
+                      isChecked,
+                      onChange,
+                    }
+                  : {
+                      defaultChecked,
+                    })}
+                {...ariaAttributes}
+                __css={switchStyles}
+              >
+                {labelText}
+              </Switch>
+            </Tooltip>
+          ) : (
+            <Switch
+              id={id}
+              isDisabled={isDisabled}
+              isInvalid={isInvalid}
+              isRequired={isRequired}
+              name={name || "default"}
+              ref={ref}
+              size={size === "default" ? "lg" : "sm"}
+              lineHeight="1.5"
+              {...(isChecked !== undefined
+                ? {
+                    isChecked,
+                    onChange,
+                  }
+                : {
+                    defaultChecked,
+                  })}
+              {...ariaAttributes}
+              __css={switchStyles}
+            >
+              {labelText}
+            </Switch>
+          )}
         </Box>
       </ComponentWrapper>
     );

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -18,6 +18,7 @@ import Link from "../Link/Link";
 import Label from "../Label/Label";
 import Image from "../Image/Image";
 import Text from "../Text/Text";
+import Toggle from "../Toggle/Toggle";
 import { VStack } from "@chakra-ui/react";
 import { getCategory } from "../../utils/componentCategories";
 import DSProvider from "../../theme/provider";
@@ -122,43 +123,34 @@ in sync with the rendered visual control.
 
 <Canvas>
   <DSProvider>
-    <Tooltip
-      content="Invite library staff to share resources at your community event"
-      shouldWrapChildren
-    >
-      <Toggle
-        id="radio3"
-        labelText="Offsite Community Outreach"
-        value="Offsite Community Outreach"
-      />
-    </Tooltip>
+    <Toggle
+      id="radio3"
+      labelText="Offsite Community Outreach"
+      tooltipLabelText="General library orientation or a customized research lesson"
+    />
     <RadioGroup
       labelText="What would you like to request?"
       id="radio-group"
       name="tooltip-example"
     >
-      <Tooltip
-        content="General library orientation or a customized research lesson"
-        shouldWrapChildren
-      >
-        <Radio id="radio1" labelText="Class Visit" value="Class Visit" />
-      </Tooltip>
-      <Tooltip
-        content="Guided exploration of the library and its resources"
-        shouldWrapChildren
-      >
-        <Radio id="radio2" labelText="Group Tour" value="Group Tour" />
-      </Tooltip>
-      <Tooltip
-        content="Invite library staff to share resources at your community event"
-        shouldWrapChildren
-      >
-        <Radio
-          id="radio3"
-          labelText="Offsite Community Outreach"
-          value="Offsite Community Outreach"
-        />
-      </Tooltip>
+      <Radio
+        id="radio1"
+        labelText="Class Visit"
+        value="Class Visit"
+        tooltipLabelText="General library orientation or a customized research lesson"
+      />
+      <Radio
+        id="radio2"
+        labelText="Group Tour"
+        value="Group Tour"
+        tooltipLabelText="Guided exploration of the library and its resources"
+      />
+      <Radio
+        id="radio3"
+        labelText="Offsite Community Outreach"
+        value="Offsite Community Outreach"
+        tooltipLabelText="Invite library staff to share resources at your community event"
+      />
     </RadioGroup>
   </DSProvider>
 </Canvas>

--- a/src/components/Tooltip/Tooltip.stories.mdx
+++ b/src/components/Tooltip/Tooltip.stories.mdx
@@ -7,6 +7,8 @@ import {
 } from "@storybook/addon-docs";
 import { withDesign } from "storybook-addon-designs";
 
+import CheckboxGroup from "../CheckboxGroup/CheckboxGroup";
+import Checkbox from "../Checkbox/Checkbox";
 import Heading from "../Heading/Heading";
 import SimpleGrid from "../Grid/SimpleGrid";
 import Tooltip from "./Tooltip";
@@ -152,6 +154,32 @@ in sync with the rendered visual control.
         tooltipLabelText="Invite library staff to share resources at your community event"
       />
     </RadioGroup>
+    <CheckboxGroup
+      id="column"
+      labelText="Column (default)"
+      name="column-example"
+    >
+      <Checkbox
+        value="2"
+        labelText="Checkbox 2"
+        tooltipLabelText="Checkbox tooltip 1"
+      />
+      <Checkbox
+        value="3"
+        labelText="Checkbox 3"
+        tooltipLabelText="Checkbox tooltip 2"
+      />
+      <Checkbox
+        value="4"
+        labelText="Checkbox 4"
+        tooltipLabelText="Checkbox tooltip 3"
+      />
+      <Checkbox
+        value="5"
+        labelText="Checkbox 5"
+        tooltipLabelText="Checkbox tooltip 4"
+      />
+    </CheckboxGroup>
   </DSProvider>
 </Canvas>
 


### PR DESCRIPTION
This is a quick test so unit tests will fail . Instead of doing 
```
<Tooltip ...>
  <Radio />
</Tooltip>
```
now the `Tooltip` component is rendered inside of the `Radio` component when it should render through the `tooltipLabelText` prop. When rendered, the `aria-describedby` will be added to the `input` html element instead of the wrapper div. This should fix a11y issues.

Only test the following section on this link https://nypl-design-system-git-tooltip-poc-update-nypl.vercel.app/?path=/docs/components-overlays-switchers-tooltip--tooltip-with-controls

<img width="321" alt="Screen Shot 2023-03-23 at 6 30 48 PM" src="https://user-images.githubusercontent.com/1280564/227379712-06fae6fd-9c87-4225-87b1-46602958bbae.png">

If it goes well, we can think through a better update for all component. This change will change how the `Tooltip` and any form component are used together so it is technically a breaking change. I'm a bit wary about releasing this soon but we should aim to bundle this with the next major bump (which is typography?).