### PR TITLE
DSD-1186: removing gap between content in TemplateAppContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the spacing gap between main content in the `TemplateAppContainer` component.
+
 ## 1.6.1 (June 22, 2023)
 
 ### Adds

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -148,7 +148,7 @@ export const WithControls: Story = {
     renderFooterElement: true,
     renderHeaderElement: true,
     renderSkipNavigation: false,
-    sidebar: "right",
+    sidebar: "left",
   },
   argTypes: {
     aboveHeader: { control: false },

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -148,7 +148,7 @@ export const WithControls: Story = {
     renderFooterElement: true,
     renderHeaderElement: true,
     renderSkipNavigation: false,
-    sidebar: "left",
+    sidebar: "right",
   },
   argTypes: {
     aboveHeader: { control: false },

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -38,8 +38,7 @@ const TemplateContent = {
     gridTemplateColumns: "1fr",
     paddingY: 0,
     paddingX: "s",
-    gap: "0",
-    rowGap: "0",
+    gap: "grid.l",
   },
   // With left or right sidebars, we need to set two grid columns and
   // the column for the sidebar is max 255px width.
@@ -61,11 +60,17 @@ const TemplateContentTopBottom = {
   },
 };
 const TemplateContentPrimary = {
+  baseStyle: {
+    gridColumn: { base: "1", md: "1 / span 2" },
+  },
   variants: {
     left: {
       gridColumn: { base: "1", md: "2" },
       marginEnd: { md: 0 },
       minWidth: { md: 0 },
+    },
+    right: {
+      gridColumn: { base: "1", md: "1" },
     },
   },
 };

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -45,11 +45,9 @@ const TemplateContent = {
   variants: {
     left: {
       gridTemplateColumns: { md: "255px 1fr" },
-      gap: "grid.l",
     },
     right: {
       gridTemplateColumns: { md: "1fr 255px" },
-      gap: "grid.l",
     },
   },
 };

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -38,16 +38,19 @@ const TemplateContent = {
     gridTemplateColumns: "1fr",
     paddingY: 0,
     paddingX: "s",
-    gap: "grid.l",
+    gap: "0",
+    rowGap: "0",
   },
   // With left or right sidebars, we need to set two grid columns and
   // the column for the sidebar is max 255px width.
   variants: {
     left: {
       gridTemplateColumns: { md: "255px 1fr" },
+      gap: "grid.l",
     },
     right: {
       gridTemplateColumns: { md: "1fr 255px" },
+      gap: "grid.l",
     },
   },
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1186](https://jira.nypl.org/browse/DSD-1186)

## This PR does the following:

- Removes the gap between content inside the main element inside `TemplateAppContainer`.
- When there is no sidebar and no top or bottom content, the main content will span the full width. 

A few examples:
Removing row gap between top/bottom content and content spanning full width
<img width="1096" alt="Screen Shot 2023-07-03 at 4 21 56 PM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/62d6c07d-c056-417b-910c-ad3a95ea8ce5">

Content spanning full width when there is no sidebar
<img width="1098" alt="Screen Shot 2023-07-03 at 4 22 09 PM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/0f09b12e-40a7-4935-b1a7-cb5788a845df">

Content spanning full width when there is no sidebar or top/bottom content
<img width="1103" alt="Screen Shot 2023-07-03 at 4 22 30 PM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/1685cc28-d18a-422d-84f3-52a6cd1abd3d">

One question, there are row gaps between `TemplateBreakout` which is mostly the header section, the main `TemplateContent`, and the `TemplateFooter`. Should those be removed?
<img width="1090" alt="Screen Shot 2023-07-03 at 4 16 36 PM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/0d37ddee-8d08-41ff-8b5d-a2aca2b66c84">


## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
