### PR TITLE
Updating documentation and links to better reference the v2 update

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Build Storybook
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-        run: npm run prebuild:storybook && npm run build-storybook:v1
+        run: npm run prebuild:storybook && npm run build-storybook:v2
 
       - name: Deploy
         uses: JamesIves/github-pages-deploy-action@releases/v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Build Storybook
         env:
           NODE_OPTIONS: "--max_old_space_size=4096"
-        run: npm run prebuild:storybook && npm run build-storybook:v1
+        run: npm run prebuild:storybook && npm run build-storybook:v2
       - name: Setup Pages
         uses: actions/configure-pages@v3
       - name: Upload artifact

--- a/CHAKRA_MIGRATION_GUIDE.md
+++ b/CHAKRA_MIGRATION_GUIDE.md
@@ -2,10 +2,12 @@
 
 The first Reservoir Design System (DS) version that includes the Chakra UI library is version `0.25.0`. This guide is meant for those who are using a version less than `0.25.0` and want to migrate to a version greater than or equal to `0.25.0`. If you're importing the latest DS version, this guide will also help!
 
+If you are using a DS version greater than 1.0, this guide does not apply.
+
 If you would rather read documentation on the Design System's internal use of Chakra, check the Storybook documentation page. The following two links have the same information but in different formats for your reading preference:
 
 - [MDX format](/src/docs/Chakra.stories.mdx)
-- [Storybook page](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/chakra-ui--docs)
+- [Storybook page](https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/chakra-ui--docs)
 
 | Table of Contents |                                                       |
 | ----------------- | ----------------------------------------------------- |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ The Reservoir Design System (DS) is NYPL’s open-source extensible React librar
 
 Storybook documentation
 
-- [Production - deployed to Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/welcome--docs)
+- [V2 Production - deployed to Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/welcome--docs)
 - [Development/QA - deployed to Vercel](https://nypl-design-system.vercel.app/?path=/docs/welcome--docs)
+- [V1 Production - deployed to Vercel](https://nypl-design-system-git-reservoir-v173-nypl.vercel.app/)
 
 | Table of Contents |                                                                                     |
 | ----------------- | ----------------------------------------------------------------------------------- |
@@ -138,27 +139,31 @@ The list of re-exported Chakra components can be found in the main [index.ts](/s
 Find more information about the Design System's internal use of Chakra to create and refactor components in the Storybook documentation page. The following two links have the same information but in different formats for your reading preference:
 
 - [MDX format](/src/docs/Chakra.stories.mdx)
-- [Storybook page](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/chakra-ui--docs)
+- [Storybook page](https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/chakra-ui--docs)
 
 Chakra was integrated into the Design System in version `0.25.0`. For those looking to update to a version greater than or equal `0.25.0`, check out our [Chakra Migration Guide](/CHAKRA_MIGRATION_GUIDE.md).
 
 ## Storybook
 
-The Reservoir Design System leverages Storybook to document all the React components and style guidelines. The Storybook documentation can be found [here](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/welcome--docs). For your convenience, the Reservoir Design System components have been organized into logical categories based on both form and function. Please refer to the COMPONENTS section in the Storybook sidebar.
+The Reservoir Design System leverages Storybook to document all the React components and style guidelines. The Storybook documentation for version 2.x can be found [on Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/welcome--docs). For your convenience, the Reservoir Design System components have been organized into logical categories based on both form and function. Please refer to the COMPONENTS section in the Storybook sidebar.
 
 ### Documentation Instances
 
-There are currently two main instances of the Reservoir Design System Storybook documentation. There are also "preview" sites that are used to quickly and easily view pull request changes.
+There are currently three main instances of the Reservoir Design System Storybook documentation. There are also "preview" sites that are used to quickly and easily view pull request changes.
 
 **Production**
 
-The production Storybook documentation is deployed to [Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/welcome--docs). This is the main instance we use to share the latest stable release of the Reservoir Design System. This documentation site is deployed through [Github Actions](/.github/workflows/gh-pages.yml) only on merges to the `release` branch.
+The production Storybook documentation for DS version 2.x is deployed to [Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/welcome--docs). This is the main instance we use to share the latest stable release of the Reservoir Design System. This documentation site is deployed through [Github Actions](/.github/workflows/gh-pages.yml) only on merges to the `release` and `gh-pages` branches.
 
 As of July, 2021, the Github Pages production site gets deployed every two weeks on the same schedule as npm releases.
 
 **Development**
 
 The development Storybook documentation is deployed to [Vercel](https://nypl-design-system.vercel.app/?path=/docs/welcome--docs). This development site has all the working updates that get merged to the `development` branch. This means that this site is constantly being updated as pull requests are being merged in. This site is used to see the lastest changes during a working sprint before a production release is made.
+
+**Version 1.x**
+
+The Storybook documentation for DS version 1.x is deployed to [Vercel](https://nypl-design-system-git-reservoir-v173-nypl.vercel.app/). If you are using a DS version less than 2.0, this is the Storybook documentation you should be referencing. While the DS team will continue to support version 1.x, we will not be adding new features or components to this version. We highly recommend updating to version 2.x for design update and bug fixes.
 
 **Preview Sites**
 
@@ -191,13 +196,13 @@ To help consuming application developers understand which version of the DS is r
 
 _Make sure not to commit the directory created from the following process_.
 
-There should be no need to run the static Storybook instance while actively developing -- it's used exclusively for building out the `gh-pages` environment and deploying it to [Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/welcome--docs). In the event that you do run the static Storybook npm script, run:
+There should be no need to run the static Storybook instance while actively developing -- it's used exclusively for building out the `gh-pages` environment and deploying it to [Github Pages](https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/welcome--docs). In the event that you do run the static Storybook npm script, run:
 
 ```sh
-$ npm run build-storybook:v1
+$ npm run build-storybook:v2
 ```
 
-You can then view `/reservoir/v1/index.html` in your browser. _Make sure not to commit this directory_.
+You can then view `/reservoir/v2/index.html` in your browser. _Make sure not to commit this directory_.
 
 ## Accessibility
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "prepare": "npm run build && husky install",
     "storybook": "storybook dev -p 6006",
     "build-storybook:v1": "storybook build -c .storybook -o ./reservoir/v1",
+    "build-storybook:v2": "storybook build -c .storybook -o ./reservoir/v2",
     "prebuild:storybook": "npm run test:generate-output",
     "build-storybook": "storybook build"
   },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "lint": "eslint src --ext=ts,tsx --cache",
     "prepare": "npm run build && husky install",
     "storybook": "storybook dev -p 6006",
-    "build-storybook:v1": "storybook build -c .storybook -o ./reservoir/v1",
     "build-storybook:v2": "storybook build -c .storybook -o ./reservoir/v2",
     "prebuild:storybook": "npm run test:generate-output",
     "build-storybook": "storybook build"

--- a/src/components/TagSet/TagSet.mdx
+++ b/src/components/TagSet/TagSet.mdx
@@ -51,7 +51,7 @@ element; typically, links are expected to be used for the "explore" variant.
 const tagSetData = [
   {
     label: (
-      <a href="https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/components-basic-elements-card--with-controls">
+      <a href="https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/story/components-basic-elements-card--with-controls">
         Card
       </a>
     ),
@@ -59,7 +59,7 @@ const tagSetData = [
   {
     iconName: "fileTypeDoc",
     label: (
-      <a href="https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/components-page-layout-structuredcontent--controls">
+      <a href="https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/story/components-page-layout-structuredcontent--controls">
         StructuredContent
       </a>
     ),
@@ -67,7 +67,7 @@ const tagSetData = [
   {
     iconName: "alertWarningOutline",
     label: (
-      <a href="https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/story/components-feedback-progressindicator--with-controls">
+      <a href="https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/story/components-feedback-progressindicator--with-controls">
         ProgressIndicator
       </a>
     ),
@@ -75,7 +75,7 @@ const tagSetData = [
   {
     iconName: "actionSettings",
     label: (
-      <a href="https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/hooks-usenyplbreakpoints--docs">
+      <a href="https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/hooks-usenyplbreakpoints--docs">
         useNYPLBreakpoints React hook
       </a>
     ),

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -3,7 +3,7 @@ import { hexToRGB } from "../../utils/utils";
 
 /**
  * All colors can be found in Storybook:
- *   https://nypl.github.io/nypl-design-system/reservoir/v1/?path=/docs/style-guide-colors--docs
+ *   https://nypl.github.io/nypl-design-system/reservoir/v2/?path=/docs/style-guide-colors--docs
  *
  * All UI Fills colors can be found in Figma:
  *   https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?node-id=47083%3A27674


### PR DESCRIPTION
No JIRA ticket.

## This PR does the following:

- Updates `/v1` Storybook documentation references to `/v2`.
- Adds better documentation about v2.x and v1.x and where each documentation site is hosted.

## How has this been tested?

Locally. Links will eventually work once we deploy.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
