### PR TITLE
DSD-1281: Fix Hero backgroundColor/foregroundColor issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
-## Updates
+### Updates
 
 - Temporarily renaming `FilterBar`, `MultiSelect`, `MultiSelectGroup`, `useMultiSelect`, and `useFilterBar` Storybook page files so they don't show up in the Storybook sidebar.
+
+### Fixes
+
+- Fixes an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.
 
 ## 2.0.1 (September 28, 2023)
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -309,12 +309,12 @@ export const Campaign: Story = {
       <div>
         <Heading
           id="campaign-hero-long-text"
-          text="Campaign Hero with separate backdrop and foreground background color"
+          text="Campaign Hero with separate backdrop and foreground background design token color"
         />
         <Hero
           backdropBackgroundColor="section.education.primary"
-          backgroundColor="#DC8034"
-          foregroundColor="black"
+          backgroundColor="dark.ui.warning.primary"
+          foregroundColor="ui.black"
           heroType="campaign"
           heading={
             <Heading

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -165,8 +165,8 @@ export const Hero = chakra(
 
       if (!heroSecondaryTypes.includes(heroType)) {
         contentBoxStyling = {
-          ...(backgroundColor && { backgroundColor }),
           ...(foregroundColor && { color: foregroundColor }),
+          ...(backgroundColor && { backgroundColor }),
         };
       } else if (
         foregroundColor ||
@@ -230,6 +230,7 @@ export const Hero = chakra(
         >
           <Box
             data-testid="hero-content"
+            style={contentBoxStyling}
             __css={{ ...styles.content, ...contentBoxStyling }}
           >
             {childrenToRender}

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -160,13 +160,13 @@ export const Hero = chakra(
           ? { bgColor: backdropBackgroundColor }
           : { backgroundColor };
       } else if (heroType === "tertiary" || heroType === "fiftyFifty") {
-        backgroundImageStyle = { backgroundColor };
+        backgroundImageStyle = { bgColor: backgroundColor };
       }
 
       if (!heroSecondaryTypes.includes(heroType)) {
         contentBoxStyling = {
-          color: foregroundColor,
-          backgroundColor,
+          ...(backgroundColor && { bgColor: backgroundColor }),
+          ...(foregroundColor && { color: foregroundColor }),
         };
       } else if (
         foregroundColor ||
@@ -230,8 +230,7 @@ export const Hero = chakra(
         >
           <Box
             data-testid="hero-content"
-            style={contentBoxStyling}
-            __css={styles.content}
+            __css={{ ...styles.content, ...contentBoxStyling }}
           >
             {childrenToRender}
           </Box>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -160,12 +160,12 @@ export const Hero = chakra(
           ? { bgColor: backdropBackgroundColor }
           : { backgroundColor };
       } else if (heroType === "tertiary" || heroType === "fiftyFifty") {
-        backgroundImageStyle = { bgColor: backgroundColor };
+        backgroundImageStyle = backgroundColor ? { bg: backgroundColor } : {};
       }
 
       if (!heroSecondaryTypes.includes(heroType)) {
         contentBoxStyling = {
-          ...(backgroundColor && { bgColor: backgroundColor }),
+          ...(backgroundColor && { backgroundColor }),
           ...(foregroundColor && { color: foregroundColor }),
         };
       } else if (

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -14,12 +14,7 @@ exports[`Hero Renders the UI snapshot correctly 1`] = `
   <div
     className="css-0"
     data-testid="hero-content"
-    style={
-      {
-        "backgroundColor": undefined,
-        "color": undefined,
-      }
-    }
+    style={{}}
   >
     <h1
       className="chakra-heading css-eyyo6e"
@@ -240,12 +235,7 @@ exports[`Hero Renders the UI snapshot correctly 7`] = `
   <div
     className="css-0"
     data-testid="hero-content"
-    style={
-      {
-        "backgroundColor": undefined,
-        "color": undefined,
-      }
-    }
+    style={{}}
   >
     <h1
       className="chakra-heading css-eyyo6e"
@@ -274,12 +264,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
   <div
     className="css-0"
     data-testid="hero-content"
-    style={
-      {
-        "backgroundColor": undefined,
-        "color": undefined,
-      }
-    }
+    style={{}}
   >
     <div
       className="css-1gt4hjv"
@@ -318,12 +303,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
   <div
     className="css-0"
     data-testid="hero-content"
-    style={
-      {
-        "backgroundColor": undefined,
-        "color": undefined,
-      }
-    }
+    style={{}}
   >
     <div
       className="css-1gt4hjv"
@@ -361,12 +341,7 @@ exports[`Hero Renders the UI snapshot correctly 10`] = `
   <div
     className="css-0"
     data-testid="hero-content"
-    style={
-      {
-        "backgroundColor": undefined,
-        "color": undefined,
-      }
-    }
+    style={{}}
   >
     <h1
       className="chakra-heading css-eyyo6e"
@@ -397,12 +372,7 @@ exports[`Hero Renders the UI snapshot correctly 11`] = `
   <div
     className="css-0"
     data-testid="hero-content"
-    style={
-      {
-        "backgroundColor": undefined,
-        "color": undefined,
-      }
-    }
+    style={{}}
   >
     <h1
       className="chakra-heading css-eyyo6e"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1281](https://jira.nypl.org/browse/DSD-1281)

## This PR does the following:

- Fixes the issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component. Chakra prioritizes `bg` over `backgroundColor` which caused the default value to overwrite the passed value.
- `foregroundColor` for the campaign variant was being overwritten by the default styles passed through `__css`, this was resolved by adding `contentBoxStyling` to the object.

## How has this been tested?

Locally in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
