### PR TITLE
[DSD-1396] Allow external clearing of TextInput's value.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Fixes a `border-radius` formatting issues on the hover state of the search field for the dark mode version of the `Header` component.
 - Fixes a `color` issue on the hover state of the links for the dark mode version of the `Footer` component.
 - Fixes a `border-color` issue for the dark mode version of the `FeedbackBox` component.
+- Fixes a bug in `TextInput` that prevented the external clearing of `value`.
 
 ## 1.5.2 (April 6, 2023)
 

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -350,7 +350,7 @@ export const FeedbackBox = chakra(
                             onChange={(e) => setComment(e.target.value)}
                             placeholder="Enter your question or feedback here"
                             type="textarea"
-                            defaultValue={state.comment}
+                            value={state.comment}
                           />
                         </FormField>
                         {showEmailField && (

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -350,7 +350,7 @@ export const FeedbackBox = chakra(
                             onChange={(e) => setComment(e.target.value)}
                             placeholder="Enter your question or feedback here"
                             type="textarea"
-                            value={state.comment}
+                            defaultValue={state.comment}
                           />
                         </FormField>
                         {showEmailField && (

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -30,6 +30,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -253,6 +254,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -350,6 +352,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -439,6 +442,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -537,6 +541,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -626,6 +631,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -717,6 +723,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
         required={true}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -808,6 +815,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
         required={true}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -1106,6 +1114,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}
@@ -1204,6 +1213,7 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
         required={false}
         step={null}
         type="text"
+        value=""
       />
       <div
         aria-atomic={true}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -254,7 +253,6 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -352,7 +350,6 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -442,7 +439,6 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -541,7 +537,6 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -631,7 +626,6 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -723,7 +717,6 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
         required={true}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -815,7 +808,6 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
         required={true}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -1114,7 +1106,6 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -1213,7 +1204,6 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -30,7 +30,6 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -351,7 +350,6 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -539,7 +537,6 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -720,7 +717,6 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
         required={true}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -1110,7 +1106,6 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -254,7 +254,6 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -442,7 +441,6 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -631,7 +629,6 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -815,7 +812,6 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
         required={true}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}
@@ -1213,7 +1209,6 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
         required={false}
         step={null}
         type="text"
-        value=""
       />
       <div
         aria-atomic={true}

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -53,7 +53,7 @@ import DSProvider from "../../theme/provider";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.22.0`   |
-| Latest            | `1.5.0`    |
+| Latest            | `Prerelease`    |
 
 ## Table of Contents
 

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -273,7 +273,7 @@ export const App = () => {
       isClearable
       isClearableCallback={() => setValue("")}
       labelText="What is your favorite color?"
-      onChange={undefined}
+      onChange={(e) => setValue(e.target.value)}
       placeholder="i.e. blue, green, etc."
       value={value}
     />

--- a/src/components/TextInput/TextInput.stories.mdx
+++ b/src/components/TextInput/TextInput.stories.mdx
@@ -273,7 +273,7 @@ export const App = () => {
       isClearable
       isClearableCallback={() => setValue("")}
       labelText="What is your favorite color?"
-      onChange={(e) => setValue(e.target.value)}
+      onChange={undefined}
       placeholder="i.e. blue, green, etc."
       value={value}
     />

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -5,11 +5,12 @@ import {
   useMergeRefs,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef, useEffect, useRef, useState } from "react";
+import React, { forwardRef, useRef } from "react";
 
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
 import Label from "../Label/Label";
 import { HelperErrorTextType } from "../HelperErrorText/HelperErrorText";
+import useStateWithDependencies from "../../hooks/useStateWithDependencies";
 import { getAriaAttrs } from "../../utils/utils";
 import Button from "../Button/Button";
 import Icon from "../Icons/Icon";
@@ -152,7 +153,7 @@ export const TextInput = chakra(
         value,
         ...rest
       } = props;
-      const [finalValue, setFinalValue] = useState<string | undefined>(value);
+      const [finalValue, setFinalValue] = useStateWithDependencies(value);
       const closedRef = useRef<HTMLInputElement>();
       const mergedRefs = useMergeRefs(closedRef, ref);
       // If a ref is not passed, then merging refs won't work.
@@ -209,12 +210,6 @@ export const TextInput = chakra(
       let fieldOutput;
       let clearButtonOutput;
       let options;
-
-      useEffect(() => {
-        if (value !== finalValue) {
-          setFinalValue(value);
-        }
-      }, [value]);
 
       if (!id) {
         console.warn(

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -150,7 +150,7 @@ export const TextInput = chakra(
         step = 1,
         textInputType = "default",
         type = "text",
-        value = "",
+        value,
         ...rest
       } = props;
       const [finalValue, setFinalValue] = useStateWithDependencies(value);

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -150,7 +150,7 @@ export const TextInput = chakra(
         step = 1,
         textInputType = "default",
         type = "text",
-        value,
+        value = "",
         ...rest
       } = props;
       const [finalValue, setFinalValue] = useStateWithDependencies(value);

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -152,7 +152,7 @@ export const TextInput = chakra(
         value,
         ...rest
       } = props;
-      const [finalValue, setFinalValue] = useState<string>(value || "");
+      const [finalValue, setFinalValue] = useState<string|undefined>(value);
       const closedRef = useRef<HTMLInputElement>();
       const mergedRefs = useMergeRefs(closedRef, ref);
       // If a ref is not passed, then merging refs won't work.

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -211,10 +211,10 @@ export const TextInput = chakra(
       let options;
 
       useEffect(() => {
-        if (value && value !== finalValue) {
+        if (value !== finalValue) {
           setFinalValue(value);
         }
-      }, [finalValue, value]);
+      }, [value]);
 
       if (!id) {
         console.warn(
@@ -314,7 +314,7 @@ export const TextInput = chakra(
             </Label>
           )}
           {fieldOutput}
-          {!isHidden && finalValue.length > 0 && clearButtonOutput}
+          {!isHidden && finalValue?.length > 0 && clearButtonOutput}
         </ComponentWrapper>
       );
     }

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -152,7 +152,7 @@ export const TextInput = chakra(
         value,
         ...rest
       } = props;
-      const [finalValue, setFinalValue] = useState<string|undefined>(value);
+      const [finalValue, setFinalValue] = useState<string | undefined>(value);
       const closedRef = useRef<HTMLInputElement>();
       const mergedRefs = useMergeRefs(closedRef, ref);
       // If a ref is not passed, then merging refs won't work.

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -101,7 +101,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -167,7 +166,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -257,7 +255,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -340,7 +337,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 9`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -413,7 +409,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 11`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -23,7 +23,9 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
     placeholder="Textarea Placeholder"
     required={false}
     step={null}
-  />
+  >
+    
+  </textarea>
   <div
     aria-atomic={true}
     aria-live="polite"
@@ -62,6 +64,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
     required={true}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -101,6 +104,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
     required={true}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -136,6 +140,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
     required={false}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -166,6 +171,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
     required={true}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -206,6 +212,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
     required={true}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -255,6 +262,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
     required={true}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -302,6 +310,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
     required={true}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -337,6 +346,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 9`] = `
     required={false}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -372,6 +382,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 10`] = `
     required={false}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}
@@ -409,6 +420,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 11`] = `
     required={false}
     step={null}
     type="text"
+    value=""
   />
   <div
     aria-atomic={true}

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -62,7 +62,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -138,7 +137,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -210,7 +208,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -308,7 +305,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -380,7 +376,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 10`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -23,9 +23,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
     placeholder="Textarea Placeholder"
     required={false}
     step={null}
-  >
-    
-  </textarea>
+  />
   <div
     aria-atomic={true}
     aria-live="polite"
@@ -64,7 +62,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -104,7 +101,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -140,7 +136,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -171,7 +166,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -212,7 +206,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -262,7 +255,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -310,7 +302,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
     required={true}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -346,7 +337,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 9`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -382,7 +372,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 10`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}
@@ -420,7 +409,6 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 11`] = `
     required={false}
     step={null}
     type="text"
-    value=""
   />
   <div
     aria-atomic={true}


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1396](https://jira.nypl.org/browse/DSD-1396)

## This PR does the following:

- It removes the check for "value" in the TextInput's useEffect. This check prevents the TextInput from being cleared externally with an empty string, which is falsey and prohibits an update to finalValue in state.
- It also allows finalValue to be undefined, effectively allowing TextInput to be uncontrolled if desired (as it is used in the FeedbackBox component for example).
- It removes finalValue from the useEffect's dependency array, which causes the useEffect to unnecessarily run on changes to finalValue.
- It adds optional chaining to a length check on final value in case it is undefined.

## How has this been tested?

I've manually tested the component and updated the test snapshots.
