### PR TITLE
DSD-1572: deprecate secondary and fiftyFifty variants for Hero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Deprecates
+
+- Deprecates the `"secondary"` and `"fiftyFifty"` variants of the `Hero` component.
+
 ## 2.1.0 (October 18, 2023)
 
 - Adds the `ComponentChangelogTable` component.

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -9,17 +9,18 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `2.1.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
-- {<Link href="#all-variations" target="_self">All Variations</Link>}
+- {<Link href="#active-variants" target="_self">Active Variants</Link>}
+- {<Link href="#deprecated-variants" target="_self">Deprecated Variants</Link>}
 - {<Link href="#color-variations-for-secondary-hero" target="_self">Color Variations for Secondary Hero</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
@@ -31,10 +32,15 @@ The `Hero` component is used to display a full width banner at the top of a page
 The `Hero` will contain a required `h1` page title and may also include optional
 descriptive text and images.
 
-There are currently five main hero types: `"primary"`, `"secondary"`,
-`"tertiary"`, `"campaign"`, and `"fiftyFifty"`. Under the `"secondary"` hero type,
-there are four additional subtypes: `"secondaryBooksAndMore"`, `"secondaryLocations"`,
-`"secondaryResearch"`, and `"secondaryWhatsOn"`.
+There are currently three main hero types: `"primary"`, `"tertiary"`, and
+`"campaign"`.
+
+Two hero types have been deprecated: `"secondary"` and `"fiftyFifty"`. The
+deprecated variants will be removed from the DS in a future release.
+
+Under the `"secondary"` hero type, there are four additional subtypes:
+`"secondaryBooksAndMore"`, `"secondaryLocations"`, `"secondaryResearch"`, and
+`"secondaryWhatsOn"`.
 
 For the variations that use image "alt" and "src" attributes, the `imageProps`
 prop should be used:
@@ -55,9 +61,10 @@ prop should be used:
   language="jsx"
 />
 
-Note: the `imageProps` prop is not the same as the `backgroundImageSrc` prop used
-for some variations. For a full list of what props to use for each variant, check
-the <Link href="#all-variations" target="_self">All Variations</Link> section.
+Note: the `imageProps` prop is not the same as the `backgroundImageSrc` prop
+used for some variations. For a full list of what props to use for each variant,
+check the <Link href="#active-variants" target="_self">Active Variants</Link>
+section.
 
 ## Component Props
 
@@ -72,7 +79,7 @@ breadcrumbs and above the main content. This means that if the `Hero` displays
 a heading element, it should be the first on the page and an `h1` element set
 through `Heading`'s `level="h1"`.
 
-## All Variations
+## Active Variants
 
 Each `Hero` variation can be rendered through the `heroType` prop.
 
@@ -91,24 +98,6 @@ heading={<Heading level="h1" id="primary-hero" text="Hero Primary" />}
 />
 
 <Canvas of={HeroStories.Primary} />
-
-### Secondary
-
-The `"secondary"` hero type can be used with the `heading`, `imageProps`, and
-`subHeaderText` props.
-
-<Source
-  code={`
-heading={
-  <Heading level="h1" id="secondary-hero" text="Hero Secondary" />
-}
-imageProps={imageProps}
-subHeaderText={secondarySubHeaderText}
-`}
-  language="jsx"
-/>
-
-<Canvas of={HeroStories.Secondary} />
 
 ### Tertiary
 
@@ -168,7 +157,33 @@ subHeaderText={otherSubHeaderText}
 
 <Canvas of={HeroStories.Campaign} />
 
+## Deprecated Variants
+
+### Secondary
+
+This `"secondary"` variant of the `Hero` component has been deprecated. This
+variant will be removed from the DS in a future release.
+
+The `"secondary"` hero type can be used with the `heading`, `imageProps`, and
+`subHeaderText` props.
+
+<Source
+  code={`
+heading={
+  <Heading level="h1" id="secondary-hero" text="Hero Secondary" />
+}
+imageProps={imageProps}
+subHeaderText={secondarySubHeaderText}
+`}
+  language="jsx"
+/>
+
+<Canvas of={HeroStories.Secondary} />
+
 ### FiftyFifty
+
+This `"fiftyFifty"` variant of the `Hero` component has been deprecated. This
+variant will be removed from the DS in a future release.
 
 The `"fiftyFifty"` hero type can be used with the `backgroundColor`,
 `foregroundColor`, `heading`, `imageProps`, and `subHeaderText` props. The
@@ -185,6 +200,10 @@ subHeaderText={otherSubHeaderText}
 <Canvas of={HeroStories.FiftyFifty} />
 
 ## Color Variations for Secondary Hero
+
+This `"secondary"` variant of the `Hero` component has been deprecated. This
+variant and the associated color variations will be removed from the DS in a
+future release.
 
 The background color for the title bar in the `"secondary"` `Hero` changes based
 on the `heroType` variants for the `"secondary"` main variant. There are four

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -17,6 +17,11 @@ const secondarySubHeaderText = (
     in between.
   </>
 );
+const deprecatedMessage = (
+  <Text mt="s" noSpace>
+    This variant has been deprecated.
+  </Text>
+);
 const otherSubHeaderText =
   "With 92 locations across the Bronx, Manhattan, and Staten Island, The New York Public Library is an essential part of neighborhoods across the city. Visit us today.";
 const otherSubHeaderTextLong = (
@@ -113,11 +118,20 @@ export const WithControls: Story = {
         <Hero
           {...args}
           heading={
-            <Heading level="h1" id="1" size="heading2" text="Hero Secondary" />
+            <Heading
+              level="h1"
+              id="1"
+              size="heading2"
+              text="Hero Secondary (deprecated)"
+            />
           }
           heroType={args.heroType}
           imageProps={args.imageProps}
-          subHeaderText={secondarySubHeaderText}
+          subHeaderText={
+            <>
+              {secondarySubHeaderText} {deprecatedMessage}
+            </>
+          }
         />
       </div>
     )) ||
@@ -149,7 +163,11 @@ export const WithControls: Story = {
           ...args.imageProps,
           src: "//placekitten.com/1200/400",
         }}
-        subHeaderText={otherSubHeaderText}
+        subHeaderText={
+          <>
+            {otherSubHeaderText} {deprecatedMessage}
+          </>
+        }
       />
     )),
   parameters: {
@@ -189,12 +207,16 @@ export const Secondary: Story = {
           level="h1"
           id="secondary-hero"
           size="heading2"
-          text="Hero Secondary"
+          text="Hero Secondary (deprecated)"
         />
       }
       heroType="secondary"
       imageProps={imageProps}
-      subHeaderText={secondarySubHeaderText}
+      subHeaderText={
+        <>
+          {secondarySubHeaderText} {deprecatedMessage}
+        </>
+      }
     />
   ),
 };
@@ -337,23 +359,33 @@ export const FiftyFifty: Story = {
       <div>
         <Heading
           id="fiftyfifty-default"
-          text="FiftyFifty Hero at Default Height"
+          overline="Deprecated"
+          text="FiftyFifty Hero at Default Height (deprecated)"
         />
         <Hero
           heroType="fiftyFifty"
           imageProps={imageProps}
-          subHeaderText={otherSubHeaderText}
+          subHeaderText={
+            <>
+              {otherSubHeaderText} {deprecatedMessage}
+            </>
+          }
         />
       </div>
       <div>
         <Heading
           id="fiftyfifty-long-text"
-          text="FiftyFifty Hero with Long Text"
+          overline="Deprecated"
+          text="FiftyFifty Hero with Long Text (deprecated)"
         />
         <Hero
           heroType="fiftyFifty"
           imageProps={imageProps}
-          subHeaderText={otherSubHeaderTextLong}
+          subHeaderText={
+            <>
+              {otherSubHeaderTextLong} {deprecatedMessage}
+            </>
+          }
         />
       </div>
     </Stack>
@@ -370,12 +402,16 @@ export const ColorVariations: Story = {
             level="h1"
             size="heading2"
             id="main-secondary-hero"
-            text="Secondary"
+            text="Secondary (deprecated)"
           />
         }
         heroType="secondary"
         imageProps={imageProps}
-        subHeaderText={secondarySubHeaderText}
+        subHeaderText={
+          <>
+            {secondarySubHeaderText} {deprecatedMessage}
+          </>
+        }
       />
       <Heading id="books-heading" text="secondaryBooksAndMore" />
       <Hero
@@ -384,12 +420,16 @@ export const ColorVariations: Story = {
             level="h1"
             size="heading2"
             id="books-hero"
-            text="Books and More"
+            text="Books and More (deprecated)"
           />
         }
         heroType="secondaryBooksAndMore"
         imageProps={imageProps}
-        subHeaderText={secondarySubHeaderText}
+        subHeaderText={
+          <>
+            {secondarySubHeaderText} {deprecatedMessage}
+          </>
+        }
       />
       <Heading id="location-heading" text="secondaryLocations" />
       <Hero
@@ -398,12 +438,16 @@ export const ColorVariations: Story = {
             level="h1"
             size="heading2"
             id="locations-hero"
-            text="Locations"
+            text="Locations (deprecated)"
           />
         }
         heroType="secondaryLocations"
         imageProps={imageProps}
-        subHeaderText={secondarySubHeaderText}
+        subHeaderText={
+          <>
+            {secondarySubHeaderText} {deprecatedMessage}
+          </>
+        }
       />
       <Heading id="research-heading" text="secondaryResearch" />
       <Hero
@@ -412,12 +456,16 @@ export const ColorVariations: Story = {
             level="h1"
             size="heading2"
             id="research-hero"
-            text="Research"
+            text="Research (deprecated)"
           />
         }
         heroType="secondaryResearch"
         imageProps={imageProps}
-        subHeaderText={secondarySubHeaderText}
+        subHeaderText={
+          <>
+            {secondarySubHeaderText} {deprecatedMessage}
+          </>
+        }
       />
       <Heading id="whats-on-heading" text="secondaryWhatsOn" />
       <Hero
@@ -426,12 +474,16 @@ export const ColorVariations: Story = {
             level="h1"
             size="heading2"
             id="whats-on-hero"
-            text="What's On"
+            text="What's On (deprecated)"
           />
         }
         heroType="secondaryWhatsOn"
         imageProps={imageProps}
-        subHeaderText={secondarySubHeaderText}
+        subHeaderText={
+          <>
+            {secondarySubHeaderText} {deprecatedMessage}
+          </>
+        }
       />
     </SimpleGrid>
   ),

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -10,12 +10,19 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Documentation"],
+    notes: ['Deprecated the "secondary" and "fiftyFifty" variants.'],
+  },
+  {
     date: "2023-10-18",
     version: "2.1.0",
     type: "Bug Fix",
     affects: ["Functionality"],
     notes: [
-      "Fixes an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.",
+      "Fixed an issue with `backgroundColor` and `foregroundColor` props not prioritizing the passed design token values for the `Hero` component.",
     ],
   },
   {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1572](https://jira.nypl.org/browse/DSD-1572)

## This PR does the following:

- Deprecates the `"secondary"` and `"fiftyFifty"` variants of the `Hero` component.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
