### PR TITLE
DSD-1568: isUnderlined adjustments in Link component

### DIFF
--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -36,6 +36,7 @@ export const WithControls: Story = {
     className: "custom-class",
     href: "https://nypl.org",
     id: "nypl-link",
+    isUnderlined: true,
     screenreaderOnlyText: "Screenreader only text",
     target: undefined,
     type: "action",

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -153,7 +153,7 @@ export const Link = chakra(
       className,
       href,
       id,
-      isUnderlined,
+      isUnderlined = true,
       onClick,
       screenreaderOnlyText,
       target,
@@ -164,10 +164,10 @@ export const Link = chakra(
     // Set initial underline style for certain variants
     const finalIsUnderlined =
       type === "backwards" || type === "forwards" || type === "standalone"
-        ? isUnderlined
-          ? true
-          : false
-        : true;
+        ? false
+        : isUnderlined
+        ? true
+        : false;
 
     // Merge the necessary props alongside any extra props for the
     // anchor element.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1568](https://jira.nypl.org/browse/DSD-1568)

## This PR does the following:

- Adjusting the logic related to the `isUnderlined` prop in the `Link` component.
- NOTE: An entry was not added to the CHANGELOG because the `isUnderlined` prop us already mentioned in another entry.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
