### PR TITLE
DSD-1308: standalone link variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds the `"tiktok"` option to the `Icon` component.
 - Adds the `role` prop to the `Text` component.
 - Adds the `isUnderlined` prop to the `Link` component.
+- Adds the `"standalone"` variant to the `Link` component.
+- Adds `NYPL Patterns` to the `Links Accessibility Guide`.
 
 ### Updates
 

--- a/src/components/AccessibilityGuide/Links.mdx
+++ b/src/components/AccessibilityGuide/Links.mdx
@@ -50,7 +50,74 @@ format are generally considered to be fine without an underline.
 
 ## NYPL Patterns
 
-TBD
+Text links can be presented in three general scenarios: in a heading, mixed
+within a block of plain text or as an isolated navigation element. In all
+instances, the aim is to reduce the visual impact of the link underline while
+still meeting accessibility requirements and best practices.
+
+In cases where an underline for a text link is necessary, the 1px width and
+dotted underline styles will allow text links to be visually highlighted without
+being overly intrusive. This, in turn, will help text- and link-heavy pages to
+be less overwhelming and cluttered.
+
+### Headings
+
+When a link is applied to a full heading, the link text SHOULD be rendered using
+the `link primary` color and the default state of the link text SHOULD NOT be
+underlined. The link text hover state SHOULD be rendered using the `link secondary` color and MUST be underlined. Applying a link to a full heading is
+the recommended pattern.
+
+When a link is applied to a subset of words within a heading, the link text MUST
+be rendered using the `link primary` color and the default state of the link
+text MUST be underlined. The link text hover state SHOULD be rendered using the
+`link secondary` color and MUST be underlined. While this is acceptable,
+applying a link to a potion of a heading is not the recommended pattern.
+
+### Mixed Text
+
+When a body text link sits within a block of plain (unlinked) text &mdash; a
+paragraph, a single setence, or even just a few words &mdash; the link text
+SHOULD be rendered using the `link primary` color and the default state of the
+link text MUST be underlined. The link text hover state SHOULD be rendered using
+the `link secondary` color and MUST be underlined.
+
+### Standalone Links
+
+When a body text link sits by itself within the page content area &mdash; a Read
+More link at the end of a short description, a View In Catelog link on a book
+detail page &mdash; the link text SHOULD be rendered using the `link primary`
+color, the default state of the link text SHOULD NOT be underlined, and the link
+text SHOULD be displayed with a "forward" directional arrow rendered using the
+`link primary` color. The link text hover state SHOULD be rendered using
+the `link secondary` color and MUST be underlined.
+
+### Tips for Writing Standalone Link Text
+
+Avoid using a URL as your text link - URLs, especially long ones, may cause
+reading difficulty for both humans and screen readers.
+
+Keep link text as short as possible - Instead of "you can contact us,"" use "contact
+us.""
+
+Link at least one full word (two is better) - Avoid using a single letter or
+a symbol for a link as it lacks context and is difficult to click on.
+
+### Acceptable Style Deviations
+
+There are times when deviations from the standard link styles are allowed.
+
+Links in main navigation areas or in a common list format can be presented
+without an underline or some other link indicator (ex. text with icon). It is
+also acceptable to use a color other than the standard link color, but it is
+generally recommended to use black or white.
+
+Links on colored backgrounds will almost always run into problems with color
+contrast. In those cases, the link color should be set to either black or
+white, depending on the background color.
+
+In situations when the link color is not used and the link color is changed to
+white or black, an underline must be applied whenever a link it mixed with plain
+text. This mirrors the patterns of the standard link styles.
 
 ## Resources
 

--- a/src/components/AccessibilityGuide/Links.mdx
+++ b/src/components/AccessibilityGuide/Links.mdx
@@ -51,7 +51,7 @@ format are generally considered to be fine without an underline.
 ## NYPL Patterns
 
 Text links can be presented in three general scenarios: in a heading, mixed
-within a block of plain text or as an isolated navigation element. In all
+within a block of plain text, or as an isolated navigation element. In all
 instances, the aim is to reduce the visual impact of the link underline while
 still meeting accessibility requirements and best practices.
 
@@ -70,13 +70,13 @@ the recommended pattern.
 When a link is applied to a subset of words within a heading, the link text MUST
 be rendered using the `link primary` color and the default state of the link
 text MUST be underlined. The link text hover state SHOULD be rendered using the
-`link secondary` color and MUST be underlined. While this is acceptable,
-applying a link to a potion of a heading is not the recommended pattern.
+`link secondary` color and MUST be underlined. **While this is acceptable,
+applying a link to a portion of a heading is not the recommended pattern.**
 
 ### Mixed Text
 
 When a body text link sits within a block of plain (unlinked) text &mdash; a
-paragraph, a single setence, or even just a few words &mdash; the link text
+paragraph, a single sentence, or even just a few words &mdash; the link text
 SHOULD be rendered using the `link primary` color and the default state of the
 link text MUST be underlined. The link text hover state SHOULD be rendered using
 the `link secondary` color and MUST be underlined.
@@ -84,7 +84,7 @@ the `link secondary` color and MUST be underlined.
 ### Standalone Links
 
 When a body text link sits by itself within the page content area &mdash; a Read
-More link at the end of a short description, a View In Catelog link on a book
+More link at the end of a short description, a View In Catalog link on a book
 detail page &mdash; the link text SHOULD be rendered using the `link primary`
 color, the default state of the link text SHOULD NOT be underlined, and the link
 text SHOULD be displayed with a "forward" directional arrow rendered using the
@@ -93,14 +93,14 @@ the `link secondary` color and MUST be underlined.
 
 ### Tips for Writing Standalone Link Text
 
-Avoid using a URL as your text link - URLs, especially long ones, may cause
-reading difficulty for both humans and screen readers.
+Avoid using a URL as a text link. URLs, especially long ones, may cause reading
+difficulty for both humans and screen readers.
 
-Keep link text as short as possible - Instead of "you can contact us,"" use "contact
-us.""
+Keep link text as short as possible. Instead of "you can contact us," use
+"contact us."
 
-Link at least one full word (two is better) - Avoid using a single letter or
-a symbol for a link as it lacks context and is difficult to click on.
+Link should have at least one full word (two is better). Avoid using a single
+letter or a symbol for a link as it lacks context and is difficult to click on.
 
 ### Acceptable Style Deviations
 

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -10,10 +10,10 @@ import * as LinkStories from "./Link.stories";
 
 # Link
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -36,9 +36,10 @@ import * as LinkStories from "./Link.stories";
 
 ## Accessibility
 
-The `Link` component should be used for navigation. If an `onClick` user
-interface action is required, a `Button` component should be used instead. The
-`Link` component renders an `<a>` element with the `href` attribute.
+The `Link` component renders an `<a>` element with the `href` attribute, so the
+`Link` component should be used for navigation. If an `onClick` user interface
+action is required, a `Button` component should be used instead. In simple
+terms, a link goes somewhere and a button does something.
 
 The `"external"` variant of the `Link` component includes `"screen reader only"`
 descriptive text to clarify that the link will open in a new tab/window.
@@ -51,6 +52,9 @@ The `Link` component also has a `screenreaderOnlyText` prop that can be used to
 add additional text to the link that is only visible to screen readers. This can
 be used to provide additional context to the link when the text is short, such
 as visible "Read more..." text.
+
+For details about NYPL link patterns, refer to the [Links Accessibility
+Guide](/?path=/docs/accessibility-guide-links--docs).
 
 Resources:
 

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -20,6 +20,7 @@ import * as LinkStories from "./Link.stories";
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
+- {<Link href="#all-link-types" target="_self">All Link Types</Link>}
 - {<Link href="#links-with-icons" target="_self">Links With Icons</Link>}
 - {<Link href="#anchor-element-rendering" target="_self">Anchor Element Rendering</Link>}
 - {<Link href="#link-with-routers" target="_self">Link with Routers</Link>}
@@ -37,9 +38,16 @@ import * as LinkStories from "./Link.stories";
 ## Accessibility
 
 The `Link` component renders an `<a>` element with the `href` attribute, so the
-`Link` component should be used for navigation. If an `onClick` user interface
-action is required, a `Button` component should be used instead. In simple
-terms, a link goes somewhere and a button does something.
+`Link` component should be used for navigation. If an `onClick` action is
+required, a `Button` component should be used instead. In simple terms, a link
+goes somewhere and a button does something.
+
+Despite these best practices and recommendations, it is possible to pass an
+`onClick` prop to the `Link` component because there are some very specific use
+cases within NYPL web apps that require this. Additionally, the `onclick`
+attribute (intentially all lowercase) is a native HTML pattern that is allowed.
+Having said that, **you are highly urged to not use the `onClick` prop unless
+you know what you are doing**.
 
 The `"external"` variant of the `Link` component includes `"screen reader only"`
 descriptive text to clarify that the link will open in a new tab/window.
@@ -62,6 +70,35 @@ Resources:
 - [Yale Usability & Web Accessibility Links](https://usability.yale.edu/web-accessibility/articles/links)
 - [WebAIM: Invisible Content Just for Screen Reader Users](https://webaim.org/techniques/css/invisiblecontent/)
 - [IANA: Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml)
+
+## All Link Types
+
+The `Link` component offers multiple variants for differing UX situations.
+
+Use the `default` and `action` variants for text links that sit within a block
+of plain (unlinked) text — a paragraph, a single sentence, or even just a few
+words — and point to other pages within the current website.
+
+Use the `external` variant for text links that sit within a block of plain
+(unlinked) text and point to something outside the current website. This variant
+will open a new browser tab by default.
+
+Use the `standalone` variant for text links that sit alone within the page
+content area. For example, a Read More link at the end of a short description or
+a View In Catalog link on a book detail page. The `backawards` and `forwards`
+variants should be used for specific situations when navigating through a series
+or related pages.
+
+Use the button variants when a link needs to be highlighted or emphasized within
+a CTA element. For example, a link to a book detail page from cards within a
+search results set. Please note that the actual `button` variant has been
+deprecated.
+
+IMPORTANT: Links that look like buttons should still act like links and not act
+like buttons. Refer to the <Link href="#accessibility"
+target="_self">Accessibility</Link> section above for clarification. 
+
+<Canvas of={LinkStories.AllLinkTypes} />
 
 ## Links With Icons
 

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -12,6 +12,7 @@ const meta: Meta<typeof Link> = {
   decorators: [withDesign],
   argTypes: {
     children: { table: { disable: true } },
+    isUnderlined: { table: { defaultValue: { summary: "true" } } },
     key: { table: { disable: true } },
     ref: { table: { disable: true } },
     target: { control: false },

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -58,6 +58,51 @@ export const Accessibility: Story = {
     </Link>
   ),
 };
+export const AllLinkTypes: Story = {
+  render: () => (
+    <VStack spacing="l" align="flex-start">
+      <Link type="default" href="#passed-in-link">
+        Default
+      </Link>
+      <Link type="action" href="#passed-in-link">
+        Action
+      </Link>
+      <Link type="external" href="#passed-in-link">
+        External
+      </Link>
+      <Link type="standalone" href="#passed-in-link">
+        Standalone
+      </Link>
+      <Link type="backwards" href="#passed-in-link">
+        Backwards
+      </Link>
+      <Link type="forwards" href="#passed-in-link">
+        Forwards
+      </Link>
+      <Link type="buttonPrimary" href="#passed-in-link">
+        Button Primary
+      </Link>
+      <Link type="buttonSecondary" href="#passed-in-link">
+        Button Secondary
+      </Link>
+      <Link type="buttonPill" href="#passed-in-link">
+        Button Pill
+      </Link>
+      <Link type="buttonCallout" href="#passed-in-link">
+        Button Callout
+      </Link>
+      <Link type="buttonNoBrand" href="#passed-in-link">
+        Button No Brand
+      </Link>
+      <Link type="buttonDisabled" href="#passed-in-link">
+        Button Disabled
+      </Link>
+      <Link type="button" href="#passed-in-link" width="auto">
+        Button (deprecated)
+      </Link>
+    </VStack>
+  ),
+};
 export const LinksWithIcons: Story = {
   render: () => (
     <VStack spacing="xs" align="flex-start">

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -202,6 +202,13 @@ describe("Link", () => {
         </Link>
       )
       .toJSON();
+    const typeStandalone = renderer
+      .create(
+        <Link href="#passed-in-link" id="standalone-link" type="standalone">
+          Standalone
+        </Link>
+      )
+      .toJSON();
     const typeButtonPrimary = renderer
       .create(
         <Link href="#passed-in-link" id="button-link" type="button">
@@ -306,6 +313,7 @@ describe("Link", () => {
     expect(typeForwards).toMatchSnapshot();
     expect(typeBackwards).toMatchSnapshot();
     expect(typeExternal).toMatchSnapshot();
+    expect(typeStandalone).toMatchSnapshot();
     expect(typeButtonPrimary).toMatchSnapshot();
     expect(typeButtonSecondary).toMatchSnapshot();
     expect(typeButtonPill).toMatchSnapshot();

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -35,11 +35,7 @@ describe("Link", () => {
   it("Can pass in an icon and text as children and url as prop", () => {
     const utils = render(
       <Link href="#passed-in-link" type="action">
-        <Icon
-          name="download"
-          align="left"
-          iconRotation="rotate0"
-        />
+        <Icon name="download" align="left" iconRotation="rotate0" />
         Download
       </Link>
     );
@@ -60,11 +56,7 @@ describe("Link", () => {
     const utils = render(
       <Link type="action">
         <a href="#test2">
-          <Icon
-            name="download"
-            align="left"
-            iconRotation="rotate0"
-          />
+          <Icon name="download" align="left" iconRotation="rotate0" />
           Test
         </a>
       </Link>
@@ -80,7 +72,9 @@ describe("Link", () => {
       </Link>
     );
     expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
-    expect(utils.container.querySelector("#link-link-text-direction-icon")).toBeInTheDocument();
+    expect(
+      utils.container.querySelector("#link-link-text-direction-icon")
+    ).toBeInTheDocument();
   });
 
   it("Generated forwards link has icon", () => {
@@ -90,9 +84,11 @@ describe("Link", () => {
       </Link>
     );
     expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
-    expect(utils.container.querySelector("#link-link-text-direction-icon")).toBeInTheDocument();
+    expect(
+      utils.container.querySelector("#link-link-text-direction-icon")
+    ).toBeInTheDocument();
   });
-  
+
   it("Generated external link has icon", () => {
     const utils = render(
       <Link href="https://nypl.org" type="external">
@@ -100,9 +96,11 @@ describe("Link", () => {
       </Link>
     );
     expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
-    expect(utils.container.querySelector("#link-link-text-external-icon")).toBeInTheDocument();
+    expect(
+      utils.container.querySelector("#link-link-text-external-icon")
+    ).toBeInTheDocument();
   });
-  
+
   it("Generated standalone link has icon", () => {
     const utils = render(
       <Link href="#passed-in-link" type="standalone">
@@ -110,7 +108,9 @@ describe("Link", () => {
       </Link>
     );
     expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
-    expect(utils.container.querySelector("#link-link-text-standalone-icon")).toBeInTheDocument();
+    expect(
+      utils.container.querySelector("#link-link-text-standalone-icon")
+    ).toBeInTheDocument();
   });
 
   it("Can pass in text as child and url as props", () => {

--- a/src/components/Link/Link.test.tsx
+++ b/src/components/Link/Link.test.tsx
@@ -36,7 +36,6 @@ describe("Link", () => {
     const utils = render(
       <Link href="#passed-in-link" type="action">
         <Icon
-          className="more-link"
           name="download"
           align="left"
           iconRotation="rotate0"
@@ -45,7 +44,7 @@ describe("Link", () => {
       </Link>
     );
     expect(screen.getByRole("link")).toBeInTheDocument();
-    expect(utils.container.querySelector(".more-link")).toBeInTheDocument();
+    expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
   });
 
   it("Can pass a link with <a> tag", () => {
@@ -62,7 +61,6 @@ describe("Link", () => {
       <Link type="action">
         <a href="#test2">
           <Icon
-            className="more-link"
             name="download"
             align="left"
             iconRotation="rotate0"
@@ -72,31 +70,47 @@ describe("Link", () => {
       </Link>
     );
     expect(screen.getByRole("link")).toBeInTheDocument();
-    expect(utils.container.querySelector(".more-link")).toBeInTheDocument();
+    expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
   });
 
   it("Generated back link has icon", () => {
     const utils = render(
       <Link href="#passed-in-link" type="backwards">
-        content
+        link text
       </Link>
     );
-    expect(utils.container.querySelector(".more-link")).toBeInTheDocument();
-    expect(
-      utils.container.querySelector(".more-link")?.getAttribute("class")
-    ).toContain("chakra-icon more-link");
+    expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
+    expect(utils.container.querySelector("#link-link-text-direction-icon")).toBeInTheDocument();
   });
 
   it("Generated forwards link has icon", () => {
     const utils = render(
       <Link href="#passed-in-link" type="forwards">
-        content
+        link text
       </Link>
     );
-    expect(utils.container.querySelector(".more-link")).toBeInTheDocument();
-    expect(
-      utils.container.querySelector(".more-link")?.getAttribute("class")
-    ).toContain("chakra-icon more-link");
+    expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
+    expect(utils.container.querySelector("#link-link-text-direction-icon")).toBeInTheDocument();
+  });
+  
+  it("Generated external link has icon", () => {
+    const utils = render(
+      <Link href="https://nypl.org" type="external">
+        link text
+      </Link>
+    );
+    expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
+    expect(utils.container.querySelector("#link-link-text-external-icon")).toBeInTheDocument();
+  });
+  
+  it("Generated standalone link has icon", () => {
+    const utils = render(
+      <Link href="#passed-in-link" type="standalone">
+        link text
+      </Link>
+    );
+    expect(utils.container.querySelector(".chakra-icon")).toBeInTheDocument();
+    expect(utils.container.querySelector("#link-link-text-standalone-icon")).toBeInTheDocument();
   });
 
   it("Can pass in text as child and url as props", () => {
@@ -256,7 +270,6 @@ describe("Link", () => {
         <Link href="#passed-in-link" id="icon-link" type="action">
           <Icon
             align="left"
-            className="more-link"
             iconRotation="rotate0"
             id="link-icon"
             name="download"

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -2,6 +2,7 @@ import { Box, chakra, useMultiStyleConfig } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 import Icon from "../Icons/Icon";
+import { sanitizeStringForAttribute } from "../../utils/utils";
 
 export const linkTypesArray = [
   "action",
@@ -70,12 +71,11 @@ function getWithDirectionIcon(
     iconAlign = "right";
   }
 
-  const iconId = `${linkId}-icon`;
+  const iconId = `${linkId}-direction-icon`;
 
   icon = (
     <Icon
       align={iconAlign}
-      className="more-link"
       iconRotation={iconRotation}
       id={iconId}
       name="arrow"
@@ -97,7 +97,7 @@ function getExternalExtraElements(
   linkId: string,
   styles: object
 ) {
-  const iconId = `${linkId}-icon`;
+  const iconId = `${linkId}-external-icon`;
   const extraElements = (
     <>
       <Box as="span" __css={styles}>
@@ -105,7 +105,6 @@ function getExternalExtraElements(
       </Box>
       <Icon
         align={"right"}
-        className="more-link"
         id={iconId}
         name="actionLaunch"
         size="medium"
@@ -123,19 +122,16 @@ function getExternalExtraElements(
 }
 
 function getStandaloneIcon(children: JSX.Element, linkId: string) {
-  const iconId = `${linkId}-icon`;
+  const iconId = `${linkId}-standalone-icon`;
   const extraElements = (
-    <>
-      <Icon
-        align={"right"}
-        className="more-link"
-        iconRotation="rotate270"
-        id={iconId}
-        name="arrow"
-        size="xsmall"
-        title="Navigation link"
-      />
-    </>
+    <Icon
+      align={"right"}
+      iconRotation="rotate270"
+      id={iconId}
+      name="arrow"
+      size="xsmall"
+      title="Navigation arrow"
+    />
   );
 
   return (
@@ -211,20 +207,24 @@ export const Link = chakra(
     const rel = type === "external" ? "nofollow noopener noreferrer" : null;
     const internalTarget =
       type === "external" ? "_blank" : target ? target : null;
-    // Render with specific direction arrows if the type is
-    // "forwards" or "backwards". Or render with the launch icon
-    // if the type is "external". Otherwise, do not add an icon.
+    const sanitizedId = id
+      ? id
+      : sanitizeStringForAttribute(`link-${children as string}`);
+    // Render with specific direction arrows if the type is "forwards" or
+    // "backwards". Or render with the launch icon if the type is "external". Or
+    // render with a smaller right-arrow if the type is "standalone." Otherwise,
+    // do not add an icon.
     const newChildren =
       ((type === "forwards" || type === "backwards") &&
-        getWithDirectionIcon(children as JSX.Element, type, id)) ||
+        getWithDirectionIcon(children as JSX.Element, type, sanitizedId)) ||
       (type === "external" &&
         getExternalExtraElements(
           children as JSX.Element,
-          id,
+          sanitizedId,
           styles.screenreaderOnly
         )) ||
       (type === "standalone" &&
-        getStandaloneIcon(children as JSX.Element, id)) ||
+        getStandaloneIcon(children as JSX.Element, sanitizedId)) ||
       children;
 
     if (!href) {

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -153,11 +153,43 @@ exports[`Link renders the UI snapshot correctly 5`] = `
 <a
   className="css-1xdhyk6"
   href="#passed-in-link"
-  id="button-link"
+  id="standalone-link"
   rel={null}
   target={null}
 >
-  Button Primary
+  Standalone
+  <svg
+    aria-hidden={true}
+    className="chakra-icon more-link css-1grhd2q"
+    focusable={false}
+    id="standalone-link-icon"
+    role="img"
+    title="Navigation link"
+    viewBox="0 0 24 24"
+  >
+    <g
+      stroke="currentColor"
+      strokeWidth="1.5"
+    >
+      <path
+        d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+        fill="none"
+        strokeLinecap="round"
+      />
+      <path
+        d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+        fill="currentColor"
+        strokeLinecap="round"
+      />
+      <circle
+        cx="12"
+        cy="12"
+        fill="none"
+        r="11.25"
+        strokeMiterlimit="10"
+      />
+    </g>
+  </svg>
 </a>
 `;
 
@@ -169,7 +201,7 @@ exports[`Link renders the UI snapshot correctly 6`] = `
   rel={null}
   target={null}
 >
-  Button Secondary
+  Button Primary
 </a>
 `;
 
@@ -181,7 +213,7 @@ exports[`Link renders the UI snapshot correctly 7`] = `
   rel={null}
   target={null}
 >
-  Button Pill
+  Button Secondary
 </a>
 `;
 
@@ -193,7 +225,7 @@ exports[`Link renders the UI snapshot correctly 8`] = `
   rel={null}
   target={null}
 >
-  Button Callout
+  Button Pill
 </a>
 `;
 
@@ -205,7 +237,7 @@ exports[`Link renders the UI snapshot correctly 9`] = `
   rel={null}
   target={null}
 >
-  Button No Brand
+  Button Callout
 </a>
 `;
 
@@ -217,11 +249,23 @@ exports[`Link renders the UI snapshot correctly 10`] = `
   rel={null}
   target={null}
 >
-  Button Disabled
+  Button No Brand
 </a>
 `;
 
 exports[`Link renders the UI snapshot correctly 11`] = `
+<a
+  className="css-1xdhyk6"
+  href="#passed-in-link"
+  id="button-link"
+  rel={null}
+  target={null}
+>
+  Button Disabled
+</a>
+`;
+
+exports[`Link renders the UI snapshot correctly 12`] = `
 <a
   className="css-1xdhyk6"
   href="#passed-in-link"
@@ -265,7 +309,7 @@ exports[`Link renders the UI snapshot correctly 11`] = `
 </a>
 `;
 
-exports[`Link renders the UI snapshot correctly 12`] = `
+exports[`Link renders the UI snapshot correctly 13`] = `
 <span
   className="css-0"
 >
@@ -281,7 +325,7 @@ exports[`Link renders the UI snapshot correctly 12`] = `
 </span>
 `;
 
-exports[`Link renders the UI snapshot correctly 13`] = `
+exports[`Link renders the UI snapshot correctly 14`] = `
 <span
   className="css-0"
 >
@@ -325,7 +369,7 @@ exports[`Link renders the UI snapshot correctly 13`] = `
 </span>
 `;
 
-exports[`Link renders the UI snapshot correctly 14`] = `
+exports[`Link renders the UI snapshot correctly 15`] = `
 <a
   className="css-kle7zy"
   href="#passed-in-link"
@@ -337,7 +381,7 @@ exports[`Link renders the UI snapshot correctly 14`] = `
 </a>
 `;
 
-exports[`Link renders the UI snapshot correctly 15`] = `
+exports[`Link renders the UI snapshot correctly 16`] = `
 <a
   className="css-1xdhyk6"
   data-testid="props"
@@ -350,7 +394,7 @@ exports[`Link renders the UI snapshot correctly 15`] = `
 </a>
 `;
 
-exports[`Link renders the UI snapshot correctly 16`] = `
+exports[`Link renders the UI snapshot correctly 17`] = `
 <span
   className="css-0"
   data-testid="props"

--- a/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -23,9 +23,9 @@ exports[`Link renders the UI snapshot correctly 2`] = `
   Forwards
   <svg
     aria-hidden={true}
-    className="chakra-icon more-link css-1grhd2q"
+    className="chakra-icon css-1grhd2q"
     focusable={false}
-    id="forwards-link-icon"
+    id="forwards-link-direction-icon"
     role="img"
     title="arrow icon"
     viewBox="0 0 24 24"
@@ -66,9 +66,9 @@ exports[`Link renders the UI snapshot correctly 3`] = `
 >
   <svg
     aria-hidden={true}
-    className="chakra-icon more-link css-1grhd2q"
+    className="chakra-icon css-1grhd2q"
     focusable={false}
-    id="backwards-link-icon"
+    id="backwards-link-direction-icon"
     role="img"
     title="arrow icon"
     viewBox="0 0 24 24"
@@ -116,9 +116,9 @@ exports[`Link renders the UI snapshot correctly 4`] = `
   </span>
   <svg
     aria-hidden={true}
-    className="chakra-icon more-link css-1grhd2q"
+    className="chakra-icon css-1grhd2q"
     focusable={false}
-    id="external-link-icon"
+    id="external-link-external-icon"
     role="img"
     title="External link"
     viewBox="0 0 24 24"
@@ -160,11 +160,11 @@ exports[`Link renders the UI snapshot correctly 5`] = `
   Standalone
   <svg
     aria-hidden={true}
-    className="chakra-icon more-link css-1grhd2q"
+    className="chakra-icon css-1grhd2q"
     focusable={false}
-    id="standalone-link-icon"
+    id="standalone-link-standalone-icon"
     role="img"
-    title="Navigation link"
+    title="Navigation arrow"
     viewBox="0 0 24 24"
   >
     <g
@@ -275,7 +275,7 @@ exports[`Link renders the UI snapshot correctly 12`] = `
 >
   <svg
     aria-hidden={true}
-    className="chakra-icon more-link css-1grhd2q"
+    className="chakra-icon css-1grhd2q"
     focusable={false}
     id="link-icon"
     role="img"

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -175,9 +175,9 @@ const variants = {
 };
 const Link = {
   parts: ["screenreaderOnly"],
-  baseStyle: ({ isUnderlined = true }) => ({
+  baseStyle: ({ finalIsUnderlined = true }) => ({
     ...baseLinkStyles,
-    textDecoration: isUnderlined ? "underline" : "none",
+    textDecoration: finalIsUnderlined ? "underline" : "none",
     /** This is needed for custom anchor elements or link components
      * that are passed as children to the `Link` component. */
     a: {

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -107,6 +107,9 @@ const variants = {
   buttonPrimary: {
     ...baseButtonLinkStyles,
     ...primary({}),
+    _hover: {
+      color: "ui.white",
+    },
     _visited: {
       color: "ui.white",
       _dark: {
@@ -127,6 +130,9 @@ const variants = {
   buttonPill: {
     ...baseButtonLinkStyles,
     ...pill({}),
+    _hover: {
+      color: "ui.black",
+    },
     _visited: {
       color: "ui.black",
       _dark: {
@@ -137,6 +143,9 @@ const variants = {
   buttonCallout: {
     ...baseButtonLinkStyles,
     ...callout({}),
+    _hover: {
+      color: "ui.white",
+    },
     _visited: {
       color: "ui.white",
       _dark: {
@@ -147,6 +156,9 @@ const variants = {
   buttonNoBrand: {
     ...baseButtonLinkStyles,
     ...noBrand({}),
+    _hover: {
+      color: "ui.white",
+    },
     _visited: {
       color: "ui.white",
       _dark: {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -125,3 +125,9 @@ export const truncateText = (text: string, truncateTextLength: number = 60) => {
   const updatedText = text.substring(0, truncateTextLength - 1);
   return `${updatedText.substring(0, updatedText.lastIndexOf(" "))}...`;
 };
+
+/** Prepare a string for use in an ID or class attribute */
+export const sanitizeStringForAttribute = (str: string) => {
+  const sanitizedStr = str.replace(/[^a-z0-9]/gi, "-").toLowerCase();
+  return sanitizedStr;
+};


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1308](https://jira.nypl.org/browse/DSD-1308)

## This PR does the following:

- Adds the `"standalone"` variant to the `Link` component.
- Adds `NYPL Patterns` to the `Links Accessibility Guide`.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Style changes and recommended patterns have been updated based on UX exploration and input from a11y consultant.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.
