### PR TITLE
DSD-1608: Hero custom background colors in dark mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Heading` component to set the `aria-roledescription` value as `"subtitle"` (a more familiar and recognizable value) for the `overline` element.
 - Updates the `FeedbackBox` and `NewsletterSignup` components to set the `tabindex` on the internal elements to `"-1"`.
 
+### Fixes
+
+- Fixes a bug in the `Hero` component where custom background colors were not rendering properly in dark mode for the `"campaign"` and `"tertiary"` variants.
+
 ### Deprecates
 
 - Deprecates the `"secondary"` and `"fiftyFifty"` variants of the `Hero` component.

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -200,6 +200,7 @@ export const Primary: Story = {
 };
 
 export const Secondary: Story = {
+  name: "Secondary (deprecated)",
   render: () => (
     <Hero
       heading={
@@ -354,6 +355,7 @@ export const Campaign: Story = {
 };
 
 export const FiftyFifty: Story = {
+  name: "FiftyFifty (deprecated)",
   render: () => (
     <Stack spacing="l">
       <div>

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -163,7 +163,10 @@ export const Hero = chakra(
         secondary: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
         tertiary: useColorModeValue("ui.gray.x-dark", "dark.ui.bg.default"),
         campaign: useColorModeValue("dark.ui.bg.default", "dark.ui.bg.default"),
-        campaignBackdrop: useColorModeValue("dark.ui.bg.active", "dark.ui.bg.active"),
+        campaignBackdrop: useColorModeValue(
+          "dark.ui.bg.active",
+          "dark.ui.bg.active"
+        ),
         fiftyFifty: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
       };
 
@@ -195,7 +198,9 @@ export const Hero = chakra(
       if (!heroSecondaryTypes.includes(heroType)) {
         contentBoxStyling = {
           ...(foregroundColor && { color: foregroundColor }),
-          ...(backgroundColor ? { backgroundColor } : { defaultBackgroundColor }),
+          ...(backgroundColor
+            ? { backgroundColor }
+            : { defaultBackgroundColor }),
         };
       } else if (
         foregroundColor ||

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -1,4 +1,9 @@
-import { Box, chakra, useMultiStyleConfig } from "@chakra-ui/react";
+import {
+  Box,
+  chakra,
+  useColorModeValue,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 import Image, { ComponentImageProps } from "../Image/Image";
@@ -149,18 +154,41 @@ export const Hero = chakra(
         );
       }
 
+      /** The _dark object in the theme file was overriding custom background
+       * colors. To overcome this issue, the background color styles were moved
+       * into the component file and the related styles for all variants, other
+       * than the "secondary" variant, were removed from the theme file. */
+      const allDefaultBackgroundColors = {
+        primary: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
+        secondary: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
+        tertiary: useColorModeValue("ui.gray.x-dark", "dark.ui.bg.default"),
+        campaign: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
+        fiftyFifty: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
+      };
+
+      const defaultBackgroundColor = allDefaultBackgroundColors[heroType];
       if (heroType === "primary") {
         backgroundImageStyle = backgroundImageSrc
-          ? { backgroundImage: `url(${backgroundImageSrc})` }
+          ? {
+              bgColor: defaultBackgroundColor,
+              backgroundImage: `url(${backgroundImageSrc})`,
+            }
           : {};
+      } else if (heroType === "secondary") {
+        backgroundImageStyle = { bgColor: defaultBackgroundColor };
       } else if (heroType === "campaign") {
         backgroundImageStyle = backgroundImageSrc
           ? { backgroundImage: `url(${backgroundImageSrc})` }
           : backdropBackgroundColor
           ? { bgColor: backdropBackgroundColor }
-          : { backgroundColor };
+          : { bgColor: defaultBackgroundColor };
       } else if (heroType === "tertiary" || heroType === "fiftyFifty") {
-        backgroundImageStyle = backgroundColor ? { bg: backgroundColor } : {};
+        const tertiaryBgColor = backgroundColor
+          ? backgroundColor
+          : defaultBackgroundColor;
+        backgroundImageStyle = backgroundColor
+          ? { bgColor: backgroundColor }
+          : { bgColor: tertiaryBgColor };
       }
 
       if (!heroSecondaryTypes.includes(heroType)) {

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -162,7 +162,8 @@ export const Hero = chakra(
         primary: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
         secondary: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
         tertiary: useColorModeValue("ui.gray.x-dark", "dark.ui.bg.default"),
-        campaign: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
+        campaign: useColorModeValue("dark.ui.bg.default", "dark.ui.bg.default"),
+        campaignBackdrop: useColorModeValue("dark.ui.bg.active", "dark.ui.bg.active"),
         fiftyFifty: useColorModeValue("ui.bg.default", "dark.ui.bg.default"),
       };
 
@@ -181,7 +182,7 @@ export const Hero = chakra(
           ? { backgroundImage: `url(${backgroundImageSrc})` }
           : backdropBackgroundColor
           ? { bgColor: backdropBackgroundColor }
-          : { bgColor: defaultBackgroundColor };
+          : { bgColor: allDefaultBackgroundColors["campaignBackdrop"] };
       } else if (heroType === "tertiary" || heroType === "fiftyFifty") {
         const tertiaryBgColor = backgroundColor
           ? backgroundColor
@@ -194,7 +195,7 @@ export const Hero = chakra(
       if (!heroSecondaryTypes.includes(heroType)) {
         contentBoxStyling = {
           ...(foregroundColor && { color: foregroundColor }),
-          ...(backgroundColor && { backgroundColor }),
+          ...(backgroundColor ? { backgroundColor } : { defaultBackgroundColor }),
         };
       } else if (
         foregroundColor ||

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -2,12 +2,13 @@
 
 exports[`Hero Renders the UI snapshot correctly 1`] = `
 <div
-  className="css-1ar4wny"
+  className="css-svxhxl"
   data-responsive-background-image={true}
   data-testid="hero"
   style={
     {
       "backgroundImage": "url(//placekitten.com/1600/800)",
+      "bgColor": "ui.bg.default",
     }
   }
 >
@@ -33,7 +34,7 @@ exports[`Hero Renders the UI snapshot correctly 1`] = `
 
 exports[`Hero Renders the UI snapshot correctly 2`] = `
 <div
-  className="css-0"
+  className="css-b2u002"
   data-responsive-background-image={true}
   data-testid="hero"
 >
@@ -228,7 +229,7 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
 
 exports[`Hero Renders the UI snapshot correctly 7`] = `
 <div
-  className="css-0"
+  className="css-14tngpx"
   data-responsive-background-image={true}
   data-testid="hero"
 >
@@ -296,7 +297,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
 
 exports[`Hero Renders the UI snapshot correctly 9`] = `
 <div
-  className="css-0"
+  className="css-b2u002"
   data-responsive-background-image={true}
   data-testid="hero"
 >
@@ -329,12 +330,13 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
 
 exports[`Hero Renders the UI snapshot correctly 10`] = `
 <div
-  className="css-1ar4wny"
+  className="css-svxhxl"
   data-responsive-background-image={true}
   data-testid="hero"
   style={
     {
       "backgroundImage": "url(//placekitten.com/1600/800)",
+      "bgColor": "ui.bg.default",
     }
   }
 >
@@ -360,12 +362,13 @@ exports[`Hero Renders the UI snapshot correctly 10`] = `
 
 exports[`Hero Renders the UI snapshot correctly 11`] = `
 <div
-  className="css-1ar4wny"
+  className="css-svxhxl"
   data-responsive-background-image={true}
   data-testid="hero"
   style={
     {
       "backgroundImage": "url(//placekitten.com/1600/800)",
+      "bgColor": "ui.bg.default",
     }
   }
 >

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -13,9 +13,13 @@ exports[`Hero Renders the UI snapshot correctly 1`] = `
   }
 >
   <div
-    className="css-0"
+    className="css-puf0z6"
     data-testid="hero-content"
-    style={{}}
+    style={
+      {
+        "defaultBackgroundColor": "ui.bg.default",
+      }
+    }
   >
     <h1
       className="chakra-heading css-eyyo6e"
@@ -234,9 +238,13 @@ exports[`Hero Renders the UI snapshot correctly 7`] = `
   data-testid="hero"
 >
   <div
-    className="css-0"
+    className="css-x9wpmn"
     data-testid="hero-content"
-    style={{}}
+    style={
+      {
+        "defaultBackgroundColor": "ui.gray.x-dark",
+      }
+    }
   >
     <h1
       className="chakra-heading css-eyyo6e"
@@ -263,9 +271,13 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
   }
 >
   <div
-    className="css-0"
+    className="css-r7tfns"
     data-testid="hero-content"
-    style={{}}
+    style={
+      {
+        "defaultBackgroundColor": "dark.ui.bg.default",
+      }
+    }
   >
     <div
       className="css-1gt4hjv"
@@ -302,9 +314,13 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
   data-testid="hero"
 >
   <div
-    className="css-0"
+    className="css-puf0z6"
     data-testid="hero-content"
-    style={{}}
+    style={
+      {
+        "defaultBackgroundColor": "ui.bg.default",
+      }
+    }
   >
     <div
       className="css-1gt4hjv"
@@ -341,9 +357,13 @@ exports[`Hero Renders the UI snapshot correctly 10`] = `
   }
 >
   <div
-    className="css-0"
+    className="css-puf0z6"
     data-testid="hero-content"
-    style={{}}
+    style={
+      {
+        "defaultBackgroundColor": "ui.bg.default",
+      }
+    }
   >
     <h1
       className="chakra-heading css-eyyo6e"
@@ -373,9 +393,13 @@ exports[`Hero Renders the UI snapshot correctly 11`] = `
   }
 >
   <div
-    className="css-0"
+    className="css-puf0z6"
     data-testid="hero-content"
-    style={{}}
+    style={
+      {
+        "defaultBackgroundColor": "ui.bg.default",
+      }
+    }
   >
     <h1
       className="chakra-heading css-eyyo6e"

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -13,8 +13,11 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Documentation"],
-    notes: ['Deprecated the "secondary" and "fiftyFifty" variants.'],
+    affects: ["Documentation", "Functionality"],
+    notes: [
+      'Deprecated the "secondary" and "fiftyFifty" variants.',
+      'Fixed a bug where custom background colors were not rendering properly in dark mode for the "campaign" and "tertiary" variants.',
+    ],
   },
   {
     date: "2023-10-18",

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -4,6 +4,7 @@ import { screenreaderOnly } from "./globalMixins";
 // Used for all "secondary" variants.
 const secondaryBase = {
   overflowX: "hidden",
+  bgColor: "ui.bg.default",
   content: {
     ...wrapperStyles,
     paddingEnd: "inset.default",
@@ -35,6 +36,9 @@ const secondaryBase = {
     paddingTop: "inset.default",
     flex: { md: "1 1 50%" },
     order: { base: "3", md: "2" },
+  },
+  _dark: {
+    bgColor: "dark.ui.bg.default",
   },
 };
 // Used for all "secondary" variants' heading component.
@@ -136,7 +140,6 @@ const secondaryLocations = getSecondaryVariantStyles(
 const secondaryResearch = getSecondaryVariantStyles("section.research.primary");
 const secondaryWhatsOn = getSecondaryVariantStyles("section.whats-on.primary");
 const tertiary = {
-  bg: "ui.gray.x-dark",
   content: {
     ...wrapperStyles,
     color: "ui.typography.inverse.body",
@@ -161,9 +164,6 @@ const tertiary = {
   },
   p: {
     marginBottom: "0",
-  },
-  _dark: {
-    bg: "dark.ui.bg.default",
   },
 };
 const campaign = {
@@ -264,10 +264,7 @@ const fiftyFifty = {
 };
 const Hero = {
   baseStyle: {
-    bgColor: "ui.gray.x-light-cool",
-    _dark: {
-      bgColor: "dark.ui.bg.default",
-    },
+    // ...
   },
   // Available variants:
   variants: {

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -195,7 +195,6 @@ const campaign = {
     position: { md: "relative" },
     top: { md: "xxl" },
     _dark: {
-      bg: "dark.ui.bg.default",
       color: "dark.ui.typography.body",
     },
   },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1608](https://jira.nypl.org/browse/DSD-1608)

## This PR does the following:

- Fixes a bug in the `Hero` component where custom background colors were not rendering properly in dark mode for the `"campaign"` and `"tertiary"` variants.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local build of Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
