### PR TITLE
DSD-1326: Adding backdropBackgroundColor prop for campaign Hero component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the "TikTok" option to the `Icon` component.
+- Adds the `backdropBackgroundColor` prop to the `Hero` component for the `"campaign"` variant.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -136,12 +136,18 @@ The `"campaign"` hero type can be used with the `backdropBackgroundColor`,
 `imageProps`, and `subHeaderText` props. The minimum props to use are
 `backgroundImageSrc`, `heading`, and `imageProps`.
 
-This variant has the special use case of having a background and foreground. The
-"backdrop" is what we call the background and that can be set through either the
-`backdropBackgroundColor` or `backgroundImageSrc` props. When both are set, the
-`backgroundImageSrc` will take precedence.
+This variant has the special use case of having a background and foreground. We
+do understand that the naming can be confusing, but it helps to think of this
+variant having two layers. The bottom is the backdrop and the top is the
+foreground.
 
-To modify the foreground, the `background` and `imageProps` props should be used.
+The "backdrop" is what we call the background and that can be set through either
+the `backdropBackgroundColor` or `backgroundImageSrc` props. When both are set,
+the `backgroundImageSrc` will take precedence.
+
+To modify the foreground, the `backgroundColor`, `foregroundColor`, `imageProps`
+props should be used.
+
 View the last example in this section to see an example of the backdrop and
 foreground settings in action.
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `1.5.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -131,10 +131,19 @@ subHeaderText={otherSubHeaderText}
 
 ### Campaign
 
-The `"campaign"` hero type can be used with the `backgroundColor`,
-`backgroundImageSrc`, `foregroundColor`, `heading`, `imageProps`, and
-`subHeaderText` props. The minimum props to use are `backgroundImageSrc`,
-`heading`, and `imageProps`.
+The `"campaign"` hero type can be used with the `backdropBackgroundColor`,
+`backgroundColor`, `backgroundImageSrc`, `foregroundColor`, `heading`,
+`imageProps`, and `subHeaderText` props. The minimum props to use are
+`backgroundImageSrc`, `heading`, and `imageProps`.
+
+This variant has the special use case of having a background and foreground. The
+"backdrop" is what we call the background and that can be set through either the
+`backdropBackgroundColor` or `backgroundImageSrc` props. When both are set, the
+`backgroundImageSrc` will take precedence.
+
+To modify the foreground, the `background` and `imageProps` props should be used.
+View the last example in this section to see an example of the backdrop and
+foreground settings in action.
 
 <Source
   code={`

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -229,6 +229,45 @@ export const Campaign: Story = {
           subHeaderText={otherSubHeaderTextLong}
         />
       </div>
+      <div>
+        <Heading
+          id="campaign-hero-long-text"
+          text="Campaign Hero with backdrop background color"
+        />
+        <Hero
+          backdropBackgroundColor="section.research.primary"
+          heroType="campaign"
+          heading={
+            <Heading
+              level="one"
+              id="campaign-hero-long-text-heading"
+              text="Hero Campaign"
+            />
+          }
+          imageProps={imageProps}
+          subHeaderText={otherSubHeaderTextLong}
+        />
+      </div>
+      <div>
+        <Heading
+          id="campaign-hero-long-text"
+          text="Campaign Hero with separate backdrop and foreground background color"
+        />
+        <Hero
+          backdropBackgroundColor="section.education.primary"
+          backgroundColor="#A03E31"
+          heroType="campaign"
+          heading={
+            <Heading
+              level="one"
+              id="campaign-hero-long-text-heading"
+              text="Hero Campaign"
+            />
+          }
+          imageProps={imageProps}
+          subHeaderText={otherSubHeaderTextLong}
+        />
+      </div>
     </Stack>
   ),
 };

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -255,7 +255,8 @@ export const Campaign: Story = {
         />
         <Hero
           backdropBackgroundColor="section.education.primary"
-          backgroundColor="#A03E31"
+          backgroundColor="#DC8034"
+          foregroundColor="black"
           heroType="campaign"
           heading={
             <Heading

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -322,9 +322,9 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Hero: The `foregroundColor` and/or `backgroundColor` " +
-        "props have been passed, but the `'secondary'` `heroType` " +
-        "variant will not use them."
+      "NYPL Reservoir Hero: The `foregroundColor`, `backgroundColor`, or " +
+        "`backdropBackgroundColor` props have been passed, but the " +
+        "`'secondary'` `heroType` variant will not use them."
     );
   });
 
@@ -403,9 +403,9 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Hero: It is recommended to use both the " +
-        "`backgroundImageSrc` and `imageProps.src` props for the `'campaign'` " +
-        "`heroType` variant."
+      "NYPL Reservoir Hero: It is recommended to use either the " +
+        "`backdropBackgroundColor`, `backgroundImageSrc`, or `imageProps.src` " +
+        "prop for the `'campaign'` `heroType` variant."
     );
 
     rerender(
@@ -418,9 +418,9 @@ describe("Hero", () => {
       />
     );
     expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir Hero: It is recommended to use both the " +
-        "`backgroundImageSrc` and `imageProps.src` props for the `'campaign'` " +
-        "`heroType` variant."
+      "NYPL Reservoir Hero: It is recommended to use either the " +
+        "`backdropBackgroundColor`, `backgroundImageSrc`, or `imageProps.src` " +
+        "prop for the `'campaign'` `heroType` variant."
     );
   });
 

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -424,6 +424,23 @@ describe("Hero", () => {
     );
   });
 
+  it("logs a warning if `backdropBackgroundColor` prop is passed but the variant is not 'campaign'", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      <Hero
+        backdropBackgroundColor="brand.primary"
+        heroType="fiftyFifty"
+        imageProps={imageProps}
+        subHeaderText={otherSubHeaderText}
+      />
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Hero: The `backdropBackgroundColor` prop has been passed, " +
+        "but the `'campaign'` `heroType` variant was not set. It will be ignored."
+    );
+  });
+
   it("renders FiftyFifty Hero with warnings in browser console", () => {
     const warn = jest.spyOn(console, "warn");
     const { rerender } = render(

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -80,7 +80,6 @@ export const Hero = chakra(
         },
         locationDetails,
         subHeaderText,
-        // ...rest
       } = props;
       const styles = useMultiStyleConfig("Hero", { variant: heroType });
       const headingStyles = styles.heading;

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -26,6 +26,12 @@ export const heroSecondaryTypes = [
 export interface HeroImageProps
   extends Pick<ComponentImageProps, "alt" | "src"> {}
 export interface HeroProps {
+  /**
+   * Optional background color for the backdrop only in the `campaign` variant.
+   * When both `backdropBackgroundColor` and `backgroundImageSrc` are passed,
+   * the `backgroundImageSrc` will take precedence.
+   */
+  backdropBackgroundColor?: string;
   /** Optional hex color value used to override the default background
    * color for a given `Hero` variation.
    * Note: not all `Hero` variations utilize this prop. */
@@ -62,6 +68,7 @@ export const Hero = chakra(
   forwardRef<HTMLDivElement, React.PropsWithChildren<HeroProps>>(
     (props, ref?) => {
       const {
+        backdropBackgroundColor,
         backgroundColor,
         backgroundImageSrc,
         foregroundColor,
@@ -73,7 +80,7 @@ export const Hero = chakra(
         },
         locationDetails,
         subHeaderText,
-        ...rest
+        // ...rest
       } = props;
       const styles = useMultiStyleConfig("Hero", { variant: heroType });
       const headingStyles = styles.heading;
@@ -120,11 +127,14 @@ export const Hero = chakra(
             "will not use any of the image props."
         );
       }
-      if (heroType === "campaign" && (!backgroundImageSrc || !imageProps.src)) {
+      if (
+        heroType === "campaign" &&
+        (!backdropBackgroundColor || !backgroundImageSrc || !imageProps.src)
+      ) {
         console.warn(
-          "NYPL Reservoir Hero: It is recommended to use both the " +
-            "`backgroundImageSrc` and `imageProps.src` props for the " +
-            "`'campaign'` `heroType` variant."
+          "NYPL Reservoir Hero: It is recommended to use either the " +
+            "`backdropBackgroundColor`, `backgroundImageSrc`, or " +
+            "`imageProps.src` prop for the `'campaign'` `heroType` variant."
         );
       }
       if (heroType === "fiftyFifty" && backgroundImageSrc) {
@@ -141,6 +151,8 @@ export const Hero = chakra(
       } else if (heroType === "campaign") {
         backgroundImageStyle = backgroundImageSrc
           ? { backgroundImage: `url(${backgroundImageSrc})` }
+          : backdropBackgroundColor
+          ? { bgColor: backdropBackgroundColor }
           : { backgroundColor };
       } else if (heroType === "tertiary" || heroType === "fiftyFifty") {
         backgroundImageStyle = { backgroundColor };
@@ -151,11 +163,15 @@ export const Hero = chakra(
           color: foregroundColor,
           backgroundColor,
         };
-      } else if (foregroundColor || backgroundColor) {
+      } else if (
+        foregroundColor ||
+        backgroundColor ||
+        backdropBackgroundColor
+      ) {
         console.warn(
-          "NYPL Reservoir Hero: The `foregroundColor` and/or `backgroundColor` " +
-            "props have been passed, but the `'secondary'` `heroType` " +
-            "variant will not use them."
+          "NYPL Reservoir Hero: The `foregroundColor`, `backgroundColor`, or " +
+            "`backdropBackgroundColor` props have been passed, but the " +
+            "`'secondary'` `heroType` variant will not use them."
         );
       }
 
@@ -203,10 +219,9 @@ export const Hero = chakra(
         <Box
           data-testid="hero"
           data-responsive-background-image
-          style={backgroundImageStyle}
+          style={backgroundImageSrc ? backgroundImageStyle : undefined}
           ref={ref}
-          __css={styles}
-          {...rest}
+          __css={{ ...styles, ...backgroundImageStyle }}
         >
           <Box
             data-testid="hero-content"

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -143,6 +143,12 @@ export const Hero = chakra(
             "but the `'fiftyFifty'` `heroType` variant hero will not use it."
         );
       }
+      if (heroType !== "campaign" && backdropBackgroundColor) {
+        console.warn(
+          "NYPL Reservoir Hero: The `backdropBackgroundColor` prop has been passed, " +
+            "but the `'campaign'` `heroType` variant was not set. It will be ignored."
+        );
+      }
 
       if (heroType === "primary") {
         backgroundImageStyle = backgroundImageSrc

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Hero Renders the UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1ar4wny"
   data-responsive-background-image={true}
   data-testid="hero"
   style={
@@ -38,10 +38,9 @@ exports[`Hero Renders the UI snapshot correctly 1`] = `
 
 exports[`Hero Renders the UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={{}}
 >
   <div
     className="css-0"
@@ -78,10 +77,9 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
 
 exports[`Hero Renders the UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={{}}
 >
   <div
     className="css-0"
@@ -118,10 +116,9 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
 
 exports[`Hero Renders the UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={{}}
 >
   <div
     className="css-0"
@@ -158,10 +155,9 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
 
 exports[`Hero Renders the UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={{}}
 >
   <div
     className="css-0"
@@ -198,10 +194,9 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
 
 exports[`Hero Renders the UI snapshot correctly 6`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={{}}
 >
   <div
     className="css-0"
@@ -238,14 +233,9 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
 
 exports[`Hero Renders the UI snapshot correctly 7`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={
-    {
-      "backgroundColor": undefined,
-    }
-  }
 >
   <div
     className="css-0"
@@ -272,7 +262,7 @@ exports[`Hero Renders the UI snapshot correctly 7`] = `
 
 exports[`Hero Renders the UI snapshot correctly 8`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1xdzljk"
   data-responsive-background-image={true}
   data-testid="hero"
   style={
@@ -321,14 +311,9 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
 
 exports[`Hero Renders the UI snapshot correctly 9`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-0"
   data-responsive-background-image={true}
   data-testid="hero"
-  style={
-    {
-      "backgroundColor": undefined,
-    }
-  }
 >
   <div
     className="css-0"
@@ -364,7 +349,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
 
 exports[`Hero Renders the UI snapshot correctly 10`] = `
 <div
-  className="css-16h1ce8"
+  className="css-1ar4wny"
   data-responsive-background-image={true}
   data-testid="hero"
   style={
@@ -400,9 +385,9 @@ exports[`Hero Renders the UI snapshot correctly 10`] = `
 
 exports[`Hero Renders the UI snapshot correctly 11`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1ar4wny"
   data-responsive-background-image={true}
-  data-testid="props"
+  data-testid="hero"
   style={
     {
       "backgroundImage": "url(//placekitten.com/1600/800)",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1326](https://jira.nypl.org/browse/DSD-1326)

## This PR does the following:

- For the `"campaign"` `Hero` variant, an additional prop `backdropBackgroudColor` is configured to set the backdrop to an image or a color. Only the `"campaign"` variant can use this prop and will be ignored otherwise.

## How has this been tested?

Locally and through examples in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A but we should be aware that devs _could_ set terrible color schemes that don't look right or are bad in contrast and we cannot readily prevent that.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
