### PR TITLE
DSD-1547: Typo2023 styles for Typography category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,9 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the hex value for the `Link Primary` color style.
 - Updates the `Link` component so that non-button variants change color once visited.
 - Updates the `Link` component to explicitly assign the text color for the `"buttonPrimary"` variant `hover` state.
-- Updates the components in the `Basic Content` category to implement the `Typo2023` styles.
-- Updates all components that render text to use the `Typoe2023` color scheme.
+- Updates all components that render text to use the `Typo2023` color scheme.
+- Updates the components in the `Basic Content` and `Typography` categories to implement the `Typo2023` styles.
+- Updates the base styles to use the `Typo2023` styles.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/components/AlphabetFilter/__snapshots__/AlphabetFilter.test.tsx.snap
+++ b/src/components/AlphabetFilter/__snapshots__/AlphabetFilter.test.tsx.snap
@@ -632,7 +632,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
     id="alphabet-filter-wrapper"
   >
     <h2
-      className="chakra-heading css-1xdhyk6"
+      className="chakra-heading css-878tmy"
       id="alphabet-filter-heading"
     >
       Heading

--- a/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
+++ b/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
   id="undefined-componentWrapper-wrapper"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="undefined-componentWrapper-heading"
   >
     Audio Player Heading

--- a/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
+++ b/src/components/ComponentWrapper/__snapshots__/ComponentWrapper.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 1`] = `
   id="id-wrapper"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="id-heading"
   >
     heading text
@@ -55,7 +55,7 @@ exports[`ComponentWrapper Renders the UI snapshot correctly 3`] = `
   id="id-wrapper"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="id-heading"
   >
     heading text

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -105,7 +105,7 @@ export const Heading = chakra(
         isCapitalized,
         isUppercase,
         isLowercase,
-        level = "two",
+        level = "h2",
         noSpace,
         overline,
         size,

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`Heading renders the UI snapshot correctly 6`] = `
 
 exports[`Heading renders the UI snapshot correctly 7`] = `
 <h2
-  className="chakra-heading css-10g9ftz"
+  className="chakra-heading css-1whog1v"
   id="chakra"
 >
   Heading
@@ -81,7 +81,7 @@ exports[`Heading renders the UI snapshot correctly 7`] = `
 
 exports[`Heading renders the UI snapshot correctly 8`] = `
 <h2
-  className="chakra-heading css-1xdhyk6"
+  className="chakra-heading css-878tmy"
   data-testid="props"
   id="props"
 >

--- a/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/src/components/List/__snapshots__/List.test.tsx.snap
@@ -86,7 +86,7 @@ exports[`List Renders the UI snapshot correctly 5`] = `
   id="description"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="description-heading"
   >
     Animal Crossing Fish
@@ -157,7 +157,7 @@ exports[`List Renders the UI snapshot correctly 8`] = `
   id="chakra"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="chakra-heading"
   >
     Animal Crossing Fish
@@ -188,7 +188,7 @@ exports[`List Renders the UI snapshot correctly 9`] = `
   id="other"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="other-heading"
   >
     Animal Crossing Fish

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -826,7 +826,7 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
   id="withHeading-wrapper"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withHeading-heading"
   >
     A Heading
@@ -947,7 +947,7 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
   id="withHeadingAndDescription-wrapper"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withHeadingAndDescription-heading"
   >
     A Heading

--- a/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
+++ b/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`StructuredContent renders the UI snapshot 1`] = `
   id="withHTMLStringContent"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withHTMLStringContent-heading"
   >
     Heading text
@@ -61,7 +61,7 @@ exports[`StructuredContent renders the UI snapshot 2`] = `
   id="withHTMLDOMContent"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withHTMLDOMContent-heading"
   >
     Heading text
@@ -150,7 +150,7 @@ exports[`StructuredContent renders the UI snapshot 3`] = `
   id="withoutAnImage"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withoutAnImage-heading"
   >
     Heading text
@@ -178,7 +178,7 @@ exports[`StructuredContent renders the UI snapshot 4`] = `
   id="withImageWithoutCaptionOrCredit"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withImageWithoutCaptionOrCredit-heading"
   >
     Heading text
@@ -264,7 +264,7 @@ exports[`StructuredContent renders the UI snapshot 6`] = `
   id="withoutCalloutText"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withoutCalloutText-heading"
   >
     Heading text
@@ -286,7 +286,7 @@ exports[`StructuredContent renders the UI snapshot 7`] = `
   id="withChakraProps"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withChakraProps-heading"
   >
     Heading text
@@ -342,7 +342,7 @@ exports[`StructuredContent renders the UI snapshot 8`] = `
   id="withOtherProps"
 >
   <h2
-    className="chakra-heading css-1xdhyk6"
+    className="chakra-heading css-878tmy"
     id="withOtherProps-heading"
   >
     Heading text

--- a/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
+++ b/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 2`] = `
     id="video-player-with-text-componentWrapper-wrapper"
   >
     <h2
-      className="chakra-heading css-1xdhyk6"
+      className="chakra-heading css-878tmy"
       id="video-player-with-text-componentWrapper-heading"
     >
       VideoPlayer Heading
@@ -90,7 +90,7 @@ exports[`VideoPlayer renders the UI snapshot correctly 3`] = `
     id="video-player-with-text-componentWrapper-wrapper"
   >
     <h2
-      className="chakra-heading css-1xdhyk6"
+      className="chakra-heading css-878tmy"
       id="video-player-with-text-componentWrapper-heading"
     >
       VideoPlayer Heading

--- a/src/theme/foundations/global.ts
+++ b/src/theme/foundations/global.ts
@@ -12,8 +12,8 @@ const global = {
     bg: "ui.white",
     color: "ui.typography.body",
     fontFamily: "body",
-    fontSize: "text.default",
-    fontWeight: "text.default",
+    fontSize: "desktop.body.body1",
+    fontWeight: "body.body1",
     lineHeight: "1.5",
     overflowX: "hidden",
     _dark: {

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -213,6 +213,7 @@ const typography: Typography = {
     bold: fontWeightValues["bold"],
     // semantic tokens
     body: {
+      default: fontWeightValues["light"],
       body1: fontWeightValues["light"],
       body2: fontWeightValues["light"],
     },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1547](https://jira.nypl.org/browse/DSD-1564)

## This PR does the following:

- Updates the components in the `Typography` category to implement the `Typo2023` styles.
- Updates the base styles to use the `Typo2023` styles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
