### PR TITLE
DSd-1401: Updating react-datepicker package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the version of the `react-datepicker` npm package.
+
 ## 1.6.1 (June 22, 2023)
 
 ### Adds

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@emotion/styled": "11.3.0",
         "downshift": "6.1.7",
         "framer-motion": "4.1.17",
-        "react-datepicker": "4.1.1",
+        "react-datepicker": "4.14.1",
         "react-intersection-observer": "9.2.2",
         "system-font-css": "2.0.2",
         "tough-cookie": "4.0.0",
@@ -28642,20 +28642,20 @@
       }
     },
     "node_modules/react-datepicker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.1.1.tgz",
-      "integrity": "sha512-vtZIA7MbUrffRw1CHiyOGtmTO/tTdZGr5BYaiRucHMTb6rCqA8TkaQhzX6tTwMwP8vV38Khv4UWohrJbiX1rMw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.14.1.tgz",
+      "integrity": "sha512-uiPfjD+25KI5WOfCAXlzQgSLyksTagk3wwKn1KGBdF19YtybFDregRmcoNNGveQHAbT10SJZdCvk/8pbc7zxJg==",
       "dependencies": {
         "@popperjs/core": "^2.9.2",
         "classnames": "^2.2.6",
-        "date-fns": "^2.0.1",
+        "date-fns": "^2.24.0",
         "prop-types": "^15.7.2",
-        "react-onclickoutside": "^6.10.0",
-        "react-popper": "^2.2.5"
+        "react-onclickoutside": "^6.12.2",
+        "react-popper": "^2.3.0"
       },
       "peerDependencies": {
-        "react": "^16.9.0 || ^17",
-        "react-dom": "^16.9.0 || ^17"
+        "react": "^16.9.0 || ^17 || ^18",
+        "react-dom": "^16.9.0 || ^17 || ^18"
       }
     },
     "node_modules/react-docgen": {
@@ -55881,16 +55881,16 @@
       "requires": {}
     },
     "react-datepicker": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.1.1.tgz",
-      "integrity": "sha512-vtZIA7MbUrffRw1CHiyOGtmTO/tTdZGr5BYaiRucHMTb6rCqA8TkaQhzX6tTwMwP8vV38Khv4UWohrJbiX1rMw==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-4.14.1.tgz",
+      "integrity": "sha512-uiPfjD+25KI5WOfCAXlzQgSLyksTagk3wwKn1KGBdF19YtybFDregRmcoNNGveQHAbT10SJZdCvk/8pbc7zxJg==",
       "requires": {
         "@popperjs/core": "^2.9.2",
         "classnames": "^2.2.6",
-        "date-fns": "^2.0.1",
+        "date-fns": "^2.24.0",
         "prop-types": "^15.7.2",
-        "react-onclickoutside": "^6.10.0",
-        "react-popper": "^2.2.5"
+        "react-onclickoutside": "^6.12.2",
+        "react-popper": "^2.3.0"
       }
     },
     "react-docgen": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5328,6 +5328,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@jridgewell/source-map": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
@@ -31484,21 +31495,22 @@
       }
     },
     "node_modules/terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "devOptional": true,
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
+      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "optional": true,
       "peer": true,
       "dependencies": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map-support": "~0.5.20"
       },
       "bin": {
         "terser": "bin/terser"
       },
       "engines": {
-        "node": ">=6.0.0"
+        "node": ">=10"
       }
     },
     "node_modules/terser-webpack-plugin": {
@@ -31524,6 +31536,13 @@
       "peerDependencies": {
         "webpack": "^4.0.0"
       }
+    },
+    "node_modules/terser-webpack-plugin/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true,
+      "peer": true
     },
     "node_modules/terser-webpack-plugin/node_modules/find-cache-dir": {
       "version": "2.1.0",
@@ -31678,6 +31697,24 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/terser-webpack-plugin/node_modules/terser": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "commander": "^2.20.0",
+        "source-map": "~0.6.1",
+        "source-map-support": "~0.5.12"
+      },
+      "bin": {
+        "terser": "bin/terser"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/terser-webpack-plugin/node_modules/webpack-sources": {
       "version": "1.4.3",
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -31689,22 +31726,25 @@
         "source-map": "~0.6.1"
       }
     },
+    "node_modules/terser/node_modules/acorn": {
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/terser/node_modules/commander": {
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "devOptional": true,
+      "optional": true,
       "peer": true
-    },
-    "node_modules/terser/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "devOptional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/test-exclude": {
       "version": "6.0.0",
@@ -38089,6 +38129,17 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
       "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw=="
+    },
+    "@jridgewell/source-map": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+      "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+      "optional": true,
+      "peer": true,
+      "requires": {
+        "@jridgewell/gen-mapping": "^0.3.0",
+        "@jridgewell/trace-mapping": "^0.3.9"
+      }
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.15",
@@ -58178,29 +58229,30 @@
       }
     },
     "terser": {
-      "version": "4.8.1",
-      "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
-      "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
-      "devOptional": true,
+      "version": "5.19.0",
+      "resolved": "https://registry.npmjs.org/terser/-/terser-5.19.0.tgz",
+      "integrity": "sha512-JpcpGOQLOXm2jsomozdMDpd5f8ZHh1rR48OFgWUH3QsyZcfPgv2qDCYbcDEAYNd4OZRj2bWYKpwdll/udZCk/Q==",
+      "optional": true,
       "peer": true,
       "requires": {
+        "@jridgewell/source-map": "^0.3.3",
+        "acorn": "^8.8.2",
         "commander": "^2.20.0",
-        "source-map": "~0.6.1",
-        "source-map-support": "~0.5.12"
+        "source-map-support": "~0.5.20"
       },
       "dependencies": {
+        "acorn": {
+          "version": "8.10.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
+          "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+          "optional": true,
+          "peer": true
+        },
         "commander": {
           "version": "2.20.3",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-          "devOptional": true,
-          "peer": true
-        },
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-          "devOptional": true,
+          "optional": true,
           "peer": true
         }
       }
@@ -58223,6 +58275,13 @@
         "worker-farm": "^1.7.0"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "peer": true
+        },
         "find-cache-dir": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-2.1.0.tgz",
@@ -58336,6 +58395,18 @@
           "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
           "dev": true,
           "peer": true
+        },
+        "terser": {
+          "version": "4.8.1",
+          "resolved": "https://registry.npmjs.org/terser/-/terser-4.8.1.tgz",
+          "integrity": "sha512-4GnLC0x667eJG0ewJTa6z/yXrbLGv80D9Ru6HIpCQmO+Q4PfEtBFi0ObSckqwL6VyQv/7ENJieXHo2ANmdQwgw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "commander": "^2.20.0",
+            "source-map": "~0.6.1",
+            "source-map-support": "~0.5.12"
+          }
         },
         "webpack-sources": {
           "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@emotion/styled": "11.3.0",
     "downshift": "6.1.7",
     "framer-motion": "4.1.17",
-    "react-datepicker": "4.1.1",
+    "react-datepicker": "4.14.1",
     "react-intersection-observer": "9.2.2",
     "system-font-css": "2.0.2",
     "tough-cookie": "4.0.0",

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -839,7 +839,7 @@ describe("DatePicker", () => {
       userEvent.click(input);
       // The popup displays. We are currently on 08/15/2021.
       expect(
-        screen.getByText(monthArray["7"], { exact: false })
+        screen.getAllByText(monthArray["7"], { exact: false })[0]
       ).toBeInTheDocument();
       userEvent.click(screen.getByLabelText("Next Month"));
       userEvent.click(screen.getByLabelText("Next Month"));

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -24,8 +24,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="basic-start-wrapper"
@@ -78,8 +83,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="basic-end-wrapper"
@@ -160,8 +170,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="no-label-start-wrapper"
@@ -214,8 +229,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="no-label-end-wrapper"
@@ -296,8 +316,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="custom-format-start-wrapper"
@@ -350,8 +375,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="custom-format-end-wrapper"
@@ -432,8 +462,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="invalid-start-wrapper"
@@ -495,8 +530,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="invalid-end-wrapper"
@@ -594,8 +634,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="disabled-start-wrapper"
@@ -648,8 +693,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="disabled-end-wrapper"
@@ -727,8 +777,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="basic-start-wrapper"
@@ -796,8 +851,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="no-label-start-wrapper"
@@ -859,8 +919,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="custom-format-start-wrapper"
@@ -928,8 +993,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="invalid-start-wrapper"
@@ -1006,8 +1076,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="disabled-start-wrapper"
@@ -1083,8 +1158,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="chakra-start-wrapper"
@@ -1161,8 +1241,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="props-start-wrapper"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1401](https://jira.nypl.org/browse/DSD-1401)

## This PR does the following:

- Updates the `react-datepicker` npm package. The previous version was logging a warning which is annoying to see in the build process:
<img width="884" alt="Screen Shot 2023-06-29 at 4 42 16 PM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/ff0e7f0e-f428-4a90-abbf-c59dcac59820">

- This has been fixed in the latest version.
- There are no functional or visual changes.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
