### PR TITLE
DSD-1301: Updates placeholder image source

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `Button` component to increase the internal spacing between the button text and an icon.
+- Updates placeholder images to come from placekitten, rather than placeimg, which is being deprecated.
 
 ## 1.6.0 (June 8, 2023)
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -74,7 +74,7 @@ export const WithControls: Story = {
     "imageProps.component": undefined,
     "imageProps.isAtEnd": false,
     "imageProps.size": "default",
-    "imageProps.src": "https://placeimg.com/400/300/animals",
+    "imageProps.src": "http://placekitten.com/400/300",
     isAlignedRightActions: false,
     isBordered: false,
     isCentered: false,
@@ -147,7 +147,7 @@ export const ImagePositionColumnCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="props-heading1">
@@ -163,7 +163,7 @@ export const ImagePositionColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           isAtEnd: true,
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="props-heading2">
@@ -185,7 +185,7 @@ export const ImagePositionRowCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -204,7 +204,7 @@ export const ImagePositionRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           isAtEnd: true,
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -230,7 +230,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "xxsmall",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
       >
@@ -251,7 +251,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "xsmall",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
       >
@@ -272,7 +272,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "small",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
       >
@@ -293,7 +293,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "medium",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
       >
@@ -314,7 +314,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "large",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
       >
@@ -334,7 +334,7 @@ export const ImageSizeColumnCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "square",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
       >
@@ -360,7 +360,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "xxsmall",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -380,7 +380,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "xsmall",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -400,7 +400,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "small",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -420,7 +420,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "medium",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -441,7 +441,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "large",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -462,7 +462,7 @@ export const ImageSizeRowCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -489,7 +489,7 @@ export const CustomImageComponent: Story = {
       imageProps={{
         alt: "Alt text",
         component: (
-          <Image src="https://placeimg.com/400/400/animals" alt="Alt text" />
+          <Image src="http://placekitten.com/400/400" alt="Alt text" />
         ),
       }}
     >
@@ -523,7 +523,7 @@ export const HeadingAsLink: Story = {
       imageProps={{
         alt: "Alt text",
         aspectRatio: "twoByOne",
-        src: "https://placeimg.com/400/200/animals",
+        src: "http://placekitten.com/400/200",
       }}
     >
       <CardHeading level="three" id="link-heading1" url="http://nypl.org">
@@ -558,7 +558,7 @@ export const FullClick: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         mainActionLink="http://nypl.org"
       >
@@ -587,7 +587,7 @@ export const FullClick: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           isAtEnd: true,
-          src: "https://placeimg.com/410/210/animals",
+          src: "http://placekitten.com/410/210",
         }}
         mainActionLink="http://nypl.org"
       >
@@ -666,7 +666,7 @@ export const CardWithRightSideCardActions: Story = {
         alt: "Alt text",
         aspectRatio: "twoByOne",
         size: "medium",
-        src: "https://placeimg.com/400/200/animals",
+        src: "http://placekitten.com/400/200",
       }}
       isAlignedRightActions
       isCentered
@@ -711,7 +711,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="grid1-heading1">
@@ -726,7 +726,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/410/210/animals",
+          src: "http://placekitten.com/410/210",
         }}
       >
         <CardHeading level="three" id="grid2-heading1">
@@ -741,7 +741,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/420/220/animals",
+          src: "http://placekitten.com/420/220",
         }}
       >
         <CardHeading level="three" id="grid3-heading1">
@@ -756,7 +756,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/430/230/animals",
+          src: "http://placekitten.com/430/230",
         }}
       >
         <CardHeading level="three" id="grid4-heading1">
@@ -771,7 +771,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/440/200/animals",
+          src: "http://placekitten.com/440/200",
         }}
       >
         <CardHeading level="three" id="grid5-heading1">
@@ -786,7 +786,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/450/200/animals",
+          src: "http://placekitten.com/450/200",
         }}
       >
         <CardHeading level="three" id="grid6-heading1">
@@ -808,7 +808,7 @@ export const StackExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -826,7 +826,7 @@ export const StackExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/410/210/animals",
+          src: "http://placekitten.com/410/210",
         }}
         isCentered
         layout="row"
@@ -844,7 +844,7 @@ export const StackExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/420/220/animals",
+          src: "http://placekitten.com/420/220",
         }}
         isCentered
         layout="row"

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -74,7 +74,7 @@ export const WithControls: Story = {
     "imageProps.component": undefined,
     "imageProps.isAtEnd": false,
     "imageProps.size": "default",
-    "imageProps.src": "http://placekitten.com/400/300",
+    "imageProps.src": "//placekitten.com/400/300",
     isAlignedRightActions: false,
     isBordered: false,
     isCentered: false,
@@ -147,7 +147,7 @@ export const ImagePositionColumnCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="props-heading1">
@@ -163,7 +163,7 @@ export const ImagePositionColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           isAtEnd: true,
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="props-heading2">
@@ -185,7 +185,7 @@ export const ImagePositionRowCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -204,7 +204,7 @@ export const ImagePositionRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           isAtEnd: true,
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -230,7 +230,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "xxsmall",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
       >
@@ -251,7 +251,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "xsmall",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
       >
@@ -272,7 +272,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "small",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
       >
@@ -293,7 +293,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "medium",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
       >
@@ -314,7 +314,7 @@ export const ImageSizeColumnCards: Story = {
           alt: "Alt text",
           aspectRatio: "square",
           size: "large",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
       >
@@ -334,7 +334,7 @@ export const ImageSizeColumnCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "square",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
       >
@@ -360,7 +360,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "xxsmall",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -380,7 +380,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "xsmall",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -400,7 +400,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "small",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -420,7 +420,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "medium",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -441,7 +441,7 @@ export const ImageSizeRowCards: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           size: "large",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -462,7 +462,7 @@ export const ImageSizeRowCards: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -488,9 +488,7 @@ export const CustomImageComponent: Story = {
     <Card
       imageProps={{
         alt: "Alt text",
-        component: (
-          <Image src="http://placekitten.com/400/400" alt="Alt text" />
-        ),
+        component: <Image src="//placekitten.com/400/400" alt="Alt text" />,
       }}
     >
       <CardHeading level="two" id="img1-heading1">
@@ -523,7 +521,7 @@ export const HeadingAsLink: Story = {
       imageProps={{
         alt: "Alt text",
         aspectRatio: "twoByOne",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
     >
       <CardHeading level="three" id="link-heading1" url="http://nypl.org">
@@ -558,7 +556,7 @@ export const FullClick: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         mainActionLink="http://nypl.org"
       >
@@ -587,7 +585,7 @@ export const FullClick: Story = {
           alt: "Alt text",
           aspectRatio: "twoByOne",
           isAtEnd: true,
-          src: "http://placekitten.com/410/210",
+          src: "//placekitten.com/410/210",
         }}
         mainActionLink="http://nypl.org"
       >
@@ -666,7 +664,7 @@ export const CardWithRightSideCardActions: Story = {
         alt: "Alt text",
         aspectRatio: "twoByOne",
         size: "medium",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
       isAlignedRightActions
       isCentered
@@ -711,7 +709,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="grid1-heading1">
@@ -726,7 +724,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/410/210",
+          src: "//placekitten.com/410/210",
         }}
       >
         <CardHeading level="three" id="grid2-heading1">
@@ -741,7 +739,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/420/220",
+          src: "//placekitten.com/420/220",
         }}
       >
         <CardHeading level="three" id="grid3-heading1">
@@ -756,7 +754,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/430/230",
+          src: "//placekitten.com/430/230",
         }}
       >
         <CardHeading level="three" id="grid4-heading1">
@@ -771,7 +769,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/440/200",
+          src: "//placekitten.com/440/200",
         }}
       >
         <CardHeading level="three" id="grid5-heading1">
@@ -786,7 +784,7 @@ export const GridExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/450/200",
+          src: "//placekitten.com/450/200",
         }}
       >
         <CardHeading level="three" id="grid6-heading1">
@@ -808,7 +806,7 @@ export const StackExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isCentered
         layout="row"
@@ -826,7 +824,7 @@ export const StackExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/410/210",
+          src: "//placekitten.com/410/210",
         }}
         isCentered
         layout="row"
@@ -844,7 +842,7 @@ export const StackExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/420/220",
+          src: "//placekitten.com/420/220",
         }}
         isCentered
         layout="row"

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -16,7 +16,7 @@ describe("Card Accessibility", () => {
         id="cardID"
         imageProps={{
           alt: "Alt text",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="heading1">
@@ -39,7 +39,7 @@ describe("Card Accessibility", () => {
         id="cardID"
         imageProps={{
           alt: "Alt text",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         mainActionLink="http://nypl.org"
       >
@@ -64,7 +64,7 @@ describe("Card", () => {
       id="regularCard"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
       ref={ref}
     >
@@ -85,7 +85,7 @@ describe("Card", () => {
       id="cardWithExtendedStyles"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/300/400",
+        src: "//placekitten.com/300/400",
       }}
     >
       <CardHeading id="editioncardheading1" level="two">
@@ -121,7 +121,7 @@ describe("Card", () => {
       id="cardWithNoCTAs"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/300/400",
+        src: "//placekitten.com/300/400",
       }}
     >
       <CardHeading id="editioncardheading1" level="two">
@@ -140,7 +140,7 @@ describe("Card", () => {
       id="cardWithNoContent"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/300/400",
+        src: "//placekitten.com/300/400",
       }}
     >
       <CardHeading id="editioncardheading1" level="two" url="#edition-link">
@@ -189,7 +189,7 @@ describe("Card", () => {
       id="fullclick"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
       mainActionLink="http://nypl.org"
     >
@@ -209,7 +209,7 @@ describe("Card", () => {
       id="fullclick"
       imageProps={{
         aspectRatio: "threeByTwo",
-        component: <Image alt="" src="http://placekitten.com/400/200" />,
+        component: <Image alt="" src="//placekitten.com/400/200" />,
       }}
     >
       <CardHeading level="three" id="heading1">
@@ -223,7 +223,7 @@ describe("Card", () => {
       id="cardID"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
       isAlignedRightActions
     >
@@ -248,7 +248,7 @@ describe("Card", () => {
       id="chakraProps"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
       p="s"
       color="ui.error.primary"
@@ -269,7 +269,7 @@ describe("Card", () => {
       id="otherProps"
       imageProps={{
         alt: "Alt text",
-        src: "http://placekitten.com/400/200",
+        src: "//placekitten.com/400/200",
       }}
       data-testid="card-testid"
     >

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -16,7 +16,7 @@ describe("Card Accessibility", () => {
         id="cardID"
         imageProps={{
           alt: "Alt text",
-          src: "https://placeimg.com/400/200/arch",
+          src: "http://placekitten.com/400/200",
         }}
       >
         <CardHeading level="three" id="heading1">
@@ -39,7 +39,7 @@ describe("Card Accessibility", () => {
         id="cardID"
         imageProps={{
           alt: "Alt text",
-          src: "https://placeimg.com/400/200/arch",
+          src: "http://placekitten.com/400/200",
         }}
         mainActionLink="http://nypl.org"
       >
@@ -64,7 +64,7 @@ describe("Card", () => {
       id="regularCard"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/400/200/arch",
+        src: "http://placekitten.com/400/200",
       }}
       ref={ref}
     >
@@ -85,7 +85,7 @@ describe("Card", () => {
       id="cardWithExtendedStyles"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/300/400/arch",
+        src: "http://placekitten.com/300/400",
       }}
     >
       <CardHeading id="editioncardheading1" level="two">
@@ -121,7 +121,7 @@ describe("Card", () => {
       id="cardWithNoCTAs"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/300/400/arch",
+        src: "http://placekitten.com/300/400",
       }}
     >
       <CardHeading id="editioncardheading1" level="two">
@@ -140,7 +140,7 @@ describe("Card", () => {
       id="cardWithNoContent"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/300/400/arch",
+        src: "http://placekitten.com/300/400",
       }}
     >
       <CardHeading id="editioncardheading1" level="two" url="#edition-link">
@@ -189,7 +189,7 @@ describe("Card", () => {
       id="fullclick"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/400/200/arch",
+        src: "http://placekitten.com/400/200",
       }}
       mainActionLink="http://nypl.org"
     >
@@ -209,7 +209,7 @@ describe("Card", () => {
       id="fullclick"
       imageProps={{
         aspectRatio: "threeByTwo",
-        component: <Image alt="" src="https://placeimg.com/400/200/arch" />,
+        component: <Image alt="" src="http://placekitten.com/400/200" />,
       }}
     >
       <CardHeading level="three" id="heading1">
@@ -223,7 +223,7 @@ describe("Card", () => {
       id="cardID"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/400/200/arch",
+        src: "http://placekitten.com/400/200",
       }}
       isAlignedRightActions
     >
@@ -248,7 +248,7 @@ describe("Card", () => {
       id="chakraProps"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/400/200/arch",
+        src: "http://placekitten.com/400/200",
       }}
       p="s"
       color="ui.error.primary"
@@ -269,7 +269,7 @@ describe("Card", () => {
       id="otherProps"
       imageProps={{
         alt: "Alt text",
-        src: "https://placeimg.com/400/200/arch",
+        src: "http://placekitten.com/400/200",
       }}
       data-testid="card-testid"
     >

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Card Renders the UI snapshot correctly 1`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/400/200/arch"
+        src="http://placekitten.com/400/200"
       />
     </div>
   </div>
@@ -63,7 +63,7 @@ exports[`Card Renders the UI snapshot correctly 2`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/300/400/arch"
+        src="http://placekitten.com/300/400"
       />
     </div>
   </div>
@@ -162,7 +162,7 @@ exports[`Card Renders the UI snapshot correctly 3`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/300/400/arch"
+        src="http://placekitten.com/300/400"
       />
     </div>
   </div>
@@ -207,7 +207,7 @@ exports[`Card Renders the UI snapshot correctly 4`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/300/400/arch"
+        src="http://placekitten.com/300/400"
       />
     </div>
   </div>
@@ -387,7 +387,7 @@ exports[`Card Renders the UI snapshot correctly 6`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/400/200/arch"
+        src="http://placekitten.com/400/200"
       />
     </div>
   </div>
@@ -441,7 +441,7 @@ exports[`Card Renders the UI snapshot correctly 7`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/400/200/arch"
+        src="http://placekitten.com/400/200"
       />
     </div>
   </div>
@@ -502,7 +502,7 @@ exports[`Card Renders the UI snapshot correctly 8`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/400/200/arch"
+        src="http://placekitten.com/400/200"
       />
     </div>
   </div>
@@ -552,7 +552,7 @@ exports[`Card Renders the UI snapshot correctly 9`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="https://placeimg.com/400/200/arch"
+        src="http://placekitten.com/400/200"
       />
     </div>
   </div>

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`Card Renders the UI snapshot correctly 1`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/400/200"
+        src="//placekitten.com/400/200"
       />
     </div>
   </div>
@@ -63,7 +63,7 @@ exports[`Card Renders the UI snapshot correctly 2`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/300/400"
+        src="//placekitten.com/300/400"
       />
     </div>
   </div>
@@ -162,7 +162,7 @@ exports[`Card Renders the UI snapshot correctly 3`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/300/400"
+        src="//placekitten.com/300/400"
       />
     </div>
   </div>
@@ -207,7 +207,7 @@ exports[`Card Renders the UI snapshot correctly 4`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/300/400"
+        src="//placekitten.com/300/400"
       />
     </div>
   </div>
@@ -387,7 +387,7 @@ exports[`Card Renders the UI snapshot correctly 6`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/400/200"
+        src="//placekitten.com/400/200"
       />
     </div>
   </div>
@@ -441,7 +441,7 @@ exports[`Card Renders the UI snapshot correctly 7`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/400/200"
+        src="//placekitten.com/400/200"
       />
     </div>
   </div>
@@ -502,7 +502,7 @@ exports[`Card Renders the UI snapshot correctly 8`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/400/200"
+        src="//placekitten.com/400/200"
       />
     </div>
   </div>
@@ -552,7 +552,7 @@ exports[`Card Renders the UI snapshot correctly 9`] = `
       <img
         alt="Alt text"
         className="css-0"
-        src="http://placekitten.com/400/200"
+        src="//placekitten.com/400/200"
       />
     </div>
   </div>

--- a/src/components/Chakra/Center.mdx
+++ b/src/components/Chakra/Center.mdx
@@ -38,7 +38,7 @@ guide on the Chakra UI site.
     <Image
       alt="Centered Image"
       size="medium"
-      src="https://placeimg.com/300/400/arch"
+      src="https://placekitten.com/300/400"
     />
   </Center>
 </Canvas>

--- a/src/components/Grid/SimpleGrid.stories.tsx
+++ b/src/components/Grid/SimpleGrid.stories.tsx
@@ -52,7 +52,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/220/animals",
+          src: "http://placekitten.com/400/220",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -65,7 +65,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/220/animals",
+          src: "http://placekitten.com/400/220",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -78,7 +78,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/240/animals",
+          src: "http://placekitten.com/400/240",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -91,7 +91,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/260/animals",
+          src: "http://placekitten.com/400/260",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -104,7 +104,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/320/animals",
+          src: "http://placekitten.com/400/320",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -117,7 +117,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -146,24 +146,24 @@ export const IconExample: Story = {
 export const ImageExample: Story = {
   render: () => (
     <SimpleGrid columns={6}>
-      <Image src="https://placeimg.com/300/300/animals?x=1" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=2" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=3" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=4" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=5" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=6" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=7" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=8" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=9" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=10" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=11" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=12" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=13" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=14" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=15" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=16" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=17" alt="" />
-      <Image src="https://placeimg.com/300/300/animals?x=18" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="http://placekitten.com/300/300" alt="" />
     </SimpleGrid>
   ),
 };
@@ -175,7 +175,7 @@ export const CardExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "fourByThree",
-          src: "https://placeimg.com/400/200/animals",
+          src: "http://placekitten.com/400/200",
         }}
         isBordered
         isCentered
@@ -194,7 +194,7 @@ export const CardExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "fourByThree",
-          src: "https://placeimg.com/410/210/animals",
+          src: "http://placekitten.com/410/210",
         }}
         isBordered
         isCentered
@@ -213,7 +213,7 @@ export const CardExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "fourByThree",
-          src: "https://placeimg.com/320/320/animals",
+          src: "http://placekitten.com/320/320",
         }}
         isBordered
         isCentered

--- a/src/components/Grid/SimpleGrid.stories.tsx
+++ b/src/components/Grid/SimpleGrid.stories.tsx
@@ -52,7 +52,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/220",
+          src: "//placekitten.com/400/220",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -65,7 +65,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/220",
+          src: "//placekitten.com/400/220",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -78,7 +78,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/240",
+          src: "//placekitten.com/400/240",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -91,7 +91,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/260",
+          src: "//placekitten.com/400/260",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -104,7 +104,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/320",
+          src: "//placekitten.com/400/320",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -117,7 +117,7 @@ export const WithControls: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       >
         <CardHeading level="three">Card Heading</CardHeading>
@@ -146,24 +146,24 @@ export const IconExample: Story = {
 export const ImageExample: Story = {
   render: () => (
     <SimpleGrid columns={6}>
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
-      <Image src="http://placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
+      <Image src="//placekitten.com/300/300" alt="" />
     </SimpleGrid>
   ),
 };
@@ -175,7 +175,7 @@ export const CardExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "fourByThree",
-          src: "http://placekitten.com/400/200",
+          src: "//placekitten.com/400/200",
         }}
         isBordered
         isCentered
@@ -194,7 +194,7 @@ export const CardExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "fourByThree",
-          src: "http://placekitten.com/410/210",
+          src: "//placekitten.com/410/210",
         }}
         isBordered
         isCentered
@@ -213,7 +213,7 @@ export const CardExample: Story = {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "fourByThree",
-          src: "http://placekitten.com/320/320",
+          src: "//placekitten.com/320/320",
         }}
         isBordered
         isCentered

--- a/src/components/Grid/SimpleGrid.test.tsx
+++ b/src/components/Grid/SimpleGrid.test.tsx
@@ -14,7 +14,7 @@ describe("Grid Accessibility", () => {
           imageProps={{
             alt: "Alt text",
             aspectRatio: "twoByOne",
-            src: "http://placekitten.com/500/200",
+            src: "//placekitten.com/500/200",
           }}
         >
           <CardHeading level="two">Card Heading</CardHeading>
@@ -27,7 +27,7 @@ describe("Grid Accessibility", () => {
           imageProps={{
             alt: "Alt text",
             aspectRatio: "twoByOne",
-            src: "http://placekitten.com/400/220",
+            src: "//placekitten.com/400/220",
           }}
         >
           <CardHeading level="three">Card Heading</CardHeading>
@@ -40,7 +40,7 @@ describe("Grid Accessibility", () => {
           imageProps={{
             alt: "Alt text",
             aspectRatio: "twoByOne",
-            src: "http://placekitten.com/400/240",
+            src: "//placekitten.com/400/240",
           }}
         >
           <CardHeading level="three">Card Heading</CardHeading>

--- a/src/components/Grid/SimpleGrid.test.tsx
+++ b/src/components/Grid/SimpleGrid.test.tsx
@@ -14,7 +14,7 @@ describe("Grid Accessibility", () => {
           imageProps={{
             alt: "Alt text",
             aspectRatio: "twoByOne",
-            src: "https://placeimg.com/500/200/animals",
+            src: "http://placekitten.com/500/200",
           }}
         >
           <CardHeading level="two">Card Heading</CardHeading>
@@ -27,7 +27,7 @@ describe("Grid Accessibility", () => {
           imageProps={{
             alt: "Alt text",
             aspectRatio: "twoByOne",
-            src: "https://placeimg.com/400/220/animals",
+            src: "http://placekitten.com/400/220",
           }}
         >
           <CardHeading level="three">Card Heading</CardHeading>
@@ -40,7 +40,7 @@ describe("Grid Accessibility", () => {
           imageProps={{
             alt: "Alt text",
             aspectRatio: "twoByOne",
-            src: "https://placeimg.com/400/240/animals",
+            src: "http://placekitten.com/400/240",
           }}
         >
           <CardHeading level="three">Card Heading</CardHeading>

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -39,12 +39,12 @@ prop should be used:
 <Source
   code={`
 <Hero
-  backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+  backgroundImageSrc="https://placekitten.com/g/2400/800"
   heroType="campaign"
   heading={<Heading level="one" id="campaign-hero" text="Hero Campaign" />}
   imageProps={{
     alt: "Image example",
-    src: "https://placeimg.com/800/400/animals",
+    src: "https://placekitten.com/800/400",
   }}
   subHeaderText="Campaign Hero Subheader Text"
 />
@@ -81,7 +81,7 @@ minimum props that should be used are `backgroundImageSrc` and `heading`.
 
 <Source
   code={`
-backgroundImageSrc="https://placeimg.com/1600/800/arch"
+backgroundImageSrc="https://placekitten.com/1600/800"
 heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
 `}
   language="jsx"
@@ -138,7 +138,7 @@ The `"campaign"` hero type can be used with the `backgroundColor`,
 
 <Source
   code={`
-backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+backgroundImageSrc="https://placekitten.com/g/2400/800"
 heading={
   <Heading level="one" id="campaign-hero" text="Hero Campaign" />
 }

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -36,7 +36,7 @@ const otherSubHeaderTextLong = (
 );
 const imageProps = {
   alt: "Image example",
-  src: "https://placeimg.com/800/400/animals",
+  src: "http://placekitten.com/800/400",
 };
 
 const meta: Meta<typeof Hero> = {
@@ -80,7 +80,7 @@ export const WithControls: Story = {
     (args.heroType === "primary" && (
       <Hero
         {...args}
-        backgroundImageSrc="https://placeimg.com/2400/800/nature"
+        backgroundImageSrc="http://placekitten.com/2400/800"
         heading={<Heading level="one" id="1" text="Hero Primary" />}
         heroType={args.heroType}
         subHeaderText="Example Subtitle"
@@ -108,7 +108,7 @@ export const WithControls: Story = {
     (args.heroType === "campaign" && (
       <Hero
         {...args}
-        backgroundImageSrc="https://placeimg.com/2400/800/nature"
+        backgroundImageSrc="http://placekitten.com/2400/800"
         heading={<Heading level="one" id="1" text="Hero Campaign" />}
         heroType={args.heroType}
         imageProps={args.imageProps}
@@ -121,7 +121,7 @@ export const WithControls: Story = {
         heroType={args.heroType}
         imageProps={{
           ...args.imageProps,
-          src: "https://placeimg.com/1200/400/animals",
+          src: "http://placekitten.com/1200/400",
         }}
         subHeaderText={otherSubHeaderText}
       />
@@ -139,7 +139,7 @@ export const WithControls: Story = {
 export const Primary: Story = {
   render: () => (
     <Hero
-      backgroundImageSrc="https://placeimg.com/1600/800/arch"
+      backgroundImageSrc="http://placekitten.com/1600/800"
       heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
       heroType="primary"
     />
@@ -197,7 +197,7 @@ export const Campaign: Story = {
           text="Campaign Hero at Default Height"
         />
         <Hero
-          backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+          backgroundImageSrc="http://placekitten.com/g/2400/800"
           heroType="campaign"
           heading={
             <Heading
@@ -216,7 +216,7 @@ export const Campaign: Story = {
           text="Campaign Hero with Long Text"
         />
         <Hero
-          backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+          backgroundImageSrc="http://placekitten.com/g/2400/800"
           heroType="campaign"
           heading={
             <Heading

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -36,7 +36,7 @@ const otherSubHeaderTextLong = (
 );
 const imageProps = {
   alt: "Image example",
-  src: "http://placekitten.com/800/400",
+  src: "//placekitten.com/800/400",
 };
 
 const meta: Meta<typeof Hero> = {
@@ -80,7 +80,7 @@ export const WithControls: Story = {
     (args.heroType === "primary" && (
       <Hero
         {...args}
-        backgroundImageSrc="http://placekitten.com/2400/800"
+        backgroundImageSrc="//placekitten.com/2400/800"
         heading={<Heading level="one" id="1" text="Hero Primary" />}
         heroType={args.heroType}
         subHeaderText="Example Subtitle"
@@ -108,7 +108,7 @@ export const WithControls: Story = {
     (args.heroType === "campaign" && (
       <Hero
         {...args}
-        backgroundImageSrc="http://placekitten.com/2400/800"
+        backgroundImageSrc="//placekitten.com/2400/800"
         heading={<Heading level="one" id="1" text="Hero Campaign" />}
         heroType={args.heroType}
         imageProps={args.imageProps}
@@ -121,7 +121,7 @@ export const WithControls: Story = {
         heroType={args.heroType}
         imageProps={{
           ...args.imageProps,
-          src: "http://placekitten.com/1200/400",
+          src: "//placekitten.com/1200/400",
         }}
         subHeaderText={otherSubHeaderText}
       />
@@ -139,7 +139,7 @@ export const WithControls: Story = {
 export const Primary: Story = {
   render: () => (
     <Hero
-      backgroundImageSrc="http://placekitten.com/1600/800"
+      backgroundImageSrc="//placekitten.com/1600/800"
       heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
       heroType="primary"
     />
@@ -197,7 +197,7 @@ export const Campaign: Story = {
           text="Campaign Hero at Default Height"
         />
         <Hero
-          backgroundImageSrc="http://placekitten.com/g/2400/800"
+          backgroundImageSrc="//placekitten.com/g/2400/800"
           heroType="campaign"
           heading={
             <Heading
@@ -216,7 +216,7 @@ export const Campaign: Story = {
           text="Campaign Hero with Long Text"
         />
         <Hero
-          backgroundImageSrc="http://placekitten.com/g/2400/800"
+          backgroundImageSrc="//placekitten.com/g/2400/800"
           heroType="campaign"
           heading={
             <Heading

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -19,7 +19,7 @@ export const otherSubHeaderText =
   "Visit us today.";
 const imageProps = {
   alt: "Image example",
-  src: "http://placekitten.com/800/400",
+  src: "//placekitten.com/800/400",
 };
 
 describe("Hero accessbility tests", () => {
@@ -29,7 +29,7 @@ describe("Hero accessbility tests", () => {
         heroType="primary"
         heading={<Heading level="one" id="a11y-hero" text="Hero Primary" />}
         subHeaderText="Example Subtitle"
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
       />
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -61,7 +61,7 @@ describe("Hero accessbility tests", () => {
   it("passes for type Campaign", async () => {
     const { container } = render(
       <Hero
-        backgroundImageSrc="http://placekitten.com/g/2400/800"
+        backgroundImageSrc="//placekitten.com/g/2400/800"
         heroType="campaign"
         heading={<Heading level="one" id="a11y-hero" text="Hero Campaign" />}
         imageProps={imageProps}
@@ -90,7 +90,7 @@ describe("Hero", () => {
         heroType="primary"
         heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
         subHeaderText="Example Subtitle"
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
       />
     );
 
@@ -98,7 +98,7 @@ describe("Hero", () => {
     expect(screen.getByText("Example Subtitle")).toBeInTheDocument();
     expect(screen.getByTestId("hero")).toHaveAttribute(
       "style",
-      "background-image: url(http://placekitten.com/1600/800);"
+      "background-image: url(//placekitten.com/1600/800);"
     );
   });
 
@@ -119,7 +119,7 @@ describe("Hero", () => {
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
-      "http://placekitten.com/800/400"
+      "//placekitten.com/800/400"
     );
   });
 
@@ -142,7 +142,7 @@ describe("Hero", () => {
   it("renders Campaign Hero", () => {
     render(
       <Hero
-        backgroundImageSrc="http://placekitten.com/g/2400/800"
+        backgroundImageSrc="//placekitten.com/g/2400/800"
         heroType="campaign"
         heading={
           <Heading level="one" id="campaign-hero" text="Hero Campaign" />
@@ -156,12 +156,12 @@ describe("Hero", () => {
     expect(screen.getByText(/With 92 locations across/i)).toBeInTheDocument();
     expect(screen.getByTestId("hero")).toHaveAttribute(
       "style",
-      "background-image: url(http://placekitten.com/g/2400/800);"
+      "background-image: url(//placekitten.com/g/2400/800);"
     );
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
-      "http://placekitten.com/800/400"
+      "//placekitten.com/800/400"
     );
   });
 
@@ -178,7 +178,7 @@ describe("Hero", () => {
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
-      "http://placekitten.com/800/400"
+      "//placekitten.com/800/400"
     );
   });
 
@@ -193,7 +193,7 @@ describe("Hero", () => {
             text="Hero with Custom Colors"
           />
         }
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
         foregroundColor="#123456"
         backgroundColor="#654321"
       />
@@ -242,7 +242,7 @@ describe("Hero", () => {
     const warn = jest.spyOn(console, "warn");
     render(
       <Hero
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
         heroType="primary"
         imageProps={{ src: imageProps.src }}
       />
@@ -266,7 +266,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
         heroType="primary"
         heading={heading}
         imageProps={imageProps}
@@ -299,7 +299,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
         heroType="secondary"
         heading={heading}
         imageProps={imageProps}
@@ -361,7 +361,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
         heroType="tertiary"
         heading={heading}
         subHeaderText={otherSubHeaderText}
@@ -380,7 +380,7 @@ describe("Hero", () => {
     );
     const { rerender } = render(
       <Hero
-        backgroundImageSrc="http://placekitten.com/g/2400/800"
+        backgroundImageSrc="//placekitten.com/g/2400/800"
         heroType="campaign"
         heading={heading}
         imageProps={imageProps}
@@ -413,7 +413,7 @@ describe("Hero", () => {
         heroType="campaign"
         heading={heading}
         subHeaderText={otherSubHeaderText}
-        backgroundImageSrc="http://placekitten.com/g/2400/800"
+        backgroundImageSrc="//placekitten.com/g/2400/800"
         locationDetails={<>Some location details.</>}
       />
     );
@@ -441,7 +441,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="http://placekitten.com/g/2400/800"
+        backgroundImageSrc="//placekitten.com/g/2400/800"
         heroType="fiftyFifty"
         imageProps={imageProps}
         subHeaderText={otherSubHeaderText}
@@ -462,7 +462,7 @@ describe("Hero", () => {
             <Heading level="one" id="primary-hero" text="Hero Primary" />
           }
           subHeaderText="Example Subtitle"
-          backgroundImageSrc="http://placekitten.com/1600/800"
+          backgroundImageSrc="//placekitten.com/1600/800"
         />
       )
       .toJSON();
@@ -541,7 +541,7 @@ describe("Hero", () => {
     const campaign = renderer
       .create(
         <Hero
-          backgroundImageSrc="http://placekitten.com/g/2400/800"
+          backgroundImageSrc="//placekitten.com/g/2400/800"
           heroType="campaign"
           heading={
             <Heading level="one" id="campaign-hero" text="Hero Campaign" />
@@ -577,7 +577,7 @@ describe("Hero", () => {
           heroType="primary"
           heading={<Heading level="one" id="chakra" text="Hero Primary" />}
           subHeaderText="Example Subtitle"
-          backgroundImageSrc="http://placekitten.com/1600/800"
+          backgroundImageSrc="//placekitten.com/1600/800"
           p="20px"
           color="ui.error.primary"
         />
@@ -589,7 +589,7 @@ describe("Hero", () => {
           heroType="primary"
           heading={<Heading level="one" id="props" text="Hero Primary" />}
           subHeaderText="Example Subtitle"
-          backgroundImageSrc="http://placekitten.com/1600/800"
+          backgroundImageSrc="//placekitten.com/1600/800"
           data-testid="props"
         />
       )
@@ -612,7 +612,7 @@ describe("Hero", () => {
     const ref = React.createRef<HTMLDivElement>();
     const { container } = render(
       <Hero
-        backgroundImageSrc="http://placekitten.com/1600/800"
+        backgroundImageSrc="//placekitten.com/1600/800"
         heroType="primary"
         heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
         ref={ref}

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -19,7 +19,7 @@ export const otherSubHeaderText =
   "Visit us today.";
 const imageProps = {
   alt: "Image example",
-  src: "https://placeimg.com/800/400/animals",
+  src: "http://placekitten.com/800/400",
 };
 
 describe("Hero accessbility tests", () => {
@@ -29,7 +29,7 @@ describe("Hero accessbility tests", () => {
         heroType="primary"
         heading={<Heading level="one" id="a11y-hero" text="Hero Primary" />}
         subHeaderText="Example Subtitle"
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
       />
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -61,7 +61,7 @@ describe("Hero accessbility tests", () => {
   it("passes for type Campaign", async () => {
     const { container } = render(
       <Hero
-        backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+        backgroundImageSrc="http://placekitten.com/g/2400/800"
         heroType="campaign"
         heading={<Heading level="one" id="a11y-hero" text="Hero Campaign" />}
         imageProps={imageProps}
@@ -90,7 +90,7 @@ describe("Hero", () => {
         heroType="primary"
         heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
         subHeaderText="Example Subtitle"
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
       />
     );
 
@@ -98,7 +98,7 @@ describe("Hero", () => {
     expect(screen.getByText("Example Subtitle")).toBeInTheDocument();
     expect(screen.getByTestId("hero")).toHaveAttribute(
       "style",
-      "background-image: url(https://placeimg.com/1600/800/arch);"
+      "background-image: url(http://placekitten.com/1600/800);"
     );
   });
 
@@ -119,7 +119,7 @@ describe("Hero", () => {
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
-      "https://placeimg.com/800/400/animals"
+      "http://placekitten.com/800/400"
     );
   });
 
@@ -142,7 +142,7 @@ describe("Hero", () => {
   it("renders Campaign Hero", () => {
     render(
       <Hero
-        backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+        backgroundImageSrc="http://placekitten.com/g/2400/800"
         heroType="campaign"
         heading={
           <Heading level="one" id="campaign-hero" text="Hero Campaign" />
@@ -156,12 +156,12 @@ describe("Hero", () => {
     expect(screen.getByText(/With 92 locations across/i)).toBeInTheDocument();
     expect(screen.getByTestId("hero")).toHaveAttribute(
       "style",
-      "background-image: url(https://placeimg.com/2400/800/nature/grayscale);"
+      "background-image: url(http://placekitten.com/g/2400/800);"
     );
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
-      "https://placeimg.com/800/400/animals"
+      "http://placekitten.com/800/400"
     );
   });
 
@@ -178,7 +178,7 @@ describe("Hero", () => {
     expect(screen.getByRole("img")).toBeInTheDocument();
     expect(screen.getByRole("img")).toHaveAttribute(
       "src",
-      "https://placeimg.com/800/400/animals"
+      "http://placekitten.com/800/400"
     );
   });
 
@@ -193,7 +193,7 @@ describe("Hero", () => {
             text="Hero with Custom Colors"
           />
         }
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
         foregroundColor="#123456"
         backgroundColor="#654321"
       />
@@ -242,7 +242,7 @@ describe("Hero", () => {
     const warn = jest.spyOn(console, "warn");
     render(
       <Hero
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
         heroType="primary"
         imageProps={{ src: imageProps.src }}
       />
@@ -266,7 +266,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
         heroType="primary"
         heading={heading}
         imageProps={imageProps}
@@ -299,7 +299,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
         heroType="secondary"
         heading={heading}
         imageProps={imageProps}
@@ -361,7 +361,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
         heroType="tertiary"
         heading={heading}
         subHeaderText={otherSubHeaderText}
@@ -380,7 +380,7 @@ describe("Hero", () => {
     );
     const { rerender } = render(
       <Hero
-        backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+        backgroundImageSrc="http://placekitten.com/g/2400/800"
         heroType="campaign"
         heading={heading}
         imageProps={imageProps}
@@ -413,7 +413,7 @@ describe("Hero", () => {
         heroType="campaign"
         heading={heading}
         subHeaderText={otherSubHeaderText}
-        backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+        backgroundImageSrc="http://placekitten.com/g/2400/800"
         locationDetails={<>Some location details.</>}
       />
     );
@@ -441,7 +441,7 @@ describe("Hero", () => {
 
     rerender(
       <Hero
-        backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+        backgroundImageSrc="http://placekitten.com/g/2400/800"
         heroType="fiftyFifty"
         imageProps={imageProps}
         subHeaderText={otherSubHeaderText}
@@ -462,7 +462,7 @@ describe("Hero", () => {
             <Heading level="one" id="primary-hero" text="Hero Primary" />
           }
           subHeaderText="Example Subtitle"
-          backgroundImageSrc="https://placeimg.com/1600/800/arch"
+          backgroundImageSrc="http://placekitten.com/1600/800"
         />
       )
       .toJSON();
@@ -541,7 +541,7 @@ describe("Hero", () => {
     const campaign = renderer
       .create(
         <Hero
-          backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+          backgroundImageSrc="http://placekitten.com/g/2400/800"
           heroType="campaign"
           heading={
             <Heading level="one" id="campaign-hero" text="Hero Campaign" />
@@ -577,7 +577,7 @@ describe("Hero", () => {
           heroType="primary"
           heading={<Heading level="one" id="chakra" text="Hero Primary" />}
           subHeaderText="Example Subtitle"
-          backgroundImageSrc="https://placeimg.com/1600/800/arch"
+          backgroundImageSrc="http://placekitten.com/1600/800"
           p="20px"
           color="ui.error.primary"
         />
@@ -589,7 +589,7 @@ describe("Hero", () => {
           heroType="primary"
           heading={<Heading level="one" id="props" text="Hero Primary" />}
           subHeaderText="Example Subtitle"
-          backgroundImageSrc="https://placeimg.com/1600/800/arch"
+          backgroundImageSrc="http://placekitten.com/1600/800"
           data-testid="props"
         />
       )
@@ -612,7 +612,7 @@ describe("Hero", () => {
     const ref = React.createRef<HTMLDivElement>();
     const { container } = render(
       <Hero
-        backgroundImageSrc="https://placeimg.com/1600/800/arch"
+        backgroundImageSrc="http://placekitten.com/1600/800"
         heroType="primary"
         heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
         ref={ref}

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Hero Renders the UI snapshot correctly 1`] = `
   data-testid="hero"
   style={
     {
-      "backgroundImage": "url(http://placekitten.com/1600/800)",
+      "backgroundImage": "url(//placekitten.com/1600/800)",
     }
   }
 >
@@ -57,7 +57,7 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -97,7 +97,7 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -137,7 +137,7 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -177,7 +177,7 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -217,7 +217,7 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -277,7 +277,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
   data-testid="hero"
   style={
     {
-      "backgroundImage": "url(http://placekitten.com/g/2400/800)",
+      "backgroundImage": "url(//placekitten.com/g/2400/800)",
     }
   }
 >
@@ -292,7 +292,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
     }
   >
     <div
-      className="css-1p1rhof"
+      className="css-1gt4hjv"
     >
       <div
         className="css-0"
@@ -300,7 +300,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -341,7 +341,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
     }
   >
     <div
-      className="css-1p1rhof"
+      className="css-1gt4hjv"
     >
       <div
         className="css-0"
@@ -349,7 +349,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="http://placekitten.com/800/400"
+          src="//placekitten.com/800/400"
         />
       </div>
     </div>
@@ -369,7 +369,7 @@ exports[`Hero Renders the UI snapshot correctly 10`] = `
   data-testid="hero"
   style={
     {
-      "backgroundImage": "url(http://placekitten.com/1600/800)",
+      "backgroundImage": "url(//placekitten.com/1600/800)",
     }
   }
 >
@@ -405,7 +405,7 @@ exports[`Hero Renders the UI snapshot correctly 11`] = `
   data-testid="props"
   style={
     {
-      "backgroundImage": "url(http://placekitten.com/1600/800)",
+      "backgroundImage": "url(//placekitten.com/1600/800)",
     }
   }
 >

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`Hero Renders the UI snapshot correctly 1`] = `
   data-testid="hero"
   style={
     {
-      "backgroundImage": "url(https://placeimg.com/1600/800/arch)",
+      "backgroundImage": "url(http://placekitten.com/1600/800)",
     }
   }
 >
@@ -57,7 +57,7 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -97,7 +97,7 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -137,7 +137,7 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -177,7 +177,7 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -217,7 +217,7 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -277,7 +277,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
   data-testid="hero"
   style={
     {
-      "backgroundImage": "url(https://placeimg.com/2400/800/nature/grayscale)",
+      "backgroundImage": "url(http://placekitten.com/g/2400/800)",
     }
   }
 >
@@ -292,7 +292,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
     }
   >
     <div
-      className="css-mswi6j"
+      className="css-1p1rhof"
     >
       <div
         className="css-0"
@@ -300,7 +300,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -341,7 +341,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
     }
   >
     <div
-      className="css-mswi6j"
+      className="css-1p1rhof"
     >
       <div
         className="css-0"
@@ -349,7 +349,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
         <img
           alt="Image example"
           className="css-0"
-          src="https://placeimg.com/800/400/animals"
+          src="http://placekitten.com/800/400"
         />
       </div>
     </div>
@@ -369,7 +369,7 @@ exports[`Hero Renders the UI snapshot correctly 10`] = `
   data-testid="hero"
   style={
     {
-      "backgroundImage": "url(https://placeimg.com/1600/800/arch)",
+      "backgroundImage": "url(http://placekitten.com/1600/800)",
     }
   }
 >
@@ -405,7 +405,7 @@ exports[`Hero Renders the UI snapshot correctly 11`] = `
   data-testid="props"
   style={
     {
-      "backgroundImage": "url(https://placeimg.com/1600/800/arch)",
+      "backgroundImage": "url(http://placekitten.com/1600/800)",
     }
   }
 >

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -111,7 +111,7 @@ pass the `isLazy` prop or set it to `true`.
 
 <Source
   code={`
-<Image alt="Alt text" isLazy src="https://placeimg.com/540/420/animals" />
+<Image alt="Alt text" isLazy src="https://placekitten.com/540/420" />
 `}
   language="jsx"
 />

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -70,7 +70,7 @@ export const WithControls: Story = {
     credit: "Image credit",
     imageType: "default",
     size: "medium",
-    src: "http://placekitten.com/400/300",
+    src: "//placekitten.com/400/300",
   },
   render: (args) => <Image {...args} />,
   parameters: {
@@ -91,7 +91,7 @@ export const FigureAndFigcaption: Story = {
     credit: "Image credit",
     imageType: "default",
     size: "medium",
-    src: "http://placekitten.com/400/300",
+    src: "//placekitten.com/400/300",
   },
   argTypes: {
     aspectRatio: { table: { disable: true } },
@@ -113,7 +113,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="32px"
           size="xxxsmall"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -122,7 +122,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="64px"
           size="xxsmall"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -131,7 +131,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="96px"
           size="xsmall"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -140,7 +140,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="165px"
           size="small"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -149,7 +149,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="225px"
           size="medium"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -158,16 +158,12 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="360px"
           size="large"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center" width="100%">
         <Heading id="Default" level="four" text="default" />
-        <Image
-          alt="Alt text"
-          caption="100%"
-          src="http://placekitten.com/400/300"
-        />
+        <Image alt="Alt text" caption="100%" src="//placekitten.com/400/300" />
       </Box>
     </VStack>
   ),
@@ -188,7 +184,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="fourByThree"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -196,7 +192,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="oneByTwo"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -204,7 +200,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="original"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -212,7 +208,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="sixteenByNine"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -220,7 +216,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="square"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -228,7 +224,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="threeByFour"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -236,7 +232,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="threeByTwo"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -244,7 +240,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="twoByOne"
-          src="http://placekitten.com/400/300"
+          src="//placekitten.com/400/300"
         />
       </Box>
     </VStack>
@@ -259,7 +255,7 @@ export const Types: Story = {
           alt="Alt text"
           aspectRatio="square"
           imageType="default"
-          src="http://placekitten.com/400/400"
+          src="//placekitten.com/400/400"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -268,7 +264,7 @@ export const Types: Story = {
           alt="Alt text"
           aspectRatio="square"
           imageType="circle"
-          src="http://placekitten.com/400/400"
+          src="//placekitten.com/400/400"
         />
       </Box>
     </VStack>
@@ -285,7 +281,7 @@ export const HTMLAttributes: Story = {
         />
         <Image
           alt="Alt text"
-          src="http://placekitten.com/400/400"
+          src="//placekitten.com/400/400"
           onLoad={({ target }: any) => {
             console.log("Image 1 loaded and `onLoad` called.");
             console.log(
@@ -304,7 +300,7 @@ export const HTMLAttributes: Story = {
         />
         <Image
           alt="Broken image with bad url"
-          src="http://placekitten.com/400/400"
+          src="//placekitten.com/400/400"
           onError={() =>
             console.warn("Image 2 error! Called through `onError`.")
           }
@@ -317,16 +313,16 @@ export const HTMLAttributes: Story = {
 export const LazyLoading: Story = {
   render: () => (
     <SimpleGrid columns={1}>
-      <Image alt="Alt text" isLazy src="http://placekitten.com/540/420" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/500/400" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/460/460" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/420/490" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/200/120" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/640/340" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/460/480" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/100/200" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/400/400" />
-      <Image alt="Alt text" isLazy src="http://placekitten.com/250/360" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/540/420" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/500/400" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/460/460" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/420/490" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/200/120" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/640/340" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/460/480" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/100/200" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/400/400" />
+      <Image alt="Alt text" isLazy src="//placekitten.com/250/360" />
     </SimpleGrid>
   ),
 };

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -70,7 +70,7 @@ export const WithControls: Story = {
     credit: "Image credit",
     imageType: "default",
     size: "medium",
-    src: "https://placeimg.com/400/300/animals",
+    src: "http://placekitten.com/400/300",
   },
   render: (args) => <Image {...args} />,
   parameters: {
@@ -91,7 +91,7 @@ export const FigureAndFigcaption: Story = {
     credit: "Image credit",
     imageType: "default",
     size: "medium",
-    src: "https://placeimg.com/400/300/animals",
+    src: "http://placekitten.com/400/300",
   },
   argTypes: {
     aspectRatio: { table: { disable: true } },
@@ -113,7 +113,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="32px"
           size="xxxsmall"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -122,7 +122,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="64px"
           size="xxsmall"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -131,7 +131,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="96px"
           size="xsmall"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -140,7 +140,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="165px"
           size="small"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -149,7 +149,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="225px"
           size="medium"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center">
@@ -158,7 +158,7 @@ export const Sizes: Story = {
           alt="Alt text"
           caption="360px"
           size="large"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box textAlign="center" width="100%">
@@ -166,7 +166,7 @@ export const Sizes: Story = {
         <Image
           alt="Alt text"
           caption="100%"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
     </VStack>
@@ -188,7 +188,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="fourByThree"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -196,7 +196,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="oneByTwo"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -204,7 +204,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="original"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -212,7 +212,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="sixteenByNine"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -220,7 +220,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="square"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -228,7 +228,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="threeByFour"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -236,7 +236,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="threeByTwo"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -244,7 +244,7 @@ export const AspectRatios: Story = {
         <Image
           alt="Alt text"
           aspectRatio="twoByOne"
-          src="https://placeimg.com/400/300/animals"
+          src="http://placekitten.com/400/300"
         />
       </Box>
     </VStack>
@@ -259,7 +259,7 @@ export const Types: Story = {
           alt="Alt text"
           aspectRatio="square"
           imageType="default"
-          src="https://placeimg.com/400/400/animals"
+          src="http://placekitten.com/400/400"
         />
       </Box>
       <Box style={imageBlockStyles}>
@@ -268,7 +268,7 @@ export const Types: Story = {
           alt="Alt text"
           aspectRatio="square"
           imageType="circle"
-          src="https://placeimg.com/400/400/animals"
+          src="http://placekitten.com/400/400"
         />
       </Box>
     </VStack>
@@ -285,7 +285,7 @@ export const HTMLAttributes: Story = {
         />
         <Image
           alt="Alt text"
-          src="https://placeimg.com/400/400/animals"
+          src="http://placekitten.com/400/400"
           onLoad={({ target }: any) => {
             console.log("Image 1 loaded and `onLoad` called.");
             console.log(
@@ -304,7 +304,7 @@ export const HTMLAttributes: Story = {
         />
         <Image
           alt="Broken image with bad url"
-          src="https://placeimcom/400/400/animals"
+          src="http://placekitten.com/400/400"
           onError={() =>
             console.warn("Image 2 error! Called through `onError`.")
           }
@@ -317,16 +317,16 @@ export const HTMLAttributes: Story = {
 export const LazyLoading: Story = {
   render: () => (
     <SimpleGrid columns={1}>
-      <Image alt="Alt text" isLazy src="https://placeimg.com/540/420/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/500/400/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/460/460/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/420/490/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/200/120/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/640/340/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/460/480/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/100/200/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/400/400/animals" />
-      <Image alt="Alt text" isLazy src="https://placeimg.com/250/360/animals" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/540/420" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/500/400" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/460/460" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/420/490" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/200/120" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/640/340" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/460/480" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/100/200" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/400/400" />
+      <Image alt="Alt text" isLazy src="http://placekitten.com/250/360" />
     </SimpleGrid>
   ),
 };

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -44,7 +44,7 @@ describe("Image", () => {
 
   // @TODO - test when it does come into view.
   it("does not render an image src when `isLazy` is true until it is 'inView'", () => {
-    const src = "https://placeimg.com/500/200/animals";
+    const src = "http://placekitten.com/500/200";
     const { container } = render(<Image alt="" isLazy src={src} />);
 
     // Mock that the image is not in view through the IntersectionObserver object.

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -44,7 +44,7 @@ describe("Image", () => {
 
   // @TODO - test when it does come into view.
   it("does not render an image src when `isLazy` is true until it is 'inView'", () => {
-    const src = "http://placekitten.com/500/200";
+    const src = "//placekitten.com/500/200";
     const { container } = render(<Image alt="" isLazy src={src} />);
 
     // Mock that the image is not in view through the IntersectionObserver object.

--- a/src/components/StructuredContent/StructuredContent.stories.tsx
+++ b/src/components/StructuredContent/StructuredContent.stories.tsx
@@ -74,7 +74,7 @@ export const Controls: Story = {
     "imageProps.credit": "Image credit",
     "imageProps.position": "left",
     "imageProps.size": "medium",
-    "imageProps.src": "https://placeimg.com/400/300/animals",
+    "imageProps.src": "http://placekitten.com/400/300",
   },
   render: (args) => (
     <StructuredContent
@@ -118,7 +118,7 @@ export const WithHTMLStringTextContent: Story = {
         credit: "Image credit",
         position: "left",
         size: "medium",
-        src: "https://placeimg.com/400/300/animals",
+        src: "http://placekitten.com/400/300",
       }}
       bodyContent={
         "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
@@ -164,7 +164,7 @@ export const WithHTMLElementTextContent: Story = {
         credit: "Image credit",
         position: "left",
         size: "medium",
-        src: "https://placeimg.com/400/300/animals",
+        src: "http://placekitten.com/400/300",
       }}
       bodyContent={
         <>
@@ -344,7 +344,7 @@ export const ExampleWithTwoComponents: Story = {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
         bodyContent={
           "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
@@ -408,7 +408,7 @@ export const ExampleWithThreeComponents: Story = {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
         bodyContent={
           "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
@@ -477,7 +477,7 @@ export const ExampleWithMixedContent: Story = {
           aspectRatio: "original",
           position: "center",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
         bodyContent={
           "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +

--- a/src/components/StructuredContent/StructuredContent.stories.tsx
+++ b/src/components/StructuredContent/StructuredContent.stories.tsx
@@ -74,7 +74,7 @@ export const Controls: Story = {
     "imageProps.credit": "Image credit",
     "imageProps.position": "left",
     "imageProps.size": "medium",
-    "imageProps.src": "http://placekitten.com/400/300",
+    "imageProps.src": "//placekitten.com/400/300",
   },
   render: (args) => (
     <StructuredContent
@@ -118,7 +118,7 @@ export const WithHTMLStringTextContent: Story = {
         credit: "Image credit",
         position: "left",
         size: "medium",
-        src: "http://placekitten.com/400/300",
+        src: "//placekitten.com/400/300",
       }}
       bodyContent={
         "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
@@ -164,7 +164,7 @@ export const WithHTMLElementTextContent: Story = {
         credit: "Image credit",
         position: "left",
         size: "medium",
-        src: "http://placekitten.com/400/300",
+        src: "//placekitten.com/400/300",
       }}
       bodyContent={
         <>
@@ -344,7 +344,7 @@ export const ExampleWithTwoComponents: Story = {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
         bodyContent={
           "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
@@ -408,7 +408,7 @@ export const ExampleWithThreeComponents: Story = {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
         bodyContent={
           "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +
@@ -477,7 +477,7 @@ export const ExampleWithMixedContent: Story = {
           aspectRatio: "original",
           position: "center",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
         bodyContent={
           "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do " +

--- a/src/components/StructuredContent/StructuredContent.test.tsx
+++ b/src/components/StructuredContent/StructuredContent.test.tsx
@@ -91,7 +91,7 @@ describe("StructuredContent Accessibility", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -111,7 +111,7 @@ describe("StructuredContent Accessibility", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -144,7 +144,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -168,7 +168,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -211,7 +211,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -236,7 +236,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -258,7 +258,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -279,7 +279,7 @@ describe("StructuredContent", () => {
           aspectRatio: "original",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
       />
     );
@@ -305,7 +305,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "http://placekitten.com/400/300",
+            src: "//placekitten.com/400/300",
           }}
         />
       )
@@ -324,7 +324,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "http://placekitten.com/400/300",
+            src: "//placekitten.com/400/300",
           }}
         />
       )
@@ -351,7 +351,7 @@ describe("StructuredContent", () => {
             aspectRatio: "original",
             position: "left",
             size: "medium",
-            src: "http://placekitten.com/400/300",
+            src: "//placekitten.com/400/300",
           }}
         />
       )
@@ -369,7 +369,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "http://placekitten.com/400/300",
+            src: "//placekitten.com/400/300",
           }}
         />
       )
@@ -396,7 +396,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "http://placekitten.com/400/300",
+            src: "//placekitten.com/400/300",
           }}
           bodyContent={htmlStringBodyContent}
           p="20px"
@@ -417,7 +417,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "http://placekitten.com/400/300",
+            src: "//placekitten.com/400/300",
           }}
           bodyContent={htmlStringBodyContent}
           data-testid="props"
@@ -449,7 +449,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "http://placekitten.com/400/300",
+          src: "//placekitten.com/400/300",
         }}
         ref={ref}
       />

--- a/src/components/StructuredContent/StructuredContent.test.tsx
+++ b/src/components/StructuredContent/StructuredContent.test.tsx
@@ -91,7 +91,7 @@ describe("StructuredContent Accessibility", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -111,7 +111,7 @@ describe("StructuredContent Accessibility", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -144,7 +144,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -168,7 +168,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -211,7 +211,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -236,7 +236,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -258,7 +258,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -279,7 +279,7 @@ describe("StructuredContent", () => {
           aspectRatio: "original",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
       />
     );
@@ -305,7 +305,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "https://placeimg.com/400/300/animals",
+            src: "http://placekitten.com/400/300",
           }}
         />
       )
@@ -324,7 +324,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "https://placeimg.com/400/300/animals",
+            src: "http://placekitten.com/400/300",
           }}
         />
       )
@@ -351,7 +351,7 @@ describe("StructuredContent", () => {
             aspectRatio: "original",
             position: "left",
             size: "medium",
-            src: "https://placeimg.com/400/300/animals",
+            src: "http://placekitten.com/400/300",
           }}
         />
       )
@@ -369,7 +369,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "https://placeimg.com/400/300/animals",
+            src: "http://placekitten.com/400/300",
           }}
         />
       )
@@ -396,7 +396,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "https://placeimg.com/400/300/animals",
+            src: "http://placekitten.com/400/300",
           }}
           bodyContent={htmlStringBodyContent}
           p="20px"
@@ -417,7 +417,7 @@ describe("StructuredContent", () => {
             credit: "Image credit",
             position: "left",
             size: "medium",
-            src: "https://placeimg.com/400/300/animals",
+            src: "http://placekitten.com/400/300",
           }}
           bodyContent={htmlStringBodyContent}
           data-testid="props"
@@ -449,7 +449,7 @@ describe("StructuredContent", () => {
           credit: "Image credit",
           position: "left",
           size: "medium",
-          src: "https://placeimg.com/400/300/animals",
+          src: "http://placekitten.com/400/300",
         }}
         ref={ref}
       />

--- a/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
+++ b/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`StructuredContent renders the UI snapshot 1`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="http://placekitten.com/400/300"
+        src="//placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -81,7 +81,7 @@ exports[`StructuredContent renders the UI snapshot 2`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="http://placekitten.com/400/300"
+        src="//placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -195,7 +195,7 @@ exports[`StructuredContent renders the UI snapshot 4`] = `
     <img
       alt="Image alt text"
       className="css-0"
-      src="http://placekitten.com/400/300"
+      src="//placekitten.com/400/300"
     />
   </div>
   <div
@@ -229,7 +229,7 @@ exports[`StructuredContent renders the UI snapshot 5`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="http://placekitten.com/400/300"
+        src="//placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -306,7 +306,7 @@ exports[`StructuredContent renders the UI snapshot 7`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="http://placekitten.com/400/300"
+        src="//placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -362,7 +362,7 @@ exports[`StructuredContent renders the UI snapshot 8`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="http://placekitten.com/400/300"
+        src="//placekitten.com/400/300"
       />
       <figcaption
         className="css-0"

--- a/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
+++ b/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`StructuredContent renders the UI snapshot 1`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="https://placeimg.com/400/300/animals"
+        src="http://placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -81,7 +81,7 @@ exports[`StructuredContent renders the UI snapshot 2`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="https://placeimg.com/400/300/animals"
+        src="http://placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -195,7 +195,7 @@ exports[`StructuredContent renders the UI snapshot 4`] = `
     <img
       alt="Image alt text"
       className="css-0"
-      src="https://placeimg.com/400/300/animals"
+      src="http://placekitten.com/400/300"
     />
   </div>
   <div
@@ -229,7 +229,7 @@ exports[`StructuredContent renders the UI snapshot 5`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="https://placeimg.com/400/300/animals"
+        src="http://placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -306,7 +306,7 @@ exports[`StructuredContent renders the UI snapshot 7`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="https://placeimg.com/400/300/animals"
+        src="http://placekitten.com/400/300"
       />
       <figcaption
         className="css-0"
@@ -362,7 +362,7 @@ exports[`StructuredContent renders the UI snapshot 8`] = `
       <img
         alt="Image alt text"
         className="css-0"
-        src="https://placeimg.com/400/300/animals"
+        src="http://placekitten.com/400/300"
       />
       <figcaption
         className="css-0"

--- a/src/components/StyleGuide/Bidirectionality.mdx
+++ b/src/components/StyleGuide/Bidirectionality.mdx
@@ -90,7 +90,7 @@ the original and intentional design layout is achieved in the RTL direction.
       imageType="circle"
       marginEnd="30px"
       size="xsmall"
-      src="https://placeimg.com/400/400/animals"
+      src="https://placekitten.com/400/400"
     />
   </Box>
   <VStack align="stretch">
@@ -120,7 +120,7 @@ the original and intentional design layout is achieved in the RTL direction.
             imageType="circle"
             marginEnd="30px"
             size="xsmall"
-            src="https://placeimg.com/400/400/animals"
+            src="https://placekitten.com/400/400"
           />
         </Box>
         <VStack align="stretch">
@@ -139,7 +139,7 @@ the original and intentional design layout is achieved in the RTL direction.
             imageType="circle"
             marginEnd="30px"
             size="xsmall"
-            src="https://placeimg.com/400/400/animals"
+            src="https://placekitten.com/400/400"
           />
         </Box>
         <VStack align="stretch">

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -268,12 +268,12 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
               ]}
             />
             <Hero
-              backgroundImageSrc="https://placeimg.com/2400/800/nature/grayscale"
+              backgroundImageSrc="http://placekitten.com/g/2400/800"
               heroType="campaign"
               heading={<Heading level="one" id="1" text="Hero Campaign" />}
               imageProps={{
                 alt: "Image example",
-                src: "https://placeimg.com/800/400/animals",
+                src: "http://placekitten.com/800/400",
               }}
               subHeaderText={otherSubHeaderText}
             />
@@ -345,7 +345,7 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
                 alt: "Alt text",
                 aspectRatio: "square",
                 size: "small",
-                src: "https://placeimg.com/400/200/animals",
+                src: "http://placekitten.com/400/200",
               }}
               isCentered
             >

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -268,12 +268,12 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
               ]}
             />
             <Hero
-              backgroundImageSrc="http://placekitten.com/g/2400/800"
+              backgroundImageSrc="//placekitten.com/g/2400/800"
               heroType="campaign"
               heading={<Heading level="one" id="1" text="Hero Campaign" />}
               imageProps={{
                 alt: "Image example",
-                src: "http://placekitten.com/800/400",
+                src: "//placekitten.com/800/400",
               }}
               subHeaderText={otherSubHeaderText}
             />
@@ -345,7 +345,7 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
                 alt: "Alt text",
                 aspectRatio: "square",
                 size: "small",
-                src: "http://placekitten.com/400/200",
+                src: "//placekitten.com/400/200",
               }}
               isCentered
             >

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -117,7 +117,7 @@ export const OnImageComponents: Story = {
             caption="Square"
             aspectRatio="square"
             size="large"
-            src="http://placekitten.com/400/400"
+            src="//placekitten.com/400/400"
           />
         </Tooltip>
         <Tooltip content="fourByThree aspect ratio" shouldWrapChildren>
@@ -126,7 +126,7 @@ export const OnImageComponents: Story = {
             caption="Four by Three"
             aspectRatio="fourByThree"
             size="default"
-            src="http://placekitten.com/400/400"
+            src="//placekitten.com/400/400"
           />
         </Tooltip>
         <Tooltip content="threeByFour aspect ratio" shouldWrapChildren>
@@ -135,7 +135,7 @@ export const OnImageComponents: Story = {
             caption="Three by Four"
             aspectRatio="threeByFour"
             size="default"
-            src="http://placekitten.com/400/400"
+            src="//placekitten.com/400/400"
           />
         </Tooltip>
       </SimpleGrid>
@@ -173,7 +173,7 @@ export const UsingIconContent: Story = {
 
 export const UsingImageContent: Story = {
   render: () => (
-    <Tooltip content={<Image src="http://placekitten.com/300/300" alt="" />}>
+    <Tooltip content={<Image src="//placekitten.com/300/300" alt="" />}>
       Hover to see image
     </Tooltip>
   ),

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -117,7 +117,7 @@ export const OnImageComponents: Story = {
             caption="Square"
             aspectRatio="square"
             size="large"
-            src="https://placeimg.com/400/400/animals"
+            src="http://placekitten.com/400/400"
           />
         </Tooltip>
         <Tooltip content="fourByThree aspect ratio" shouldWrapChildren>
@@ -126,7 +126,7 @@ export const OnImageComponents: Story = {
             caption="Four by Three"
             aspectRatio="fourByThree"
             size="default"
-            src="https://placeimg.com/400/400/animals"
+            src="http://placekitten.com/400/400"
           />
         </Tooltip>
         <Tooltip content="threeByFour aspect ratio" shouldWrapChildren>
@@ -135,7 +135,7 @@ export const OnImageComponents: Story = {
             caption="Three by Four"
             aspectRatio="threeByFour"
             size="default"
-            src="https://placeimg.com/400/400/animals"
+            src="http://placekitten.com/400/400"
           />
         </Tooltip>
       </SimpleGrid>
@@ -173,9 +173,7 @@ export const UsingIconContent: Story = {
 
 export const UsingImageContent: Story = {
   render: () => (
-    <Tooltip
-      content={<Image src="https://placeimg.com/300/300/animals?x=1" alt="" />}
-    >
+    <Tooltip content={<Image src="http://placekitten.com/300/300" alt="" />}>
       Hover to see image
     </Tooltip>
   ),

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -39,7 +39,7 @@ describe("Tooltip accessibility", () => {
 
   it("passes axe accessibility test with Image content", async () => {
     render(
-      <Tooltip content={<Image src="http://placekitten.com/300/300" alt="" />}>
+      <Tooltip content={<Image src="//placekitten.com/300/300" alt="" />}>
         {buttonLabel}
       </Tooltip>
     );

--- a/src/components/Tooltip/Tooltip.test.tsx
+++ b/src/components/Tooltip/Tooltip.test.tsx
@@ -39,11 +39,7 @@ describe("Tooltip accessibility", () => {
 
   it("passes axe accessibility test with Image content", async () => {
     render(
-      <Tooltip
-        content={
-          <Image src="https://placeimg.com/300/300/animals?x=1" alt="" />
-        }
-      >
+      <Tooltip content={<Image src="http://placekitten.com/300/300" alt="" />}>
         {buttonLabel}
       </Tooltip>
     );


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1301](https://jira.nypl.org/browse/DSD-1301).

## This PR does the following:

- Updates placeholder images to come from placekitten, rather than placeimg, which is being deprecated.

## How has this been tested?

- Locally in Storybook
- With unit tests

## Accessibility concerns or updates

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
