### PR TITLE
DSD-1549: Typo2023 styles for Content Display category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the hex value for the `Link Primary` color style.
 - Updates the `Link` component so that non-button variants change color once visited.
 - Updates the `Link` component to explicitly assign the text color for the `"buttonPrimary"` variant `hover` state.
-- Updates the components in the `Basic Content` category to implement the `Typo2023` styles.
-- Updates all components that render text to use the `Typoe2023` color scheme.
+- Updates the components in the `Basic Content` and `Content Display` categories to implement the `Typo2023` styles.
+- Updates all components that render text to use the `Typo2023` color scheme.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/theme/components/statusBadge.ts
+++ b/src/theme/components/statusBadge.ts
@@ -3,7 +3,7 @@ const StatusBadge = {
     borderRadius: "base",
     color: "ui.typography.heading",
     display: "block",
-    fontSize: "-1", // slightly smaller than the default size
+    fontSize: "desktop.body.body2", // slightly smaller than the default size
     fontStyle: "italic",
     py: "inset.extranarrow",
     px: "inset.narrow",
@@ -12,7 +12,7 @@ const StatusBadge = {
     _dark: {
       backgroundColor: "dark.ui.bg.active",
       borderLeft: "4px solid",
-      borderColor: "ui.gray.medium",
+      borderColor: "dark.ui.border.default",
       color: "dark.ui.typography.heading",
     },
   },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1549](https://jira.nypl.org/browse/DSD-1549)

## This PR does the following:

- Updates the components in the `Content Display` category to implement the `Typo2023` styles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
