### PR TITLE
DSD-1569: Updating layout for Hero campaign variant

### DIFF
--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `2.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      'Updates the layout for the "campaign" variant to have consistent padding on its left and right sides.',
+    ],
+  },
+  {
     date: "2023-10-26",
     version: "2.1.1",
     type: "Update",

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -177,7 +177,7 @@ const campaign = {
   overflow: "visible",
   padding: {
     base: "inset.wide",
-    md: "0",
+    md: "s",
   },
   position: "relative",
   content: {
@@ -190,8 +190,8 @@ const campaign = {
       lg: "row nowrap",
     },
     minHeight: "320px",
-    flex: { md: "0 0 90%" },
-    maxWidth: { md: "1280px" },
+    flex: { md: "0 100%" },
+    maxWidth: { md: "1248px" },
     position: { md: "relative" },
     top: { md: "xxl" },
     _dark: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1569](https://jira.nypl.org/browse/DSD-1569)

## This PR does the following:

- Updates the left and right spacing in the "campaign" variant for the `Hero` component.
- @bigfishdesign13 because of the structure, the implementation is different than what's in the other similar components, such as `Breadcrumbs`. It works and also removes the 90% width restriction, but let me know what you think. This is best seen in the Template example: https://nypl-design-system-git-dsd-1569-hero-campaign-spacing-nypl.vercel.app/?path=%2Fstory%2Fcomponents-page-layout-template--full-example-with-template-children-components

## How has this been tested?

Locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
