### PR TITLE
DSD-1599: Updates DatePicker style so helper text does not shift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the following components to accept `JSX.Element` type values into their `"headingText"` prop: `AlphabetFilter`, `AudioPlayer`, `ComponentWrapper`, `SearchBar`, `VideoPlayer`
 - Updates the `Notification` component to accept `JSX.Element` type values into its `"notificationHeading"` prop.
 - Updates the `StructuredContent` component to accept `JSX.Element` type values into its `"headingText"` and `"calloutText"` props.
+- Adds z-index to the `DatePicker`'s calendar container so that the helper text does not shift when the calendar opens.
 
 ## Fixes
 

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -10,10 +10,10 @@ import Table from "../Table/Table";
 
 # DatePicker
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `2.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/DatePicker/_DatePicker.scss
+++ b/src/components/DatePicker/_DatePicker.scss
@@ -1,4 +1,10 @@
 // Styles needed to override `react-datepicker` plugin styles.
+.react-datepicker__tab-loop {
+  // Prevents the calendar from shifting any elements below it.
+  position: absolute;
+  z-index: 1000;
+}
+
 .date-picker-calendar {
   font-family: var(--nypl-fonts-body);
 

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2023-11-28",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Adds z-index to calendar container so that helper text does not shift when calendar opens.",
+    ],
+  },
+  {
     date: "2023-10-26",
     version: "2.1.1",
     type: "Update",

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -10,7 +10,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "2023-11-28",
+    date: "Prerelease",
     version: "Prerelease",
     type: "Update",
     affects: ["Styles"],


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1599](https://jira.nypl.org/browse/DSD-1599).

## This PR does the following:

- Adds z-index to the `DatePicker`'s calendar container so that the helper text does not shift when the calendar opens.

## How has this been tested?

- Locally on Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
