### PR TITLE
DSD-1581: better aria-label values for Slider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ## Updates
 
 - Temporarily renaming `FilterBar`, `MultiSelect`, `MultiSelectGroup`, `useMultiSelect`, and `useFilterBar` Storybook page files so they don't show up in the Storybook sidebar.
+- Updates the `Slider` component to use appropriate `aria-label` values for the slider thumbs and text input fields.
 
 ## 2.0.1 (September 28, 2023)
 

--- a/src/components/Slider/Slider.mdx
+++ b/src/components/Slider/Slider.mdx
@@ -44,9 +44,15 @@ color and background color is 4.5:1. If text size is 200%, the button scales
 with text so there is no overlap. Internally, a `Label` is associated with the
 `<input>` element.
 
-When `showLabel` is set to false, the `labelText` value will be set to the
-main `<div>`'s `aria-label` attribute. This is the same `<div>` that contains the
-`aria-valuemin`, `aria-valuemax`, `aria-orientation`, and `aria-valuenow`
+The `labelText` value is used to populate a global visual label for component.
+The value is also used to generate appropriate `aria-label` values for the
+component's text input and slider thumb. When `showLabel` is set to false, the
+visual label will be removed from the UI, but the value will still be used to
+generate the aria-label values for the previously mentioned internal
+elements.
+
+In addition to the `aria-label` attribute, the slider thumb will also contains
+the `aria-valuemin`, `aria-valuemax`, `aria-orientation`, and `aria-valuenow`
 attributes.
 
 Resources:
@@ -65,8 +71,11 @@ which shows the current value. This `input` element also has its own
 `aria-label`. When the input box is hidden, the `for` attribute in the `label`
 element is removed.
 
-Note that Chakra handles its single slider thumb aria attributes: `aria-valuemin`,
-`aria-valuemax`, `aria-valuenow`, and `aria-orientation`.
+Note that Chakra will automatically generate the values for the following aria
+attributes on the single slider thumb: `aria-valuemin`, `aria-valuemax`,
+`aria-valuenow`, and `aria-orientation`. However, Chakra does not generate the
+value for the `aria-label` attribute on the single slider thumb. The value for
+the `aria-label` attribute is dependent on the `labelText` value.
 
 ## RangeSlider
 
@@ -75,20 +84,28 @@ components double as displays for the slider's current minimum and maximum
 value. For this type of component, the `value` prop must be an array of two
 numbers. This signifies the starting and ending values of the range slider.
 
+Similar to the single slider configuration, each of the two sliders in the range
+slider configuration will contain the `aria-label`, `aria-valuemin`,
+`aria-valuemax`, `aria-orientation`, and `aria-valuenow` attributes.
+
 <Canvas of={SliderStories.RangeSliderWithControls} />
 
 ### RangeSlider Accessibility Implementation
 
 Chakra's `RangeSlider` component is accessible and, as recommended, we pass in
-two `aria-label`s to their `RangeSlider` component. The syntax is different than
-the expected standard string; the `RangeSlider` expect `aria-label` to be an array
-of two strings. On top of this, the DS `Slider`'s `<label>` element, when in the
-`isRangeSlider` state, points to the _first_ `<input>` element which shows the
-current _start_ value. These two `input` elements also have their own `aria-label`s.
-When the input boxes are hidden, the `for` attribute in the `label` element is removed.
+two `aria-label` values to their `RangeSlider` component. The syntax is
+different than the expected standard string; the `RangeSlider` expects
+`aria-label` to be an array of two strings. On top of this, the DS `Slider`'s
+`<label>` element, when in the `isRangeSlider` state, points to the _first_
+`<input>` element which shows the current _start_ value. These two `input`
+elements also have their own `aria-label`s. When the input boxes are hidden, the
+`for` attribute in the `label` element is removed.
 
-Note that Chakra handles its two slider thumbs aria attributes: `aria-valuemin`,
-`aria-valuemax`, `aria-valuenow`, and `aria-orientation`.
+Note that Chakra will automatically generate the values for the following aria
+attributes on the two slider thumbs: `aria-valuemin`, `aria-valuemax`,
+`aria-valuenow`, and `aria-orientation`. However, Chakra will not generate the
+values for the `aria-label` attributes on the two slider thumbs. The values for
+the `aria-label` attributes are dependent on the `labelText` value.
 
 ## Examples
 

--- a/src/components/Slider/Slider.mdx
+++ b/src/components/Slider/Slider.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Slider
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.4`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Slider/Slider.stories.tsx
+++ b/src/components/Slider/Slider.stories.tsx
@@ -595,7 +595,7 @@ function RangeSliderValuesUpdateExample() {
         <FormField>
           <Slider
             defaultValue={[15, 75]}
-            helperText="Values can be updated through the two inputs aboev."
+            helperText="Values can be updated through the two inputs above."
             id="range-slider-text-example"
             isRangeSlider
             labelText="Slider with Updated Values"

--- a/src/components/Slider/Slider.test.tsx
+++ b/src/components/Slider/Slider.test.tsx
@@ -131,7 +131,7 @@ describe("Slider", () => {
       expect(slider).toHaveAttribute("aria-valuemin", "0");
       expect(slider).toHaveAttribute("aria-valuemax", "100");
       expect(slider).toHaveAttribute("aria-valuenow", "50");
-      expect(slider).toHaveAttribute("aria-labelledBy", "sliderId-label");
+      expect(slider).toHaveAttribute("aria-label", "Label - slider handle");
     });
 
     it("renders the '(Required)' text in the label or hides it", () => {
@@ -174,7 +174,10 @@ describe("Slider", () => {
       );
 
       expect(screen.queryByText(/Label/i)).not.toBeInTheDocument();
-      expect(screen.getByRole("slider")).toHaveAttribute("aria-label", "Label");
+      expect(screen.getByRole("slider")).toHaveAttribute(
+        "aria-label",
+        "Label - slider handle"
+      );
     });
 
     it("hides the min/max static values", () => {
@@ -634,12 +637,18 @@ describe("Slider", () => {
       // This is set so the starting thumb can't go past the current end value.
       expect(slider[0]).toHaveAttribute("aria-valuemax", "75");
       expect(slider[0]).toHaveAttribute("aria-valuenow", "25");
-      expect(slider[0]).toHaveAttribute("aria-labelledBy", "sliderId-label");
+      expect(slider[0]).toHaveAttribute(
+        "aria-label",
+        "Label - slider handle for start value"
+      );
       // This is set so the ending thumb can't go below the current start value.
       expect(slider[1]).toHaveAttribute("aria-valuemin", "25");
       expect(slider[1]).toHaveAttribute("aria-valuemax", "100");
       expect(slider[1]).toHaveAttribute("aria-valuenow", "75");
-      expect(slider[1]).toHaveAttribute("aria-labelledBy", "sliderId-label");
+      expect(slider[1]).toHaveAttribute(
+        "aria-label",
+        "Label - slider handle for end value"
+      );
     });
 
     it("hides the label but adds it as an aria-label attribute", () => {
@@ -658,11 +667,11 @@ describe("Slider", () => {
       expect(screen.queryByText(/Label/i)).not.toBeInTheDocument();
       expect(screen.getAllByRole("slider")[0]).toHaveAttribute(
         "aria-label",
-        "Custom Label - start value"
+        "Custom Label - slider handle for start value"
       );
       expect(screen.getAllByRole("slider")[1]).toHaveAttribute(
         "aria-label",
-        "Custom Label - end value"
+        "Custom Label - slider handle for end value"
       );
     });
 

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -276,17 +276,15 @@ export const Slider = chakra(
       const getSliderType = () => {
         return isRangeSlider ? (
           <ChakraRangeSlider
-            // Both slider thumbs need values and should be in an array.
+            /**
+             * ChakraRangeSlider expects an array and applies the values to the
+             * `aria-label` attributes on the two slider thumbs respectively.
+             */
             aria-label={
-              showLabel
-                ? [
-                    `${labelText} - slider handle for start value`,
-                    `${labelText} - slider handle for end value`,
-                  ]
-                : [
-                    `${labelText} - slider handle for start value`,
-                    `${labelText} - slider handle for end value`,
-                  ]
+              [
+                `${labelText} - slider handle for start value`,
+                `${labelText} - slider handle for end value`,
+              ] as string[]
             }
             value={currentValue as number[]}
             // Make the thumbs larger.
@@ -301,6 +299,10 @@ export const Slider = chakra(
           </ChakraRangeSlider>
         ) : (
           <ChakraSlider
+            /**
+             * ChakraSlider uses this value to apply the `aria-label` attribute
+             * to the slider thumb.
+             */
             aria-label={`${labelText} - slider handle`}
             value={currentValue as number}
             // Make the thumb larger.

--- a/src/components/Slider/Slider.tsx
+++ b/src/components/Slider/Slider.tsx
@@ -252,7 +252,7 @@ export const Slider = chakra(
           },
         };
         const updatedLabel = !isRangeSlider
-          ? labelText
+          ? `${labelText} - value`
           : `${labelText} - ${type} value`;
         return (
           <TextInput
@@ -278,14 +278,15 @@ export const Slider = chakra(
           <ChakraRangeSlider
             // Both slider thumbs need values and should be in an array.
             aria-label={
-              !showLabel
-                ? [`${labelText} - start value`, `${labelText} - end value`]
-                : undefined
-            }
-            // Both slider thumbs need values and should be in an array,
-            // even if it's the same label.
-            aria-labelledby={
-              showLabel ? [`${id}-label`, `${id}-label`] : undefined
+              showLabel
+                ? [
+                    `${labelText} - slider handle for start value`,
+                    `${labelText} - slider handle for end value`,
+                  ]
+                : [
+                    `${labelText} - slider handle for start value`,
+                    `${labelText} - slider handle for end value`,
+                  ]
             }
             value={currentValue as number[]}
             // Make the thumbs larger.
@@ -300,8 +301,7 @@ export const Slider = chakra(
           </ChakraRangeSlider>
         ) : (
           <ChakraSlider
-            aria-label={!showLabel ? labelText : undefined}
-            aria-labelledby={`${id}-label`}
+            aria-label={`${labelText} - slider handle`}
             value={currentValue as number}
             // Make the thumb larger.
             size="lg"

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -89,7 +89,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
         />
       </div>
       <div
-        aria-labelledby="defaultRangeSlider-label"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -114,7 +114,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
         tabIndex={0}
       />
       <div
-        aria-labelledby="defaultRangeSlider-label"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -286,7 +286,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
         />
       </div>
       <div
-        aria-labelledby="errored-label"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -311,7 +311,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
         tabIndex={0}
       />
       <div
-        aria-labelledby="errored-label"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -487,7 +487,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
         />
       </div>
       <div
-        aria-labelledby="required-label"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -512,7 +512,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
         tabIndex={0}
       />
       <div
-        aria-labelledby="required-label"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -680,7 +680,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       </div>
       <div
         aria-disabled={true}
-        aria-labelledby="disabled-label"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -705,7 +705,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       />
       <div
         aria-disabled={true}
-        aria-labelledby="disabled-label"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -861,7 +861,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
         />
       </div>
       <div
-        aria-label="Label - start value"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -886,7 +886,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
         tabIndex={0}
       />
       <div
-        aria-label="Label - end value"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -1011,7 +1011,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
         />
       </div>
       <div
-        aria-labelledby="noVisibleValues-label"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -1036,7 +1036,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 6`] = `
         tabIndex={0}
       />
       <div
-        aria-labelledby="noVisibleValues-label"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -1133,7 +1133,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 7`] = `
         />
       </div>
       <div
-        aria-label="Label - start value"
+        aria-label="Label - slider handle for start value"
         aria-orientation="horizontal"
         aria-valuemax={75}
         aria-valuemin={0}
@@ -1158,7 +1158,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 7`] = `
         tabIndex={0}
       />
       <div
-        aria-label="Label - end value"
+        aria-label="Label - slider handle for end value"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={25}
@@ -1255,7 +1255,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
         />
       </div>
       <div
-        aria-labelledby="defaultSlider-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -1297,7 +1297,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
         className="css-79elbk"
       >
         <input
-          aria-label="Label"
+          aria-label="Label - value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}
@@ -1395,7 +1395,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
         />
       </div>
       <div
-        aria-labelledby="errored-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -1438,7 +1438,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
       >
         <input
           aria-invalid={true}
-          aria-label="Label - There is an error related to this field."
+          aria-label="Label - value - There is an error related to this field."
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}
@@ -1546,7 +1546,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
         />
       </div>
       <div
-        aria-labelledby="required-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -1588,7 +1588,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
         className="css-79elbk"
       >
         <input
-          aria-label="Label"
+          aria-label="Label - value"
           aria-required={true}
           autoComplete={null}
           className="chakra-input css-0"
@@ -1690,7 +1690,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
       </div>
       <div
         aria-disabled={true}
-        aria-labelledby="disabled-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -1731,7 +1731,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
         className="css-79elbk"
       >
         <input
-          aria-label="Label"
+          aria-label="Label - value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={true}
@@ -1822,7 +1822,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
         />
       </div>
       <div
-        aria-label="Label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -1864,7 +1864,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
         className="css-79elbk"
       >
         <input
-          aria-label="Label"
+          aria-label="Label - value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}
@@ -1948,7 +1948,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 6`] = `
         />
       </div>
       <div
-        aria-labelledby="noVisibleValues-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -2046,7 +2046,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 7`] = `
         />
       </div>
       <div
-        aria-label="Label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -2147,7 +2147,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
         />
       </div>
       <div
-        aria-labelledby="chakra-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -2189,7 +2189,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
         className="css-79elbk"
       >
         <input
-          aria-label="Label"
+          aria-label="Label - value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}
@@ -2288,7 +2288,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
         />
       </div>
       <div
-        aria-labelledby="props-label"
+        aria-label="Label - slider handle"
         aria-orientation="horizontal"
         aria-valuemax={100}
         aria-valuemin={0}
@@ -2330,7 +2330,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
         className="css-79elbk"
       >
         <input
-          aria-label="Label"
+          aria-label="Label - value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1581](https://jira.nypl.org/browse/DSD-1581)

## This PR does the following:

- Updates the `Slider` component to use appropriate `aria-label` values for the slider thumbs and text input fields.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The aria-label attribute on the slider thumbs will now always be present and the thumbs will no longer point to the main commponent label in aria-describedby.   Additionalmly, the aria-label attributes on the text input fields was updated to better align with the aria-label values on the slider thumbs.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
