### PR TITLE
DSD-1361: Accordion right-to-left support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the right-to-left visual display for the `Accordion` component.
+
 ## 1.6.1 (June 22, 2023)
 
 ### Adds

--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Accordion
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -144,8 +144,8 @@ const getElementsFromData = (
                   },
                   bg: "dark.ui.bg.default",
                   color: "dark.ui.typography.heading",
-                  borderLeft: "4px solid",
-                  borderLeftColor:
+                  borderStart: "4px solid",
+                  borderStartColor:
                     !content.accordionType ||
                     content.accordionType === "default"
                       ? "dark.ui.border.hover"
@@ -156,7 +156,7 @@ const getElementsFromData = (
                   as="span"
                   flex="1"
                   fontSize={multipleFontSize}
-                  textAlign="left"
+                  textAlign="start"
                 >
                   {content.label}
                 </Box>

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1qa7iva"
+      className="chakra-accordion__button css-h5m7h6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -20,7 +20,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>
@@ -72,7 +72,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1qa7iva"
+      className="chakra-accordion__button css-h5m7h6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -81,7 +81,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>
@@ -133,7 +133,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1qa7iva"
+      className="chakra-accordion__button css-h5m7h6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -142,7 +142,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>
@@ -195,7 +195,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1qa7iva"
+      className="chakra-accordion__button css-h5m7h6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -204,7 +204,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>
@@ -256,7 +256,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-1qa7iva"
+      className="chakra-accordion__button css-h5m7h6"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -265,7 +265,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>
@@ -317,7 +317,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-wztri9"
+      className="chakra-accordion__button css-1sdpt8p"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -326,7 +326,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>
@@ -378,7 +378,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
     <button
       aria-controls="accordion-panel-accordian-item-0"
       aria-expanded={false}
-      className="chakra-accordion__button css-17kfyub"
+      className="chakra-accordion__button css-2zrpsj"
       disabled={false}
       id="accordion-button-accordian-item-0"
       onClick={[Function]}
@@ -387,7 +387,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
       type="button"
     >
       <span
-        className="css-ox82o1"
+        className="css-1p6r3oe"
       >
         Gerry Kellman
       </span>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1361](https://jira.nypl.org/browse/DSD-1361)

## This PR does the following:

- Better RTL support for `Accordion` component including in dark mode.

## How has this been tested?

Locally in storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
