### PR TITLE
DSD-1405: Adds Audio/Video Accessibility Guide

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
     "plugin:react/recommended",
     "plugin:jsx-a11y/strict",
     "prettier",
-    "prettier/react",
     "plugin:storybook/recommended",
   ],
   rules: {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds `ui.gray.semi-medium` and `ui.gray.semi-dark` to the color palette.
+- Adds `Audio and Video` page to the `Accessibility Guide` section of Storybook.
 
 ### Updates
 

--- a/src/components/AccessibilityGuide/AudioAndVideo.stories.mdx
+++ b/src/components/AccessibilityGuide/AudioAndVideo.stories.mdx
@@ -1,0 +1,64 @@
+import { Meta } from "@storybook/addon-docs";
+
+import { getCategory } from "../../utils/componentCategories";
+import DSProvider from "../../theme/provider";
+
+<Meta title={getCategory("Audio and Video")} />
+
+# Audio and Video
+
+## Table of Contents
+
+- [General Information](#general-information)
+- [Captions](#captions)
+- [Transcripts](#transcripts)
+- [Audio Description](#audio-description)
+
+## General Information
+
+Audio and video content need to be made accessible for NYPL audiences.
+Information conveyed solely through audio is not accessible to people
+with hearing impairments. Information conveyed visually through video
+is not accessible to people who are blind.
+
+## Captions
+
+Captions should be provided for any videos that also contain audio.
+The captions provide a text alternative for the audio information for
+anyone who cannot hear the content. Captions typically include any
+dialogue, identify speakers, and include any sound effects. Captions
+must be accurate, synchronized with the video, and use proper
+punctuation and grammar. Unedited automatic captions are generally not
+sufficient. Automated captions can be a useful starting point, but
+should be edited for accuracy.
+
+## Transcripts
+
+Transcripts should be provided for any audio-only content, such as
+podcasts. Transcripts should match the audio content exactly, plus
+include any relevant cues for understanding, such as identifying speakers.
+If the audio is the result of a scripted production, then the script
+itself can serve as the transcript.
+
+## Audio Description
+
+Audio description involves adding additional audio explanation of important
+visual information that is not already contained in the associated audio.
+It benefits users who cannot see the video content and may not obtain all
+the information conveyed in the video based solely on hearing the audio.
+Audio description can be added within any existing pauses in audio, or if
+necessary, by inserting pauses in the video to accommodate longer description.
+This process is typically done by a qualified third-party description provider.
+
+When audio description is needed, it is typically done as a separate audio
+track or a second version of the video with that audio track substituted.
+
+It is better to plan your video to not require audio description. By ensuring
+that any visual information is also conveyed in the audio/narration, you can
+avoid having to separately describe the video.
+
+[Example of audio described Frozen movie trailer](https://www.youtube.com/watch?v=O7j4_aP8dWA)
+
+<!-- hack to make sure correct styles are used on the page -->
+
+<DSProvider />

--- a/src/components/AccessibilityGuide/AudioAndVideo.stories.mdx
+++ b/src/components/AccessibilityGuide/AudioAndVideo.stories.mdx
@@ -13,6 +13,7 @@ import DSProvider from "../../theme/provider";
 - [Captions](#captions)
 - [Transcripts](#transcripts)
 - [Audio Description](#audio-description)
+- [Resources](#resources)
 
 ## General Information
 
@@ -58,6 +59,12 @@ that any visual information is also conveyed in the audio/narration, you can
 avoid having to separately describe the video.
 
 [Example of audio described Frozen movie trailer](https://www.youtube.com/watch?v=O7j4_aP8dWA)
+
+## Resources
+
+- [W3C Making Audio and Video Media Accessible](https://www.w3.org/WAI/media/av/)
+- [W3C Audio & Video Media: Captions/Subtitles](https://www.w3.org/WAI/media/av/captions/)
+- [W3C Audio & Video Media: Transcript](https://www.w3.org/WAI/media/av/transcripts/)
 
 <!-- hack to make sure correct styles are used on the page -->
 

--- a/src/utils/componentCategories.ts
+++ b/src/utils/componentCategories.ts
@@ -4,6 +4,7 @@ const categories = {
   accessibility: {
     title: "Accessibility Guide",
     components: [
+      "Audio and Video",
       "Dynamic Content",
       "Links",
       "Repetitive Actions",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1405.](https://jira.nypl.org/browse/DSD-1405)

## This PR does the following:

- Adds `Audio and Video` page to the `Accessibility Guide` section of Storybook.
- Removes 'prettier/react' config as it has been merged into the 'prettier' config and was giving me a linter error. See here for details: https://github.com/prettier/eslint-config-prettier/blob/main/CHANGELOG.md#version-800-2021-02-21.

## How has this been tested?

- Locally, in Storybook.

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
