### PR TITLE
DSD-1548: Typo2023 styles for Basic Content components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates underline styles of the `Link` component.
 - Updates the hex value for the `Link Primary` color style.
 - Updates the `Link` component so that non-button variants change color once visited.
+- Updates the `Link` component to explicitly assign the text color for the `"buttonPrimary"` variant `hover` state.
+- Updates the components in the `Basic Content` category to implement the `Typo2023` styles.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Card
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -101,11 +101,12 @@ export const WithControls: Story = {
       layout={args.layout}
       mainActionLink={args.mainActionLink}
     >
-      <CardHeading level="two" id="main-heading1">
+      <CardHeading
+        level="h3"
+        id="main-heading1"
+        subtitle="Sollicitudin Lorem Tortor Purus Ornare"
+      >
         Optional Header
-      </CardHeading>
-      <CardHeading level="three" id="main-heading2">
-        Sollicitudin Lorem Tortor Purus Ornare
       </CardHeading>
       <CardContent>
         Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -150,7 +151,7 @@ export const ImagePositionColumnCards: Story = {
           src: "//placekitten.com/400/200",
         }}
       >
-        <CardHeading level="three" id="props-heading1">
+        <CardHeading level="h3" id="props-heading1" size="heading4">
           Image on Top (default)
         </CardHeading>
         <CardContent>
@@ -166,7 +167,7 @@ export const ImagePositionColumnCards: Story = {
           src: "//placekitten.com/400/200",
         }}
       >
-        <CardHeading level="three" id="props-heading2">
+        <CardHeading level="h3" id="props-heading2" size="heading4">
           Image on Bottom
         </CardHeading>
         <CardContent>
@@ -190,7 +191,7 @@ export const ImagePositionRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="four" id="row-heading1">
+        <CardHeading level="h3" id="row-heading1" size="heading6">
           Image on Left (default)
         </CardHeading>
         <CardContent>
@@ -209,7 +210,7 @@ export const ImagePositionRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="four" id="row-heading2">
+        <CardHeading level="h3" id="row-heading2" size="heading6">
           Image on Right
         </CardHeading>
         <CardContent>
@@ -234,11 +235,13 @@ export const ImageSizeColumnCards: Story = {
         }}
         isCentered
       >
-        <CardHeading level="three" id="column-heading1">
+        <CardHeading
+          level="h3"
+          id="column1-heading"
+          size="heading6"
+          subtitle="Max-Width: 64px"
+        >
           Extra Extra Small Image
-        </CardHeading>
-        <CardHeading level="four" id="column-heading2">
-          Max-Width: 64px
         </CardHeading>
         <CardContent>
           Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -255,11 +258,13 @@ export const ImageSizeColumnCards: Story = {
         }}
         isCentered
       >
-        <CardHeading level="three" id="column-heading1">
+        <CardHeading
+          level="h3"
+          id="column2-heading"
+          size="heading6"
+          subtitle="Max-Width: 96px"
+        >
           Extra Small Image
-        </CardHeading>
-        <CardHeading level="four" id="column-heading2">
-          Max-Width: 96px
         </CardHeading>
         <CardContent>
           Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -276,11 +281,13 @@ export const ImageSizeColumnCards: Story = {
         }}
         isCentered
       >
-        <CardHeading level="three" id="column-heading1">
+        <CardHeading
+          level="h3"
+          id="column3-heading"
+          size="heading6"
+          subtitle="Max-Width: 165px"
+        >
           Small Image
-        </CardHeading>
-        <CardHeading level="four" id="column-heading2">
-          Max-Width: 165px
         </CardHeading>
         <CardContent>
           Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -297,11 +304,13 @@ export const ImageSizeColumnCards: Story = {
         }}
         isCentered
       >
-        <CardHeading level="three" id="column2-heading1">
+        <CardHeading
+          level="h3"
+          id="column4-heading"
+          size="heading6"
+          subtitle="Max-Width: 225px"
+        >
           Medium Image
-        </CardHeading>
-        <CardHeading level="four" id="column2-heading2">
-          Max-Width: 225px
         </CardHeading>
         <CardContent>
           Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -318,11 +327,13 @@ export const ImageSizeColumnCards: Story = {
         }}
         isCentered
       >
-        <CardHeading level="three" id="column3-heading1">
+        <CardHeading
+          level="h3"
+          id="column5-heading"
+          size="heading6"
+          subtitle="Max-Width: 360px"
+        >
           Large Image
-        </CardHeading>
-        <CardHeading level="four" id="column3-heading2">
-          Max-Width: 360px
         </CardHeading>
         <CardContent>
           Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -338,11 +349,13 @@ export const ImageSizeColumnCards: Story = {
         }}
         isCentered
       >
-        <CardHeading level="three" id="column-4heading1">
+        <CardHeading
+          level="h3"
+          id="column6-heading"
+          size="heading6"
+          subtitle="Width: 100%"
+        >
           Default Image
-        </CardHeading>
-        <CardHeading level="four" id="column-4heading2">
-          Width: 100%
         </CardHeading>
         <CardContent>
           Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -365,11 +378,13 @@ export const ImageSizeRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="three" id="row2-heading1">
+        <CardHeading
+          level="h3"
+          id="row1-heading"
+          size="heading6"
+          subtitle="Max-Width: 64px"
+        >
           Extra Extra Small Image
-        </CardHeading>
-        <CardHeading level="four" id="row2-heading2">
-          Max-Width: 64px
         </CardHeading>
         <CardContent>
           Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -385,11 +400,13 @@ export const ImageSizeRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="three" id="row2-heading1">
+        <CardHeading
+          level="h3"
+          id="row2-heading"
+          size="heading6"
+          subtitle="Max-Width: 96px"
+        >
           Extra Small Image
-        </CardHeading>
-        <CardHeading level="four" id="row2-heading2">
-          Max-Width: 96px
         </CardHeading>
         <CardContent>
           Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -405,11 +422,13 @@ export const ImageSizeRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="three" id="row2-heading1">
+        <CardHeading
+          level="h3"
+          id="row3-heading"
+          size="heading6"
+          subtitle="Max-Width: 165px"
+        >
           Small Image
-        </CardHeading>
-        <CardHeading level="four" id="row2-heading2">
-          Max-Width: 165px
         </CardHeading>
         <CardContent>
           Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -425,11 +444,13 @@ export const ImageSizeRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="three" id="row3-heading2">
+        <CardHeading
+          level="h3"
+          id="row4-heading"
+          size="heading6"
+          subtitle="Max-Width: 225px"
+        >
           Medium Image
-        </CardHeading>
-        <CardHeading level="four" id="row3-heading2">
-          Max-Width: 225px
         </CardHeading>
         <CardContent>
           Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -446,11 +467,13 @@ export const ImageSizeRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="three" id="row4-heading1">
+        <CardHeading
+          level="h3"
+          id="row5-heading"
+          size="heading6"
+          subtitle="Max-Width: 360px"
+        >
           Large Image
-        </CardHeading>
-        <CardHeading level="four" id="row4-heading2">
-          Max-Width: 360px
         </CardHeading>
         <CardContent>
           Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -467,11 +490,13 @@ export const ImageSizeRowCards: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="three" id="row5-heading2">
+        <CardHeading
+          level="h3"
+          id="row6-heading"
+          size="heading6"
+          subtitle="Max-Width: 225px"
+        >
           Default Image
-        </CardHeading>
-        <CardHeading level="four" id="row5-heading2">
-          Max-Width: 225px
         </CardHeading>
         <CardContent>
           Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -491,11 +516,13 @@ export const CustomImageComponent: Story = {
         component: <Image src="//placekitten.com/400/400" alt="Alt text" />,
       }}
     >
-      <CardHeading level="two" id="img1-heading1">
+      <CardHeading
+        level="h3"
+        id="img1-heading1"
+        size="heading5"
+        subtitle="Subtitle on the card"
+      >
         Card Component with Custom Image Component
-      </CardHeading>
-      <CardHeading level="three" id="img2-heading2">
-        Secondary Heading
       </CardHeading>
       <CardContent>
         Nulla vitae elit libero, a pharetra augue. Lorem ipsum dolor sit amet,
@@ -524,13 +551,18 @@ export const HeadingAsLink: Story = {
         src: "//placekitten.com/400/200",
       }}
     >
-      <CardHeading level="three" id="link-heading1" url="http://nypl.org">
+      <CardHeading
+        level="h3"
+        id="link-heading1"
+        size="heading5"
+        subtitle={
+          <>
+            Go to NYPL <Link href="http://nypl.org">home page</Link>.
+          </>
+        }
+        url="http://nypl.org"
+      >
         Go to NYPL home page.
-      </CardHeading>
-      <CardHeading level="four" id="link-heading2">
-        <>
-          Go to NYPL <Link href="http://nypl.org">home page</Link>.
-        </>
       </CardHeading>
       <CardContent>
         This entire `Card` component is clickable, but the links below are still
@@ -560,11 +592,13 @@ export const FullClick: Story = {
         }}
         mainActionLink="http://nypl.org"
       >
-        <CardHeading level="three" id="fullclick1-heading1">
+        <CardHeading
+          level="h3"
+          id="fullclick1-heading1"
+          size="heading5"
+          subtitle="Some other subtitle."
+        >
           Go to NYPL home page.
-        </CardHeading>
-        <CardHeading level="four" id="fullclick1-heading2">
-          Some other heading.
         </CardHeading>
         <CardContent>
           This entire `Card` component is clickable, but the links below are
@@ -572,11 +606,11 @@ export const FullClick: Story = {
           clicking with a mouse.
         </CardContent>
         <CardActions>
-          <Link href="#" type="button">
-            Button
+          <Link href="#" type="buttonPrimary">
+            Link Button
           </Link>
-          <Link href="#" type="forwards">
-            Other link
+          <Link href="#" type="buttonSecondary">
+            Other Link
           </Link>
         </CardActions>
       </Card>
@@ -589,7 +623,7 @@ export const FullClick: Story = {
         }}
         mainActionLink="http://nypl.org"
       >
-        <CardHeading level="three" id="fullclick2-heading1">
+        <CardHeading level="h3" id="fullclick2-heading1" size="heading5">
           Go to NYPL home page.
         </CardHeading>
         <CardContent>
@@ -608,7 +642,9 @@ export const CardFullClickTurbineExample: Story = {
         isBordered
         mainActionLink="https://nypl-ds-test-app.vercel.app/fullPages/blog/lunar-new-year#above-header-notification"
       >
-        <CardHeading level="four">Lunar New Year Blog</CardHeading>
+        <CardHeading level="h3" overline="Example" size="heading6">
+          Lunar New Year Blog
+        </CardHeading>
         <CardContent>
           A basic blog post, including text chracters outside a standard Western
           font-set.
@@ -618,28 +654,36 @@ export const CardFullClickTurbineExample: Story = {
         isBordered
         mainActionLink="https://nypl-ds-test-app.vercel.app/fullPages/blog/doc-chat-forty-two#above-header-notification"
       >
-        <CardHeading level="four">Doc Chat Forty-Two Blog</CardHeading>
+        <CardHeading level="h3" overline="Example" size="heading6">
+          Doc Chat Forty-Two Blog
+        </CardHeading>
         <CardContent>A blog post with an array of components.</CardContent>
       </Card>
       <Card
         isBordered
         mainActionLink="https://nypl-ds-test-app.vercel.app/fullPages/homepage#above-header-notification"
       >
-        <CardHeading level="four">Homepage</CardHeading>
+        <CardHeading level="h3" overline="Example" size="heading6">
+          Homepage
+        </CardHeading>
         <CardContent>A layout to mimic a basic homepage structure.</CardContent>
       </Card>
       <Card
         isBordered
         mainActionLink="https://nypl-ds-test-app.vercel.app/fullPages/library-registry#above-header-notification"
       >
-        <CardHeading level="four">Library Registry Interface</CardHeading>
+        <CardHeading level="h3" overline="Example" size="heading6">
+          Library Registry Interface
+        </CardHeading>
         <CardContent>A POC for the Library Registry admin tools.</CardContent>
       </Card>
       <Card
         isBordered
         mainActionLink="https://nypl-ds-test-app.vercel.app/fullPages/search-and-filter#above-header-notification"
       >
-        <CardHeading level="four">Search and Filter</CardHeading>
+        <CardHeading level="h3" overline="Example" size="heading6">
+          Search and Filter
+        </CardHeading>
         <CardContent>
           A functional form to showcase search filtering and content cards.
         </CardContent>
@@ -648,7 +692,9 @@ export const CardFullClickTurbineExample: Story = {
         isBordered
         mainActionLink="https://nypl-ds-test-app.vercel.app/fullPages/sign-up#above-header-notification"
       >
-        <CardHeading level="four">Sign-Up</CardHeading>
+        <CardHeading level="h3" overline="Example" size="heading6">
+          Sign-Up
+        </CardHeading>
         <CardContent>
           A functional form to utilize multiple form input components.
         </CardContent>
@@ -662,7 +708,7 @@ export const CardWithRightSideCardActions: Story = {
     <Card
       imageProps={{
         alt: "Alt text",
-        aspectRatio: "twoByOne",
+        aspectRatio: "square",
         size: "medium",
         src: "//placekitten.com/400/200",
       }}
@@ -670,11 +716,13 @@ export const CardWithRightSideCardActions: Story = {
       isCentered
       layout="row"
     >
-      <CardHeading level="two" id="main-heading1">
+      <CardHeading
+        level="h3"
+        id="main-heading1"
+        size="heading4"
+        subtitle="Sollicitudin Lorem Tortor Purus Ornare"
+      >
         Optional Header
-      </CardHeading>
-      <CardHeading level="three" id="main-heading2">
-        Sollicitudin Lorem Tortor Purus Ornare
       </CardHeading>
       <CardContent>
         Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
@@ -712,7 +760,13 @@ export const GridExample: Story = {
           src: "//placekitten.com/400/200",
         }}
       >
-        <CardHeading level="three" id="grid1-heading1">
+        <CardHeading
+          level="h3"
+          id="grid1-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -727,7 +781,13 @@ export const GridExample: Story = {
           src: "//placekitten.com/410/210",
         }}
       >
-        <CardHeading level="three" id="grid2-heading1">
+        <CardHeading
+          level="h3"
+          id="grid2-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -742,7 +802,13 @@ export const GridExample: Story = {
           src: "//placekitten.com/420/220",
         }}
       >
-        <CardHeading level="three" id="grid3-heading1">
+        <CardHeading
+          level="h3"
+          id="grid3-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -757,7 +823,13 @@ export const GridExample: Story = {
           src: "//placekitten.com/430/230",
         }}
       >
-        <CardHeading level="three" id="grid4-heading1">
+        <CardHeading
+          level="h3"
+          id="grid4-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -772,7 +844,13 @@ export const GridExample: Story = {
           src: "//placekitten.com/440/200",
         }}
       >
-        <CardHeading level="three" id="grid5-heading1">
+        <CardHeading
+          level="h3"
+          id="grid5-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -787,7 +865,13 @@ export const GridExample: Story = {
           src: "//placekitten.com/450/200",
         }}
       >
-        <CardHeading level="three" id="grid6-heading1">
+        <CardHeading
+          level="h3"
+          id="grid6-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -811,7 +895,13 @@ export const StackExample: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="four" id="stack1-heading1">
+        <CardHeading
+          level="h3"
+          id="stack1-heading1"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -829,7 +919,13 @@ export const StackExample: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="four" id="stack2-heading2">
+        <CardHeading
+          level="h3"
+          id="stack2-heading2"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -847,7 +943,13 @@ export const StackExample: Story = {
         isCentered
         layout="row"
       >
-        <CardHeading level="four" id="stack3-heading3">
+        <CardHeading
+          level="h3"
+          id="stack3-heading3"
+          noSpace
+          overline="Cats"
+          size="heading5"
+        >
           Card Heading
         </CardHeading>
         <CardContent>
@@ -865,7 +967,13 @@ export const WithoutImages: Story = {
     <>
       <SimpleGrid columns={3}>
         <Card isBordered>
-          <CardHeading level="three" id="no-img1-heading1">
+          <CardHeading
+            level="h3"
+            id="no-img1-heading1"
+            overline="Cards"
+            size="heading4"
+            subtitle="Donec id elit non mi porta gravida at eget metus."
+          >
             Card Heading
           </CardHeading>
           <CardContent>
@@ -875,7 +983,13 @@ export const WithoutImages: Story = {
           </CardContent>
         </Card>
         <Card isBordered>
-          <CardHeading level="three" id="no-img2-heading1">
+          <CardHeading
+            level="h3"
+            id="no-img2-heading1"
+            overline="Cards"
+            size="heading4"
+            subtitle="Donec id elit non mi porta gravida at eget metus."
+          >
             Card Heading
           </CardHeading>
           <CardContent>
@@ -885,7 +999,13 @@ export const WithoutImages: Story = {
           </CardContent>
         </Card>
         <Card isBordered>
-          <CardHeading level="three" id="no-img3-heading1">
+          <CardHeading
+            level="h3"
+            id="no-img3-heading1"
+            overline="Cards"
+            size="heading4"
+            subtitle="Donec id elit non mi porta gravida at eget metus."
+          >
             Card Heading
           </CardHeading>
           <CardContent>
@@ -898,7 +1018,13 @@ export const WithoutImages: Story = {
       <br />
       <SimpleGrid columns={1}>
         <Card layout="row" isBordered>
-          <CardHeading level="three" id="no-img4-heading1">
+          <CardHeading
+            level="h3"
+            id="no-img4-heading1"
+            overline="Cards"
+            size="heading4"
+            subtitle="Donec id elit non mi porta gravida at eget metus."
+          >
             Card Heading
           </CardHeading>
           <CardContent>
@@ -911,7 +1037,13 @@ export const WithoutImages: Story = {
           </CardContent>
         </Card>
         <Card layout="row" isBordered>
-          <CardHeading level="three" id="no-img5-heading1">
+          <CardHeading
+            level="h3"
+            id="no-img5-heading1"
+            overline="Cards"
+            size="heading4"
+            subtitle="Donec id elit non mi porta gravida at eget metus."
+          >
             Card Heading
           </CardHeading>
           <CardContent>
@@ -924,7 +1056,13 @@ export const WithoutImages: Story = {
           </CardContent>
         </Card>
         <Card layout="row" isBordered>
-          <CardHeading level="three" id="no-img6-heading1">
+          <CardHeading
+            level="h3"
+            id="no-img6-heading1"
+            overline="Cards"
+            size="heading4"
+            subtitle="Donec id elit non mi porta gravida at eget metus."
+          >
             Card Heading
           </CardHeading>
           <CardContent>

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `1.5.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -2,6 +2,8 @@ import { Stack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 
+import Button from "../Button/Button";
+import ButtonGroup from "../ButtonGroup/ButtonGroup";
 import Heading from "../Heading/Heading";
 import Hero, { heroSecondaryTypes, heroTypesArray } from "./Hero";
 import SimpleGrid from "../Grid/SimpleGrid";
@@ -19,12 +21,17 @@ const otherSubHeaderText =
   "With 92 locations across the Bronx, Manhattan, and Staten Island, The New York Public Library is an essential part of neighborhoods across the city. Visit us today.";
 const otherSubHeaderTextLong = (
   <>
-    <Heading level="two" noSpace>
+    <Heading
+      level="h2"
+      size="heading3"
+      subtitle="Lorem Parturient Bibendum Aenean Cras"
+    >
       Subheading
     </Heading>
-    <Text size="caption">Lorem Parturient Bibendum Aenean Cras</Text>
-    <Heading level="three">Subheading</Heading>
-    <Text noSpace>
+    <Heading level="h3" noSpace size="heading6">
+      Subheading
+    </Heading>
+    <Text>
       Donec ullamcorper nulla non metus auctor fringilla. Cras mattis
       consectetur purus sit amet fermentum. Nulla vitae elit libero, a pharetra
       augue. Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
@@ -32,6 +39,12 @@ const otherSubHeaderTextLong = (
       felis euismod semper. Donec sed odio dui. Nullam quis risus eget urna
       mollis ornare vel eu leo.
     </Text>
+    <ButtonGroup>
+      <Button id="other-button-example-1">Button</Button>
+      <Button id="other-button-example-2" buttonType="secondary">
+        Button
+      </Button>
+    </ButtonGroup>
   </>
 );
 const imageProps = {
@@ -81,16 +94,25 @@ export const WithControls: Story = {
       <Hero
         {...args}
         backgroundImageSrc="//placekitten.com/2400/800"
-        heading={<Heading level="one" id="1" text="Hero Primary" />}
+        heading={
+          <Heading
+            level="h1"
+            id="1"
+            subtitle="Example Subtitle"
+            text="Hero Primary"
+          />
+        }
         heroType={args.heroType}
-        subHeaderText="Example Subtitle"
+        subHeaderText="Nullam id dolor id nibh ultricies vehicula ut id elit. Sed posuere consectetur est at lobortis."
       />
     )) ||
     (heroSecondaryTypes.includes(args.heroType) && (
       <div className="nypl--books-and-more">
         <Hero
           {...args}
-          heading={<Heading level="one" id="1" text="Hero Secondary" />}
+          heading={
+            <Heading level="h1" id="1" size="heading2" text="Hero Secondary" />
+          }
           heroType={args.heroType}
           imageProps={args.imageProps}
           subHeaderText={secondarySubHeaderText}
@@ -100,7 +122,9 @@ export const WithControls: Story = {
     (args.heroType === "tertiary" && (
       <Hero
         {...args}
-        heading={<Heading level="one" id="1" text="Hero Tertiary" />}
+        heading={
+          <Heading level="h1" id="1" size="heading2" text="Hero Tertiary" />
+        }
         heroType={args.heroType}
         subHeaderText={otherSubHeaderText}
       />
@@ -109,7 +133,7 @@ export const WithControls: Story = {
       <Hero
         {...args}
         backgroundImageSrc="//placekitten.com/2400/800"
-        heading={<Heading level="one" id="1" text="Hero Campaign" />}
+        heading={<Heading level="h1" id="1" text="Hero Campaign" />}
         heroType={args.heroType}
         imageProps={args.imageProps}
         subHeaderText={otherSubHeaderText}
@@ -140,7 +164,16 @@ export const Primary: Story = {
   render: () => (
     <Hero
       backgroundImageSrc="//placekitten.com/1600/800"
-      heading={<Heading level="one" id="primary-hero" text="Hero Primary" />}
+      heading={
+        <Heading
+          id="primary-hero"
+          level="h1"
+          noSpace
+          overline="Hero Example"
+          subtitle="Integer posuere erat a ante venenatis dapibus posuere velit aliquet."
+          text="Hero Primary"
+        />
+      }
       heroType="primary"
     />
   ),
@@ -150,7 +183,12 @@ export const Secondary: Story = {
   render: () => (
     <Hero
       heading={
-        <Heading level="one" id="secondary-hero" text="Hero Secondary" />
+        <Heading
+          level="h1"
+          id="secondary-hero"
+          size="heading2"
+          text="Hero Secondary"
+        />
       }
       heroType="secondary"
       imageProps={imageProps}
@@ -165,8 +203,23 @@ export const Tertiary: Story = {
       <Hero
         heading={
           <Heading
-            level="one"
+            level="h1"
             id="tertiary-hero-subheading"
+            size="heading2"
+            subtitle="This is the subtitle"
+            text="Hero Tertiary with Subtitle & Sub-Heading"
+          />
+        }
+        heroType="tertiary"
+        subHeaderText={otherSubHeaderText}
+      />
+      <br />
+      <Hero
+        heading={
+          <Heading
+            level="h1"
+            id="tertiary-hero-subheading"
+            size="heading2"
             text="Hero Tertiary with Sub-Heading"
           />
         }
@@ -177,9 +230,10 @@ export const Tertiary: Story = {
       <Hero
         heading={
           <Heading
-            level="one"
+            level="h1"
             id="tertiary-hero"
-            text="Hero Tertiary without Sub-Heading text"
+            size="heading2"
+            text="Hero Tertiary without Additional Elements"
           />
         }
         heroType="tertiary"
@@ -201,7 +255,7 @@ export const Campaign: Story = {
           heroType="campaign"
           heading={
             <Heading
-              level="one"
+              level="h1"
               id="campaign-hero-default-heading"
               text="Hero Campaign"
             />
@@ -220,8 +274,10 @@ export const Campaign: Story = {
           heroType="campaign"
           heading={
             <Heading
-              level="one"
+              level="h1"
               id="campaign-hero-long-text-heading"
+              overline="Example"
+              subtitle="Donec id elit non mi porta gravida at eget metus."
               text="Hero Campaign"
             />
           }
@@ -268,7 +324,12 @@ export const ColorVariations: Story = {
       <Heading id="main-secondary-heading" text="secondary" />
       <Hero
         heading={
-          <Heading level="one" id="main-secondary-hero" text="Secondary" />
+          <Heading
+            level="h1"
+            size="heading2"
+            id="main-secondary-hero"
+            text="Secondary"
+          />
         }
         heroType="secondary"
         imageProps={imageProps}
@@ -276,28 +337,56 @@ export const ColorVariations: Story = {
       />
       <Heading id="books-heading" text="secondaryBooksAndMore" />
       <Hero
-        heading={<Heading level="one" id="books-hero" text="Books and More" />}
+        heading={
+          <Heading
+            level="h1"
+            size="heading2"
+            id="books-hero"
+            text="Books and More"
+          />
+        }
         heroType="secondaryBooksAndMore"
         imageProps={imageProps}
         subHeaderText={secondarySubHeaderText}
       />
       <Heading id="location-heading" text="secondaryLocations" />
       <Hero
-        heading={<Heading level="one" id="locations-hero" text="Locations" />}
+        heading={
+          <Heading
+            level="h1"
+            size="heading2"
+            id="locations-hero"
+            text="Locations"
+          />
+        }
         heroType="secondaryLocations"
         imageProps={imageProps}
         subHeaderText={secondarySubHeaderText}
       />
       <Heading id="research-heading" text="secondaryResearch" />
       <Hero
-        heading={<Heading level="one" id="research-hero" text="Research" />}
+        heading={
+          <Heading
+            level="h1"
+            size="heading2"
+            id="research-hero"
+            text="Research"
+          />
+        }
         heroType="secondaryResearch"
         imageProps={imageProps}
         subHeaderText={secondarySubHeaderText}
       />
       <Heading id="whats-on-heading" text="secondaryWhatsOn" />
       <Hero
-        heading={<Heading level="one" id="whats-on-hero" text="What's On" />}
+        heading={
+          <Heading
+            level="h1"
+            size="heading2"
+            id="whats-on-hero"
+            text="What's On"
+          />
+        }
         heroType="secondaryWhatsOn"
         imageProps={imageProps}
         subHeaderText={secondarySubHeaderText}

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -10,10 +10,10 @@ import * as LinkStories from "./Link.stories";
 
 # Link
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -107,6 +107,10 @@ const variants = {
   buttonPrimary: {
     ...baseButtonLinkStyles,
     ...primary({}),
+    _hover: {
+      backgroundColor: "ui.link.secondary",
+      color: "ui.white",
+    },
     _visited: {
       color: "ui.white",
       _dark: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1548](https://jira.nypl.org/browse/DSD-1548)

## This PR does the following:

- Updates the components in the `Basic Content` category to implement the `Typo2023` styles.
- Updates the `Link` component to explicitly assign the text color for the `"buttonPrimary"` variant `hover` state.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
