### PR TITLE
DSD-1554: Typo2023 styles for Overlays & Content Switchers category

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Link` component to explicitly assign the text color for the `"buttonPrimary"` variant `hover` state.
 - Updates all components that render text to use the `Typo2023` color scheme.
 - Updates the base styles to use the `Typo2023` styles.
-- Updates the components in the `Basic Content`, `Content Display`, `Feedback`, `Forms`, and `Typography` categories to implement the `Typo2023` styles.
+- Updates the components in the `Basic Content`, `Content Display`, `Feedback`, `Forms`, `Overlays & Content Switchers`, and `Typography` categories to implement the `Typo2023` styles.
 
 ## 1.7.0 (July 20, 2023)
 

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -80,7 +80,7 @@ const getElementsFromData = (
       };
   // For FAQ-style multiple accordions, the button should be bigger.
   // Otherwise, use the default.
-  const multipleFontSize = data?.length > 1 ? "text.default" : "text.caption";
+  const multipleFontSize = data?.length > 1 ? "desktop.body.body1" : "desktop.body.body2";
   const multiplePadding = data?.length > 1 ? "s" : "xs s";
 
   return data.map((content, index) => {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -80,7 +80,8 @@ const getElementsFromData = (
       };
   // For FAQ-style multiple accordions, the button should be bigger.
   // Otherwise, use the default.
-  const multipleFontSize = data?.length > 1 ? "desktop.body.body1" : "desktop.body.body2";
+  const multipleFontSize =
+    data?.length > 1 ? "desktop.body.body1" : "desktop.body.body2";
   const multiplePadding = data?.length > 1 ? "s" : "xs s";
 
   return data.map((content, index) => {

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>
@@ -81,7 +81,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>
@@ -142,7 +142,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>
@@ -204,7 +204,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>
@@ -265,7 +265,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>
@@ -326,7 +326,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>
@@ -387,7 +387,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
       type="button"
     >
       <span
-        className="css-1p6r3oe"
+        className="css-1kmgev1"
       >
         Gerry Kellman
       </span>

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -75,7 +75,10 @@ const getElementsFromData = (
     // For URL hash enabled tabs, we need to add a custom `onClick` to handle the URL hash.
     const tempTab = (
       <Tab
-        fontSize={["0", null, "1"]}
+        fontSize={{
+          base: "mobile.subtitle.subtitle1",
+          md: "desktop.subtitle.subtitle1",
+        }}
         key={index}
         onClick={useHash ? () => onClickHash(`tab${index + 1}`) : undefined}
       >

--- a/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
+++ b/src/components/Tabs/__snapshots__/Tabs.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Tabs renders the UI snapshot correctly 1`] = `
           <button
             aria-controls="basic--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="basic--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -76,7 +76,7 @@ exports[`Tabs renders the UI snapshot correctly 1`] = `
           <button
             aria-controls="basic--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="basic--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -89,7 +89,7 @@ exports[`Tabs renders the UI snapshot correctly 1`] = `
           <button
             aria-controls="basic--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="basic--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -255,7 +255,7 @@ exports[`Tabs renders the UI snapshot correctly 2`] = `
           <button
             aria-controls="chakra--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="chakra--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -268,7 +268,7 @@ exports[`Tabs renders the UI snapshot correctly 2`] = `
           <button
             aria-controls="chakra--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="chakra--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -281,7 +281,7 @@ exports[`Tabs renders the UI snapshot correctly 2`] = `
           <button
             aria-controls="chakra--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="chakra--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -448,7 +448,7 @@ exports[`Tabs renders the UI snapshot correctly 3`] = `
           <button
             aria-controls="props--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="props--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -461,7 +461,7 @@ exports[`Tabs renders the UI snapshot correctly 3`] = `
           <button
             aria-controls="props--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="props--tab--1"
             onClick={[Function]}
             onFocus={[Function]}
@@ -474,7 +474,7 @@ exports[`Tabs renders the UI snapshot correctly 3`] = `
           <button
             aria-controls="props--tabpanel--1"
             aria-selected={false}
-            className="chakra-tabs__tab css-abpfcx"
+            className="chakra-tabs__tab css-p5yrdq"
             id="props--tab--1"
             onClick={[Function]}
             onFocus={[Function]}

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -16,6 +16,10 @@ const Modal = {
     },
     header: {
       color: "ui.typography.heading",
+      fontSize: {
+        base: "mobile.heading.heading4",
+        md: "desktop.heading.heading4",
+      },
       fontWeight: "medium",
       _dark: {
         color: "dark.ui.typography.heading",

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -8,7 +8,7 @@ const Tooltip = {
     borderRadius: "4px",
     boxShadow: "none",
     color: "ui.typography.inverse.body",
-    fontSize: "text.tag",
+    fontSize: "desktop.caption",
     marginBottom: "xxs",
     maxWidth: "240px",
     px: "s",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1554](https://jira.nypl.org/browse/DSD-1554)

## This PR does the following:

- Updates the components in the `Overlays & Content Switchers` category to implement the `Typo2023` styles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
