### PR TITLE
DSD-1265/1269: Adding screenreaderOnlyText prop to the Link and Button components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `screenreaderOnlyText` prop to the `Button` and `Link` components.
+
 ## 1.6.1 (June 22, 2023)
 
 ### Adds

--- a/src/components/Button/Button.mdx
+++ b/src/components/Button/Button.mdx
@@ -10,7 +10,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `1.6.1`    |
+| Latest            | `Prelease` |
 
 ## Table of Contents
 
@@ -59,6 +59,11 @@ have images of text.
 `Button`s can be rendered in three sizes through the `size` prop: `"small"`,
 `"medium"`, and `"large"`. The default size is `"medium"`. Even though the `"small"`
 size is available, we recommend to use the `"medium"` and `"large"` sizes.
+
+The `Button` component also has a `screenreaderOnlyText` prop that can be used to
+add additional text to the component that is only visible to screen readers. This
+can be used to provide additional context when the visible text in the `Button`
+component is not enough.
 
 Resources:
 

--- a/src/components/Button/Button.mdx
+++ b/src/components/Button/Button.mdx
@@ -62,8 +62,8 @@ size is available, we recommend to use the `"medium"` and `"large"` sizes.
 
 The `Button` component also has a `screenreaderOnlyText` prop that can be used to
 add additional text to the component that is only visible to screen readers. This
-can be used to provide additional context when the visible text in the `Button`
-component is not enough.
+can be used to provide additional context to the `Button` when the text is short,
+such as visible "Read more..." text.
 
 Resources:
 

--- a/src/components/Button/Button.stories.tsx
+++ b/src/components/Button/Button.stories.tsx
@@ -75,6 +75,7 @@ export const WithControls: Story = {
     isDisabled: false,
     mouseDown: undefined,
     onClick: undefined,
+    screenreaderOnlyText: "Screenreader only text",
     size: undefined,
     type: "button",
   },

--- a/src/components/Button/Button.test.tsx
+++ b/src/components/Button/Button.test.tsx
@@ -22,6 +22,16 @@ describe("Button Accessibility", () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
+
+  it("passes axe accessibility test for hidden text", async () => {
+    const onClick = jest.fn();
+    const { container } = render(
+      <Button id="button" onClick={onClick} screenreaderOnlyText="hidden text">
+        Submit
+      </Button>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
 });
 
 describe("Button", () => {

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,7 +1,8 @@
 import {
+  Box,
   Button as ChakraButton,
   chakra,
-  useStyleConfig,
+  useMultiStyleConfig,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
@@ -37,6 +38,8 @@ interface ButtonProps {
   mouseDown?: boolean;
   /** The action to perform on the `<button>`'s onClick function. */
   onClick?: (event: React.MouseEvent | React.KeyboardEvent) => void;
+  /** Visibly hidden text that will only be read by screenreaders. */
+  screenreaderOnlyText?: string;
   /** The size of the `Button`. */
   size?: ButtonSizes;
   /** The HTML button type attribute. */
@@ -57,6 +60,7 @@ export const Button = chakra(
         isDisabled = false,
         mouseDown = false,
         onClick,
+        screenreaderOnlyText,
         size = "medium",
         type = "button",
         ...rest
@@ -65,7 +69,7 @@ export const Button = chakra(
       let childCount = 0;
       let hasIcon = false;
       let variant: string | ButtonTypes = buttonType;
-      let styles = {};
+      let styles: any = {};
 
       if (!id) {
         console.warn(
@@ -89,7 +93,7 @@ export const Button = chakra(
         variant = "iconOnly";
       }
 
-      styles = useStyleConfig("Button", { variant, buttonSize: size });
+      styles = useMultiStyleConfig("Button", { variant, buttonSize: size });
 
       return (
         <ChakraButton
@@ -103,6 +107,11 @@ export const Button = chakra(
           __css={styles}
           {...rest}
         >
+          {screenreaderOnlyText && (
+            <Box as="span" __css={styles.screenreaderOnly}>
+              {screenreaderOnlyText}
+            </Box>
+          )}
           {children}
         </ChakraButton>
       );

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -107,12 +107,12 @@ export const Button = chakra(
           __css={styles}
           {...rest}
         >
+          {children}
           {screenreaderOnlyText && (
             <Box as="span" __css={styles.screenreaderOnly}>
               {screenreaderOnlyText}
             </Box>
           )}
-          {children}
         </ChakraButton>
       );
     }

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -10,10 +10,10 @@ import * as LinkStories from "./Link.stories";
 
 # Link
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.6.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -46,6 +46,11 @@ Additionally it renders with the `rel` attribute containing
 the relation names "nofollow", "noopener" and "noreferrer".
 
 <Canvas of={LinkStories.Accessibility} />
+
+The `Link` component also has a `screenreaderOnlyText` prop that can be used to
+add additional text to the link that is only visible to screen readers. This can
+be used to provide additional context to the link when the text is short, such
+as visible "Read more..." text.
 
 Resources:
 

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -35,6 +35,7 @@ export const WithControls: Story = {
     className: "custom-class",
     href: "https://nypl.org",
     id: "nypl-link",
+    screenreaderOnlyText: "Screenreader only text",
     target: undefined,
     type: "action",
   },

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -16,6 +16,15 @@ describe("Link Accessibility", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
+  it("passes axe accessibility test for screenreader only text", async () => {
+    const { container } = render(
+      <Link href="#test" screenreaderOnlyText="hidden text">
+        Test
+      </Link>
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
   it("passes axe accessibility test for href prop", async () => {
     const { container } = render(<Link href="#test">Test</Link>);
     expect(await axe(container)).toHaveNoViolations();

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -33,6 +33,8 @@ export interface LinkProps {
   onClick?: (
     event: React.MouseEvent<HTMLDivElement | HTMLAnchorElement, MouseEvent>
   ) => void;
+  /** Visibly hidden text that will only be read by screenreaders. */
+  screenreaderOnlyText?: string;
   /** Prop that sets the HTML attribute to target where the link should go. */
   target?: "_blank" | "_parent" | "_self" | "_top";
   /** Controls the link visuals: action, button, backwards, forwards, or default. */
@@ -126,6 +128,7 @@ export const Link = chakra(
       href,
       id,
       onClick,
+      screenreaderOnlyText,
       target,
       type = "default",
       ...rest
@@ -175,7 +178,11 @@ export const Link = chakra(
       ((type === "forwards" || type === "backwards") &&
         getWithDirectionIcon(children as JSX.Element, type, id)) ||
       (type === "external" &&
-        getExternalExtraElements(children as JSX.Element, id, styles.srOnly)) ||
+        getExternalExtraElements(
+          children as JSX.Element,
+          id,
+          styles.screenreaderOnly
+        )) ||
       children;
 
     if (!href) {
@@ -190,20 +197,27 @@ export const Link = chakra(
       const childrenToClone: any = children[0] ? children[0] : children;
       const childProps = childrenToClone.props;
       return (
-        <Box as="span" __css={styles} {...rest}>
-          {React.cloneElement(
-            childrenToClone,
-            {
-              className,
-              ...linkProps,
-              ...childProps,
-              ref,
-              rel,
-              target: internalTarget,
-            },
-            [childrenToClone.props.children]
+        <>
+          {screenreaderOnlyText && (
+            <Box as="span" __css={styles.screenreaderOnly}>
+              {screenreaderOnlyText}
+            </Box>
           )}
-        </Box>
+          <Box as="span" __css={styles} {...rest}>
+            {React.cloneElement(
+              childrenToClone,
+              {
+                className,
+                ...linkProps,
+                ...childProps,
+                ref,
+                rel,
+                target: internalTarget,
+              },
+              [childrenToClone.props.children]
+            )}
+          </Box>
+        </>
       );
     } else {
       return (
@@ -217,6 +231,11 @@ export const Link = chakra(
           {...linkProps}
           __css={styles}
         >
+          {screenreaderOnlyText && (
+            <Box as="span" __css={styles.screenreaderOnly}>
+              {screenreaderOnlyText}
+            </Box>
+          )}
           {newChildren}
         </Box>
       );

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -198,11 +198,6 @@ export const Link = chakra(
       const childProps = childrenToClone.props;
       return (
         <>
-          {screenreaderOnlyText && (
-            <Box as="span" __css={styles.screenreaderOnly}>
-              {screenreaderOnlyText}
-            </Box>
-          )}
           <Box as="span" __css={styles} {...rest}>
             {React.cloneElement(
               childrenToClone,
@@ -217,6 +212,11 @@ export const Link = chakra(
               [childrenToClone.props.children]
             )}
           </Box>
+          {screenreaderOnlyText && (
+            <Box as="span" __css={styles.screenreaderOnly}>
+              {screenreaderOnlyText}
+            </Box>
+          )}
         </>
       );
     } else {
@@ -231,12 +231,12 @@ export const Link = chakra(
           {...linkProps}
           __css={styles}
         >
+          {newChildren}
           {screenreaderOnlyText && (
             <Box as="span" __css={styles.screenreaderOnly}>
               {screenreaderOnlyText}
             </Box>
           )}
-          {newChildren}
         </Box>
       );
     }

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -1,4 +1,4 @@
-import { defaultElementSizes } from "./global";
+import { defaultElementSizes, screenreaderOnly } from "./global";
 
 // Style object for base or default style
 export const buttonBaseStyle = {
@@ -12,6 +12,9 @@ export const buttonBaseStyle = {
   lineHeight: "1.5",
   textDecoration: "none",
   wordWrap: "normal",
+  /** The element will handle descriptive text added to aid
+   * screen readers. */
+  screenreaderOnly: screenreaderOnly(),
   svg: {
     fill: "currentColor",
   },
@@ -234,6 +237,7 @@ export const noBrand = ({ buttonSize = "medium" }) => ({
 });
 
 const Button = {
+  parts: ["screenreaderOnly"],
   baseStyle: buttonBaseStyle,
   // Available variants:
   variants: {

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -114,7 +114,7 @@ const variants = {
   },
 };
 const Link = {
-  parts: ["srOnly"],
+  parts: ["screenreaderOnly"],
   baseStyle: {
     ...baseLinkStyles,
     /** This is needed for custom anchor elements or link components
@@ -126,7 +126,7 @@ const Link = {
     },
     /** The element will handle descriptive text added to aid
      * screen readers. */
-    srOnly: screenreaderOnly(),
+    screenreaderOnly: screenreaderOnly(),
   },
   variants,
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1265](https://jira.nypl.org/browse/DSD-1265) and [DSD-1269](https://jira.nypl.org/browse/DSD-1265)

## This PR does the following:

- Adds `screenreaderOnlyText` prop to the `Link` and `Button` component. This adds the passed text to the component's DOM and visually hides but screenreaders can still read it.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Tested this with VO but should be further reviewed.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
