### PR TITLE
DSD-1442: Updating Storybook documentation for Link component

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -84,6 +84,8 @@ const config: StorybookConfig = {
     "../src/components/Icons/Icon.mdx",
     "../src/components/Label/Label.stories.tsx",
     "../src/components/Label/Label.mdx",
+    "../src/components/Link/Link.stories.tsx",
+    "../src/components/Link/Link.mdx",
     "../src/components/Modal/Modal.stories.tsx",
     "../src/components/Modal/Modal.mdx",
     "../src/components/Notification/Notification.stories.tsx",

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -1,38 +1,8 @@
-import { VStack } from "@chakra-ui/react";
-import {
-  ArgsTable,
-  Canvas,
-  Description,
-  Meta,
-  Story,
-} from "@storybook/addon-docs";
-import { withDesign } from "storybook-addon-designs";
+import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import Link from "./Link";
-import Icon from "../Icons/Icon";
-import { getCategory } from "../../utils/componentCategories";
-import DSProvider from "../../theme/provider";
+import * as LinkStories from "./Link.stories";
 
-<Meta
-  title={getCategory("Link")}
-  component={Link}
-  decorators={[withDesign]}
-  parameters={{
-    design: {
-      type: "figma",
-      url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=36854%3A24387",
-    },
-    jest: ["Link.test.tsx"],
-  }}
-  argTypes={{
-    children: { table: { disable: true } },
-    key: { table: { disable: true } },
-    ref: { table: { disable: true } },
-    type: {
-      table: { defaultValue: { summary: "default" } },
-    },
-  }}
-/>
+<Meta of={LinkStories} />
 
 # Link
 
@@ -52,25 +22,13 @@ import DSProvider from "../../theme/provider";
 
 ## Overview
 
-<Description of={Link} />
+<Description of={LinkStories} />
 
 ## Component Props
 
-<Canvas withToolbar>
-  <Story
-    name="Link with Controls"
-    args={{
-      className: "custom-class",
-      href: "https://nypl.org",
-      id: "nypl-link",
-      type: "action",
-    }}
-  >
-    {(args) => <Link {...args}>Link</Link>}
-  </Story>
-</Canvas>
+<Canvas of={LinkStories.WithControls} />
 
-<ArgsTable story="Link with Controls" />
+<ArgTypes of={LinkStories.WithControls} />
 
 ## Accessibility
 
@@ -83,13 +41,7 @@ descriptive text to clarify that the link will open in a new tab/window.
 Additionally it renders with the `rel` attribute containing
 the relation names "nofollow", "noopener" and "noreferrer".
 
-<Canvas>
-  <DSProvider>
-    <Link type="external" href="https://nypl.org">
-      NYPL Website
-    </Link>
-  </DSProvider>
-</Canvas>
+<Canvas of={LinkStories.Accessibility} />
 
 Resources:
 
@@ -104,40 +56,20 @@ To render an `Icon` as part of the link, make sure that the `Link` component
 wraps the `Icon`. Use `type="action"` to apply appropriate styling to
 links with icons. Icons can be rendered to the left or right of the link text.
 
-<Canvas>
-  <Story name="With Icons">
-    <VStack spacing="xs" align="flex-start">
-      <Link type="action" href="#passed-in-link">
-        <Icon name="headset" align="left" size="small" />
-        Headset Link
-      </Link>
-      <Link type="action" href="#passed-in-link">
-        <Icon name="clock" align="left" size="small" />
-        Clock Link
-      </Link>
-      <Link type="action" href="#passed-in-link">
-        <Icon name="check" align="left" size="small" />
-        Check Link
-      </Link>
-      <Link type="action" href="#passed-in-link-right">
-        Check Link Right
-        <Icon name="check" align="right" size="small" />
-      </Link>
-    </VStack>
-  </Story>
-</Canvas>
+<Canvas of={LinkStories.LinksWithIcons} />
 
 ## Anchor Element Rendering
 
 `Link` can wrap an existing `<a>` element (and `Icon` component) or it
 can use the `href` prop to generate an `<a>` element.
 
-```jsx
+<Source
+  code={`
 // Existing anchor element
 <Link type="action">
   <a href="#existing-anchor-tag">link</a>
 </Link>
-
+// ...
 // Also works with an icon component. Make sure to wrap the icon and anchor
 // in a single element for this pattern.
 <Link type="action">
@@ -146,36 +78,16 @@ can use the `href` prop to generate an `<a>` element.
     <a href="#existing-anchor-tag">check link</a>
   </>
 </Link>
-
-// Otherwise, the `href` prop will generate an `<a>` tag.
+// ...
+// Otherwise, the \`href\` prop will generate an \`<a>\` tag.
 <Link type="action" href="#passed-in-link">
   link
 </Link>
-```
+`}
+  language="jsx"
+/>
 
-<Canvas>
-  <Story name="Anchor Element Rendering">
-    <>
-      This is a{" "}
-      <Link type="action">
-        <a href="#existing-anchor-tag">link</a>
-      </Link>{" "}
-      with the &lt;a&gt; element as a child of the `Link` component. This is a{" "}
-      <Link type="action" href="#passed-in-link">
-        link
-      </Link>{" "}
-      where the `Link` component uses the `href` prop and has a string-only
-      child. Finally, this is a{" "}
-      <Link type="action">
-        <>
-          <Icon name="check" align="left" size="small" />
-          <a href="#existing-anchor-tag">link</a>
-        </>
-      </Link>{" "}
-      with a check icon.
-    </>
-  </Story>
-</Canvas>
+<Canvas of={LinkStories.AnchorElementRendering} />
 
 ## Link with Routers
 
@@ -185,39 +97,52 @@ The Design System's `Link` component should wrap around `react-router`'s own
 `Link` component. To avoid name conflicts, rename either the Design System's
 or `react-router`'s `Link` component. Any of the following patterns are valid.
 
-```jsx
-// In this first example, React Router's `Link` component
-// is renamed as `ReactRouterLink`.
+<Source
+  code={`
+// In this first example, React Router's \`Link\` component
+// is renamed as \`ReactRouterLink\`.
 import {
   BrowserRouter as Router,
   Link as ReactRouterLink,
 } from "react-router-dom";
 import { Link } from "@nypl/design-system-react-components";
-
+// ...
 <Link type="action">
   <ReactRouterLink to="#">Next Page</ReactRouterLink>
 </Link>;
+`}
+  language="jsx"
+/>
 
-// In this second example, React Router's `Link` component
-// is not renamed but the DS's `Link` component is renamed
-// to `DSLink`.
+<Source
+  code={`
+// In this second example, React Router's \`Link\` component
+// is not renamed but the DS's \`Link\` component is renamed
+// to \`DSLink\`.
 import { BrowserRouter, Link } from "react-router-dom";
 import { Link as DSLink } from "@nypl/design-system-react-components";
-
+// ...
 <DSLink type="action">
   <Link to="#">Next Page</Link>
 </DSLink>;
+`}
+  language="jsx"
+/>
 
-// In this third example, React Router's `Link` component
-// is not renamed and the DS's `Link` component is
-// imported and rendered as `DS.Link`.
+<Source
+  code={`
+// In this third example, React Router's \`Link\` component
+// is not renamed and the DS's \`Link\` component is
+// imported and rendered as \`DS.Link\`.
 import { BrowserRouter, Link } from "react-router-dom";
 import DS from "@nypl/design-system-react-components";
-
+// ...
 <DS.Link type="action">
   <Link to="#">Next Page</Link>
 </DS.Link>;
-```
+`}
+  language="jsx"
+/>
 
 ### NextJS
 
@@ -227,13 +152,14 @@ These props, along with an implicit `ref` from NextJS and the Design System's
 `Link` component `forwardRef` implementation, handle correctly routing between
 pages in a NextJS app.
 
-```jsx
+<Source
+  code={`
 import { Link } from "@nypl/design-system-react-components";
-
+// ...
 /**
- * This is just an example wrapper that works similarly to NextJS' `Link`
- * component. In real life, NextJS's `Link` component will pass down the
- * `href` and `passHref` props and a `ref` to make routing functional.
+ * This is just an example wrapper that works similarly to NextJS' \`Link\`
+ * component. In real life, NextJS's \`Link\` component will pass down the
+ * \`href\` and \`passHref\` props and a \`ref\` to make routing functional.
  */
 export const NextJsLink = (props: HTMLAnchorElement) =>
   React.cloneElement(
@@ -241,24 +167,13 @@ export const NextJsLink = (props: HTMLAnchorElement) =>
     { ...props },
     props.children.props.children
   );
-
-// Note that NextJS' `href` and `passHref` props are required.
+// ...
+// Note that NextJS' \`href\` and \`passHref\` props are required.
 <NextJsLink href="#" passHref>
   <Link type="action">Next Page</Link>
 </NextJsLink>;
-```
+`}
+  language="jsx"
+/>
 
-export const NextJsLink = (props) =>
-  React.cloneElement(
-    props.children,
-    { href: props.href },
-    props.children.props.children
-  );
-
-<Canvas>
-  <DSProvider>
-    <NextJsLink href="#" passHref>
-      <Link type="action">Next Page</Link>
-    </NextJsLink>
-  </DSProvider>
-</Canvas>
+<Canvas of={LinkStories.NextJSExample} />

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -1,5 +1,9 @@
+import { Box } from "@chakra-ui/react";
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+import { cloneElement } from "react";
 
+import Link from "./Link";
+import Icon from "../Icons/Icon";
 import * as LinkStories from "./Link.stories";
 
 <Meta of={LinkStories} />
@@ -87,7 +91,29 @@ can use the `href` prop to generate an `<a>` element.
   language="jsx"
 />
 
-<Canvas of={LinkStories.AnchorElementRendering} />
+{
+
+<>
+  This is a{" "}
+  <Link type="action">
+    <a href="#existing-anchor-tag">link</a>
+  </Link>{" "}
+  with the &lt;a&gt; element as a child of the `Link` component. This is a{" "}
+  <Link type="action" href="#passed-in-link">
+    link
+  </Link>{" "}
+  where the `Link` component uses the `href` prop and has a string-only child.
+  Finally, this is a{" "}
+  <Link type="action">
+    <>
+      <Icon name="check" align="left" size="small" />
+      <a href="#existing-anchor-tag">link</a>
+    </>
+  </Link>{" "}
+  with a check icon.
+  <Box mb="20px"></Box>
+</>
+}
 
 ## Link with Routers
 
@@ -176,4 +202,16 @@ export const NextJsLink = (props: HTMLAnchorElement) =>
   language="jsx"
 />
 
-<Canvas of={LinkStories.NextJSExample} />
+export const NextJsLink = (props) =>
+  cloneElement(
+    props.children,
+    { href: props.href },
+    props.children.props.children
+  );
+
+{
+
+<NextJsLink href="#" passHref>
+  <Link type="action">Next Page</Link>
+</NextJsLink>
+}

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,7 +1,7 @@
 import { VStack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
-import { cloneElement } from "react";
+// import { cloneElement } from "react";
 
 import Link, { linkTypesArray } from "./Link";
 import Icon from "../Icons/Icon";
@@ -76,42 +76,42 @@ export const LinksWithIcons: Story = {
     </VStack>
   ),
 };
-export const AnchorElementRendering: Story = {
-  render: () => (
-    <>
-      This is a{" "}
-      <Link type="action">
-        <a href="#existing-anchor-tag">link</a>
-      </Link>{" "}
-      with the &lt;a&gt; element as a child of the `Link` component. This is a{" "}
-      <Link type="action" href="#passed-in-link">
-        link
-      </Link>{" "}
-      where the `Link` component uses the `href` prop and has a string-only
-      child. Finally, this is a{" "}
-      <Link type="action">
-        <>
-          <Icon name="check" align="left" size="small" />
-          <a href="#existing-anchor-tag">link</a>
-        </>
-      </Link>{" "}
-      with a check icon.
-    </>
-  ),
-};
+// export const AnchorElementRendering: Story = {
+//   render: () => (
+//     <>
+//       This is a{" "}
+//       <Link type="action">
+//         <a href="#existing-anchor-tag">link</a>
+//       </Link>{" "}
+//       with the &lt;a&gt; element as a child of the `Link` component. This is a{" "}
+//       <Link type="action" href="#passed-in-link">
+//         link
+//       </Link>{" "}
+//       where the `Link` component uses the `href` prop and has a string-only
+//       child. Finally, this is a{" "}
+//       <Link type="action">
+//         <>
+//           <Icon name="check" align="left" size="small" />
+//           <a href="#existing-anchor-tag">link</a>
+//         </>
+//       </Link>{" "}
+//       with a check icon.
+//     </>
+//   ),
+// };
 
-const NextJsLink = (props) =>
-  cloneElement(
-    props.children,
-    { href: props.href },
-    props.children.props.children
-  );
+// const NextJsLink = (props) =>
+//   cloneElement(
+//     props.children,
+//     { href: props.href },
+//     props.children.props.children
+//   );
 
-export const NextJSExample: Story = {
-  render: () => (
-    <NextJsLink href="#" passHref>
-      <Link type="action">Next Page</Link>
-    </NextJsLink>
-  ),
-  name: "Next.js Router example",
-};
+// export const NextJSExample: Story = {
+//   render: () => (
+//     <NextJsLink href="#" passHref>
+//       <Link type="action">Next Page</Link>
+//     </NextJsLink>
+//   ),
+//   name: "Next.js Router example",
+// };

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -1,0 +1,117 @@
+import { VStack } from "@chakra-ui/react";
+import type { Meta, StoryObj } from "@storybook/react";
+import { withDesign } from "storybook-addon-designs";
+import { cloneElement } from "react";
+
+import Link, { linkTypesArray } from "./Link";
+import Icon from "../Icons/Icon";
+
+const meta: Meta<typeof Link> = {
+  title: "Components/Navigation/Link",
+  component: Link,
+  decorators: [withDesign],
+  argTypes: {
+    children: { table: { disable: true } },
+    key: { table: { disable: true } },
+    ref: { table: { disable: true } },
+    type: {
+      control: { type: "select" },
+      options: linkTypesArray,
+      table: { defaultValue: { summary: "default" } },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Link>;
+
+/**
+ * Main Story for the Link component. This must contains the `args`
+ * and `parameters` properties in this object.
+ */
+export const WithControls: Story = {
+  args: {
+    className: "custom-class",
+    href: "https://nypl.org",
+    id: "nypl-link",
+    type: "action",
+  },
+  render: (args) => <Link {...args}>Link</Link>,
+  parameters: {
+    design: {
+      type: "figma",
+      url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=36854%3A24387",
+    },
+    jest: ["Link.test.tsx"],
+  },
+};
+
+// The following are additional Link example Stories.
+export const Accessibility: Story = {
+  render: () => (
+    <Link type="external" href="https://nypl.org">
+      NYPL Website
+    </Link>
+  ),
+};
+export const LinksWithIcons: Story = {
+  render: () => (
+    <VStack spacing="xs" align="flex-start">
+      <Link type="action" href="#passed-in-link">
+        <Icon name="headset" align="left" size="small" />
+        Headset Link
+      </Link>
+      <Link type="action" href="#passed-in-link">
+        <Icon name="clock" align="left" size="small" />
+        Clock Link
+      </Link>
+      <Link type="action" href="#passed-in-link">
+        <Icon name="check" align="left" size="small" />
+        Check Link
+      </Link>
+      <Link type="action" href="#passed-in-link-right">
+        Check Link Right
+        <Icon name="check" align="right" size="small" />
+      </Link>
+    </VStack>
+  ),
+};
+export const AnchorElementRendering: Story = {
+  render: () => (
+    <>
+      This is a{" "}
+      <Link type="action">
+        <a href="#existing-anchor-tag">link</a>
+      </Link>{" "}
+      with the &lt;a&gt; element as a child of the `Link` component. This is a{" "}
+      <Link type="action" href="#passed-in-link">
+        link
+      </Link>{" "}
+      where the `Link` component uses the `href` prop and has a string-only
+      child. Finally, this is a{" "}
+      <Link type="action">
+        <>
+          <Icon name="check" align="left" size="small" />
+          <a href="#existing-anchor-tag">link</a>
+        </>
+      </Link>{" "}
+      with a check icon.
+    </>
+  ),
+};
+
+const NextJsLink = (props) =>
+  cloneElement(
+    props.children,
+    { href: props.href },
+    props.children.props.children
+  );
+
+export const NextJSExample: Story = {
+  render: () => (
+    <NextJsLink href="#" passHref>
+      <Link type="action">Next Page</Link>
+    </NextJsLink>
+  ),
+  name: "Next.js Router example",
+};

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -3,21 +3,24 @@ import React, { forwardRef } from "react";
 
 import Icon from "../Icons/Icon";
 
-export type LinkTypes =
-  | "action"
-  | "backwards"
+export const linkTypesArray = [
+  "action",
+  "backwards",
   // The "button" type is deprecated as of 1.2.x.
-  | "button"
+  "button",
   // Instead, use the following "buttonX" types.
-  | "buttonPrimary"
-  | "buttonSecondary"
-  | "buttonPill"
-  | "buttonCallout"
-  | "buttonNoBrand"
-  | "buttonDisabled"
-  | "default"
-  | "external"
-  | "forwards";
+  "buttonPrimary",
+  "buttonSecondary",
+  "buttonPill",
+  "buttonCallout",
+  "buttonNoBrand",
+  "buttonDisabled",
+  "default",
+  "external",
+  "forwards",
+] as const;
+export type LinkTypes = typeof linkTypesArray[number];
+
 export interface LinkProps {
   /** Any child node passed to the component. */
   children: React.ReactNode;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1442](https://jira.nypl.org/browse/DSD-1442)

## This PR does the following:

- Updates the `Link` Storybook documentation to version 7.
- Compare with prod: https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/components-navigation-link--link-with-controls

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
