### PR TITLE
DSD-1628: font weight for subtitle styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `hasVisitedStyles` prop to `Link` which is used to include or omit the visited state styles. Default value is true.
 - Removes `disabled` variant from `Link` theme file, as it isn't being used.
+- Updates the `font-weight` to `"regular"` for the `subtitle1` and `subtitle2` text styles.
 
 ## Fixes
 

--- a/src/components/DevelopmentGuide/DesignTokens.mdx
+++ b/src/components/DevelopmentGuide/DesignTokens.mdx
@@ -573,8 +573,8 @@ The following tokens can be used with the `fontWeight` (js) and `font-weight`
 |                 | heading.tertiary      | --nypl-fontWeights-heading-tertiary      | medium   | x          |
 |                 | heading.callout       | --nypl-fontWeights-heading-callout       | medium   | x          |
 |                 |                       |                                          |          |            |
-| **Subtitle**    | subtitle.subtitle1    | --nypl-fontWeights-subtitle-subtitle1    | medium   |            |
-|                 | subtitle.subtitle2    | --nypl-fontWeights-subtitle-subtitle2    | medium   |            |
+| **Subtitle**    | subtitle.subtitle1    | --nypl-fontWeights-subtitle-subtitle1    | regular  |            |
+|                 | subtitle.subtitle2    | --nypl-fontWeights-subtitle-subtitle2    | regular  |            |
 |                 |                       |                                          |          |            |
 | **Overline**    | overline.overline1    | --nypl-fontWeights-overline-overline1    | semibold |            |
 |                 | overline.overline2    | --nypl-fontWeights-overline-overline2    | semibold |            |

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./headingChangelogData";
 
 # Heading
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `2.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/StyleGuide/Typography.mdx
+++ b/src/components/StyleGuide/Typography.mdx
@@ -746,7 +746,7 @@ The `size` prop can be used to render a specific style from the DS default text 
 |                 | JS Token                     | CSS Token                                          | Value             |
 | --------------- | :--------------------------- | :------------------------------------------------- | :---------------- |
 | **Font Size**   | `desktop.subtitle.subtitle1` | `var(--nypl-fontSizes-desktop-subtitle-subtitle1)` | `1.125rem` (18px) |
-| **Font Weight** | `subtitle.subtitle1`         | `var(--nypl-fontWeights-subtitle-subtitle1)`       | `500` (medium)    |
+| **Font Weight** | `subtitle.subtitle1`         | `var(--nypl-fontWeights-subtitle-subtitle1)`       | `400` (regular)   |
 | **Line Height** | --                           | --                                                 | `1.25`            |
 
 {
@@ -786,11 +786,11 @@ The `size` prop can be used to render a specific style from the DS default text 
 </List>
 }
 
-|                 | JS Token                     | CSS Token                                          | Value          |
-| --------------- | :--------------------------- | :------------------------------------------------- | :------------- |
-| **Font Size**   | `desktop.subtitle.subtitle2` | `var(--nypl-fontSizes-desktop-subtitle-subtitle2)` | `1rem` (16px)  |
-| **Font Weight** | `subtitle.subtitle2`         | `var(--nypl-fontWeights-subtitle-subtitle2)`       | `500` (medium) |
-| **Line Height** | --                           | --                                                 | `1.3`          |
+|                 | JS Token                     | CSS Token                                          | Value           |
+| --------------- | :--------------------------- | :------------------------------------------------- | :-------------- |
+| **Font Size**   | `desktop.subtitle.subtitle2` | `var(--nypl-fontSizes-desktop-subtitle-subtitle2)` | `1rem` (16px)   |
+| **Font Weight** | `subtitle.subtitle2`         | `var(--nypl-fontWeights-subtitle-subtitle2)`       | `400` (regular) |
+| **Line Height** | --                           | --                                                 | `1.3`           |
 
 {
 

--- a/src/components/Text/Text.mdx
+++ b/src/components/Text/Text.mdx
@@ -2,21 +2,23 @@ import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 
 import * as TextStories from "./Text.stories";
 import Link from "../Link/Link";
+import { changelogData } from "./headingChangelogData";
 
 <Meta of={TextStories} />
 
 # Text
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.1`   |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.1`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -61,3 +63,7 @@ Guide](../?path=/docs/style-guide-typography--docs#text-display-sizes).
 `tag`, `mini`
 
 <Canvas of={TextStories.DeprecatedOptions} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Text/Text.mdx
+++ b/src/components/Text/Text.mdx
@@ -1,8 +1,9 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as TextStories from "./Text.stories";
 import Link from "../Link/Link";
-import { changelogData } from "./headingChangelogData";
+import { changelogData } from "./textChangelogData";
 
 <Meta of={TextStories} />
 

--- a/src/components/Text/textChangelogData.ts
+++ b/src/components/Text/textChangelogData.ts
@@ -13,18 +13,9 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Styles"],
-    notes: [
-      'Updates the `font-weight` to "regular" for the `subtitle1` and `subtitle2` text styles.',
-    ],
-  },
-  {
-    date: "2023-10-26",
-    version: "2.1.1",
-    type: "Update",
     affects: ["Accessibility"],
     notes: [
-      'Updated the `aria-roledescription` value to "subtitle" (a more familiar and recognizable term) for the `overline` element.',
+      'Updates the `font-weight` to "regular" for the `subtitle1` and `subtitle2` text styles.',
     ],
   },
   {

--- a/src/theme/foundations/typography.ts
+++ b/src/theme/foundations/typography.ts
@@ -254,8 +254,8 @@ const typography: Typography = {
       overline2: fontWeightValues["semibold"],
     },
     subtitle: {
-      subtitle1: fontWeightValues["medium"],
-      subtitle2: fontWeightValues["medium"],
+      subtitle1: fontWeightValues["regular"],
+      subtitle2: fontWeightValues["regular"],
     },
     text: {
       default: fontWeightValues["light"],


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1628](https://jira.nypl.org/browse/DSD-1628)

## This PR does the following:

- Updates the `font-weight` to `"regular"` for the `subtitle1` and `subtitle2` text styles.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
