### PR TITLE
DSD-1579: Adds aria-label to input for DatePicker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `Heading` component to set the `aria-roledescription` value as `"subtitle"` (a more familiar and recognizable value) for the `overline` element.
+- Updates `DatePicker`'s `TextInput` to always have an `aria-label` attribute that tells screen reader users how to access the calendar.
 
 ## 2.1.0 (October 18, 2023)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -40638,7 +40638,7 @@
       "version": "0.29.3",
       "dev": true,
       "requires": {
-        "types-ramda": "0.29.4"
+        "types-ramda": "^0.29.4"
       }
     },
     "@types/range-parser": {

--- a/src/components/Checkbox/Checkbox.test.tsx
+++ b/src/components/Checkbox/Checkbox.test.tsx
@@ -60,20 +60,6 @@ describe("Checkbox", () => {
     );
   });
 
-  it("Renders with appropriate 'aria-label' attribute and value when 'showLabel' prop is set to false and 'helperText' has been passed", () => {
-    render(
-      <Checkbox
-        id="inputID"
-        labelText="Test Label"
-        showLabel={false}
-        helperText="This is the helper text."
-      />
-    );
-    expect(
-      screen.getByLabelText("Test Label - This is the helper text.")
-    ).toBeInTheDocument();
-  });
-
   it("Renders visible helper or error text", () => {
     const { rerender } = render(
       <Checkbox

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -63,11 +63,9 @@ attribute. If a `helperTextFrom` or `helperTextTo` is passed in addition to a ge
 `helperText` for the entire `DatePicker`, then the `aria-describedby` attribute of the
 `<input>` element will be "[general-helperText-id] [input-helperText-id]".
 
-The `DatePicker`'s `<input>` has an `aria-label` that tells screen reader users how
-to access the calendar. Additionally, when `showLabel` is set to false, the single
-`<input>` element's `aria-label` attribute contains the required `labelText` value.
-In the "date range" mode, when `showLabel` is set to false, the `<fieldset>`'s
-`<legend>` will have the `labelText` visually hidden.
+The `DatePicker`'s `<input>` has an `aria-label` that tells screen reader users what
+the element is and how to access its calendar. In the "date range" mode, when `showLabel`
+is set to false, the `<fieldset>`'s `<legend>` will have the `labelText` visually hidden.
 
 Resources:
 

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -10,10 +10,10 @@ import Table from "../Table/Table";
 
 # DatePicker
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `2.1.0`    |
+| Component Version | DS Version  |
+| ----------------- | ----------- |
+| Added             | `0.24.0`    |
+| Latest            | `Prerelease |
 
 ## Table of Contents
 
@@ -63,10 +63,11 @@ attribute. If a `helperTextFrom` or `helperTextTo` is passed in addition to a ge
 `helperText` for the entire `DatePicker`, then the `aria-describedby` attribute of the
 `<input>` element will be "[general-helperText-id] [input-helperText-id]".
 
-When `showLabel` is set to false, the single `<input>` element's `aria-label`
-attribute is set to the required `labelText` value. In the "date range" mode,
-when `showLabel` is set to false, the `<fieldset>`'s `<legend>` will have the
-`labelText` visually hidden.
+The `DatePicker`'s `<input>` has an `aria-label` that tells screen reader users how
+to access the calendar. Additionally, when `showLabel` is set to false, the single
+`<input>` element's `aria-label` attribute contains the required `labelText` value.
+In the "date range" mode, when `showLabel` is set to false, the `<fieldset>`'s
+`<legend>` will have the `labelText` visually hidden.
 
 Resources:
 

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -105,7 +105,10 @@ describe("DatePicker", () => {
       );
 
       expect(input).toBeInTheDocument();
-      expect(input).not.toHaveAttribute("aria-label");
+      expect(input).toHaveAttribute(
+        "aria-label",
+        "Press tab to access the calendar."
+      );
       // Date format based on component specification yyyy-mm-dd.
       expect(date).toEqual(`${year}-${month}-${day}`);
       expect(screen.getByDisplayValue(date)).toBeInTheDocument();
@@ -596,20 +599,21 @@ describe("DatePicker", () => {
       // Helper text for the "To" input
       expect(screen.getByText(/Note for the 'to' field./i)).toBeInTheDocument();
 
-      const fromInput = screen.getByRole("textbox", { name: "From" });
-      const toInput = screen.getByRole("textbox", { name: "To" });
+      const inputs = screen.getAllByRole("textbox", {
+        name: "Press tab to access the calendar.",
+      });
 
       // The `fromInput` should have an `aria-describedby` value of both the id of
       // the `helperText` and the id of the `helperTextFrom` in that order - from
       // more general to more specific.
-      expect(fromInput).toHaveAttribute(
+      expect(inputs[0]).toHaveAttribute(
         "aria-describedby",
         "datePicker-helper-text datePicker-start-helperText"
       );
       // The `toInput` should have an `aria-describedby` value of both the id of
       // the `helperText` and the id of the `helperTextTo` in that order - from
       // more general to more specific.
-      expect(toInput).toHaveAttribute(
+      expect(inputs[1]).toHaveAttribute(
         "aria-describedby",
         "datePicker-helper-text datePicker-end-helperText"
       );
@@ -645,8 +649,11 @@ describe("DatePicker", () => {
         />
       );
       // Both input fields are disabled.
-      expect(screen.getByLabelText(/From/i)).toHaveAttribute("disabled");
-      expect(screen.getByLabelText(/To/i)).toHaveAttribute("disabled");
+      let inputs = screen.getAllByLabelText(
+        "Press tab to access the calendar."
+      );
+      expect(inputs[0]).toHaveAttribute("disabled");
+      expect(inputs[1]).toHaveAttribute("disabled");
 
       rerender(
         <DatePicker
@@ -659,11 +666,13 @@ describe("DatePicker", () => {
           isDateRange
         />
       );
+
+      inputs = screen.getAllByLabelText("Press tab to access the calendar.");
       // Both input fields are required.
       // The "Required" text is only displayed once in the `legend`.
       expect(screen.getAllByText(/Required/i)).toHaveLength(1);
-      expect(screen.getByLabelText(/From/i)).toHaveAttribute("required");
-      expect(screen.getByLabelText(/To/i)).toHaveAttribute("required");
+      expect(inputs[0]).toHaveAttribute("required");
+      expect(inputs[1]).toHaveAttribute("required");
     });
 
     // Note: Have to add initial dates so that the snapshot tests always
@@ -750,15 +759,16 @@ describe("DatePicker", () => {
           labelText="Select the date range you want to visit NYPL"
         />
       );
-      const fromInput = screen.getByLabelText(/From/i);
-      const toInput = screen.getByLabelText(/To/i);
+      const inputs = screen.getAllByLabelText(
+        "Press tab to access the calendar."
+      );
 
-      expect(fromInput).toHaveValue("1988-03-02");
-      expect(toInput).toHaveValue("1988-03-28");
+      expect(inputs[0]).toHaveValue("1988-03-02");
+      expect(inputs[1]).toHaveValue("1988-03-28");
       // expect(screen.getAllByDisplayValue(date)).toHaveLength(2);
 
       // Let's select a new day.
-      userEvent.click(fromInput);
+      userEvent.click(inputs[0]);
       // The popup displays. Select a new day.
       const newDateFrom = 5;
       const newDateTo = 25;
@@ -771,7 +781,7 @@ describe("DatePicker", () => {
       // expect(screen.getAllByDisplayValue(date)).toHaveLength(1);
 
       // Now select the "To" date.
-      userEvent.click(toInput);
+      userEvent.click(inputs[1]);
       // The popup displays.
       userEvent.click(screen.getByText(newDateTo));
 

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -600,10 +600,10 @@ describe("DatePicker", () => {
       expect(screen.getByText(/Note for the 'to' field./i)).toBeInTheDocument();
 
       const inputFrom = screen.getByRole("textbox", {
-        name: "From - Note for the 'from' field., Press tab to access the calendar.",
+        name: "From, Press tab to access the calendar.",
       });
       const inputTo = screen.getByRole("textbox", {
-        name: "To - Note for the 'to' field., Press tab to access the calendar.",
+        name: "To, Press tab to access the calendar.",
       });
 
       // The `fromInput` should have an `aria-describedby` value of both the id of
@@ -656,7 +656,7 @@ describe("DatePicker", () => {
         name: "From, Press tab to access the calendar.",
       });
       let inputTo = screen.getByRole("textbox", {
-        name: "To - Note for the 'to' field., Press tab to access the calendar.",
+        name: "To, Press tab to access the calendar.",
       });
       expect(inputFrom).toHaveAttribute("disabled");
       expect(inputTo).toHaveAttribute("disabled");
@@ -677,7 +677,7 @@ describe("DatePicker", () => {
         name: "From, Press tab to access the calendar.",
       });
       inputTo = screen.getByRole("textbox", {
-        name: "To - Note for the 'to' field., Press tab to access the calendar.",
+        name: "To, Press tab to access the calendar.",
       }); // Both input fields are required.
       // The "Required" text is only displayed once in the `legend`.
       expect(screen.getAllByText(/Required/i)).toHaveLength(1);

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -107,7 +107,7 @@ describe("DatePicker", () => {
       expect(input).toBeInTheDocument();
       expect(input).toHaveAttribute(
         "aria-label",
-        "Press tab to access the calendar."
+        "Select the full date you want to visit NYPL, Press tab to access the calendar."
       );
       // Date format based on component specification yyyy-mm-dd.
       expect(date).toEqual(`${year}-${month}-${day}`);
@@ -599,21 +599,24 @@ describe("DatePicker", () => {
       // Helper text for the "To" input
       expect(screen.getByText(/Note for the 'to' field./i)).toBeInTheDocument();
 
-      const inputs = screen.getAllByRole("textbox", {
-        name: "Press tab to access the calendar.",
+      const inputFrom = screen.getByRole("textbox", {
+        name: "From - Note for the 'from' field., Press tab to access the calendar.",
+      });
+      const inputTo = screen.getByRole("textbox", {
+        name: "To - Note for the 'to' field., Press tab to access the calendar.",
       });
 
       // The `fromInput` should have an `aria-describedby` value of both the id of
       // the `helperText` and the id of the `helperTextFrom` in that order - from
       // more general to more specific.
-      expect(inputs[0]).toHaveAttribute(
+      expect(inputFrom).toHaveAttribute(
         "aria-describedby",
         "datePicker-helper-text datePicker-start-helperText"
       );
       // The `toInput` should have an `aria-describedby` value of both the id of
       // the `helperText` and the id of the `helperTextTo` in that order - from
       // more general to more specific.
-      expect(inputs[1]).toHaveAttribute(
+      expect(inputTo).toHaveAttribute(
         "aria-describedby",
         "datePicker-helper-text datePicker-end-helperText"
       );
@@ -649,11 +652,14 @@ describe("DatePicker", () => {
         />
       );
       // Both input fields are disabled.
-      let inputs = screen.getAllByLabelText(
-        "Press tab to access the calendar."
-      );
-      expect(inputs[0]).toHaveAttribute("disabled");
-      expect(inputs[1]).toHaveAttribute("disabled");
+      let inputFrom = screen.getByRole("textbox", {
+        name: "From, Press tab to access the calendar.",
+      });
+      let inputTo = screen.getByRole("textbox", {
+        name: "To - Note for the 'to' field., Press tab to access the calendar.",
+      });
+      expect(inputFrom).toHaveAttribute("disabled");
+      expect(inputTo).toHaveAttribute("disabled");
 
       rerender(
         <DatePicker
@@ -667,12 +673,16 @@ describe("DatePicker", () => {
         />
       );
 
-      inputs = screen.getAllByLabelText("Press tab to access the calendar.");
-      // Both input fields are required.
+      inputFrom = screen.getByRole("textbox", {
+        name: "From, Press tab to access the calendar.",
+      });
+      inputTo = screen.getByRole("textbox", {
+        name: "To - Note for the 'to' field., Press tab to access the calendar.",
+      }); // Both input fields are required.
       // The "Required" text is only displayed once in the `legend`.
       expect(screen.getAllByText(/Required/i)).toHaveLength(1);
-      expect(inputs[0]).toHaveAttribute("required");
-      expect(inputs[1]).toHaveAttribute("required");
+      expect(inputFrom).toHaveAttribute("required");
+      expect(inputTo).toHaveAttribute("required");
     });
 
     // Note: Have to add initial dates so that the snapshot tests always
@@ -759,16 +769,19 @@ describe("DatePicker", () => {
           labelText="Select the date range you want to visit NYPL"
         />
       );
-      const inputs = screen.getAllByLabelText(
-        "Press tab to access the calendar."
-      );
+      const inputFrom = screen.getByRole("textbox", {
+        name: "From, Press tab to access the calendar.",
+      });
+      const inputTo = screen.getByRole("textbox", {
+        name: "To, Press tab to access the calendar.",
+      });
 
-      expect(inputs[0]).toHaveValue("1988-03-02");
-      expect(inputs[1]).toHaveValue("1988-03-28");
+      expect(inputFrom).toHaveValue("1988-03-02");
+      expect(inputTo).toHaveValue("1988-03-28");
       // expect(screen.getAllByDisplayValue(date)).toHaveLength(2);
 
       // Let's select a new day.
-      userEvent.click(inputs[0]);
+      userEvent.click(inputFrom);
       // The popup displays. Select a new day.
       const newDateFrom = 5;
       const newDateTo = 25;
@@ -781,7 +794,7 @@ describe("DatePicker", () => {
       // expect(screen.getAllByDisplayValue(date)).toHaveLength(1);
 
       // Now select the "To" date.
-      userEvent.click(inputs[1]);
+      userEvent.click(inputTo);
       // The popup displays.
       userEvent.click(screen.getByText(newDateTo));
 

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -159,6 +159,7 @@ const CustomTextInput = forwardRef<TextInputRefType, CustomTextInputProps>(
 
     return (
       <TextInput
+        additionalAriaLabel="Press tab to access the calendar."
         helperText={helperText}
         id={id}
         invalidText={invalidText}

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -49,7 +49,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="From, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="basic-start"
@@ -102,7 +102,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="To, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="basic-end"
@@ -183,7 +183,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="From, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="no-label-start"
@@ -236,7 +236,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="To, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="no-label-end"
@@ -317,7 +317,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="From, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="custom-format-start"
@@ -370,7 +370,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="To, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="custom-format-end"
@@ -453,7 +453,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 <input
                   aria-describedby="invalid-start-helperText"
                   aria-invalid={true}
-                  aria-label="Press tab to access the calendar."
+                  aria-label="From - Please select a valid date., Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="invalid-start"
@@ -524,7 +524,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 <input
                   aria-describedby="invalid-end-helperText"
                   aria-invalid={true}
-                  aria-label="Press tab to access the calendar."
+                  aria-label="To - Please select a valid date., Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="invalid-end"
@@ -630,7 +630,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="From, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={true}
                   id="disabled-start"
@@ -683,7 +683,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
                 className="css-79elbk"
               >
                 <input
-                  aria-label="Press tab to access the calendar."
+                  aria-label="To, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={true}
                   id="disabled-end"
@@ -762,7 +762,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
             className="css-79elbk"
           >
             <input
-              aria-label="Press tab to access the calendar."
+              aria-label="Select the full date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="basic-start"
@@ -823,7 +823,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
             className="css-79elbk"
           >
             <input
-              aria-label="Select the date you want to visit NYPL Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="no-label-start"
@@ -891,7 +891,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
             className="css-79elbk"
           >
             <input
-              aria-label="Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="custom-format-start"
@@ -961,7 +961,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
             <input
               aria-describedby="invalid-start-helperText"
               aria-invalid={true}
-              aria-label="Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL - Please select a valid date., Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="invalid-start"
@@ -1046,7 +1046,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
           >
             <input
               aria-describedby="disabled-start-helperText"
-              aria-label="Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL - Note that the Library may be closed on Sundays., Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={true}
               id="disabled-start"
@@ -1131,7 +1131,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
           >
             <input
               aria-describedby="chakra-start-helperText"
-              aria-label="Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL - Note that the Library may be closed on Sundays., Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="chakra-start"
@@ -1217,7 +1217,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
           >
             <input
               aria-describedby="props-start-helperText"
-              aria-label="Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL - Note that the Library may be closed on Sundays., Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="props-start"

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -24,8 +24,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="basic-start-wrapper"
@@ -72,8 +77,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="basic-end-wrapper"
@@ -148,8 +158,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="no-label-start-wrapper"
@@ -196,8 +211,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="no-label-end-wrapper"
@@ -272,8 +292,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="custom-format-start-wrapper"
@@ -320,8 +345,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="custom-format-end-wrapper"
@@ -396,8 +426,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="invalid-start-wrapper"
@@ -462,8 +497,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="invalid-end-wrapper"
@@ -565,8 +605,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="disabled-start-wrapper"
@@ -613,8 +658,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container"
+            className="react-datepicker__input-container "
           >
+            <span
+              aria-live="polite"
+              className="react-datepicker__aria-live"
+              role="alert"
+            />
             <div
               className=" css-1u8qly9"
               id="disabled-end-wrapper"
@@ -687,8 +737,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="basic-start-wrapper"
@@ -750,8 +805,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="no-label-start-wrapper"
@@ -806,8 +866,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="custom-format-start-wrapper"
@@ -869,8 +934,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="invalid-start-wrapper"
@@ -950,8 +1020,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="disabled-start-wrapper"
@@ -1030,8 +1105,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="chakra-start-wrapper"
@@ -1111,8 +1191,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container"
+        className="react-datepicker__input-container "
       >
+        <span
+          aria-live="polite"
+          className="react-datepicker__aria-live"
+          role="alert"
+        />
         <div
           className=" css-1u8qly9"
           id="props-start-wrapper"

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -24,13 +24,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="basic-start-wrapper"
@@ -49,6 +44,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="basic-start"
@@ -76,13 +72,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="basic-end-wrapper"
@@ -101,6 +92,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="basic-end"
@@ -156,13 +148,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="no-label-start-wrapper"
@@ -181,6 +168,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="no-label-start"
@@ -208,13 +196,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="no-label-end-wrapper"
@@ -233,6 +216,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="no-label-end"
@@ -288,13 +272,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="custom-format-start-wrapper"
@@ -313,6 +292,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="custom-format-start"
@@ -340,13 +320,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="custom-format-end-wrapper"
@@ -365,6 +340,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="custom-format-end"
@@ -420,13 +396,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="invalid-start-wrapper"
@@ -447,6 +418,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 <input
                   aria-describedby="invalid-start-helperText"
                   aria-invalid={true}
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="invalid-start"
@@ -490,13 +462,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="invalid-end-wrapper"
@@ -517,6 +484,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 <input
                   aria-describedby="invalid-end-helperText"
                   aria-invalid={true}
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="invalid-end"
@@ -597,13 +565,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="disabled-start-wrapper"
@@ -622,6 +585,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={true}
                   id="disabled-start"
@@ -649,13 +613,8 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
           className="react-datepicker-wrapper"
         >
           <div
-            className="react-datepicker__input-container "
+            className="react-datepicker__input-container"
           >
-            <span
-              aria-live="polite"
-              className="react-datepicker__aria-live"
-              role="alert"
-            />
             <div
               className=" css-1u8qly9"
               id="disabled-end-wrapper"
@@ -674,6 +633,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
                 className="css-79elbk"
               >
                 <input
+                  aria-label="Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={true}
                   id="disabled-end"
@@ -727,13 +687,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="basic-start-wrapper"
@@ -752,6 +707,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
             className="css-79elbk"
           >
             <input
+              aria-label="Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="basic-start"
@@ -794,13 +750,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="no-label-start-wrapper"
@@ -812,7 +763,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
             className="css-79elbk"
           >
             <input
-              aria-label="Select the date you want to visit NYPL"
+              aria-label="Select the date you want to visit NYPL Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="no-label-start"
@@ -855,13 +806,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="custom-format-start-wrapper"
@@ -880,6 +826,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
             className="css-79elbk"
           >
             <input
+              aria-label="Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="custom-format-start"
@@ -922,13 +869,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="invalid-start-wrapper"
@@ -949,6 +891,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
             <input
               aria-describedby="invalid-start-helperText"
               aria-invalid={true}
+              aria-label="Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="invalid-start"
@@ -1007,13 +950,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="disabled-start-wrapper"
@@ -1033,6 +971,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
           >
             <input
               aria-describedby="disabled-start-helperText"
+              aria-label="Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={true}
               id="disabled-start"
@@ -1091,13 +1030,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="chakra-start-wrapper"
@@ -1117,6 +1051,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
           >
             <input
               aria-describedby="chakra-start-helperText"
+              aria-label="Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="chakra-start"
@@ -1176,13 +1111,8 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
       className="react-datepicker-wrapper"
     >
       <div
-        className="react-datepicker__input-container "
+        className="react-datepicker__input-container"
       >
-        <span
-          aria-live="polite"
-          className="react-datepicker__aria-live"
-          role="alert"
-        />
         <div
           className=" css-1u8qly9"
           id="props-start-wrapper"
@@ -1202,6 +1132,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
           >
             <input
               aria-describedby="props-start-helperText"
+              aria-label="Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="props-start"

--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -453,7 +453,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 <input
                   aria-describedby="invalid-start-helperText"
                   aria-invalid={true}
-                  aria-label="From - Please select a valid date., Press tab to access the calendar."
+                  aria-label="From, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="invalid-start"
@@ -524,7 +524,7 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                 <input
                   aria-describedby="invalid-end-helperText"
                   aria-invalid={true}
-                  aria-label="To - Please select a valid date., Press tab to access the calendar."
+                  aria-label="To, Press tab to access the calendar."
                   className="chakra-input css-0"
                   disabled={false}
                   id="invalid-end"
@@ -961,7 +961,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
             <input
               aria-describedby="invalid-start-helperText"
               aria-invalid={true}
-              aria-label="Select the date you want to visit NYPL - Please select a valid date., Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="invalid-start"
@@ -1046,7 +1046,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
           >
             <input
               aria-describedby="disabled-start-helperText"
-              aria-label="Select the date you want to visit NYPL - Note that the Library may be closed on Sundays., Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={true}
               id="disabled-start"
@@ -1131,7 +1131,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
           >
             <input
               aria-describedby="chakra-start-helperText"
-              aria-label="Select the date you want to visit NYPL - Note that the Library may be closed on Sundays., Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="chakra-start"
@@ -1217,7 +1217,7 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
           >
             <input
               aria-describedby="props-start-helperText"
-              aria-label="Select the date you want to visit NYPL - Note that the Library may be closed on Sundays., Press tab to access the calendar."
+              aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               className="chakra-input css-0"
               disabled={false}
               id="props-start"

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -508,8 +508,9 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
         className="css-79elbk"
       >
         <input
+          aria-describedby="searchbar-textinput-invalidState-helperText"
           aria-invalid={true}
-          aria-label="Item Search - There is an error related to this field."
+          aria-label="Item Search"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -70,10 +70,7 @@ describe("Select", () => {
     );
     expect(
       screen.getByLabelText(/What is your favorite color/i)
-    ).toHaveAttribute(
-      "aria-label",
-      "What is your favorite color? - This is the helper text."
-    );
+    ).toHaveAttribute("aria-label", "What is your favorite color?");
   });
 
   it("renders aria-describedby when helperText prop is passed", () => {

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -212,8 +212,9 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
         className="css-79elbk"
       >
         <input
+          aria-describedby="errored-textInput-start-helperText"
           aria-invalid={true}
-          aria-label="Label - start value - There is an error related to this field."
+          aria-label="Label - start value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}
@@ -349,8 +350,9 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
         className="css-79elbk"
       >
         <input
+          aria-describedby="errored-textInput-end-helperText"
           aria-invalid={true}
-          aria-label="Label - end value - There is an error related to this field."
+          aria-label="Label - end value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}
@@ -1437,8 +1439,9 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
         className="css-79elbk"
       >
         <input
+          aria-describedby="errored-textInput-end-helperText"
           aria-invalid={true}
-          aria-label="Label - value - There is an error related to this field."
+          aria-label="Label - value"
           autoComplete={null}
           className="chakra-input css-0"
           disabled={false}

--- a/src/components/TextInput/TextInput.mdx
+++ b/src/components/TextInput/TextInput.mdx
@@ -55,8 +55,8 @@ Internally, a `Label` is associated with the `<input>` element. When `showLabel`
 is set to false, the `<input>` element's `aria-label` attribute is set to the
 required `labelText` value. Some components that use `TextInput`, like `DatePicker`,
 give the `<input>` an `aria-label` regardless of whether `showLabel` is true or false.
-This happens when interacting with the element is not as obvious to those using screen
-readers and more information is necessary.
+This is because interacting with these elements is not as obvious to those using
+screen readers and more information is necessary.
 
 The `helperText` and the `invalidText` are associated with the `<input>` element
 through the `aria-describedby` attribute.

--- a/src/components/TextInput/TextInput.mdx
+++ b/src/components/TextInput/TextInput.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./textInputChangelogData";
 
 # TextInput
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.22.0`   |
-| Latest            | `2.1.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.22.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -53,7 +53,10 @@ prop.
 
 Internally, a `Label` is associated with the `<input>` element. When `showLabel`
 is set to false, the `<input>` element's `aria-label` attribute is set to the
-required `labelText` value.
+required `labelText` value. Some components that use `TextInput`, like `DatePicker`,
+give the `<input>` an `aria-label` regardless of whether `showLabel` is true or false.
+This happens when interacting with the element is not as obvious to those using screen
+readers and more information is necessary.
 
 The `helperText` and the `invalidText` are associated with the `<input>` element
 through the `aria-describedby` attribute.

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -44,6 +44,8 @@ export const TextInputFormats = {
 export type TextInputVariants = "default" | "searchBar" | "searchBarSelect";
 
 export interface InputProps {
+  /** FOR INTERNAL DS USE ONLY: Adds an aria-label or appends to an existing aria-label for screen readers.*/
+  additionalAriaLabel?: string;
   /** FOR INTERNAL DS USE ONLY: additional helper text id(s) to be used for the input's `aria-describedby` value.
    * If more than one, separate each with a space */
   additionalHelperTextIds?: string;
@@ -129,6 +131,7 @@ export const TextInput = chakra(
   forwardRef<TextInputRefType, InputProps>(
     (props, ref: React.Ref<TextInputRefType>) => {
       const {
+        additionalAriaLabel,
         additionalHelperTextIds,
         className,
         defaultValue,
@@ -200,6 +203,7 @@ export const TextInput = chakra(
       }
 
       const ariaAttributes = getAriaAttrs({
+        additionalAriaLabel,
         footnote,
         id,
         labelText,

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -48,6 +48,7 @@ export const getStorybookHrefProps = (pageCount: number) => {
 };
 
 interface GetAriaAttrsProps {
+  additionalAriaLabel?: string;
   footnote: HelperErrorTextType;
   id: string;
   labelText: HelperErrorTextType;
@@ -60,6 +61,7 @@ interface GetAriaAttrsProps {
  * `aria-describedby` attributes, based on the label and footnote values.
  */
 export const getAriaAttrs = ({
+  additionalAriaLabel,
   footnote,
   id,
   labelText,
@@ -83,6 +85,12 @@ export const getAriaAttrs = ({
     ariaAttributes["aria-describedby"] = `${
       additionalHelperTextIds ? additionalHelperTextIds + " " : ""
     }${id}-helperText`;
+  }
+
+  if (additionalAriaLabel) {
+    ariaAttributes["aria-label"]
+      ? (ariaAttributes["aria-label"] += ` ${additionalAriaLabel}`)
+      : (ariaAttributes["aria-label"] = additionalAriaLabel);
   }
   return ariaAttributes;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -73,7 +73,7 @@ export const getAriaAttrs = ({
 
   // If both a label and an aria-label are present, screen
   // readers will only read the aria-label so we need to
-  // provide all necessary details in the aria-label
+  // provide all necessary details in the aria-label.
   if (additionalAriaLabel) {
     ariaAttributes["aria-label"] = `${
       labelText && footnote

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -71,26 +71,36 @@ export const getAriaAttrs = ({
 }: GetAriaAttrsProps): AriaAttributes => {
   let ariaAttributes: AriaAttributes = {};
 
+  // If both a label and an aria-label are present, screen
+  // readers will only read the aria-label so we need to
+  // provide all necessary details in the aria-label
+  if (additionalAriaLabel) {
+    ariaAttributes["aria-label"] = `${
+      labelText && footnote
+        ? `${labelText} - ${footnote}`
+        : (labelText as string)
+    } ${additionalAriaLabel}`;
+  }
+
   if (!showLabel) {
     if (typeof labelText !== "string") {
       console.warn(
         `NYPL Reservoir ${name}: \`labelText\` must be a string when \`showLabel\` is false.`
       );
     }
-    ariaAttributes["aria-label"] =
-      labelText && footnote
-        ? `${labelText} - ${footnote}`
-        : (labelText as string);
+    // If showLabel is false and we have not yet added an
+    // aria-label, we need to add one with all relevant
+    // details.
+    if (!("aria-label" in ariaAttributes)) {
+      ariaAttributes["aria-label"] =
+        labelText && footnote
+          ? `${labelText} - ${footnote}`
+          : (labelText as string);
+    }
   } else if (footnote) {
     ariaAttributes["aria-describedby"] = `${
       additionalHelperTextIds ? additionalHelperTextIds + " " : ""
     }${id}-helperText`;
-  }
-
-  if (additionalAriaLabel) {
-    ariaAttributes["aria-label"]
-      ? (ariaAttributes["aria-label"] += ` ${additionalAriaLabel}`)
-      : (ariaAttributes["aria-label"] = additionalAriaLabel);
   }
   return ariaAttributes;
 };

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -75,11 +75,7 @@ export const getAriaAttrs = ({
   // readers will only read the aria-label so we need to
   // provide all necessary details in the aria-label.
   if (additionalAriaLabel) {
-    ariaAttributes["aria-label"] = `${
-      labelText && footnote
-        ? `${labelText} - ${footnote}`
-        : (labelText as string)
-    }, ${additionalAriaLabel}`;
+    ariaAttributes["aria-label"] = `${labelText}, ${additionalAriaLabel}`;
   }
 
   if (!showLabel) {
@@ -92,12 +88,14 @@ export const getAriaAttrs = ({
     // aria-label, we need to add one with all relevant
     // details.
     if (!("aria-label" in ariaAttributes)) {
-      ariaAttributes["aria-label"] =
-        labelText && footnote
-          ? `${labelText} - ${footnote}`
-          : (labelText as string);
+      ariaAttributes["aria-label"] = labelText as string;
     }
-  } else if (footnote) {
+  }
+
+  // Screen readers will read both the `aria-label` and the
+  // `aria-describedby`. The footnote should not be added to
+  // the `aria-label` because it would be read twice.
+  if (footnote) {
     ariaAttributes["aria-describedby"] = `${
       additionalHelperTextIds ? additionalHelperTextIds + " " : ""
     }${id}-helperText`;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -79,7 +79,7 @@ export const getAriaAttrs = ({
       labelText && footnote
         ? `${labelText} - ${footnote}`
         : (labelText as string)
-    } ${additionalAriaLabel}`;
+    }, ${additionalAriaLabel}`;
   }
 
   if (!showLabel) {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1579](https://jira.nypl.org/browse/DSD-1579)

## This PR does the following:

- Updates `DatePicker`'s `TextInput` to always have an `aria-label` attribute that tells screen reader users how to access the calendar.

## How has this been tested?

- Locally, in Storybook
- RTL tests needed to be updated

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Accessibility improvement

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
