### PR TITLE
Fixing typo for header documentation

### DIFF
--- a/src/components/DevelopmentGuide/Header.mdx
+++ b/src/components/DevelopmentGuide/Header.mdx
@@ -45,7 +45,7 @@ The `Header` should be embedded on an NYPL app through the following code snippe
   code={`
 <style>
   #header-placeholder {
-    minheight: 70px;
+    min-height: 70px;
   }
   @media screen and (min-width: 1024px) {
     #header-placeholder {


### PR DESCRIPTION
## This PR does the following:

- The minHeight name is correct but only for Chakra and not for browsers. This is meant for any app and not just Chakra-based ones.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
