### PR TITLE
DSD-1603: component changelogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+- Adds the `ComponentChangelogTable` component.
+- Adds a changelog to the story pages for the `DatePicker`, `FeedbackBox`, `Hero`, and `Slider` components.
+
 ### Updates
 
 - Temporarily renaming `FilterBar`, `MultiSelect`, `MultiSelectGroup`, `useMultiSelect`, and `useFilterBar` Storybook page files so they don't show up in the Storybook sidebar.

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -1,9 +1,10 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as DatePickerStories from "./DatePicker.stories";
+import { changelogData } from "./datePickerChangelogData";
 import Link from "../Link/Link";
 import Table from "../Table/Table";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 <Meta of={DatePickerStories} />
 
@@ -257,27 +258,5 @@ const onSubmit = () => {
 />
 
 ## Changelog
-
-export const changelogData = [
-  {
-    date: "???",
-    version: "Prerelease",
-    type: "Update",
-    affects: "Accessibility",
-    notes: [
-      "Updates to pass a secondaryHelperTextId to its TextInput if needed so that the aria-describedby value can be associated with all relevant helperTexts.",
-      "Updates so that focus remains on input after value is changed.",
-    ],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: "Styles",
-    notes: [
-      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
-    ],
-  },
-];
 
 <ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -2,6 +2,8 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import * as DatePickerStories from "./DatePicker.stories";
 import Link from "../Link/Link";
+import Table from "../Table/Table";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 <Meta of={DatePickerStories} />
 
@@ -22,6 +24,7 @@ import Link from "../Link/Link";
 - {<Link href="#other-states" target="_self">Other States</Link>}
 - {<Link href="#date-inputs-and-output" target="_self">Date Inputs and Output</Link>}
 - {<Link href="#getting-date-input-values" target="_self">Getting Date Input Values</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -252,3 +255,29 @@ const onSubmit = () => {
 `}
   language="jsx"
 />
+
+## Changelog
+
+export const changelogData = [
+  {
+    date: "???",
+    version: "Prerelease",
+    type: "Update",
+    affects: "Accessibility",
+    notes: [
+      "Updates to pass a secondaryHelperTextId to its TextInput if needed so that the aria-describedby value can be associated with all relevant helperTexts.",
+      "Updates so that focus remains on input after value is changed.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: [
+      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
+    ],
+  },
+];
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -3,15 +3,17 @@
  * date: string (when adding new entry during development, set value as "Prerelease")
  * version: string (when adding new entry during development, set value as "Prerelease")
  * type: "Bug Fix" | "New Feature" | "Update";
- * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
  * notes: array (will render as a bulleted list, add one array element for each list element)
  */
-export const changelogData = [
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
   {
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: "Accessibility",
+    affects: ["Accessibility"],
     notes: [
       "Updates to pass a secondaryHelperTextId to its TextInput if needed so that the aria-describedby value can be associated with all relevant helperTexts.",
       "Updates so that focus remains on input after value is changed.",
@@ -21,7 +23,7 @@ export const changelogData = [
     date: "2023-9-28",
     version: "2.0.0",
     type: "Update",
-    affects: "Styles",
+    affects: ["Styles"],
     notes: [
       "Applied Typo2023 styles, including font size, font color, and text link patterns.",
     ],

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -1,0 +1,29 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+export const changelogData = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: "Accessibility",
+    notes: [
+      "Updates to pass a secondaryHelperTextId to its TextInput if needed so that the aria-describedby value can be associated with all relevant helperTexts.",
+      "Updates so that focus remains on input after value is changed.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: [
+      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
+    ],
+  },
+];

--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -1,8 +1,9 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as FeedbackBoxStories from "./FeedbackBox.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import * as FeedbackBoxStories from "./FeedbackBox.stories";
+import { changelogData } from "./feedbackBoxChangelogData";
+import Link from "../Link/Link";
 
 <Meta of={FeedbackBoxStories} />
 
@@ -387,26 +388,5 @@ const MyComponent = () => {
 />
 
 ## Changelog
-
-export const changelogData = [
-  {
-    date: "???",
-    version: "Prerelease",
-    type: "Update",
-    affects: "Accessibility, Styles",
-    notes: [
-      "Remove the underline on the component's `Privacy Policy` link.",
-    ],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: "Styles",
-    notes: [
-      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
-    ],
-  },
-];
 
 <ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -2,6 +2,7 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import * as FeedbackBoxStories from "./FeedbackBox.stories";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 <Meta of={FeedbackBoxStories} />
 
@@ -22,6 +23,7 @@ import Link from "../Link/Link";
 - {<Link href="#feedbackbox-screens" target="_self">FeedbackBox Screens</Link>}
 - {<Link href="#form-submission-data" target="_self">Form Submission Data</Link>}
 - {<Link href="#programmatically-open" target="_self">Programmatically Open</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -383,3 +385,28 @@ const MyComponent = () => {
 }; `}
   language="jsx"
 />
+
+## Changelog
+
+export const changelogData = [
+  {
+    date: "???",
+    version: "Prerelease",
+    type: "Update",
+    affects: "Accessibility, Styles",
+    notes: [
+      "Remove the underline on the component's `Privacy Policy` link.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: [
+      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
+    ],
+  },
+];
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -3,22 +3,24 @@
  * date: string (when adding new entry during development, set value as "Prerelease")
  * version: string (when adding new entry during development, set value as "Prerelease")
  * type: "Bug Fix" | "New Feature" | "Update";
- * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
  * notes: array (will render as a bulleted list, add one array element for each list element)
  */
-export const changelogData = [
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
   {
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: "Accessibility, Styles",
+    affects: ["Accessibility", "Styles"],
     notes: ["Remove the underline on the component's `Privacy Policy` link."],
   },
   {
     date: "2023-9-28",
     version: "2.0.0",
     type: "Update",
-    affects: "Styles",
+    affects: ["Styles"],
     notes: [
       "Applied Typo2023 styles, including font size, font color, and text link patterns.",
     ],

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -1,0 +1,26 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+export const changelogData = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: "Accessibility, Styles",
+    notes: ["Remove the underline on the component's `Privacy Policy` link."],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: [
+      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
+    ],
+  },
+];

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -1,8 +1,9 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as HeroStories from "./Hero.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import * as HeroStories from "./Hero.stories";
+import { changelogData } from "./heroChangelogData";
+import Link from "../Link/Link";
 
 <Meta of={HeroStories} />
 
@@ -201,26 +202,5 @@ and `"secondaryWhatsOn"`.
 <Canvas of={HeroStories.ColorVariations} />
 
 ## Changelog
-
-export const changelogData = [
-  {
-    date: "???",
-    version: "Prerelease",
-    type: "Bug Fix",
-    affects: "Functionality",
-    notes: [
-      "Fixes an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.",
-    ],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: "Styles",
-    notes: [
-      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
-    ],
-  },
-];
 
 <ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -2,6 +2,7 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import * as HeroStories from "./Hero.stories";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 <Meta of={HeroStories} />
 
@@ -19,6 +20,7 @@ import Link from "../Link/Link";
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#all-variations" target="_self">All Variations</Link>}
 - {<Link href="#color-variations-for-secondary-hero" target="_self">Color Variations for Secondary Hero</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -197,3 +199,28 @@ and `"secondaryWhatsOn"`.
 />
 
 <Canvas of={HeroStories.ColorVariations} />
+
+## Changelog
+
+export const changelogData = [
+  {
+    date: "???",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: "Functionality",
+    notes: [
+      "Fixes an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: [
+      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
+    ],
+  },
+];
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -1,0 +1,28 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+export const changelogData = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: "Functionality",
+    notes: [
+      "Fixes an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: [
+      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
+    ],
+  },
+] as const;

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -3,15 +3,17 @@
  * date: string (when adding new entry during development, set value as "Prerelease")
  * version: string (when adding new entry during development, set value as "Prerelease")
  * type: "Bug Fix" | "New Feature" | "Update";
- * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
  * notes: array (will render as a bulleted list, add one array element for each list element)
  */
-export const changelogData = [
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
   {
     date: "Prerelease",
     version: "Prerelease",
     type: "Bug Fix",
-    affects: "Functionality",
+    affects: ["Functionality"],
     notes: [
       "Fixes an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.",
     ],
@@ -20,9 +22,9 @@ export const changelogData = [
     date: "2023-9-28",
     version: "2.0.0",
     type: "Update",
-    affects: "Styles",
+    affects: ["Styles"],
     notes: [
       "Applied Typo2023 styles, including font size, font color, and text link patterns.",
     ],
   },
-] as const;
+];

--- a/src/components/Slider/Slider.mdx
+++ b/src/components/Slider/Slider.mdx
@@ -2,6 +2,7 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import * as SliderStories from "./Slider.stories";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 <Meta of={SliderStories} />
 
@@ -21,6 +22,7 @@ import Link from "../Link/Link";
 - {<Link href="#examples" target="_self">Examples</Link>}
 - {<Link href="#get-input-values" target="_self">Get Input Values</Link>}
 - {<Link href="#programmatically-update" target="_self">Programmatically Update</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -330,3 +332,26 @@ function RangeSliderValuesUpdateExample() {
 />
 
 <Canvas of={SliderStories.ProgrammaticallyUpdate} />
+
+## Changelog
+
+export const changelogData = [
+  {
+    date: "???",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: "Functionality",
+    notes: [
+      "Updated to use appropriate aria-label values for the slider thumbs and text input fields.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: ["Applied Typo2023 styles, including font size and font color."],
+  },
+];
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Slider/Slider.mdx
+++ b/src/components/Slider/Slider.mdx
@@ -1,8 +1,9 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as SliderStories from "./Slider.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import * as SliderStories from "./Slider.stories";
+import { changelogData } from "./sliderChangelogData";
+import Link from "../Link/Link";
 
 <Meta of={SliderStories} />
 
@@ -334,24 +335,5 @@ function RangeSliderValuesUpdateExample() {
 <Canvas of={SliderStories.ProgrammaticallyUpdate} />
 
 ## Changelog
-
-export const changelogData = [
-  {
-    date: "???",
-    version: "Prerelease",
-    type: "Bug Fix",
-    affects: "Functionality",
-    notes: [
-      "Updated to use appropriate aria-label values for the slider thumbs and text input fields.",
-    ],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: "Styles",
-    notes: ["Applied Typo2023 styles, including font size and font color."],
-  },
-];
 
 <ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Slider/sliderChangelogData.ts
+++ b/src/components/Slider/sliderChangelogData.ts
@@ -3,15 +3,17 @@
  * date: string (when adding new entry during development, set value as "Prerelease")
  * version: string (when adding new entry during development, set value as "Prerelease")
  * type: "Bug Fix" | "New Feature" | "Update";
- * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
  * notes: array (will render as a bulleted list, add one array element for each list element)
  */
-export const changelogData = [
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
   {
     date: "Prerelease",
     version: "Prerelease",
     type: "Bug Fix",
-    affects: "Functionality",
+    affects: ["Accessibility", "Functionality"],
     notes: [
       "Updated to use appropriate aria-label values for the slider thumbs and text input fields.",
     ],
@@ -20,7 +22,7 @@ export const changelogData = [
     date: "2023-9-28",
     version: "2.0.0",
     type: "Update",
-    affects: "Styles",
+    affects: ["Styles"],
     notes: ["Applied Typo2023 styles, including font size and font color."],
   },
 ];

--- a/src/components/Slider/sliderChangelogData.ts
+++ b/src/components/Slider/sliderChangelogData.ts
@@ -1,0 +1,26 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+export const changelogData = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: "Functionality",
+    notes: [
+      "Updated to use appropriate aria-label values for the slider thumbs and text input fields.",
+    ],
+  },
+  {
+    date: "2023-9-28",
+    version: "2.0.0",
+    type: "Update",
+    affects: "Styles",
+    notes: ["Applied Typo2023 styles, including font size and font color."],
+  },
+];

--- a/src/utils/ComponentChangelogTable.tsx
+++ b/src/utils/ComponentChangelogTable.tsx
@@ -1,11 +1,24 @@
 import List from "../components/List/List";
 import Table from "../components/Table/Table";
 
+export const affectTypesArray = [
+  "Accessibility",
+  "Documentation",
+  "Functionality",
+  "Styles",
+] as const;
+export type AffectTypes = typeof affectTypesArray[number];
+
 export interface ChangelogData {
+  /** Date of the release; format yyyy-mm-dd; when adding new entry during development, set value as "Prerelease" */
   date: string;
+  /** Version nunber of the release; when adding new entry during development, set value as "Prerelease" */
   version: string;
+  /** The type of update  */
   type: "Bug Fix" | "New Feature" | "Update";
-  affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+  /** The scope of the update */
+  affects: AffectTypes[];
+  /** Details about the update; this array will be rendered as a bulleted list */
   notes: string[];
 }
 
@@ -27,9 +40,10 @@ export const ComponentChangelogTable = (
             month: "short",
             day: "numeric",
           });
+    const affectsFormatted = affects.sort().join(", ");
     const notesItems = notes.map((item, i) => <li key={i}>{item}</li>);
     const notesList = <List type="ul">{notesItems}</List>;
-    const rowData = [dateFormatted, version, type, affects, notesList];
+    const rowData = [dateFormatted, version, type, affectsFormatted, notesList];
     return rowData;
   });
 

--- a/src/utils/ComponentChangelogTable.tsx
+++ b/src/utils/ComponentChangelogTable.tsx
@@ -52,7 +52,7 @@ export const ComponentChangelogTable = (
       fontSize: "desktop.caption",
       _last: {
         borderColor: borderColor,
-      }
+      },
     },
     td: {
       borderColor: borderColor,
@@ -61,7 +61,7 @@ export const ComponentChangelogTable = (
       // pt: "xs",
       _last: {
         borderColor: borderColor,
-      }
+      },
     },
     "th:nth-child(1)": {
       width: { base: "auto", md: narrowTdWidth },

--- a/src/utils/ComponentChangelogTable.tsx
+++ b/src/utils/ComponentChangelogTable.tsx
@@ -1,36 +1,36 @@
-import { PropsWithChildren } from "react";
-
 import List from "../components/List/List";
 import Table from "../components/Table/Table";
 
-export interface ComponentChangelogTableProps {
-  changelogData: any[];
-}
-export interface TableRowProps {
+export interface ChangelogData {
   date: string;
   version: string;
   type: "Bug Fix" | "New Feature" | "Update";
   affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
-  notes: any[];
+  notes: string[];
+}
+
+export interface ComponentChangelogTableProps {
+  changelogData: ChangelogData[];
 }
 
 export const ComponentChangelogTable = (
-  props: PropsWithChildren<ComponentChangelogTableProps>
+  props: ComponentChangelogTableProps
 ) => {
   const { changelogData } = props;
-  const tableData = [];
-
-  changelogData.forEach((tableRow: PropsWithChildren<TableRowProps>) => {
+  const tableData = changelogData.map((tableRow: ChangelogData) => {
     const { date, version, type, affects, notes } = tableRow;
-    const dateFormatted = new Date(date).toLocaleDateString("en-us", {
-      year: "numeric",
-      month: "short",
-      day: "numeric",
-    });
+    const dateFormatted =
+      date === "Prerelease"
+        ? date
+        : new Date(date).toLocaleDateString("en-us", {
+            year: "numeric",
+            month: "short",
+            day: "numeric",
+          });
     const notesItems = notes.map((item, i) => <li key={i}>{item}</li>);
     const notesList = <List type="ul">{notesItems}</List>;
     const rowData = [dateFormatted, version, type, affects, notesList];
-    tableData.push(rowData);
+    return rowData;
   });
 
   const headersData = ["Date", "Version", "Type", "Affects", "Notes"];

--- a/src/utils/ComponentChangelogTable.tsx
+++ b/src/utils/ComponentChangelogTable.tsx
@@ -1,0 +1,99 @@
+import { PropsWithChildren } from "react";
+
+import List from "../components/List/List";
+import Table from "../components/Table/Table";
+
+export interface ComponentChangelogTableProps {
+  changelogData: any[];
+}
+export interface TableRowProps {
+  date: string;
+  version: string;
+  type: "Bug Fix" | "New Feature" | "Update";
+  affects: "Accessibility" | "Documentation" | "Functionality" | "Styles";
+  notes: any[];
+}
+
+export const ComponentChangelogTable = (
+  props: PropsWithChildren<ComponentChangelogTableProps>
+) => {
+  const { changelogData } = props;
+  const tableData = [];
+
+  changelogData.forEach((tableRow: PropsWithChildren<TableRowProps>) => {
+    const { date, version, type, affects, notes } = tableRow;
+    const dateFormatted = new Date(date).toLocaleDateString("en-us", {
+      year: "numeric",
+      month: "short",
+      day: "numeric",
+    });
+    const notesItems = notes.map((item, i) => <li key={i}>{item}</li>);
+    const notesList = <List type="ul">{notesItems}</List>;
+    const rowData = [dateFormatted, version, type, affects, notesList];
+    tableData.push(rowData);
+  });
+
+  const headersData = ["Date", "Version", "Type", "Affects", "Notes"];
+  const narrowTdWidth = "9rem";
+  const narrowerTdWidth = "7rem";
+  const borderColor = "ui.gray.semi-medium";
+  const customStyles = {
+    thead: {
+      th: {
+        borderColor: borderColor,
+        fontSize: "desktop.overline.overline2",
+        pb: "xs",
+        pt: "xs",
+        textTransform: "uppercase",
+      },
+    },
+    th: {
+      borderColor: borderColor,
+      fontSize: "desktop.caption",
+      _last: {
+        borderColor: borderColor,
+      }
+    },
+    td: {
+      borderColor: borderColor,
+      fontSize: "desktop.caption",
+      // pb: "xs",
+      // pt: "xs",
+      _last: {
+        borderColor: borderColor,
+      }
+    },
+    "th:nth-child(1)": {
+      width: { base: "auto", md: narrowTdWidth },
+    },
+    "th:nth-child(2)": {
+      width: narrowerTdWidth,
+    },
+    "th:nth-child(3)": {
+      width: narrowerTdWidth,
+    },
+    "th:nth-child(4)": {
+      width: narrowerTdWidth,
+    },
+    ul: {
+      m: "0",
+    },
+    li: {
+      _notFirst: { mt: "xs" },
+    },
+  };
+
+  return (
+    <Table
+      className="sb-unstyled"
+      columnHeaders={headersData}
+      columnHeadersBackgroundColor="ui.bg.default"
+      showRowDividers
+      tableData={tableData}
+      useRowHeaders
+      sx={customStyles}
+    />
+  );
+};
+
+export default ComponentChangelogTable;

--- a/src/utils/ComponentChangelogTable.tsx
+++ b/src/utils/ComponentChangelogTable.tsx
@@ -71,8 +71,6 @@ export const ComponentChangelogTable = (
     td: {
       borderColor: borderColor,
       fontSize: "desktop.caption",
-      // pb: "xs",
-      // pt: "xs",
       _last: {
         borderColor: borderColor,
       },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1603](https://jira.nypl.org/browse/DSD-1603)

## This PR does the following:

- Adds the `ComponentChangelogTable` component.
- Adds a changelog to the story pages for the `DatePicker`, `FeedbackBox`, `Hero`, and `Slider` components.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
