### PR TITLE
DSD-1589: Adds placeholder props and allows empty state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
-- Fixes bug where month and year `Datepicker` calendars were rendering vertically rather than horizontally.
+### Adds
+
+- Adds optional `placeholder` and `placeholderTo` props to the `DatePicker` component.
+
+### Updates
+
+- Updates the `DatePicker`'s `initialDate` and `initialDateTo` props to accept an empty string.
 
 ## 2.1.3 (December 7, 2023)
 
@@ -18,7 +24,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds the `useDSHeading` hook to render a default H2 heading or a custom heading element.
 - Adds the `sizeBasedOn` prop to the `Image` component.
 - Adds the `isDarkBackgroundImage` prop to the `Hero` component.
-- Adds optional `placeholder` and `placeholderTo` props to the `DatePicker` component.
 
 ### Updates
 
@@ -32,8 +37,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `FeaturedContent` component by adjusting the spacing in the `"fullScreen"` variant to better align the component text content with the page text content.
 - Updates the `"campaign"` variant of the `Hero` component to improve the spacing around the component.
 - Updates the `Card` component so that it accepts the `imageProps.isLazy` prop and passes it to its internal `Image` component.
-- Updates the `DatePicker`'s `initialDate` and `initialDateTo` props to accept an empty string.
-
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds the `useDSHeading` hook to render a default H2 heading or a custom heading element.
 - Adds the `sizeBasedOn` prop to the `Image` component.
 - Adds the `isDarkBackgroundImage` prop to the `Hero` component.
+- Adds optional `placeholder` and `placeholderTo` props to the `DatePicker` component.
 
 ### Updates
 
@@ -29,6 +30,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `FeaturedContent` component by adjusting the spacing in the `"fullScreen"` variant to better align the component text content with the page text content.
 - Updates the `"campaign"` variant of the `Hero` component to improve the spacing around the component.
 - Updates the `Card` component so that it accepts the `imageProps.isLazy` prop and passes it to its internal `Image` component.
+- Updates the `DatePicker`'s `initialDate` and `initialDateTo` props to accept an empty string.
+
 
 ## Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+- Fixes bug where month and year `Datepicker` calendars were being displayed vertically rather than horizontally.
+
 ## 2.1.3 (December 7, 2023)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
-- Fixes bug where month and year `Datepicker` calendars were being displayed vertically rather than horizontally.
+- Fixes bug where month and year `Datepicker` calendars were rendering vertically rather than horizontally.
 
 ## 2.1.3 (December 7, 2023)
 

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -10,10 +10,10 @@ import Table from "../Table/Table";
 
 # DatePicker
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `2.1.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -186,8 +186,17 @@ export const OtherStates: Story = {
   ),
 };
 
-export const InitialDate: Story = {
-  render: () => (
+// Examples that use the `initialDate` and `initialDateTo` props and
+// also the `onChange` prop to show an empty input returns null.
+function InitialDateExample() {
+  const onChange = (data) => {
+    console.log({
+      startDate: data.startDate,
+      endDate: data.endDate,
+    });
+  };
+
+  return (
     <VStack align="stretch" spacing="s">
       <DatePicker
         id="init-dates"
@@ -207,6 +216,7 @@ export const InitialDate: Story = {
         initialDate=""
         initialDateTo=""
         isDateRange
+        onChange={onChange}
       />
       <Heading level="h3" size="heading6">
         Passing no initialDate renders today's date
@@ -218,7 +228,11 @@ export const InitialDate: Story = {
         isDateRange
       />
     </VStack>
-  ),
+  );
+}
+
+export const InitialDate: Story = {
+  render: () => InitialDateExample(),
 };
 
 export const Placeholder: Story = {

--- a/src/components/DatePicker/DatePicker.stories.tsx
+++ b/src/components/DatePicker/DatePicker.stories.tsx
@@ -188,12 +188,50 @@ export const OtherStates: Story = {
 
 export const InitialDate: Story = {
   render: () => (
+    <VStack align="stretch" spacing="s">
+      <DatePicker
+        id="init-dates"
+        dateType="full"
+        labelText="Select the date you want to visit NYPL"
+        initialDate="12/1/21"
+        initialDateTo="12/10/21"
+        isDateRange
+      />
+      <Heading level="h3" size="heading6">
+        Passing initialDate an empty string renders an empty input
+      </Heading>
+      <DatePicker
+        id="init-dates"
+        dateType="full"
+        labelText="Select the date you want to visit NYPL"
+        initialDate=""
+        initialDateTo=""
+        isDateRange
+      />
+      <Heading level="h3" size="heading6">
+        Passing no initialDate renders today's date
+      </Heading>
+      <DatePicker
+        id="init-dates"
+        dateType="full"
+        labelText="Select the date you want to visit NYPL"
+        isDateRange
+      />
+    </VStack>
+  ),
+};
+
+export const Placeholder: Story = {
+  render: () => (
     <DatePicker
-      id="init-dates"
+      id="format-date"
+      dateFormat="MM-dd-yyyy"
       dateType="full"
       labelText="Select the date you want to visit NYPL"
-      initialDate="12/1/21"
-      initialDateTo="12/10/21"
+      initialDate=""
+      initialDateTo=""
+      placeholder="This is placeholder text"
+      placeholderTo="This is placeholderTo text"
       isDateRange
     />
   ),

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -114,7 +114,7 @@ describe("DatePicker", () => {
       expect(screen.getByDisplayValue(date)).toBeInTheDocument();
     });
 
-    it("should render with an initial date", () => {
+    it("should render with an initial date if a date is passed", () => {
       render(
         <DatePicker
           id="datePicker"
@@ -125,6 +125,34 @@ describe("DatePicker", () => {
       const date = screen.getByDisplayValue("1988-01-02");
 
       expect(date).toBeInTheDocument();
+    });
+
+    it("should render with an empty input if an empty string is passed as the initialDate", () => {
+      render(
+        <DatePicker
+          id="datePicker"
+          labelText="Select the full date you want to visit NYPL"
+          initialDate=""
+        />
+      );
+      const input = screen.getByLabelText(
+        "Select the full date you want to visit NYPL"
+      );
+
+      expect(input).toHaveValue("");
+    });
+
+    it("should render with today's date if no initialDate is passed", () => {
+      render(
+        <DatePicker
+          id="datePicker"
+          labelText="Select the full date you want to visit NYPL"
+        />
+      );
+
+      const today = getTodaysDateDisplay("full");
+
+      expect(today).toBeInTheDocument();
     });
 
     it("should render the 'month' DatePicker type", () => {

--- a/src/components/DatePicker/DatePicker.test.tsx
+++ b/src/components/DatePicker/DatePicker.test.tsx
@@ -152,7 +152,9 @@ describe("DatePicker", () => {
 
       const today = getTodaysDateDisplay("full");
 
-      expect(today).toBeInTheDocument();
+      const date = screen.getByDisplayValue(today);
+
+      expect(date).toBeInTheDocument();
     });
 
     it("should render the 'month' DatePicker type", () => {

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -88,10 +88,13 @@ export interface DatePickerProps extends DatePickerWrapperProps {
   helperTextFrom?: string;
   /** Populates the `HelperErrorText` component in the "To" `TextInput` component. */
   helperTextTo?: string;
-  /** The initial date value. This must be in the mm/dd/yyyy format. */
+  /** The initial date value. If no initialDate is passed, the input will render with
+   * today's date. If an empty string is passed, the input will render with no initial
+   * value. If a date is passed, it must be in the mm/dd/yyyy format. */
   initialDate?: string;
-  /** The initialTo date value used for date ranges.
-   * This must be in the mm/dd/yyyy format. */
+  /** The initialTo date value (used for date ranges). If no initialTo is passed, the input
+   * will render with today's date. If an empty string is passed, the input will render with
+   * no initial value.  If a date is passed, it must be in the mm/dd/yyyy format. */
   initialDateTo?: string;
   /** Populates the `HelperErrorText` error state for both "From"
    * and "To" input components. */
@@ -116,6 +119,10 @@ export interface DatePickerProps extends DatePickerWrapperProps {
    * This will return the data in an object with `startDate` and `endDate` keys.
    */
   onChange?: (data: FullDateType) => void;
+  /** Placeholder text for the input. */
+  placeholder?: string;
+  /** Placeholder text for the end date input (used in date ranges). */
+  placeholderTo?: string;
   /** An additional explicit React ref passed for a date range's "To"
    * input field. Note that the "From" input takes the initial "ref" value. */
   refTo?: React.Ref<TextInputRefType>;
@@ -267,6 +274,8 @@ export const DatePicker = chakra(
       nameFrom,
       nameTo,
       onChange,
+      placeholder,
+      placeholderTo,
       refTo,
       showHelperInvalidText = true,
       showLabel = true,
@@ -275,8 +284,16 @@ export const DatePicker = chakra(
     } = props;
     const styles = useMultiStyleConfig("DatePicker", {});
     const finalStyles = isDateRange ? styles : {};
-    const initStartDate = initialDate ? new Date(initialDate) : new Date();
-    const initEndDate = initialDateTo ? new Date(initialDateTo) : new Date();
+    const initStartDate = initialDate
+      ? new Date(initialDate)
+      : initialDate === ""
+      ? null
+      : new Date();
+    const initEndDate = initialDateTo
+      ? new Date(initialDateTo)
+      : initialDateTo === ""
+      ? null
+      : new Date();
     const startDateInputRef = useRef(null);
     const endDateInputRef = useRef(null);
 
@@ -421,6 +438,7 @@ export const DatePicker = chakra(
           id={`${id}-end`}
           name={nameTo}
           onChange={(date: Date) => onChangeDefault(date, "endDate")}
+          placeholderText={placeholderTo}
           selected={fullDate.endDate}
           {...endDatePickerAttrs}
         />
@@ -445,6 +463,7 @@ export const DatePicker = chakra(
         id={`${id}-start`}
         name={nameFrom}
         onChange={(date: Date) => onChangeDefault(date, "startDate")}
+        placeholderText={placeholder}
         selected={fullDate.startDate}
         {...startDatePickerAttrs}
       />

--- a/src/components/DatePicker/DatePicker.tsx
+++ b/src/components/DatePicker/DatePicker.tsx
@@ -31,9 +31,9 @@ export type DatePickerTypes = typeof datePickerTypesArray[number];
 export interface FullDateType {
   /** Date object that gets returned for the onChange
    * function only for date ranges. */
-  endDate?: Date;
+  endDate?: Date | null;
   /** Date object that gets returned for the onChange function. */
-  startDate: Date;
+  startDate: Date | null;
 }
 
 // Used for the input fields' parent wrapper. Internal use only.

--- a/src/components/DatePicker/_DatePicker.scss
+++ b/src/components/DatePicker/_DatePicker.scss
@@ -7,6 +7,7 @@
 
 .date-picker-calendar {
   font-family: var(--nypl-fonts-body);
+  position: unset !important;
 
   .react-datepicker {
     border-color: var(--nypl-colors-ui-border-default);

--- a/src/components/DatePicker/_DatePicker.scss
+++ b/src/components/DatePicker/_DatePicker.scss
@@ -7,7 +7,6 @@
 
 .date-picker-calendar {
   font-family: var(--nypl-fonts-body);
-  position: unset !important;
 
   .react-datepicker {
     border-color: var(--nypl-colors-ui-border-default);

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -13,6 +13,15 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Fixes bug where month and year `Datepicker` calendars were rendering vertically rather than horizontally.",
+    ],
+  },
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
     affects: ["Functionality"],
     notes: [
       "Updates the `initialDate` and `initialDateTo` props to accept an empty string and adds optional `placeholder` and `placeholderTo` props.",

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: [
+      "Updates the `initialDate` and `initialDateTo` props to accept an empty string and adds optional `placeholder` and `placeholderTo` props.",
+    ],
+  },
+  {
     date: "2023-12-07",
     version: "2.1.3",
     type: "Update",

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -13,15 +13,6 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Styles"],
-    notes: [
-      "Fixes bug where month and year `Datepicker` calendars were rendering vertically rather than horizontally.",
-    ],
-  },
-  {
-    date: "Prerelease",
-    version: "Prerelease",
-    type: "Update",
     affects: ["Functionality"],
     notes: [
       "Updates the `initialDate` and `initialDateTo` props to accept an empty string and adds optional `placeholder` and `placeholderTo` props.",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1589](https://jira.nypl.org/browse/DSD-1589). 

NOTE: this is a draft PR because Edwin and I made some assumptions about how this should work and want to get sign off from others on the approach before finishing the PR (adding to the Changelogs, updating Storybook, etc).

## This PR does the following:

- Allows users to pass an empty string for initialDate and initialDateTo, which results in empty inputs.
- Allows users to optionally pass a string placeholder and placeholderTo.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- Locally, on Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
