### PR TITLE
DSD-1598: updated link patterns in FeedbackBox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Temporarily renaming `FilterBar`, `MultiSelect`, `MultiSelectGroup`, `useMultiSelect`, and `useFilterBar` Storybook page files so they don't show up in the Storybook sidebar.
 - Updates the `Slider` component to use appropriate `aria-label` values for the slider thumbs and text input fields.
+- Updates the `FeedbackBox` component to remove the underline on the component's `Privacy Policy` link.
 
 ## 2.0.1 (September 28, 2023)
 

--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # FeedbackBox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.3.0`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.3.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -189,6 +189,7 @@ export const FeedbackBox = chakra(
             href="https://www.nypl.org/help/about-nypl/legal-notices/privacy-policy"
             type="external"
             fontSize="text.tag"
+            isUnderlined={false}
             width="fit-content"
           >
             Privacy Policy


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1598](https://jira.nypl.org/browse/DSD-1598)

## This PR does the following:

- Updates the `FeedbackBox` component to remove the underline on the component's `Privacy Policy` link.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- The new text link patterns continue to adhere to a11y best practices and WCAG guidelines.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
