### PR TITLE
DSD-1505: redux of overline and subtitle for Heading

### DIFF
--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -55,7 +55,7 @@ proper order and not skipping any. For example, the following is invalid HTML:
 />
 
 When either the overline or subtitle elements are rendered as part of the
-heading, then the whole lockup should be wrapped in an `<hgroup>` element with
+heading, then the whole lockup will be wrapped in an `<hgroup>` element with
 proper `role` and `aria-roledescription` attributes applied.
 
 <Source
@@ -164,8 +164,14 @@ each `Heading` component and the `size` prop is used to adjust the text size.
 
 The `Heading` component offers two additional text elements as part of the full
 heading lockup: overline and subtitle. When the `overline` or `subtitle` props
-are passed, the `Heading` component will handle the styling for the
-corresponding text element.
+are passed, the `Heading` component will handle the DOM structure and styling
+for the corresponding text elements.
+
+The styling of the overline and subtitle elements include differentiating the
+font size for both elements based on the `size` prop. For `display1`,
+`heading1`, and `heading2`, the text for these elements will be one size. And
+for `heading3`, `heading4`, `heading5`, and `heading6`, the text for these
+elements will be another (smaller) size.
 
 **Note:** In the examples below, the `level` prop is set to `level="h1"` for
 each `Heading` component and the `size` prop is used to adjust the text size.

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -20,6 +20,7 @@ import Link from "../Link/Link";
 - {<Link href="#updated-typographic-styles" target="_self">Updated Typographic Styles</Link>}
 - {<Link href="#native-heading-elements" target="_self">Native Heading Elements</Link>}
 - {<Link href="#size-styles" target="_self">Size Styles</Link>}
+- {<Link href="#overline-and-subtitle" target="_self">Overline and Subtitle Elements</Link>}
 - {<Link href="#heading-with-bold-text" target="_self">Heading with Bold Text</Link>}
 - {<Link href="#heading-with-links" target="_self">Heading with Links</Link>}
 
@@ -70,13 +71,13 @@ The `level` prop can be used to set a native heading element (ex. `<h1>`,
 `<h2>`, ...).
 
 The default text styles for the native heading element levels are directly
-related to the corresponding values of the `size` prop. 
+related to the corresponding values of the `size` prop.
 
-For example, for the __recommended__ options listed below, the `heading1` size
+For example, for the **recommended** options listed below, the `heading1` size
 is the default style for the `<h1>` element. The `heading2` size is the default
 style for the `<h2>` element. And so on.
 
-For the __deprecated__ options listed below, the `primary` size is the default
+For the **deprecated** options listed below, the `primary` size is the default
 style for the `<h1>` element. The `secondary` size is the default style for the
 `<h2>` element. The `tertiary` size is the default style for the `<h3>` element.
 And the `callout` size is the default style for the `<h4>` element. `<h5>` and
@@ -105,7 +106,7 @@ older design requirements.
 
 When adopting the new `level` values, there is a direct relationship between the
 deprecated values and the new values. For example, from a native element
-persepctive, `two` should be  replaced with `h2`, as they will both render the
+persepctive, `two` should be replaced with `h2`, as they will both render the
 `<h2>` element. However, there is no direct relationship between the styles
 applied to the native elements. Make sure to utilize the `size` prop to render
 the proper size styles.
@@ -144,6 +145,28 @@ Note: The `level` prop for the `Heading` components in this example are all set
 to `level="one"`.
 
 <Canvas of={HeadingStories.SizeStylesDeprecated} />
+
+## Overline and Subtitle
+
+The `Heading` component offers two additional text elements as part of the full
+heading lockup: overline and subtitle. When the `overline` or `subtitle` props
+are passed, the `Heading` component will handle the styling for the
+corresponding text element.
+
+Use the `overline` prop to set the text for an eyebrow text element that sits
+above the heading text.
+
+<Canvas of={HeadingStories.Overline} />
+
+Use the `subtitle` prop to set the text for a text element that sits below the
+heading text.
+
+<Canvas of={HeadingStories.Subtitle} />
+
+Or use both the `overview` and `subtitle` props in combination to render a fully
+composed heading lockup.
+
+<Canvas of={HeadingStories.OverlineAndSubtitle} />
 
 ## Heading with Bold Text
 

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -54,6 +54,20 @@ proper order and not skipping any. For example, the following is invalid HTML:
   language="html"
 />
 
+When either the overline or subtitle elements are rendered as part of the
+heading, then the whole lockup should be wrapped in an `<hgroup>` element with
+proper `role` and `aria-roledescription` attributes applied.
+
+<Source
+  code={`
+<hgroup role="group" aria-roledescription="Heading group">
+  <h2>Heading Title</h2>
+  <p aria-roledescription="subtitle">Subtitle</p>
+</hgroup>
+`}
+  language="html"
+/>
+
 Resources:
 
 - [W3C WAI Headings](https://www.w3.org/WAI/tutorials/page-structure/headings/)
@@ -128,8 +142,8 @@ For usage recommendations of each of the `size` options, please refer to the
 [Typography Style
 Guide](../?path=/docs/style-guide-typography--docs#size-options).
 
-Note: The `level` prop for the `Heading` components in this example are all set
-to `level="h1"`.
+**Note:** In the examples below, the `level` prop is set to `level="h1"` for
+each `Heading` component and the `size` prop is used to adjust the text size.
 
 <Canvas of={HeadingStories.SizeStyles} />
 
@@ -141,8 +155,8 @@ older design requirements.
 
 `primary`, `secondary`, `tertiary`, `callout`
 
-Note: The `level` prop for the `Heading` components in this example are all set
-to `level="one"`.
+**Note:** In the examples below, the `level` prop is set to `level="one"` for
+each `Heading` component and the `size` prop is used to adjust the text size.
 
 <Canvas of={HeadingStories.SizeStylesDeprecated} />
 
@@ -153,15 +167,24 @@ heading lockup: overline and subtitle. When the `overline` or `subtitle` props
 are passed, the `Heading` component will handle the styling for the
 corresponding text element.
 
+**Note:** In the examples below, the `level` prop is set to `level="h1"` for
+each `Heading` component and the `size` prop is used to adjust the text size.
+
+### Overline
+
 Use the `overline` prop to set the text for an eyebrow text element that sits
-above the heading text.
+above the heading text. The overline text is styled to be all uppercase.
 
 <Canvas of={HeadingStories.Overline} />
+
+### Subtitle
 
 Use the `subtitle` prop to set the text for a text element that sits below the
 heading text.
 
 <Canvas of={HeadingStories.Subtitle} />
+
+### Full Heading Lockup
 
 Or use both the `overview` and `subtitle` props in combination to render a fully
 composed heading lockup.

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -40,7 +40,9 @@ export const WithControls: Story = {
     isLowercase: false,
     noSpace: true,
     level: "h2",
+    overline: undefined,
     size: undefined,
+    subtitle: undefined,
     text: "Default Heading",
     url: undefined,
     urlClass: undefined,
@@ -193,6 +195,196 @@ export const SizeStylesDeprecated: Story = {
         level="one"
         size="callout"
         text="(callout) Lorem ipsum dolor"
+      />
+    </VStack>
+  ),
+};
+
+export const Overline: Story = {
+  render: () => (
+    <VStack align="left" spacing="l">
+      <Heading
+        id="heading-display1"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="display1"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading1"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="heading1"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading2"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="heading2"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading3"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="heading3"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading4"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="heading4"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading5"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="heading5"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading6"
+        level="h1"
+        noSpace
+        overline="Overline"
+        size="heading6"
+        text="Lorem ipsum dolor"
+      />
+    </VStack>
+  ),
+};
+
+export const Subtitle: Story = {
+  render: () => (
+    <VStack align="left" spacing="l">
+      <Heading
+        id="heading-display1"
+        level="h1"
+        noSpace
+        size="display1"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading1"
+        level="h1"
+        noSpace
+        size="heading1"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading2"
+        level="h1"
+        noSpace
+        size="heading2"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading3"
+        level="h1"
+        noSpace
+        size="heading3"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading4"
+        level="h1"
+        noSpace
+        size="heading4"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading5"
+        level="h1"
+        noSpace
+        size="heading5"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading6"
+        level="h1"
+        noSpace
+        size="heading6"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+    </VStack>
+  ),
+};
+
+export const OverlineAndSubtitle: Story = {
+  name: "Overline and Subtitle",
+  render: () => (
+    <VStack align="left" spacing="l">
+      <Heading
+        id="heading-display1"
+        level="h1"
+        overline="Overline"
+        size="display1"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading1"
+        level="h1"
+        overline="Overline"
+        size="heading1"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading2"
+        level="h1"
+        overline="Overline"
+        size="heading2"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading3"
+        level="h1"
+        overline="Overline"
+        size="heading3"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading4"
+        level="h1"
+        overline="Overline"
+        size="heading4"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading5"
+        level="h1"
+        overline="Overline"
+        size="heading5"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        id="heading-heading6"
+        level="h1"
+        overline="Overline"
+        size="heading6"
+        subtitle="The subtitle text sits below the main heading text."
+        text="Lorem ipsum dolor"
       />
     </VStack>
   ),

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -180,6 +180,28 @@ describe("Heading", () => {
     const withOtherProps = renderer
       .create(<Heading id="props" text="Heading" data-testid="props" />)
       .toJSON();
+    const withOverline = renderer
+      .create(
+        <Heading
+          id="customDisplaySize"
+          level="one"
+          overline="Overline"
+          size="secondary"
+          text="Heading with Secondary size"
+        />
+      )
+      .toJSON();
+    const withSubtitle = renderer
+      .create(
+        <Heading
+          id="customDisplaySize"
+          level="one"
+          size="secondary"
+          subtitle="This is the subtitle"
+          text="Heading with Secondary size"
+        />
+      )
+      .toJSON();
     const withOverlineAndSubtitle = renderer
       .create(
         <Heading
@@ -201,6 +223,8 @@ describe("Heading", () => {
     expect(withCustomLink).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
+    expect(withOverline).toMatchSnapshot();
+    expect(withSubtitle).toMatchSnapshot();
     expect(withOverlineAndSubtitle).toMatchSnapshot();
   });
 

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -6,9 +6,22 @@ import renderer from "react-test-renderer";
 import Heading from "./Heading";
 
 describe("Heading Accessibility", () => {
-  it("passes axe accessibility test", async () => {
+  it("passes axe accessibility test as standalone heading element", async () => {
     const { container } = render(
       <Heading id="h1" level="one" text="Heading 1" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
+  it("passes axe accessibility test with hgroup element", async () => {
+    const { container } = render(
+      <Heading
+        id="h1"
+        level="one"
+        overline="Overline"
+        subtitle="Subtitle text"
+        text="Heading 1"
+      />
     );
     expect(await axe(container)).toHaveNoViolations();
   });

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -104,6 +104,28 @@ describe("Heading", () => {
     });
   });
 
+  it("uses new custom display size", () => {
+    render(<Heading id="h1" level="h2" text="Heading with heading2 size" />);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveStyle({
+      "font-size": "1.5em",
+    });
+  });
+
+  it("renders overline and subtitle elements", () => {
+    render(
+      <Heading
+        id="h1"
+        level="h1"
+        overline="Overline"
+        subtitle="This is the subtitle"
+        text="Heading 1"
+      />
+    );
+    expect(screen.getByRole("heading", { level: 1 })).toBeInTheDocument();
+    expect(screen.getByText("Overline")).toBeInTheDocument();
+    expect(screen.getByText("This is the subtitle")).toBeInTheDocument();
+  });
+
   it("renders the UI snapshot correctly", () => {
     const basic = renderer
       .create(<Heading id="basic" level="one" text="Heading text" />)
@@ -158,6 +180,18 @@ describe("Heading", () => {
     const withOtherProps = renderer
       .create(<Heading id="props" text="Heading" data-testid="props" />)
       .toJSON();
+    const withOverlineAndSubtitle = renderer
+      .create(
+        <Heading
+          id="customDisplaySize"
+          level="one"
+          overline="Overline"
+          size="secondary"
+          subtitle="This is the subtitle"
+          text="Heading with Secondary size"
+        />
+      )
+      .toJSON();
 
     expect(basic).toMatchSnapshot();
     expect(basicWithChildText).toMatchSnapshot();
@@ -167,6 +201,7 @@ describe("Heading", () => {
     expect(withCustomLink).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
+    expect(withOverlineAndSubtitle).toMatchSnapshot();
   });
 
   it("passes a ref to the heading element", () => {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -168,12 +168,46 @@ export const Heading = chakra(
       ) : (
         contentToRender
       );
-      /* The syntax for responsive styles is not working properly for fontSize
-       * in the theme object, so logic for the responsive styleshas been written here. */
+
+      /** *********************************************************************
+       * The syntax for responsive styles is not working properly for fontSize
+       * in the theme object, so logic for the responsive styleshas been written
+       * here.
+       * *********************************************************************/
+
+      /** The default style used to map the `level` value to the corresponding
+       * `size` value. */
       const defaultRoot = "heading";
-      const variantRoot = variant.slice(0, -1); // get the root of the variant being set
-      const finalRoot = variantRoot === "h" ? defaultRoot : variantRoot; // set the final root used to build the style
-      const sizeIndex = parseInt(variant.at(-1)); // get last character in string ${s} variant.at(-1)
+
+      /** The heading size index that acts as a separator between the smaller
+       * and larger sizing styles of the overline and subtitle elements. This
+       * demarcation is purely based on design and aesthetics. */
+      const overlineSubtitleSizeDemacation = 2;
+
+      /**  Most variant values have a number at the end, so let's remove the
+       * last character from that value and see what's left. */
+      const variantRoot = variant.slice(0, -1);
+
+      /** The `level` values should map to a corresponding `size` value. If the
+       * root is "h", then reassign the root to the `defaultRoot`. This value
+       * will be used to build the style object. */
+      const finalRoot = variantRoot === "h" ? defaultRoot : variantRoot;
+
+      /** The new heading styles use a number with the variant style to indicate
+       * which style should be used. For examepl, heading1, heading2, and so on.
+       * If that number is set, we'll need it later. Let's grab the last
+       * character in string now, so we can use later in the code. In fact,
+       * let's gran that character and type is as an integer. */
+      const sizeIndex = parseInt(variant.at(-1));
+
+      /** The 2023 typography styles call for the Heading component to be
+       * responsive and set differing font-size values for desktop and mobile.
+       * We can tell if the new styles are being used if the size index is in
+       * fact a number. If it is a number, let's go ahead and setup the
+       * responsive styles. If it is not a number, then the deprecated styles
+       * are being used and we don't need to worry about responsive font-size
+       * styles.
+       * */
       const responsiveStyles = !isNaN(sizeIndex)
         ? isLargerThanMobile
           ? {
@@ -181,17 +215,31 @@ export const Heading = chakra(
             }
           : { fontSize: `mobile.heading.${finalRoot}${sizeIndex}` }
         : undefined;
+
+      /** If the overline element is rendered, we'll also need responsive styles
+       * for that. */
       const overlineSize = !isNaN(sizeIndex)
-        ? sizeIndex <= 2
+        ? sizeIndex <= overlineSubtitleSizeDemacation
           ? "overline1"
           : "overline2"
         : undefined;
+
+      /** If the subtitle element is rendered, we'll also need responsive styles
+       * for that. */
       const subtitleSize = !isNaN(sizeIndex)
-        ? sizeIndex <= 2
+        ? sizeIndex <= overlineSubtitleSizeDemacation
           ? "subtitle1"
           : "subtitle2"
         : undefined;
+
+      /** The styles that should be applied to the outer-most wrapper of the
+       * Heading component. */
       const wrapperStyles = styles.headingWrapper;
+
+      /** The styles for the actual native heading element. If the native
+       * element is going to sit by itself, without the overline or subtitle
+       * elements, then the wrapper styles can be applied directly to the native
+       * element. Otherwise, the wrapper styles will be used later. */
       const headingStyles =
         overline || subtitle
           ? {
@@ -203,6 +251,8 @@ export const Heading = chakra(
               ...responsiveStyles,
               ...wrapperStyles,
             };
+
+      /** The final text elements that will make up the rendered component. */
       const finalContent = (
         <>
           {overline && (
@@ -229,8 +279,18 @@ export const Heading = chakra(
           )}
         </>
       );
+
+      /** Return the final content. If either the overline or subtitle elements
+       * are included, then the heading lockup needs to be wrapped in am
+       * <hgroup> element for semantic and accessibility reasons. */
       return overline || subtitle ? (
-        <Box as="hgroup" sx={{ ...wrapperStyles }} {...rest}>
+        <Box
+          as="hgroup"
+          role="group"
+          aria-roledescription="Heading group"
+          sx={{ ...wrapperStyles }}
+          {...rest}
+        >
           {finalContent}
         </Box>
       ) : (

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -1,11 +1,13 @@
 import {
+  Box,
   chakra,
   Heading as ChakraHeading,
-  useStyleConfig,
+  useMultiStyleConfig,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 import Link from "../Link/Link";
+import Text from "../Text/Text";
 import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 export const headingSizesArray = [
@@ -42,7 +44,8 @@ export type HeadingLevels = typeof headingLevelsArray[number];
 export interface HeadingProps {
   /** Optional className that appears in addition to `heading` */
   className?: string;
-  /** Optional ID that other components can cross reference for accessibility purposes */
+  /** Optional ID that other components can cross reference for accessibility
+   * purposes */
   id?: string;
   /** Optional prop used to show capitalized text */
   isCapitalized?: boolean;
@@ -53,16 +56,20 @@ export interface HeadingProps {
   /** Optional number 1-6 used to create the `<h*>` tag; if prop is not passed,
    * `Heading` will default to `<h2>` */
   level?: HeadingLevels;
-  /** Optional size used to override the default styles of the semantic HTM
-   * `<h>` elements */
-  size?: HeadingSizes;
   /** Optional prop used to remove default spacing */
   noSpace?: boolean;
+  /** String to populate the overline element */
+  overline?: string;
+  /** Optional size used to override the default styles of the native HTML `<h>`
+   * elements */
+  size?: HeadingSizes;
+  /** String to populate the subtitle element */
+  subtitle?: string;
   /** Inner text of the `<h*>` element */
   text?: string;
   /** Optional URL that header points to; when `url` prop is passed to
-   * `Heading`, a child `<a>` element is created and the heading text becomes
-   * an active link */
+   * `Heading`, a child `<a>` element is created and the heading text becomes an
+   * active link */
   url?: string;
   /** Optional className for the URL when the `url` prop is passed */
   urlClass?: string;
@@ -100,7 +107,9 @@ export const Heading = chakra(
         isLowercase,
         level = "two",
         noSpace,
+        overline,
         size,
+        subtitle,
         text,
         url,
         urlClass,
@@ -108,7 +117,7 @@ export const Heading = chakra(
       } = props;
       const finalLevel = getMappedLevel(level);
       const variant = size ? size : level;
-      const styles = useStyleConfig("Heading", {
+      const styles = useMultiStyleConfig("Heading", {
         variant,
         isCapitalized,
         isUppercase,
@@ -172,20 +181,60 @@ export const Heading = chakra(
             }
           : { fontSize: `mobile.heading.${finalRoot}${sizeIndex}` }
         : undefined;
-      return (
-        <ChakraHeading
-          as={asHeading}
-          className={className}
-          id={id}
-          ref={ref}
-          sx={{
-            ...styles,
-            ...responsiveStyles,
-          }}
-          {...rest}
-        >
-          {content}
-        </ChakraHeading>
+      const overlineSize = !isNaN(sizeIndex)
+        ? sizeIndex <= 2
+          ? "overline1"
+          : "overline2"
+        : undefined;
+      const subtitleSize = !isNaN(sizeIndex)
+        ? sizeIndex <= 2
+          ? "subtitle1"
+          : "subtitle2"
+        : undefined;
+      const wrapperStyles = styles.headingWrapper;
+      const headingStyles =
+        overline || subtitle
+          ? {
+              ...styles,
+              ...responsiveStyles,
+            }
+          : {
+              ...styles,
+              ...responsiveStyles,
+              ...wrapperStyles,
+            };
+      const finalContent = (
+        <>
+          {overline && (
+            <Text mb="xxs" size={overlineSize}>
+              {overline}
+            </Text>
+          )}
+          <ChakraHeading
+            as={asHeading}
+            className={className}
+            id={id}
+            ref={ref}
+            sx={{
+              ...headingStyles,
+            }}
+            {...rest}
+          >
+            {content}
+          </ChakraHeading>
+          {subtitle && (
+            <Text mt="xs" noSpace size={subtitleSize}>
+              {subtitle}
+            </Text>
+          )}
+        </>
+      );
+      return overline || subtitle ? (
+        <Box as="hgroup" sx={{ ...wrapperStyles }} {...rest}>
+          {finalContent}
+        </Box>
+      ) : (
+        <>{finalContent}</>
       );
     }
   )

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -182,7 +182,7 @@ export const Heading = chakra(
       /** The heading size index that acts as a separator between the smaller
        * and larger sizing styles of the overline and subtitle elements. This
        * demarcation is purely based on design and aesthetics. */
-      const overlineSubtitleSizeDemacation = 2;
+      const overlineSubtitleSizeDemarcation = 2;
 
       /**  Most variant values have a number at the end, so let's remove the
        * last character from that value and see what's left. */
@@ -194,10 +194,10 @@ export const Heading = chakra(
       const finalRoot = variantRoot === "h" ? defaultRoot : variantRoot;
 
       /** The new heading styles use a number with the variant style to indicate
-       * which style should be used. For examepl, heading1, heading2, and so on.
+       * which style should be used. For example, heading1, heading2, and so on.
        * If that number is set, we'll need it later. Let's grab the last
        * character in string now, so we can use later in the code. In fact,
-       * let's gran that character and type is as an integer. */
+       * let's grab that character and type it as an integer. */
       const sizeIndex = parseInt(variant.at(-1));
 
       /** The 2023 typography styles call for the Heading component to be
@@ -219,7 +219,7 @@ export const Heading = chakra(
       /** If the overline element is rendered, we'll also need responsive styles
        * for that. */
       const overlineSize = !isNaN(sizeIndex)
-        ? sizeIndex <= overlineSubtitleSizeDemacation
+        ? sizeIndex <= overlineSubtitleSizeDemarcation
           ? "overline1"
           : "overline2"
         : undefined;
@@ -227,7 +227,7 @@ export const Heading = chakra(
       /** If the subtitle element is rendered, we'll also need responsive styles
        * for that. */
       const subtitleSize = !isNaN(sizeIndex)
-        ? sizeIndex <= overlineSubtitleSizeDemacation
+        ? sizeIndex <= overlineSubtitleSizeDemarcation
           ? "subtitle1"
           : "subtitle2"
         : undefined;

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -88,3 +88,26 @@ exports[`Heading renders the UI snapshot correctly 8`] = `
   Heading
 </h2>
 `;
+
+exports[`Heading renders the UI snapshot correctly 9`] = `
+<hgroup
+  className="css-0"
+>
+  <p
+    className="chakra-text css-e3ddnr"
+  >
+    Overline
+  </p>
+  <h1
+    className="chakra-heading css-1xdhyk6"
+    id="customDisplaySize"
+  >
+    Heading with Secondary size
+  </h1>
+  <p
+    className="chakra-text css-dqoc1s"
+  >
+    This is the subtitle
+  </p>
+</hgroup>
+`;

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -91,7 +91,49 @@ exports[`Heading renders the UI snapshot correctly 8`] = `
 
 exports[`Heading renders the UI snapshot correctly 9`] = `
 <hgroup
+  aria-roledescription="Heading group"
   className="css-0"
+  role="group"
+>
+  <p
+    className="chakra-text css-e3ddnr"
+  >
+    Overline
+  </p>
+  <h1
+    className="chakra-heading css-1xdhyk6"
+    id="customDisplaySize"
+  >
+    Heading with Secondary size
+  </h1>
+</hgroup>
+`;
+
+exports[`Heading renders the UI snapshot correctly 10`] = `
+<hgroup
+  aria-roledescription="Heading group"
+  className="css-0"
+  role="group"
+>
+  <h1
+    className="chakra-heading css-1xdhyk6"
+    id="customDisplaySize"
+  >
+    Heading with Secondary size
+  </h1>
+  <p
+    className="chakra-text css-dqoc1s"
+  >
+    This is the subtitle
+  </p>
+</hgroup>
+`;
+
+exports[`Heading renders the UI snapshot correctly 11`] = `
+<hgroup
+  aria-roledescription="Heading group"
+  className="css-0"
+  role="group"
 >
   <p
     className="chakra-text css-e3ddnr"

--- a/src/components/StyleGuide/Typography.mdx
+++ b/src/components/StyleGuide/Typography.mdx
@@ -680,12 +680,13 @@ The `size` prop can be used to render a specific style from the DS default text 
   mb="m"
   p="inset.default"
 >
-  <Heading size="heading2" border="0" mb="xs">
-    Lorem ipsum dolor
-  </Heading>
-  <Text size="subtitle1" m="0">
-    Subtitle nullam id dolor id nibh ultricies vehicula ut id elit.
-  </Text>
+  <Heading
+    border="0"
+    mb="xs"
+    size="heading2"
+    subtitle="Subtitle nullam id dolor id nibh ultricies vehicula ut id elit."
+    text="Lorem ipsum dolor"
+  />
 </Box>
 }
 
@@ -721,12 +722,13 @@ The `size` prop can be used to render a specific style from the DS default text 
   mb="m"
   p="inset.default"
 >
-  <Heading size="heading5" border="0" mb="xxs">
-    Lorem ipsum dolor
-  </Heading>
-  <Text size="subtitle2" m="0">
-    Subtitle nullam id dolor id nibh ultricies vehicula ut id elit.
-  </Text>
+  <Heading
+    border="0"
+    mb="xs"
+    size="heading5"
+    subtitle="Subtitle nullam id dolor id nibh ultricies vehicula ut id elit."
+    text="Lorem ipsum dolor"
+  />
 </Box>
 }
 
@@ -740,6 +742,7 @@ The `size` prop can be used to render a specific style from the DS default text 
     heading element.
   </li>
   <li>Text set in this style SHOULD be one or two words in length.</li>
+  <li>The overline text is styled to be all uppercase.</li>
   <li>
     This style is for DS internal use only. It is used in the DS `Heading`
     component.
@@ -762,12 +765,12 @@ The `size` prop can be used to render a specific style from the DS default text 
   mb="m"
   p="inset.default"
 >
-  <Text size="overline1" m="0">
-    Overline
-  </Text>
-  <Heading size="heading2" border="0">
-    Lorem ipsum dolor
-  </Heading>
+  <Heading
+    border="0"
+    overline="Overline"
+    size="heading2"
+    text="Lorem ipsum dolor"
+  />
 </Box>
 }
 
@@ -803,12 +806,12 @@ The `size` prop can be used to render a specific style from the DS default text 
   mb="m"
   p="inset.default"
 >
-  <Text size="overline2" m="0">
-    Overline
-  </Text>
-  <Heading size="heading5" border="0">
-    Lorem ipsum dolor
-  </Heading>
+  <Heading
+    border="0"
+    overline="Overline"
+    size="heading5"
+    text="Lorem ipsum dolor"
+  />
 </Box>
 }
 

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -48,46 +48,39 @@ export const headings = {
     fontWeight: "heading.display1",
     letterSpacing: "1px",
     lineHeight: "1.05",
-    ...margins,
     width: "auto",
   },
   heading1: {
     fontWeight: "heading.heading1",
     letterSpacing: "1px",
     lineHeight: "1.05",
-    ...margins,
     width: "auto",
   },
   heading2: {
     fontWeight: "heading.heading2",
     letterSpacing: "1px",
     lineHeight: "1.15",
-    ...margins,
     width: "auto",
   },
   heading3: {
     fontWeight: "heading.heading3",
     letterSpacing: "1px",
     lineHeight: "1.15",
-    ...margins,
     width: "auto",
   },
   heading4: {
     fontWeight: "heading.heading4",
     lineHeight: "1.2",
-    ...margins,
     width: "auto",
   },
   heading5: {
     fontWeight: "heading.heading5",
     lineHeight: "1.2",
-    ...margins,
     width: "auto",
   },
   heading6: {
     fontWeight: "heading.heading6",
     lineHeight: "1.2",
-    ...margins,
     width: "auto",
   },
 };
@@ -124,11 +117,11 @@ const variants = {
 };
 
 const Heading = {
+  parts: ["headingWrapper"],
   baseStyle: ({ isCapitalized, isUppercase, isLowercase, noSpace }) => ({
     // This is to help target custom anchor elements
     // passed as children to the Heading component.
     a: baseLinkStyles,
-    marginBottom: noSpace ? "0" : "s",
     textTransform: isCapitalized
       ? "capitalize"
       : isUppercase
@@ -138,6 +131,10 @@ const Heading = {
       : null,
     _dark: {
       color: "dark.ui.typography.heading",
+    },
+    headingWrapper: {
+      marginBottom: noSpace ? "0" : "s",
+      ...margins,
     },
   }),
   // Available variants:


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1505](https://jira.nypl.org/browse/DSD-1505)

## This PR does the following:

- Updates the `Heading` component to include `overline` and `subtitle` elements.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
