### PR TITLE
DSD-1372: Export useCloseDropDown for header app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates `useCloseDropDown` hook to be exported for nypl-header-app.
+
 ## 1.5.1 (March 23, 2023)
 
 ### Updates

--- a/src/components/Header/components/HeaderLoginButton.tsx
+++ b/src/components/Header/components/HeaderLoginButton.tsx
@@ -5,7 +5,7 @@ import FocusLock from "@chakra-ui/focus-lock";
 import Button from "../../Button/Button";
 import HeaderLogin from "./HeaderLogin";
 import Icon from "../../Icons/Icon";
-import { useCloseDropDown } from "../../../hooks/useCloseDropDown";
+import useCloseDropDown from "../../../hooks/useCloseDropDown";
 import gaUtils from "../utils/googleAnalyticsUtils";
 
 export interface HeaderLoginButtonProps {

--- a/src/components/Header/components/HeaderMobileNavButton.tsx
+++ b/src/components/Header/components/HeaderMobileNavButton.tsx
@@ -5,7 +5,7 @@ import React, { useState, useRef } from "react";
 import Button from "../../Button/Button";
 import Icon from "../../Icons/Icon";
 import HeaderMobileNav from "./HeaderMobileNav";
-import { useCloseDropDown } from "../../../hooks/useCloseDropDown";
+import useCloseDropDown from "../../../hooks/useCloseDropDown";
 import gaUtils from "../utils/googleAnalyticsUtils";
 
 /**

--- a/src/components/Header/components/HeaderSearchButton.tsx
+++ b/src/components/Header/components/HeaderSearchButton.tsx
@@ -5,7 +5,7 @@ import React, { useState, useRef } from "react";
 import Button from "../../Button/Button";
 import HeaderSearchForm from "./HeaderSearchForm";
 import Icon from "../../Icons/Icon";
-import { useCloseDropDown } from "../../../hooks/useCloseDropDown";
+import useCloseDropDown from "../../../hooks/useCloseDropDown";
 import gaUtils from "../utils/googleAnalyticsUtils";
 
 export interface HeaderSearchButtonProps {

--- a/src/components/MultiSelect/MultiSelectDialog.tsx
+++ b/src/components/MultiSelect/MultiSelectDialog.tsx
@@ -16,7 +16,7 @@ import Checkbox from "./../Checkbox/Checkbox";
 import { MultiSelectItem, MultiSelectProps } from "./MultiSelect";
 import MultiSelectMenuButton from "./MultiSelectMenuButton";
 import useNYPLBreakpoints from "./../../hooks/useNYPLBreakpoints";
-import { useCloseDropDown } from "./../../hooks/useCloseDropDown";
+import useCloseDropDown from "../../hooks/useCloseDropDown";
 
 type MultiSelectDialogProps = Omit<MultiSelectProps, "onChange"> & {
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;

--- a/src/hooks/__tests__/useCloseDropDown.test.tsx
+++ b/src/hooks/__tests__/useCloseDropDown.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 
-import { useCloseDropDown } from "../useCloseDropDown";
+import useCloseDropDown from "../useCloseDropDown";
 
 describe("useCloseDropDown hook", () => {
   const TestComponent = () => {

--- a/src/hooks/useCloseDropDown.ts
+++ b/src/hooks/useCloseDropDown.ts
@@ -6,7 +6,7 @@ import { useOutsideClick } from "@chakra-ui/react";
  * the escape key. It expects an action callback that will set
  * the dropdown state to false (close).
  */
-export const useCloseDropDown = (
+const useCloseDropDown = (
   actionCb: (val: boolean) => void,
   ref: React.RefObject<HTMLDivElement>
 ) => {
@@ -30,3 +30,5 @@ export const useCloseDropDown = (
     handler: () => actionCb(false),
   });
 };
+
+export default useCloseDropDown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,7 @@ export { default as useMultiSelect } from "./hooks/useMultiSelect";
 export { default as useNYPLBreakpoints } from "./hooks/useNYPLBreakpoints";
 export { default as useNYPLTheme } from "./hooks/useNYPLTheme";
 export { default as useWindowSize } from "./hooks/useWindowSize";
+export { default as useCloseDropDown } from "./hooks/useCloseDropDown";
 export {
   default as VideoPlayer,
   VideoPlayerAspectRatios,


### PR DESCRIPTION
Related to JIRA ticket [DSD-1372](https://jira.nypl.org/browse/DSD-1372)

## This PR does the following:

- Exports useCloseDropDown hook to be imported into the header app since it is also being used in MultiSelect

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
