### PR TITLE
DSD-1558: applying Typo2023 color scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates underline styles of the `Link` component.
 - Updates the hex value for the `Link Primary` color style.
 - Updates the `Link` component so that non-button variants change color once visited.
+- Updates all components that render text to use the `Typoe2023` color scheme.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Accordion
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/AlphabetFilter/AlphabetFilter.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # AlphabetFilter
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/AudioPlayer/AudioPlayer.mdx
+++ b/src/components/AudioPlayer/AudioPlayer.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Audio Player
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Breadcrumbs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.3`    |
-| Latest            | `1.6.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.3`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Button/Button.mdx
+++ b/src/components/Button/Button.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Button
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Card
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Checkbox/Checkbox.mdx
+++ b/src/components/Checkbox/Checkbox.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Checkbox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # DatePicker
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # FeedbackBox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.3.0`    |
-| Latest            | `1.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.3.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -173,9 +173,13 @@ export const FeedbackBox = chakra(
             width="100%"
           />
         ) : undefined;
+      const descriptionColor = useColorModeValue(
+        "ui.typography.heading",
+        "dark.ui.typography.heading"
+      );
       const descriptionElement =
         isFormView && descriptionText ? (
-          <Text fontWeight="medium" noSpace>
+          <Text color={descriptionColor} fontWeight="medium" noSpace>
             {descriptionText}
           </Text>
         ) : undefined;

--- a/src/components/Fieldset/Fieldset.mdx
+++ b/src/components/Fieldset/Fieldset.mdx
@@ -7,10 +7,10 @@ import { Link } from "../Link/Link";
 
 # Fieldset
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.3`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.3`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/HelperErrorText/HelperErrorText.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # HelperErrorText
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.10`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `1.5.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Image
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.6`    |
-| Latest            | `1.6.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.6`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Label/Label.mdx
+++ b/src/components/Label/Label.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Label
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.10`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/List/List.mdx
+++ b/src/components/List/List.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # List
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | `1.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.7.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -8,10 +8,10 @@ import Link from "../Link/Link";
 
 # Modal
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.4.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Notification/Notification.mdx
+++ b/src/components/Notification/Notification.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Notification
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.2`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Pagination
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.10`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -130,7 +130,7 @@ export const Pagination = chakra(
       // The current page link has different styles.
       const currentStyles = isSelectedPage
         ? {
-          color: "ui.typography.body",
+            color: "ui.typography.body",
             pointerEvent: "none",
             _dark: {
               color: "dark.ui.typography.body",

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -130,7 +130,7 @@ export const Pagination = chakra(
       // The current page link has different styles.
       const currentStyles = isSelectedPage
         ? {
-            color: "ui.black",
+          color: "ui.typography.body",
             pointerEvent: "none",
             _dark: {
               color: "dark.ui.typography.body",

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="css-u4fxc5"
+        className="css-17tw9ye"
         href="page=1"
         id="firstPage-1"
         rel={null}
@@ -203,7 +203,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-current="page"
         aria-label="Page 10"
-        className="css-u4fxc5"
+        className="css-17tw9ye"
         href="page=10"
         id="lastPage-10"
         rel={null}
@@ -272,7 +272,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-current="page"
         aria-label="Page 5"
-        className="css-u4fxc5"
+        className="css-17tw9ye"
         href="page=5"
         id="middlePage-5"
         rel={null}
@@ -341,7 +341,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="css-u4fxc5"
+        className="css-17tw9ye"
         href="page=1"
         id="chakra-1"
         rel={null}
@@ -450,7 +450,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="css-u4fxc5"
+        className="css-17tw9ye"
         href="page=1"
         id="props-1"
         rel={null}

--- a/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # ProgressIndicator
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.4`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Radio/Radio.mdx
+++ b/src/components/Radio/Radio.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Radio
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.22.0`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.22.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/SearchBar/SearchBar.mdx
+++ b/src/components/SearchBar/SearchBar.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # SearchBar
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `1.5.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Select
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | `1.5.4`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.7.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Slider/Slider.mdx
+++ b/src/components/Slider/Slider.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Slider
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `1.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.4`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # StatusBadge
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.18.7`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.18.7`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/StructuredContent/StructuredContent.mdx
+++ b/src/components/StructuredContent/StructuredContent.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # StructuredContent
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.9`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.9`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/StyledList/StyledList.mdx
+++ b/src/components/StyledList/StyledList.mdx
@@ -8,10 +8,10 @@ import Link from "../Link/Link";
 
 # StyledList
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.3.0`    |
-| Latest            | `1.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.3.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Table/Table.mdx
+++ b/src/components/Table/Table.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Table
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.9`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.9`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Tabs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `1.5.2`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/TagSet/TagSet.mdx
+++ b/src/components/TagSet/TagSet.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # TagSet
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Text/Text.mdx
+++ b/src/components/Text/Text.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Text
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.1`   |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.1`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/TextInput/TextInput.mdx
+++ b/src/components/TextInput/TextInput.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # TextInput
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.22.0`   |
-| Latest            | `1.7.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.22.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Toggle/Toggle.mdx
+++ b/src/components/Toggle/Toggle.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Toggle
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.8`   |
-| Latest            | `1.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.8`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Tooltip
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.1.0`    |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/VideoPlayer/VideoPlayer.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Video Player
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `1.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.2`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/theme/components/accordion.ts
+++ b/src/theme/components/accordion.ts
@@ -3,12 +3,12 @@ const containerStyles = {
   width: "100%",
   _dark: {
     bg: "dark.ui.bg.default",
-    color: "dark.ui.typography.heading",
     borderColor: "dark.ui.border.default",
   },
 };
 const buttonStyles = {
   borderWidth: "1px",
+  color: "ui.typography.heading",
   fontWeight: "medium",
   _dark: {
     bg: "dark.ui.bg.default",

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -164,7 +164,7 @@ export const pill = ({ buttonSize = "medium" }) => ({
   border: "1px solid",
   borderColor: "ui.border.default",
   borderRadius: "button.pill",
-  color: "inherit",
+  color: "ui.typography.heading",
   ...generalSizeValues(buttonSize, true),
   _hover: {
     bg: "ui.gray.xx-light-cool",

--- a/src/theme/components/customTable.ts
+++ b/src/theme/components/customTable.ts
@@ -80,7 +80,7 @@ export const baseCellStyles = (
       bg: columnHeadersBackgroundColor
         ? columnHeadersBackgroundColor
         : undefined,
-      color: columnHeadersTextColor ? columnHeadersTextColor : "ui.black",
+      color: columnHeadersTextColor ? columnHeadersTextColor : "ui.typography.heading",
       fontWeight: "medium",
       paddingStart:
         columnHeadersBackgroundColor || showRowDividers || useRowHeaders
@@ -106,7 +106,7 @@ export const baseTHStyles = (
     showRowDividers,
     useRowHeaders
   ),
-  color: columnHeadersTextColor ? columnHeadersTextColor : "ui.black",
+  color: columnHeadersTextColor ? columnHeadersTextColor : "ui.typography.heading",
   fontWeight: "medium",
   textTransform: "capitalize",
   _first: {
@@ -156,15 +156,15 @@ export const baseStyle = ({
 }: BaseStyleProps) => ({
   // Headers `th` can be rendered as the first cell in every row through the
   // `useRowHeaders`. Whereas the header `th` in the `thead` can be rendered
-  // with a custom color, the row header `th` in the `tbody` should always
-  // have text color black for light color mode and `dark.ui.typography.heading`
-  // for dark color mode.
+  // with a custom color, the row header `th` in the `tbody` should always have
+  // text color `ui.typography.heading` for light color mode and
+  // `dark.ui.typography.heading` for dark color mode.
   tbody: {
     th: {
       backgroundColor: useRowHeaders
         ? { base: "ui.gray.x-light-cool", md: "unset" }
         : undefined,
-      color: "ui.black",
+      color: "ui.typography.heading",
       verticalAlign: "top",
       _dark: {
         backgroundColor: useRowHeaders
@@ -199,7 +199,7 @@ export const baseStyle = ({
   ),
   caption: {
     captionSide: "top",
-    color: "ui.black",
+    color: "ui.typography.body",
     fontSize: "heading.secondary",
     fontWeight: "heading.secondary",
     marginBottom: "s",

--- a/src/theme/components/customTable.ts
+++ b/src/theme/components/customTable.ts
@@ -80,7 +80,9 @@ export const baseCellStyles = (
       bg: columnHeadersBackgroundColor
         ? columnHeadersBackgroundColor
         : undefined,
-      color: columnHeadersTextColor ? columnHeadersTextColor : "ui.typography.heading",
+      color: columnHeadersTextColor
+        ? columnHeadersTextColor
+        : "ui.typography.heading",
       fontWeight: "medium",
       paddingStart:
         columnHeadersBackgroundColor || showRowDividers || useRowHeaders
@@ -106,7 +108,9 @@ export const baseTHStyles = (
     showRowDividers,
     useRowHeaders
   ),
-  color: columnHeadersTextColor ? columnHeadersTextColor : "ui.typography.heading",
+  color: columnHeadersTextColor
+    ? columnHeadersTextColor
+    : "ui.typography.heading",
   fontWeight: "medium",
   textTransform: "capitalize",
   _first: {

--- a/src/theme/components/feedbackBox.ts
+++ b/src/theme/components/feedbackBox.ts
@@ -37,6 +37,10 @@ const FeedbackBox = {
     drawerContent: {
       marginStart: "auto",
       width: { base: "100%", md: "375px" },
+      aside: {
+        color: "ui.typography.heading",
+        _dark: { color: "dark.ui.typography.heading" },
+      },
     },
     drawerHeader: {
       alignItems: "baseline",
@@ -44,6 +48,7 @@ const FeedbackBox = {
       borderBottomWidth: "1px",
       borderLeftWidth: { base: undefined, md: "1px" },
       borderTopWidth: "1px",
+      color: "ui.typography.heading",
       display: "flex",
       fontSize: "text.default",
       px: "m",
@@ -55,6 +60,7 @@ const FeedbackBox = {
       _dark: {
         background: "dark.ui.bg.hover",
         borderColor: "dark.ui.border.default",
+        color: "dark.ui.typography.heading",
       },
     },
     openButton: {

--- a/src/theme/components/fieldset.ts
+++ b/src/theme/components/fieldset.ts
@@ -13,8 +13,12 @@ const Fieldset = {
       border: 0,
       padding: 0,
       legend: {
+        color: "ui.typography.heading",
         ...labelLegendText,
         ...screenreaderStyles,
+        _dark: {
+          color: "dark.ui.typography.heading",
+        },
       },
     };
   },

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -101,6 +101,7 @@ const defaultElementSizes = {
 };
 // Used in `Label` and `Fieldset`.
 const labelLegendText = {
+  color: "ui.typography.heading",
   display: "inline-block",
   fontSize: "desktop.label.label1",
   fontWeight: "label.default",

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -122,6 +122,7 @@ const Heading = {
     // This is to help target custom anchor elements
     // passed as children to the Heading component.
     a: baseLinkStyles,
+    color: "ui.typography.heading",
     textTransform: isCapitalized
       ? "capitalize"
       : isUppercase

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -40,7 +40,7 @@ const secondaryBase = {
 // Used for all "secondary" variants' heading component.
 const secondaryHeadingBase = {
   marginBottom: "0",
-  color: "ui.white",
+  color: "ui.typography.inverse.heading",
   flex: "1 1 100%",
   marginTop: "0",
   paddingBottom: "xxs",
@@ -71,11 +71,13 @@ const getSecondaryVariantStyles = (bgColor: string = "") => {
     ...secondaryBase,
     heading: {
       ...secondaryHeadingBase,
+      color: bgColor ? "ui.white" : "ui.typography.inverse.heading",
       _before: {
         ...secondaryHeadingBase["_before"],
         bg: finalBgColor.light,
       },
       _dark: {
+        color: "dark.ui.typography.heading",
         _before: {
           bg: finalBgColor.dark,
         },
@@ -97,7 +99,7 @@ const primary = {
   minHeight: "350px",
   content: {
     bg: "ui.black",
-    color: "ui.white",
+    color: "ui.typography.inverse.body",
     flex: {
       base: "0 0 100%",
       md: "0 0 60%",
@@ -111,16 +113,17 @@ const primary = {
       color: "inherit",
       display: "inline-block",
     },
-    heading: {
-      marginBottom: "0",
-    },
     bodyText: {
       marginBottom: "0",
     },
+    // h1: { color: "ui.typography.inverse.heading" },
     _dark: {
       bgColor: "dark.ui.bg.default",
       color: "dark.ui.typography.body",
     },
+  },
+  heading: {
+    color: "dark.ui.typography.heading",
   },
 };
 const secondary = getSecondaryVariantStyles();
@@ -136,7 +139,7 @@ const tertiary = {
   bg: "ui.gray.x-dark",
   content: {
     ...wrapperStyles,
-    color: "ui.white",
+    color: "ui.typography.inverse.body",
     display: "flex",
     flexFlow: "column nowrap",
     px: "inset.default",
@@ -146,10 +149,11 @@ const tertiary = {
       marginTop: { base: "xxs", xl: "xs" },
     },
     _dark: {
-      color: "dark.ui.typography.body",
+      p: { color: "dark.ui.typography.body" },
     },
   },
   heading: {
+    color: "ui.typography.inverse.heading",
     marginBottom: "0",
     _lastChild: {
       marginBottom: "0",
@@ -179,7 +183,7 @@ const campaign = {
   content: {
     alignItems: "stretch",
     bg: "ui.black",
-    color: "ui.white",
+    color: "ui.typography.inverse.body",
     display: "flex",
     flexFlow: {
       base: "column nowrap",
@@ -194,6 +198,9 @@ const campaign = {
       bg: "dark.ui.bg.default",
       color: "dark.ui.typography.body",
     },
+  },
+  heading: {
+    color: "dark.ui.typography.heading",
   },
   a: {
     color: "inherit",

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -72,6 +72,7 @@ export const baseDescriptionStyles = {
   dt: {
     borderTop: "1px solid",
     borderColor: "ui.border.default",
+    color: "ui.typography.heading",
     fontWeight: "label.default",
     paddingBottom: { base: "0", md: "s" },
     paddingTop: "s",

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -15,6 +15,8 @@ const Modal = {
       },
     },
     header: {
+      color: "ui.typography.heading",
+      fontWeight: "medium",
       _dark: {
         color: "dark.ui.typography.heading",
       },

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -19,8 +19,10 @@ const MultiSelectMenuButton = {
       whiteSpace: "nowrap",
       transition: "margin 150ms ease-out",
       _dark: {
-        color: isOpen ? "dark.ui.typography.heading" : "dark.ui.typography.body",
-      }
+        color: isOpen
+          ? "dark.ui.typography.heading"
+          : "dark.ui.typography.body",
+      },
     },
     menuButton: {
       alignItems: "center",

--- a/src/theme/components/multiSelectMenuButton.ts
+++ b/src/theme/components/multiSelectMenuButton.ts
@@ -9,6 +9,7 @@ const MultiSelectMenuButton = {
   ],
   baseStyle: ({ hasSelectedItems = false, isOpen = false }) => ({
     buttonLabel: {
+      color: isOpen ? "ui.typography.heading" : "ui.typography.body",
       justifyContent: "flex-start",
       overflow: "hidden",
       marginLeft: hasSelectedItems ? "50px" : "0",
@@ -17,6 +18,9 @@ const MultiSelectMenuButton = {
       textOverflow: "ellipsis",
       whiteSpace: "nowrap",
       transition: "margin 150ms ease-out",
+      _dark: {
+        color: isOpen ? "dark.ui.typography.heading" : "dark.ui.typography.body",
+      }
     },
     menuButton: {
       alignItems: "center",

--- a/src/theme/components/notification.ts
+++ b/src/theme/components/notification.ts
@@ -57,7 +57,7 @@ const Notification = {
         border: "none",
         bgColor: "inherit",
         alignItems: "center",
-        color: "ui.black",
+        color: "ui.typography.heading",
         display: "flex",
         h: "32px",
         w: "32px",
@@ -69,7 +69,7 @@ const Notification = {
           marginTop: "0",
         },
         _dark: {
-          color: "dark.ui.typography.body",
+          color: "dark.ui.typography.heading",
         },
         _hover: {
           bg: "inherit",
@@ -133,7 +133,7 @@ const NotificationHeading = {
     isCentered,
     notificationType,
   }: NotificationHeadingBaseStyle) => {
-    let color = "ui.black";
+    let color = "ui.typography.heading";
     if (notificationType === "announcement") {
       color = "section.research.secondary";
     } else if (notificationType === "warning") {

--- a/src/theme/components/progressIndicator.ts
+++ b/src/theme/components/progressIndicator.ts
@@ -17,7 +17,7 @@ const ProgressIndicator = {
   ],
   baseStyle: ({ darkMode, size }: ProgressIndicatorBaseStyle) => {
     return {
-      color: darkMode ? "ui.white" : "ui.black",
+      color: darkMode ? "dark.ui.typography.heading" : "ui.typography.heading",
       _dark: {
         color: "dark.ui.typography.heading",
       },

--- a/src/theme/components/statusBadge.ts
+++ b/src/theme/components/statusBadge.ts
@@ -1,7 +1,7 @@
 const StatusBadge = {
   baseStyle: {
     borderRadius: "base",
-    color: "ui.black",
+    color: "ui.typography.heading",
     display: "block",
     fontSize: "-1", // slightly smaller than the default size
     fontStyle: "italic",

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -2,12 +2,10 @@ const tablist = {
   borderColor: "ui.black",
 };
 const tab = {
-  paddingInlineStart: "s",
-  paddingStart: "s",
   background: "transparent",
   border: "0",
   borderBottom: "1px solid",
-  borderColor: "red",
+  color: "ui.typography.heading",
   height: { base: "44px" },
   marginEnd: {
     base: "0",
@@ -18,6 +16,8 @@ const tab = {
     md: "l",
     lg: "xl",
   },
+  paddingInlineStart: "s",
+  paddingStart: "s",
   whiteSpace: "nowrap",
   _hover: {
     bg: "ui.gray.x-light-cool",

--- a/src/theme/components/tagSet.ts
+++ b/src/theme/components/tagSet.ts
@@ -10,7 +10,7 @@ const TagSetFilter = {
     border: "1px solid",
     borderColor: "ui.border.default",
     borderRadius: "pill",
-    color: "ui.black",
+    color: "ui.typography.body",
     cursor: isDismissible ? "pointer" : "auto",
     height: { base: "32px", md: "22px" },
     minHeight: "22px",
@@ -41,7 +41,7 @@ const TagSetFilter = {
       },
     },
     clearAll: {
-      color: "ui.black",
+      color: "ui.typography.body",
       height: { base: "32px", md: "22px" },
       fontSize: "text.tag",
       minHeight: "22px",

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -7,7 +7,7 @@ const Tooltip = {
     [$bg.variable]: "colors.ui.gray.xx-dark",
     borderRadius: "4px",
     boxShadow: "none",
-    color: "ui.white",
+    color: "ui.typography.inverse.body",
     fontSize: "text.tag",
     marginBottom: "xxs",
     maxWidth: "240px",
@@ -15,6 +15,7 @@ const Tooltip = {
     py: "xs",
     _dark: {
       [$bg.variable]: "colors.ui.gray.x-dark",
+      color: "dark.ui.typography.heading",
     },
   },
 };

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -187,11 +187,11 @@ const colors: Colors = {
       hover: grayDark,
     },
     typography: {
-      heading: black,
-      body: black,
+      heading: grayxxxxDark,
+      body: grayxxDark,
       inverse: {
-        heading: white,
-        body: white,
+        heading: grayLightCool,
+        body: grayMedium,
       },
     },
     // Grayscale
@@ -272,8 +272,8 @@ const colors: Colors = {
         heading: grayLightCool,
         body: grayMedium,
         inverse: {
-          heading: grayxxxDark,
-          body: grayxxxDark,
+          heading: grayxxxxDark,
+          body: grayxxDark,
         },
       },
     },

--- a/src/theme/foundations/global.ts
+++ b/src/theme/foundations/global.ts
@@ -10,7 +10,7 @@ const global = {
   body: {
     boxSizing: "border-box",
     bg: "ui.white",
-    color: "ui.black",
+    color: "ui.typography.body",
     fontFamily: "body",
     fontSize: "text.default",
     fontWeight: "text.default",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1558](https://jira.nypl.org/browse/DSD-1558)

## This PR does the following:

- Updates all components that render text to use the `Typoe2023` color scheme.
- NOTE: A lot of files were updated, but a big chunk of theme are the story files were the Latest Version number was updated.  You should be able to quick move through those files when reviewing.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The `Typo2023` color styles use a preapproved WCAG compliant color palette.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
