### PR TITLE
DSD-1552: Typo2023 styles for Media & Icons category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Link` component to explicitly assign the text color for the `"buttonPrimary"` variant `hover` state.
 - Updates all components that render text to use the `Typo2023` color scheme.
 - Updates the base styles to use the `Typo2023` styles.
-- Updates the components in the `Basic Content`, `Content Display`, `Feedback`, and `Typography` categories to implement the `Typo2023` styles.
+- Updates the components in the `Basic Content`, `Content Display`, `Feedback`, `Media & Icons`, and `Typography` categories to implement the `Typo2023` styles.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -7,6 +7,7 @@ import {
 } from "@chakra-ui/react";
 import React, { forwardRef, ImgHTMLAttributes } from "react";
 import { useInView } from "react-intersection-observer";
+import HelperErrorText from "../HelperErrorText/HelperErrorText";
 
 export const imageRatiosArray = [
   "fourByThree",
@@ -212,8 +213,20 @@ export const Image = chakra(
           >
             {finalImage}
             <Box as="figcaption" __css={styles.figcaption}>
-              {caption && <Box __css={styles.captionWrappers}>{caption}</Box>}
-              {credit && <Box __css={styles.captionWrappers}>{credit}</Box>}
+              {caption && (
+                <HelperErrorText
+                  ariaLive="off"
+                  ariaAtomic={false}
+                  text={caption}
+                />
+              )}
+              {credit && (
+                <HelperErrorText
+                  ariaLive="off"
+                  ariaAtomic={false}
+                  text={credit}
+                />
+              )}
             </Box>
           </Box>
         ) : (

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -28,9 +28,18 @@ exports[`Image Renders the UI snapshot correctly 2`] = `
       className="css-0"
     >
       <div
-        className="css-0"
+        aria-atomic={false}
+        className="css-1xdhyk6"
+        data-isinvalid={false}
       >
-        Caption
+        <div
+          className="css-0"
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Caption",
+            }
+          }
+        />
       </div>
     </figcaption>
   </figure>
@@ -53,9 +62,18 @@ exports[`Image Renders the UI snapshot correctly 3`] = `
       className="css-0"
     >
       <div
-        className="css-0"
+        aria-atomic={false}
+        className="css-1xdhyk6"
+        data-isinvalid={false}
       >
-        Credit
+        <div
+          className="css-0"
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Credit",
+            }
+          }
+        />
       </div>
     </figcaption>
   </figure>
@@ -78,14 +96,32 @@ exports[`Image Renders the UI snapshot correctly 4`] = `
       className="css-0"
     >
       <div
-        className="css-0"
+        aria-atomic={false}
+        className="css-1xdhyk6"
+        data-isinvalid={false}
       >
-        Caption
+        <div
+          className="css-0"
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Caption",
+            }
+          }
+        />
       </div>
       <div
-        className="css-0"
+        aria-atomic={false}
+        className="css-1xdhyk6"
+        data-isinvalid={false}
       >
-        Credit
+        <div
+          className="css-0"
+          dangerouslySetInnerHTML={
+            {
+              "__html": "Credit",
+            }
+          }
+        />
       </div>
     </figcaption>
   </figure>

--- a/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
+++ b/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
@@ -32,14 +32,32 @@ exports[`StructuredContent renders the UI snapshot 1`] = `
         className="css-0"
       >
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image caption
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image caption",
+              }
+            }
+          />
         </div>
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image credit
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image credit",
+              }
+            }
+          />
         </div>
       </figcaption>
     </figure>
@@ -87,14 +105,32 @@ exports[`StructuredContent renders the UI snapshot 2`] = `
         className="css-0"
       >
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image caption
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image caption",
+              }
+            }
+          />
         </div>
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image credit
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image credit",
+              }
+            }
+          />
         </div>
       </figcaption>
     </figure>
@@ -235,14 +271,32 @@ exports[`StructuredContent renders the UI snapshot 5`] = `
         className="css-0"
       >
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image caption
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image caption",
+              }
+            }
+          />
         </div>
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image credit
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image credit",
+              }
+            }
+          />
         </div>
       </figcaption>
     </figure>
@@ -312,14 +366,32 @@ exports[`StructuredContent renders the UI snapshot 7`] = `
         className="css-0"
       >
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image caption
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image caption",
+              }
+            }
+          />
         </div>
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image credit
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image credit",
+              }
+            }
+          />
         </div>
       </figcaption>
     </figure>
@@ -368,14 +440,32 @@ exports[`StructuredContent renders the UI snapshot 8`] = `
         className="css-0"
       >
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image caption
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image caption",
+              }
+            }
+          />
         </div>
         <div
-          className="css-0"
+          aria-atomic={false}
+          className="css-1xdhyk6"
+          data-isinvalid={false}
         >
-          Image credit
+          <div
+            className="css-0"
+            dangerouslySetInnerHTML={
+              {
+                "__html": "Image credit",
+              }
+            }
+          />
         </div>
       </figcaption>
     </figure>

--- a/src/theme/components/image.ts
+++ b/src/theme/components/image.ts
@@ -102,7 +102,6 @@ const CustomImage = {
     },
     figcaption: {
       fontStyle: "italic",
-      fontSize: "text.tag",
     },
     img: {
       display: "block",
@@ -115,9 +114,6 @@ const CustomImage = {
       _dark: {
         backgroundColor: "dark.ui.bg.default",
       },
-    },
-    captionWrappers: {
-      marginTop: "xxs",
     },
   }),
 };


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1552](https://jira.nypl.org/browse/DSD-1552)

## This PR does the following:

- Updates the components in the `Media & Icons` category to implement the `Typo2023` styles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
