### PR TITLE
DSD-1520: Add sizeBasedOn prop to Logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `sizeBasedOn` prop to the `Logo` component.
+
 ## 2.1.1 (October 26, 2023)
 
 ### Adds

--- a/src/components/Logo/Logo.mdx
+++ b/src/components/Logo/Logo.mdx
@@ -21,6 +21,7 @@ import Link from "../Link/Link";
 - {<Link href="#sizes" target="_self">Sizes</Link>}
 - {<Link href="#all-logos" target="_self">All Logos</Link>}
 - {<Link href="#custom-logos" target="_self">Custom Logos</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 

--- a/src/components/Logo/Logo.mdx
+++ b/src/components/Logo/Logo.mdx
@@ -1,5 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-
+import { changelogData } from "./logoChangelogData";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as LogoStories from "./Logo.stories";
 import Link from "../Link/Link";
 
@@ -132,3 +133,7 @@ child to the `Logo` component.
 />
 
 <Canvas of={LogoStories.CustomLogos} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Logo/Logo.mdx
+++ b/src/components/Logo/Logo.mdx
@@ -7,10 +7,10 @@ import Link from "../Link/Link";
 
 # Logo
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.9`   |
-| Latest            | `1.5.2`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.9`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -59,6 +59,10 @@ from the `LogoSizes` type. The values are `"default"`, `"xxsmall"`, `"xsmall"`,
 Note: `"default"` sets the width to `100%` and the rendered logo will expand to
 fill the full width of the parent element.
 
+In addition, the `sizeBasedOn` prop can be passed to determine whether the size
+of the `Logo` is updated based on either the `"height"` or `"width"`. By default,
+the `sizeBasedOn` prop is set to `"width"`.
+
 <Source
   code={`
 // Example
@@ -68,6 +72,16 @@ fill the full width of the parent element.
 />
 
 <Canvas of={LogoStories.Sizes} />
+
+<Source
+  code={`
+// Example
+<Logo name="nyplFullBlack" size="large" sizeBasedOn="height" />
+`}
+  language="jsx"
+/>
+
+<Canvas of={LogoStories.SizesBasedOnHeight} />
 
 ## All Logos
 

--- a/src/components/Logo/Logo.stories.tsx
+++ b/src/components/Logo/Logo.stories.tsx
@@ -4,7 +4,11 @@ import { withDesign } from "storybook-addon-designs";
 import Logo from "./Logo";
 import Heading from "../Heading/Heading";
 import SimpleGrid from "../Grid/SimpleGrid";
-import { logoNamesArray, logoSizesArray } from "./logoVariables";
+import {
+  logoNamesArray,
+  logoSizeBasedOnArray,
+  logoSizesArray,
+} from "./logoVariables";
 
 const meta: Meta<typeof Logo> = {
   title: "Components/Media & Icons/Logo",
@@ -22,6 +26,11 @@ const meta: Meta<typeof Logo> = {
       control: { type: "select" },
       options: logoSizesArray,
       table: { defaultValue: { summary: "medium" } },
+    },
+    sizeBasedOn: {
+      control: { type: "radio" },
+      options: logoSizeBasedOnArray,
+      table: { defaultValue: { summary: "width" } },
     },
     title: {
       control: false,
@@ -44,6 +53,7 @@ export const WithControls: Story = {
     id: "logo-id",
     name: "nyplFullBlack",
     size: "large",
+    sizeBasedOn: "width",
     title: undefined,
   },
   render: (args) => (
@@ -76,7 +86,7 @@ const logoRow = (logo, opts: any = {}) => {
   // We'll use this setup function to render all the logos in a list item.
   // Some logos display better with a dark background.
   const styles: any = { textAlign: "center" };
-  const { size = "large", displayValue } = opts;
+  const { size = "large", displayValue, sizeBasedOn = "width" } = opts;
   let key = logo;
 
   if (logo.indexOf("White") !== -1 || logo.indexOf("Negative") !== -1) {
@@ -94,12 +104,13 @@ const logoRow = (logo, opts: any = {}) => {
       <Heading level="h4" size="heading6">
         {displayValue}
       </Heading>
-      <Logo name={logo} size={size} />
+      <Logo name={logo} size={size} sizeBasedOn={sizeBasedOn} />
     </div>
   );
 };
 const logos = [];
 const sizes = [];
+const sizesBasedOnHeight = [];
 const logoNameValues = logoNamesArray;
 const logoSizeValues = [
   { size: "default", display: "default (100%)" },
@@ -122,11 +133,24 @@ for (const logoSizeIndex in logoSizeValues) {
     })
   );
 }
+for (const logoSizeIndex in logoSizeValues) {
+  sizesBasedOnHeight.push(
+    logoRow("nyplFullBlack", {
+      displayValue: logoSizeValues[logoSizeIndex].display,
+      size: logoSizeValues[logoSizeIndex].size,
+      sizeBasedOn: "height",
+    })
+  );
+}
 const allLogosGrid = (list) => <SimpleGrid columns={1}>{list}</SimpleGrid>;
 
 // The following are additional Logo example Stories.
 export const Sizes: Story = {
   render: () => allLogosGrid(sizes),
+};
+
+export const SizesBasedOnHeight: Story = {
+  render: () => allLogosGrid(sizesBasedOnHeight),
 };
 
 export const AllLogos: Story = {

--- a/src/components/Logo/Logo.test.tsx
+++ b/src/components/Logo/Logo.test.tsx
@@ -94,6 +94,16 @@ describe("Logo", () => {
     const withCustomSize = renderer
       .create(<Logo id="test-logo-size" name="nyplFullBlack" size="large" />)
       .toJSON();
+    const withCustomSizeBasedOnHeight = renderer
+      .create(
+        <Logo
+          id="test-logo-size"
+          name="nyplFullBlack"
+          size="large"
+          sizeBasedOn="height"
+        />
+      )
+      .toJSON();
     const withChakraProps = renderer
       .create(
         <Logo
@@ -110,6 +120,7 @@ describe("Logo", () => {
 
     expect(standard).toMatchSnapshot();
     expect(withCustomSize).toMatchSnapshot();
+    expect(withCustomSizeBasedOnHeight).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
   });

--- a/src/components/Logo/Logo.tsx
+++ b/src/components/Logo/Logo.tsx
@@ -7,10 +7,15 @@ import {
 import React, { forwardRef } from "react";
 
 import logoSvgs from "./LogoSvgs";
-import { logoNamesArray, logoSizesArray } from "./logoVariables";
+import {
+  logoNamesArray,
+  logoSizeBasedOnArray,
+  logoSizesArray,
+} from "./logoVariables";
 
 export type LogoNames = typeof logoNamesArray[number];
 export type LogoSizes = typeof logoSizesArray[number];
+export type LogoSizeBasedOn = typeof logoSizeBasedOnArray[number];
 
 export interface LogoProps {
   /** Optional className that will be added to the parent element */
@@ -24,6 +29,8 @@ export interface LogoProps {
   name?: LogoNames;
   /** Sets the logo size. */
   size?: LogoSizes;
+  /** Sets the logo size based on the width or height. Width by default. */
+  sizeBasedOn?: LogoSizeBasedOn;
   /** For accessibility purposes, the text passed in the `title` prop gets
    * rendered in a `title` element in the SVG. This descriptive text is not
    * visible but is needed for screenreaders to describe the graphic. */
@@ -46,11 +53,13 @@ export const Logo = chakra(
       id,
       name,
       size = "medium",
+      sizeBasedOn = "width",
       title = `${name} logo`,
       ...rest
     } = props;
     const styles = useStyleConfig("Logo", {
       size,
+      sizeBasedOn,
     });
     const logoProps = {
       "aria-hidden": decorative,

--- a/src/components/Logo/__snapshots__/Logo.test.tsx.snap
+++ b/src/components/Logo/__snapshots__/Logo.test.tsx.snap
@@ -73,6 +73,41 @@ exports[`Logo renders the UI snapshot correctly 2`] = `
 exports[`Logo renders the UI snapshot correctly 3`] = `
 <svg
   aria-hidden={false}
+  className="chakra-icon css-1grhd2q"
+  focusable={false}
+  id="test-logo-size"
+  role="img"
+  title="nyplFullBlack logo"
+  viewBox="0 0 24 24"
+>
+  <g
+    stroke="currentColor"
+    strokeWidth="1.5"
+  >
+    <path
+      d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+      fill="none"
+      strokeLinecap="round"
+    />
+    <path
+      d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+      fill="currentColor"
+      strokeLinecap="round"
+    />
+    <circle
+      cx="12"
+      cy="12"
+      fill="none"
+      r="11.25"
+      strokeMiterlimit="10"
+    />
+  </g>
+</svg>
+`;
+
+exports[`Logo renders the UI snapshot correctly 4`] = `
+<svg
+  aria-hidden={false}
   className="chakra-icon css-1ayys74"
   focusable={false}
   id="chakra"
@@ -105,7 +140,7 @@ exports[`Logo renders the UI snapshot correctly 3`] = `
 </svg>
 `;
 
-exports[`Logo renders the UI snapshot correctly 4`] = `
+exports[`Logo renders the UI snapshot correctly 5`] = `
 <svg
   aria-hidden={false}
   className="chakra-icon css-1grhd2q"

--- a/src/components/Logo/logoChangelogData.ts
+++ b/src/components/Logo/logoChangelogData.ts
@@ -1,0 +1,19 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Documentation", "Functionality", "Styles"],
+    notes: ["Adds `sizeBasedOn` prop to the `Logo` component."],
+  },
+];

--- a/src/components/Logo/logoVariables.ts
+++ b/src/components/Logo/logoVariables.ts
@@ -62,3 +62,4 @@ export const logoSizesArray = [
   "medium",
   "large",
 ] as const;
+export const logoSizeBasedOnArray = ["height", "width"] as const;

--- a/src/theme/components/logo.ts
+++ b/src/theme/components/logo.ts
@@ -1,12 +1,16 @@
 interface LogoBaseStyle {
-  size: keyof typeof size;
+  size: keyof typeof size | keyof typeof sizeBasedOnHeight;
+  sizeBasedOn: "height" | "width";
 }
 
-const svgBase = {
-  display: "inline-block",
-  height: "auto",
-  width: "100%",
+const svgBase = (sizeBasedOn: "height" | "width") => {
+  return {
+    display: "inline-block",
+    height: sizeBasedOn === "width" ? "auto" : "100%",
+    width: sizeBasedOn === "width" ? "100%" : "auto",
+  };
 };
+
 const size = {
   default: {
     maxWidth: "100%",
@@ -38,11 +42,44 @@ const size = {
     width: "var(--nypl-space-xxl)",
   },
 };
+const sizeBasedOnHeight = {
+  default: {
+    maxHeight: "100%",
+  },
+  xxsmall: {
+    maxHeight: "64px",
+  },
+  xsmall: {
+    maxHeight: "96px",
+  },
+  small: {
+    maxHeight: "165px",
+  },
+  medium: {
+    maxHeight: "225px",
+  },
+  large: {
+    maxHeight: "360px",
+  },
+  xlarge: {
+    maxHeight: "360px",
+  },
+  xxlarge: {
+    height: "var(--nypl-space-xl)",
+    width: "var(--nypl-space-xl)",
+  },
+  xxxlarge: {
+    height: "var(--nypl-space-xxl)",
+    width: "var(--nypl-space-xxl)",
+  },
+};
 const Logo = {
   baseStyle: (props: LogoBaseStyle) => {
     const allStyles = {
-      ...svgBase,
-      ...size[props.size],
+      ...svgBase(props.sizeBasedOn),
+      ...(props.sizeBasedOn === "width"
+        ? size[props.size]
+        : sizeBasedOnHeight[props.size]),
     };
     return {
       ...allStyles,


### PR DESCRIPTION
Fixes [JIRA ticket 1520](https://jira.nypl.org/browse/DSD-1520)

## This PR does the following:

- Adds sizeBasedOn prop to Logo and corresponding info in Storybook docs
- Adds snapshot test for size based on height

## How has this been tested?

Locally in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
