### PR TITLE
DSD-624: hasVisitedState prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles.
+- Removes `disabled` variant from `Link` theme file, as it isn't being used.
 
 ## 2.1.2 (November 9, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles.
+
 ## 2.1.2 (November 9, 2023)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Updates
 
-- Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles.
+- Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles. Default value is true.
 - Removes `disabled` variant from `Link` theme file, as it isn't being used.
 
 ## 2.1.2 (November 9, 2023)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles. Default value is true.
 - Removes `disabled` variant from `Link` theme file, as it isn't being used.
 
+## Fixes
+
+- Adds a z-index on hover to the `SearchBar`'s select icon so it no longer disappears.
+
 ## 2.1.2 (November 9, 2023)
 
 ### Adds
@@ -26,11 +30,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the layout for the `"campaign"` variant of the `Hero` component to have consistent padding on its left and right sides.
 - Updates the `getSectionColors` function to also return dark mode color variants.
 - Updates the `NewsletterSignup` component's `newsletterSignupType` prop to render proper dark mode variant colors.
-
-## Fixes
-
-- Adds a z-index on hover to the `SearchBar`'s select icon so it no longer disappears.
-
 
 ## 2.1.1 (October 26, 2023)
 

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -1,7 +1,9 @@
 import { Box } from "@chakra-ui/react";
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 import { cloneElement } from "react";
+import { changelogData } from "./linkChangelogData";
 
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import Link from "./Link";
 import Icon from "../Icons/Icon";
 import * as LinkStories from "./Link.stories";
@@ -10,10 +12,10 @@ import * as LinkStories from "./Link.stories";
 
 # Link
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -24,6 +26,7 @@ import * as LinkStories from "./Link.stories";
 - {<Link href="#links-with-icons" target="_self">Links With Icons</Link>}
 - {<Link href="#anchor-element-rendering" target="_self">Anchor Element Rendering</Link>}
 - {<Link href="#link-with-routers" target="_self">Link with Routers</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -261,3 +264,7 @@ export const NextJsLink = (props) =>
   <Link type="action">Next Page</Link>
 </NextJsLink>
 }
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -28,6 +28,8 @@ export interface LinkProps {
   children: React.ReactNode;
   /** Additional class name to render in the `Link` component. */
   className?: string;
+  /** Used to include or remove visited state styles. Default is true. */
+  hasVisitedState?: boolean;
   /** The `href` attribute for the anchor element. */
   href?: string;
   /** ID used for accessibility purposes. */
@@ -152,6 +154,7 @@ export const Link = chakra(
     const {
       children,
       className,
+      hasVisitedState = false,
       href,
       id,
       isUnderlined = true,
@@ -204,7 +207,11 @@ export const Link = chakra(
       // }
       variant = type;
     }
-    const styles = useMultiStyleConfig("Link", { variant, finalIsUnderlined });
+    const styles = useMultiStyleConfig("Link", {
+      variant,
+      finalIsUnderlined,
+      hasVisitedState,
+    });
     const rel = type === "external" ? "nofollow noopener noreferrer" : null;
     const internalTarget =
       type === "external" ? "_blank" : target ? target : null;

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -154,7 +154,7 @@ export const Link = chakra(
     const {
       children,
       className,
-      hasVisitedState = false,
+      hasVisitedState = true,
       href,
       id,
       isUnderlined = true,

--- a/src/components/Link/linkChangelogData.ts
+++ b/src/components/Link/linkChangelogData.ts
@@ -1,0 +1,21 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "2023-11-14",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Adds `hasVisitedStyles` prop which is used to include or omit the component's visited state styles.",
+    ],
+  },
+];

--- a/src/components/Link/linkChangelogData.ts
+++ b/src/components/Link/linkChangelogData.ts
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Styles"],
     notes: [
-      "Added `hasVisitedStyles` prop which is used to include or omit the component's visited state styles.",
+      "Added `hasVisitedStyles` prop which is used to include or omit the component's visited state styles. Default value is true.",
       "Removed `disabled` variant from theme file, as it isn't being used.",
     ],
   },

--- a/src/components/Link/linkChangelogData.ts
+++ b/src/components/Link/linkChangelogData.ts
@@ -15,7 +15,8 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Styles"],
     notes: [
-      "Adds `hasVisitedStyles` prop which is used to include or omit the component's visited state styles.",
+      "Added `hasVisitedStyles` prop which is used to include or omit the component's visited state styles.",
+      "Removed `disabled` variant from theme file, as it isn't being used.",
     ],
   },
 ];

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -60,7 +60,7 @@ const moreLink = ({ hasVisitedState }) => ({
 });
 
 // The "button" variant is deprecated.
-const button = () => ({
+const button = {
   width: "100px",
   borderRadius: "sm",
   lineHeight: "1.5",
@@ -94,7 +94,7 @@ const button = () => ({
       },
     },
   },
-});
+};
 
 const buttonPrimary = ({ hasVisitedState }) => ({
   ...baseButtonLinkStyles,

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -32,166 +32,166 @@ const baseButtonLinkStyles = {
   display: "inline-flex",
 };
 
-const variants = ({ hasVisitedState }) => ({
-  link: {},
-  disabled: {
-    color: "ui.gray.dark",
-    pointerEvents: "none",
-  },
-  moreLink: {
-    alignItems: "center",
-    display: "inline-flex",
-    svg: {
-      height: "s",
-      width: "s",
-      textDecoration: "none",
-      fill: "currentColor",
-    },
-    _hover: {
-      color: "ui.link.secondary",
-      textDecoration: "underline",
-    },
-    _visited: hasVisitedState
-      ? {
-          svg: {
-            fill: "ui.link.tertiary",
-          },
-          _dark: {
-            svg: {
-              fill: "dark.ui.link.tertiary",
-            },
-          },
-        }
-      : {},
-  },
-  // The "button" variant is deprecated.
-  button: {
-    width: "100px",
-    borderRadius: "sm",
-    lineHeight: "1.5",
-    display: "flex",
-    cursor: "pointer",
-    color: "ui.white",
-    justifyContent: "center",
-    py: "xs",
-    px: "xs",
+const moreLink = ({ hasVisitedState }) => ({
+  alignItems: "center",
+  display: "inline-flex",
+  svg: {
+    height: "s",
+    width: "s",
     textDecoration: "none",
-    fontWeight: "button.default",
-    bg: "ui.link.primary",
+    fill: "currentColor",
+  },
+  _hover: {
+    color: "ui.link.secondary",
+    textDecoration: "underline",
+  },
+  _visited: hasVisitedState
+    ? {
+        svg: {
+          fill: "ui.link.tertiary",
+        },
+        _dark: {
+          svg: {
+            fill: "dark.ui.link.tertiary",
+          },
+        },
+      }
+    : {},
+});
+
+// The "button" variant is deprecated.
+const button = () => ({
+  width: "100px",
+  borderRadius: "sm",
+  lineHeight: "1.5",
+  display: "flex",
+  cursor: "pointer",
+  color: "ui.white",
+  justifyContent: "center",
+  py: "xs",
+  px: "xs",
+  textDecoration: "none",
+  fontWeight: "button.default",
+  bg: "ui.link.primary",
+  _dark: {
+    color: "ui.gray.xxx-dark",
+    bg: "dark.ui.link.primary",
+  },
+  _hover: {
+    color: "ui.white",
+    bg: "ui.link.secondary",
+    textDecoration: "underline",
     _dark: {
       color: "ui.gray.xxx-dark",
-      bg: "dark.ui.link.primary",
+      bg: "dark.ui.link.secondary",
     },
-    _hover: {
-      color: "ui.white",
-      bg: "ui.link.secondary",
-      textDecoration: "underline",
-      _dark: {
+  },
+  _visited: {
+    color: "ui.white",
+    _dark: {
+      _visited: {
         color: "ui.gray.xxx-dark",
-        bg: "dark.ui.link.secondary",
       },
     },
-    _visited: {
-      color: "ui.white",
-      _dark: {
-        _visited: {
+  },
+});
+
+const buttonPrimary = ({ hasVisitedState }) => ({
+  ...baseButtonLinkStyles,
+  ...primary({}),
+  _hover: {
+    backgroundColor: "ui.link.secondary",
+    color: "ui.white",
+  },
+  _visited: hasVisitedState
+    ? {
+        color: "ui.white",
+        _dark: {
           color: "ui.gray.xxx-dark",
         },
-      },
-    },
+      }
+    : {},
+});
+
+const buttonSecondary = ({ hasVisitedState }) => ({
+  ...baseButtonLinkStyles,
+  ...secondary({}),
+  _visited: hasVisitedState
+    ? {
+        color: "ui.link.primary",
+        _dark: {
+          color: "dark.ui.link.primary",
+        },
+      }
+    : {},
+});
+
+const buttonPill = ({ hasVisitedState }) => ({
+  ...baseButtonLinkStyles,
+  ...pill({}),
+  _hover: {
+    color: "ui.black",
   },
-  buttonPrimary: {
-    ...baseButtonLinkStyles,
-    ...primary({}),
-    _hover: {
-      backgroundColor: "ui.link.secondary",
-      color: "ui.white",
-    },
-    _visited: hasVisitedState
-      ? {
+  _visited: hasVisitedState
+    ? {
+        color: "ui.black",
+        _dark: {
           color: "ui.white",
-          _dark: {
-            color: "ui.gray.xxx-dark",
-          },
-        }
-      : {},
+        },
+      }
+    : {},
+});
+
+const buttonCallout = ({ hasVisitedState }) => ({
+  ...baseButtonLinkStyles,
+  ...callout({}),
+  _hover: {
+    color: "ui.white",
   },
-  buttonSecondary: {
-    ...baseButtonLinkStyles,
-    ...secondary({}),
-    _visited: hasVisitedState
-      ? {
-          color: "ui.link.primary",
-          _dark: {
-            color: "dark.ui.link.primary",
-          },
-        }
-      : {},
-  },
-  buttonPill: {
-    ...baseButtonLinkStyles,
-    ...pill({}),
-    _hover: {
-      color: "ui.black",
-    },
-    _visited: hasVisitedState
-      ? {
-          color: "ui.black",
-          _dark: {
-            color: "ui.white",
-          },
-        }
-      : {},
-  },
-  buttonCallout: {
-    ...baseButtonLinkStyles,
-    ...callout({}),
-    _hover: {
-      color: "ui.white",
-    },
-    _visited: hasVisitedState
-      ? {
+  _visited: hasVisitedState
+    ? {
+        color: "ui.white",
+        _dark: {
           color: "ui.white",
-          _dark: {
-            color: "ui.white",
-          },
-        }
-      : {},
+        },
+      }
+    : {},
+});
+
+const buttonNoBrand = ({ hasVisitedState }) => ({
+  ...baseButtonLinkStyles,
+  ...noBrand({}),
+  _hover: {
+    color: "ui.white",
   },
-  buttonNoBrand: {
-    ...baseButtonLinkStyles,
-    ...noBrand({}),
-    _hover: {
-      color: "ui.white",
-    },
-    _visited: hasVisitedState
-      ? {
+  _visited: hasVisitedState
+    ? {
+        color: "ui.white",
+        _dark: {
           color: "ui.white",
-          _dark: {
-            color: "ui.white",
-          },
-        }
-      : {},
-  },
-  buttonDisabled: {
-    ...baseButtonLinkStyles,
-    ...primary({}),
-    bg: "ui.gray.light-cool",
-    color: "ui.gray.dark",
-    opacity: "1",
-    pointerEvents: "none",
-    _visited: hasVisitedState
-      ? {
-          color: "ui.gray.dark",
-          _dark: {
-            color: "dark.ui.disabled.primary",
-          },
-        }
-      : {},
-    _dark: {
-      bg: "dark.ui.disabled.secondary",
-      color: "dark.ui.disabled.primary",
-    },
+        },
+      }
+    : {},
+});
+
+const buttonDisabled = ({ hasVisitedState }) => ({
+  ...baseButtonLinkStyles,
+  ...primary({}),
+  bg: "ui.gray.light-cool",
+  color: "ui.gray.dark",
+  opacity: "1",
+  pointerEvents: "none",
+  _visited: hasVisitedState
+    ? {
+        color: "ui.gray.dark",
+        _dark: {
+          color: "dark.ui.disabled.primary",
+        },
+      }
+    : {},
+  _dark: {
+    bg: "dark.ui.disabled.secondary",
+    color: "dark.ui.disabled.primary",
   },
 });
 
@@ -219,7 +219,16 @@ const Link = {
      * screen readers. */
     screenreaderOnly: screenreaderOnly(),
   }),
-  variants,
+  variants: {
+    button,
+    buttonCallout,
+    buttonDisabled,
+    buttonNoBrand,
+    buttonPill,
+    buttonPrimary,
+    buttonSecondary,
+    moreLink,
+  },
 };
 
 export default Link;

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -25,12 +25,6 @@ export const baseLinkStyles = {
       color: "dark.ui.link.secondary",
     },
   },
-  _visited: {
-    color: "ui.link.tertiary",
-    _dark: {
-      color: "dark.ui.link.tertiary",
-    },
-  },
 };
 
 const baseButtonLinkStyles = {
@@ -38,7 +32,7 @@ const baseButtonLinkStyles = {
   display: "inline-flex",
 };
 
-const variants = {
+const variants = ({ hasVisitedState }) => ({
   link: {},
   disabled: {
     color: "ui.gray.dark",
@@ -57,16 +51,18 @@ const variants = {
       color: "ui.link.secondary",
       textDecoration: "underline",
     },
-    _visited: {
-      svg: {
-        fill: "ui.link.tertiary",
-      },
-      _dark: {
-        svg: {
-          fill: "dark.ui.link.tertiary",
-        },
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          svg: {
+            fill: "ui.link.tertiary",
+          },
+          _dark: {
+            svg: {
+              fill: "dark.ui.link.tertiary",
+            },
+          },
+        }
+      : {},
   },
   // The "button" variant is deprecated.
   button: {
@@ -111,22 +107,26 @@ const variants = {
       backgroundColor: "ui.link.secondary",
       color: "ui.white",
     },
-    _visited: {
-      color: "ui.white",
-      _dark: {
-        color: "ui.gray.xxx-dark",
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          color: "ui.white",
+          _dark: {
+            color: "ui.gray.xxx-dark",
+          },
+        }
+      : {},
   },
   buttonSecondary: {
     ...baseButtonLinkStyles,
     ...secondary({}),
-    _visited: {
-      color: "ui.link.primary",
-      _dark: {
-        color: "dark.ui.link.primary",
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          color: "ui.link.primary",
+          _dark: {
+            color: "dark.ui.link.primary",
+          },
+        }
+      : {},
   },
   buttonPill: {
     ...baseButtonLinkStyles,
@@ -134,12 +134,14 @@ const variants = {
     _hover: {
       color: "ui.black",
     },
-    _visited: {
-      color: "ui.black",
-      _dark: {
-        color: "ui.white",
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          color: "ui.black",
+          _dark: {
+            color: "ui.white",
+          },
+        }
+      : {},
   },
   buttonCallout: {
     ...baseButtonLinkStyles,
@@ -147,12 +149,14 @@ const variants = {
     _hover: {
       color: "ui.white",
     },
-    _visited: {
-      color: "ui.white",
-      _dark: {
-        color: "ui.white",
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          color: "ui.white",
+          _dark: {
+            color: "ui.white",
+          },
+        }
+      : {},
   },
   buttonNoBrand: {
     ...baseButtonLinkStyles,
@@ -160,12 +164,14 @@ const variants = {
     _hover: {
       color: "ui.white",
     },
-    _visited: {
-      color: "ui.white",
-      _dark: {
-        color: "ui.white",
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          color: "ui.white",
+          _dark: {
+            color: "ui.white",
+          },
+        }
+      : {},
   },
   buttonDisabled: {
     ...baseButtonLinkStyles,
@@ -174,22 +180,33 @@ const variants = {
     color: "ui.gray.dark",
     opacity: "1",
     pointerEvents: "none",
-    _visited: {
-      color: "ui.gray.dark",
-      _dark: {
-        color: "dark.ui.disabled.primary",
-      },
-    },
+    _visited: hasVisitedState
+      ? {
+          color: "ui.gray.dark",
+          _dark: {
+            color: "dark.ui.disabled.primary",
+          },
+        }
+      : {},
     _dark: {
       bg: "dark.ui.disabled.secondary",
       color: "dark.ui.disabled.primary",
     },
   },
-};
+});
+
 const Link = {
   parts: ["screenreaderOnly"],
-  baseStyle: ({ finalIsUnderlined = true }) => ({
+  baseStyle: ({ finalIsUnderlined = true, hasVisitedState }) => ({
     ...baseLinkStyles,
+    _visited: hasVisitedState
+      ? {
+          color: "ui.link.tertiary",
+          _dark: {
+            color: "dark.ui.link.tertiary",
+          },
+        }
+      : {},
     textDecoration: finalIsUnderlined ? "underline" : "none",
     /** This is needed for custom anchor elements or link components
      * that are passed as children to the `Link` component. */


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1624](https://jira.nypl.org/browse/DSD-1624).

## This PR does the following:

- Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles.
- Removes `disabled` variant from `Link` theme file, as it isn't being used.

## How has this been tested?

- Locally on Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
