### PR TITLE
hotfix:  breadcrumb fontsize for older design token value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the `Logo` component to include variants for `NYC Public Schools`.
 - Updates the `Icon` component to include varisnts for `"sunFull"` and `"moonCrescent"`.
+- Updates `Breadcrumbs` default design token to support apps using both newer and older DS versions.
 
 ## 1.7.2 (August 31 , 2023)
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Breadcrumbs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.3`    |
-| Latest            | `1.6.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.3`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -168,7 +168,9 @@ const typography: Typography = {
     },
     // deprecated semantic tokens
     breadcrumbs: {
-      default: fontSizeValues.desktop["caption"],
+      // The deprecated value is "caption" but we should use body2 instead
+      // for backwards compatibility
+      default: fontSizeValues.desktop["body2"],
     },
     button: {
       small: {


### PR DESCRIPTION
## This PR does the following:

- Updates the value of the breadcrumbs fontsize for the older design token for visual consistency in apps that don't use the latest vesion.
- This occurred in the Header app that uses the latest DS version and has a new value for the breadcrumb design token, but an app was expecting the older design token value.

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
