### PR TITLE
DSD-1436: HelperErrorText in Storybook 7

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -77,6 +77,8 @@ const config: StorybookConfig = {
     "../src/components/Fieldset/Fieldset.stories.tsx",
     "../src/components/Fieldset/Fieldset.mdx",
     "../src/components/Hero/Hero.stories.tsx",
+    "../src/components/HelperErrorText/HelperErrorText.stories.tsx",
+    "../src/components/HelperErrorText/HelperErrorText.mdx",
     "../src/components/Hero/Hero.mdx",
     "../src/components/HorizontalRule/HorizontalRule.stories.tsx",
     "../src/components/HorizontalRule/HorizontalRule.mdx",

--- a/src/components/HelperErrorText/HelperErrorText.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.mdx
@@ -1,49 +1,8 @@
-import {
-  ArgsTable,
-  Canvas,
-  Description,
-  Meta,
-  Story,
-} from "@storybook/addon-docs";
-import { withDesign } from "storybook-addon-designs";
+import { Meta, Canvas, Description, ArgTypes, Source } from "@storybook/blocks";
 
-import HelperErrorText from "./HelperErrorText";
-import Link from "../Link/Link";
-import Text from "../Text/Text";
-import TextInput from "../TextInput/TextInput";
-import { getCategory } from "../../utils/componentCategories";
-import DSProvider from "../../theme/provider";
+import * as HelperErrorTextStories from "./HelperErrorText.stories";
 
-<Meta
-  title={getCategory("HelperErrorText")}
-  component={HelperErrorText}
-  decorators={[withDesign]}
-  parameters={{
-    design: {
-      type: "figma",
-      url: "",
-    },
-    jest: ["HelperErrorText.test.tsx"],
-  }}
-  argTypes={{
-    ariaAtomic: {
-      control: false,
-      table: { defaultValue: { summary: true } },
-    },
-    ariaLive: {
-      table: { defaultValue: { summary: "polite" } },
-    },
-    children: { table: { disable: true } },
-    className: { control: false },
-    id: { control: false },
-    isInvalid: {
-      table: { defaultValue: { summary: false } },
-    },
-    isRenderedText: {
-      table: { defaultValue: { summary: false } },
-    },
-  }}
-/>
+<Meta of={HelperErrorTextStories} />
 
 # HelperErrorText
 
@@ -57,37 +16,18 @@ import DSProvider from "../../theme/provider";
 - [Overview](#overview)
 - [Component Props](#component-props)
 - [Accessibility](#accessibility)
-- [With HTML Children](#with-html-children)
+- [HTML and JSX Children](#html-and-jsx-children)
 - [Invalid State](#invalid-state)
 
 ## Overview
 
-<Description of={HelperErrorText} />
+<Description of={HelperErrorTextStories} />
 
 ## Component Props
 
-<Canvas withToolbar>
-  <Story
-    name="HelperErrorText with Controls"
-    args={{
-      ariaAtomic: undefined,
-      ariaLive: undefined,
-      className: undefined,
-      id: "helperErrorText-id",
-      isInvalid: false,
-      text: "This is the helper text!",
-    }}
-  >
-    {(args) => (
-      <HelperErrorText
-        {...args}
-        text={args.isInvalid ? "This is the error text :(" : args.text}
-      />
-    )}
-  </Story>
-</Canvas>
+<Canvas of={HelperErrorTextStories.WithControls} />
 
-<ArgsTable story="HelperErrorText with Controls" />
+<ArgTypes of={HelperErrorTextStories.WithControls} />
 
 ## Accessibility
 
@@ -96,8 +36,8 @@ used as a child component when composing more complex components.
 
 In the case of form components, the `HelperErrorText` component is associated
 with a related input field by using the `aria-describedby` attribute in the
-associated element. This pattern ensures that the content of the `HelperErrorText`
-component is made available to screenreaders.
+associated element. This pattern ensures that the content of the
+`HelperErrorText` component is made available to screenreaders.
 
 This component will always render at least an empty `<div>` element with an
 `aria-live="polite"` attribute set even if no text content is passed. This is to
@@ -111,22 +51,7 @@ uses the `HelperErrorText` component to render the red-colored `"This is error t
 the `aria-describedby` attribute on the HTML input element. This type of
 association is handled automatically by all DS `Form Elements` components.
 
-<Canvas>
-  <Story
-    name="Text Input with HelperErrorText"
-    args={{
-      helperText: "Choose wisely.",
-      id: "textInput-id",
-      invalidText: "This is error text :(",
-      isInvalid: true,
-      labelText: "What is your favorite color?",
-      name: "textInput-name",
-      placeholder: "e.g. blue, green, etc.",
-    }}
-  >
-    {(args) => <TextInput {...args} />}
-  </Story>
-</Canvas>
+<Canvas of={HelperErrorTextStories.TextInputExample} />
 
 ### ariaAtomic
 
@@ -155,22 +80,7 @@ attribute is set in the wrapper `<div>` element that is always rendered by the
 
 By default, this prop is set to `"polite"`.
 
-<Canvas>
-  <Story
-    name="With Aria Controls"
-    args={{
-      ariaAtomic: true,
-      ariaLive: "polite",
-    }}
-  >
-    {(args) => (
-      <HelperErrorText
-        {...args}
-        text="Live updates to the helper and error text can be read to screen readers with the appropriate aria-atomic and aria-live props."
-      />
-    )}
-  </Story>
-</Canvas>
+<Canvas of={HelperErrorTextStories.AriaControls} />
 
 Resources:
 
@@ -180,40 +90,16 @@ Resources:
 - [W3C ARIA19: Using ARIA role=alert or Live Regions to Identify Errors](https://www.w3.org/TR/WCAG20-TECHS/ARIA19.html)
 - [DigitalA11y WAI-ARIA:aria-live (Property)](https://www.digitala11y.com/aria-live-properties/)
 
-## With HTML Children
+## HTML and JSX Children
 
-The `HelperErrorText` component can render any React component or HTML element
+The `HelperErrorText` component can render any HTML element or React component
 through the `text` prop.
 
-<Canvas>
-  <Story name="With HTML Children">
-    <HelperErrorText
-      text={
-        <>
-          This first example uses an HTML anchor element for{" "}
-          <a href="#">a link</a>.
-        </>
-      }
-    />
-    <HelperErrorText
-      text={
-        <Text>
-          This second example uses Reservoir Design System (DS) components, such
-          as the <Link href="#">`Link`</Link> component, and the `Text`
-          component.
-        </Text>
-      }
-    />
-  </Story>
-</Canvas>
+<Canvas of={HelperErrorTextStories.HTMLChildren} />
 
 ## Invalid State
 
 Set the `isInvalid` prop to `true` to render the passed text content with the
 NYPL "invalid" styling.
 
-<Canvas>
-  <Story name="Invalid State">
-    <HelperErrorText isInvalid text="This is the error text :(" />
-  </Story>
-</Canvas>
+<Canvas of={HelperErrorTextStories.InvalidState} />

--- a/src/components/HelperErrorText/HelperErrorText.stories.tsx
+++ b/src/components/HelperErrorText/HelperErrorText.stories.tsx
@@ -1,0 +1,122 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+
+import HelperErrorText from "./HelperErrorText";
+import Link from "../Link/Link";
+import Text from "../Text/Text";
+import TextInput from "../TextInput/TextInput";
+
+const meta: Meta<typeof HelperErrorText> = {
+  title: "Components/Content Display/HelperErrorText",
+  component: HelperErrorText,
+  decorators: [withDesign],
+  argTypes: {
+    ariaAtomic: {
+      control: false,
+      table: { defaultValue: { summary: true } },
+    },
+    ariaLive: {
+      table: { defaultValue: { summary: "polite" } },
+    },
+    children: { table: { disable: true } },
+    className: { control: false },
+    id: { control: false },
+    isInvalid: {
+      table: { defaultValue: { summary: false } },
+    },
+    isRenderedText: {
+      table: { defaultValue: { summary: false } },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof HelperErrorText>;
+
+/**
+ * Main Story for the HelperErrorText component. This must contains the `args`
+ * and `parameters` properties in this object.
+ */
+export const WithControls: Story = {
+  args: {
+    ariaAtomic: undefined,
+    ariaLive: undefined,
+    className: undefined,
+    id: "helperErrorText-id",
+    isInvalid: false,
+    text: "This is the helper text!",
+  },
+  parameters: {
+    design: {
+      type: "figma",
+      url: "",
+    },
+    jest: ["HelperErrorText.test.tsx"],
+  },
+  render: (args) => (
+    <HelperErrorText
+      {...args}
+      text={args.isInvalid ? "This is the error text :(" : args.text}
+    />
+  ),
+};
+
+// The following are additional HelperErrorText example Stories.
+export const TextInputExample: Story = {
+  name: "TextInput Example",
+  render: () => (
+    <TextInput
+      helperText="Choose wisely."
+      id="textInput-id"
+      invalidText="This is error text :("
+      isInvalid={true}
+      labelText="What is your favorite color?"
+      name="textInput-name"
+      placeholder="e.g. blue, green, etc."
+    />
+  ),
+};
+
+export const AriaControls: Story = {
+  args: {
+    ariaAtomic: true,
+    ariaLive: "polite",
+  },
+  name: "ARIA Controls",
+  render: (args) => (
+    <HelperErrorText
+      {...args}
+      text="Live updates to the helper and error text can be read to screen readers with the appropriate aria-atomic and aria-live props."
+    />
+  ),
+};
+
+export const HTMLChildren: Story = {
+  name: "HTML Children",
+  render: () => (
+    <>
+      <HelperErrorText
+        text={
+          <>
+            This first example uses an HTML anchor element for{" "}
+            <a href="https://nypl.org">a link</a>.
+          </>
+        }
+      />
+      <HelperErrorText
+        text={
+          <Text>
+            This second example uses Reservoir Design System (DS) components,
+            such as the <Link href="#">`Link`</Link> component, and the `Text`
+            component.
+          </Text>
+        }
+      />
+    </>
+  ),
+};
+
+export const InvalidState: Story = {
+  name: "Invalid State",
+  render: () => <HelperErrorText isInvalid text="This is the error text :(" />,
+};


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1436](https://jira.nypl.org/browse/DSD-1436)

## This PR does the following:

- Updates the stories for the `HelperErrorText` component to work in Storybook 7.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
