### PR TITLE
DSD-1470: Updating clearable button in the TextInput component for Dark Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the background color of the "clear" button in Dark Mode for the `TextInput` component. This also affects the `SearchBar` component when a clear button is present in the `TextInput` component.
+
 ## 1.6.1 (June 22, 2023)
 
 ### Adds

--- a/src/theme/components/textInput.ts
+++ b/src/theme/components/textInput.ts
@@ -87,6 +87,9 @@ const TextInput = {
       // use the "text" `Button` type.
       span: screenreaderOnly(),
       zIndex: "9999",
+      _dark: {
+        backgroundColor: "dark.ui.typography.heading",
+      },
     },
   }),
   variants: {

--- a/src/theme/components/textInput.ts
+++ b/src/theme/components/textInput.ts
@@ -88,7 +88,9 @@ const TextInput = {
       span: screenreaderOnly(),
       zIndex: "9999",
       _dark: {
-        backgroundColor: "dark.ui.typography.heading",
+        svg: {
+          fill: "dark.ui.typography.heading",
+        },
       },
     },
   }),


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1470](https://jira.nypl.org/browse/DSD-1470)

## This PR does the following:

- Updates the background color of the clearable button for Dark Mode in the `TextInput` component. This also affects the `SearchBar` component.

Looks slightly odd but should be ok?
<img width="694" alt="Screen Shot 2023-07-03 at 4 43 44 PM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/55ff8620-f71a-406b-adf1-603782daf16a">

Update
<img width="619" alt="Screen Shot 2023-07-06 at 9 56 33 AM" src="https://github.com/NYPL/nypl-design-system/assets/1280564/4d57665c-9c81-4b15-9463-37692d7b8c4f">


## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
