### PR TITLE
DSD-1645: Updating Form, Fieldset, Label, and FeedbackBox to Chakra 2.8 theme API

### DIFF
--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # FeedbackBox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.3.0`    |
-| Latest            | `2.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.3.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   chakra,
+  ChakraComponent,
   Drawer,
   DrawerBody,
   DrawerContent,
@@ -86,8 +87,14 @@ interface FeedbackBoxProps {
  * submitted data; that feature is the responsibility of the consuming
  * application.
  */
-export const FeedbackBox: React.FC<any> = chakra(
-  forwardRef<any, FeedbackBoxProps>(
+export const FeedbackBox: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<FeedbackBoxProps> &
+      React.RefAttributes<HTMLDivElement>
+  >,
+  FeedbackBoxProps
+> = chakra(
+  forwardRef<HTMLDivElement, FeedbackBoxProps>(
     (
       {
         className,

--- a/src/components/Fieldset/Fieldset.mdx
+++ b/src/components/Fieldset/Fieldset.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
+import { changelogData } from "./fieldsetChangelogData";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 import * as FieldsetStories from "./Fieldset.stories";
 import { Link } from "../Link/Link";
@@ -7,16 +9,17 @@ import { Link } from "../Link/Link";
 
 # Fieldset
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.3`   |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.3`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -47,3 +50,7 @@ Resources:
 - [W3C Grouping form controls with FIELDSET and LEGEND](https://www.w3.org/TR/2008/WD-WCAG20-TECHS-20080430/H82.html)
 - [GOV.UK Using the fieldset and legend elements](https://accessibility.blog.gov.uk/2016/07/22/using-the-fieldset-and-legend-elements/)
 - [MDN fieldset: The Field Set element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/fieldset)
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Fieldset/Fieldset.tsx
+++ b/src/components/Fieldset/Fieldset.tsx
@@ -1,4 +1,9 @@
-import { Box, chakra, useMultiStyleConfig } from "@chakra-ui/react";
+import {
+  Box,
+  chakra,
+  ChakraComponent,
+  useMultiStyleConfig,
+} from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 interface FieldsetProps {
@@ -21,7 +26,13 @@ interface FieldsetProps {
  * A wrapper component that renders a `fieldset` element along with a `legend`
  * element as its first child. Commonly used to wrap form components.
  */
-export const Fieldset: React.FC<React.PropsWithChildren<any>> = chakra(
+export const Fieldset: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<FieldsetProps> &
+      React.RefAttributes<HTMLDivElement & HTMLFieldSetElement>
+  >,
+  React.PropsWithChildren<FieldsetProps>
+> = chakra(
   forwardRef<
     HTMLDivElement & HTMLFieldSetElement,
     React.PropsWithChildren<FieldsetProps>

--- a/src/components/Fieldset/fieldsetChangelogData.ts
+++ b/src/components/Fieldset/fieldsetChangelogData.ts
@@ -16,29 +16,4 @@ export const changelogData: ChangelogData[] = [
     affects: ["Styles"],
     notes: ["Chakra 2.8 update."],
   },
-  {
-    date: "2023-10-26",
-    version: "2.1.1",
-    type: "Update",
-    affects: ["Accessibility"],
-    notes: [
-      "Updates `tabindex` value from 0 to -1. See Accessibility section for details.",
-    ],
-  },
-  {
-    date: "2023-10-18",
-    version: "2.1.0",
-    type: "Update",
-    affects: ["Styles"],
-    notes: ["Remove the underline on the component's `Privacy Policy` link."],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: ["Styles"],
-    notes: [
-      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
-    ],
-  },
 ];

--- a/src/components/Form/Form.mdx
+++ b/src/components/Form/Form.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+import { changelogData } from "./formChangelogData";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 import * as FormStories from "./Form.stories";
 import Link from "../Link/Link";
@@ -7,10 +9,10 @@ import Link from "../Link/Link";
 
 # Form
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `1.0.6`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.2`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -19,6 +21,7 @@ import Link from "../Link/Link";
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#spacing-variants" target="_self">Spacing Variants</Link>}
 - {<Link href="#example-code" target="_self">Example Code</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -130,3 +133,7 @@ the `Form` component: `"grid.xxs"`, `"grid.xs"`, `"grid.s"`, `"grid.m"`,
 `}
   language="tsx"
 />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,4 +1,4 @@
-import { Box, chakra } from "@chakra-ui/react";
+import { Box, chakra, ChakraComponent } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 import SimpleGrid, { GridGaps } from "../Grid/SimpleGrid";
@@ -26,51 +26,65 @@ export interface FormProps extends FormBaseProps {
 }
 
 /** FormRow child-component */
-export const FormRow: React.FC<any> = chakra(
-  (props: React.PropsWithChildren<FormChildProps>) => {
-    const { children, className, gap, id, ...rest } = props;
-    const count = React.Children.count(children);
-    const alteredChildren = React.Children.map(
-      children as JSX.Element,
-      (child: React.ReactElement, i) => {
-        if (!child) return null;
-        if (child.type === FormField || child.props.mdxType === "FormField") {
-          return React.cloneElement(child, { id: `${id}-grandchild${i}` });
-        }
-        console.warn(
-          "NYPL Reservoir FormRow: Children must be `FormField` components."
-        );
-        return null;
+export const FormRow: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<FormChildProps> &
+      React.RefAttributes<HTMLDivElement>
+  >,
+  FormChildProps
+> = chakra((props: React.PropsWithChildren<FormChildProps>) => {
+  const { children, className, gap, id, ...rest } = props;
+  const count = React.Children.count(children);
+  const alteredChildren = React.Children.map(
+    children as JSX.Element,
+    (child: React.ReactElement, i) => {
+      if (!child) return null;
+      if (child.type === FormField || child.props.mdxType === "FormField") {
+        return React.cloneElement(child, { id: `${id}-grandchild${i}` });
       }
-    );
-    return (
-      <SimpleGrid
-        columns={count}
-        className={className}
-        gap={gap}
-        id={id}
-        {...rest}
-      >
-        {alteredChildren}
-      </SimpleGrid>
-    );
-  }
-);
+      console.warn(
+        "NYPL Reservoir FormRow: Children must be `FormField` components."
+      );
+      return null;
+    }
+  );
+  return (
+    <SimpleGrid
+      columns={count}
+      className={className}
+      gap={gap}
+      id={id}
+      {...rest}
+    >
+      {alteredChildren}
+    </SimpleGrid>
+  );
+});
 
 /** FormField child-component */
-export const FormField: React.FC<any> = chakra(
-  (props: React.PropsWithChildren<FormChildProps>) => {
-    const { children, className, gap, id, ...rest } = props;
-    return (
-      <SimpleGrid columns={1} className={className} gap={gap} id={id} {...rest}>
-        {children}
-      </SimpleGrid>
-    );
-  }
-);
+export const FormField: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<FormChildProps> &
+      React.RefAttributes<HTMLDivElement>
+  >,
+  FormChildProps
+> = chakra((props: React.PropsWithChildren<FormChildProps>) => {
+  const { children, className, gap, id, ...rest } = props;
+  return (
+    <SimpleGrid columns={1} className={className} gap={gap} id={id} {...rest}>
+      {children}
+    </SimpleGrid>
+  );
+});
 
 /** Main Form component */
-export const Form: React.FC<any> = chakra(
+export const Form: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<FormProps> &
+      React.RefAttributes<HTMLDivElement & HTMLFormElement>
+  >,
+  React.PropsWithChildren<FormProps>
+> = chakra(
   forwardRef<
     HTMLDivElement & HTMLFormElement,
     React.PropsWithChildren<FormProps>

--- a/src/components/Form/formChangelogData.ts
+++ b/src/components/Form/formChangelogData.ts
@@ -13,32 +13,7 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Styles"],
-    notes: ["Chakra 2.8 update."],
-  },
-  {
-    date: "2023-10-26",
-    version: "2.1.1",
-    type: "Update",
-    affects: ["Accessibility"],
-    notes: [
-      "Updates `tabindex` value from 0 to -1. See Accessibility section for details.",
-    ],
-  },
-  {
-    date: "2023-10-18",
-    version: "2.1.0",
-    type: "Update",
-    affects: ["Styles"],
-    notes: ["Remove the underline on the component's `Privacy Policy` link."],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: ["Styles"],
-    notes: [
-      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
-    ],
+    affects: ["Documentation"],
+    notes: ["Updates the component's type definition to be more specific."],
   },
 ];

--- a/src/components/Label/Label.mdx
+++ b/src/components/Label/Label.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
+import { changelogData } from "./labelChangelogData";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 import * as LabelStories from "./Label.stories";
 import Link from "../Link/Link";
@@ -7,10 +9,10 @@ import Link from "../Link/Link";
 
 # Label
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.10`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -19,6 +21,7 @@ import Link from "../Link/Link";
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#isrequired-helper-text" target="_self">isRequired helper text</Link>}
 - {<Link href="#requiredlabeltext-to-customize-required-label" target="_self">requiredLabelText to customize required label</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -63,3 +66,7 @@ We also recommend a maximum of two words for this text.
 Note: The parenthesis will be added automatically by the component.
 
 <Canvas of={LabelStories.CustomRequiredText} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -1,4 +1,4 @@
-import { Box, chakra, useStyleConfig } from "@chakra-ui/react";
+import { Box, chakra, ChakraComponent, useStyleConfig } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
 interface LabelProps {
@@ -22,7 +22,13 @@ interface LabelProps {
 /**
  * A label for form inputs. It should never be used alone.
  */
-export const Label: React.FC<any> = chakra(
+export const Label: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<LabelProps> &
+      React.RefAttributes<HTMLDivElement & HTMLLabelElement>
+  >,
+  React.PropsWithChildren<LabelProps>
+> = chakra(
   forwardRef<
     HTMLDivElement & HTMLLabelElement,
     React.PropsWithChildren<LabelProps>

--- a/src/components/Label/labelChangelogData.ts
+++ b/src/components/Label/labelChangelogData.ts
@@ -16,29 +16,4 @@ export const changelogData: ChangelogData[] = [
     affects: ["Styles"],
     notes: ["Chakra 2.8 update."],
   },
-  {
-    date: "2023-10-26",
-    version: "2.1.1",
-    type: "Update",
-    affects: ["Accessibility"],
-    notes: [
-      "Updates `tabindex` value from 0 to -1. See Accessibility section for details.",
-    ],
-  },
-  {
-    date: "2023-10-18",
-    version: "2.1.0",
-    type: "Update",
-    affects: ["Styles"],
-    notes: ["Remove the underline on the component's `Privacy Policy` link."],
-  },
-  {
-    date: "2023-9-28",
-    version: "2.0.0",
-    type: "Update",
-    affects: ["Styles"],
-    notes: [
-      "Applied Typo2023 styles, including font size, font color, and text link patterns.",
-    ],
-  },
 ];

--- a/src/theme/components/feedbackBox.ts
+++ b/src/theme/components/feedbackBox.ts
@@ -1,14 +1,17 @@
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 import { screenreaderOnly } from "./globalMixins";
 
-const FeedbackBox = {
-  parts: [
+const { defineMultiStyleConfig, definePartsStyle } =
+  createMultiStyleConfigHelpers([
     "closeButton",
     "drawerBody",
     "drawerContent",
     "drawerHeader",
     "openButton",
-  ],
-  baseStyle: {
+  ]);
+
+const FeedbackBox = defineMultiStyleConfig({
+  baseStyle: definePartsStyle({
     closeButton: {
       /** This is overriding the default min-height value in order to keep the
        * button spacing symmetrical. */
@@ -70,7 +73,7 @@ const FeedbackBox = {
       right: "0",
       zIndex: "5",
     },
-  },
-};
+  }),
+});
 
 export default FeedbackBox;

--- a/src/theme/components/feedbackBox.ts
+++ b/src/theme/components/feedbackBox.ts
@@ -16,6 +16,7 @@ const FeedbackBox = defineMultiStyleConfig({
       /** This is overriding the default min-height value in order to keep the
        * button spacing symmetrical. */
       minHeight: "40px",
+      minWidth: "40px",
       right: "xs",
       p: "0",
       position: "absolute",

--- a/src/theme/components/fieldset.ts
+++ b/src/theme/components/fieldset.ts
@@ -1,13 +1,15 @@
+import { defineStyleConfig, StyleFunctionProps } from "@chakra-ui/react";
+import { defineStyle } from "@chakra-ui/system";
 import { labelLegendText } from "./global";
 import { screenreaderOnly } from "./globalMixins";
 
-interface FieldSetProps {
+interface FieldSetProps extends StyleFunctionProps {
   isLegendHidden?: boolean;
 }
 
-const Fieldset = {
-  baseStyle: ({ isLegendHidden }: FieldSetProps) => {
-    const screenreaderStyles = isLegendHidden ? screenreaderOnly() : {};
+const Fieldset = defineStyleConfig({
+  baseStyle: defineStyle((props: FieldSetProps) => {
+    const screenreaderStyles = props.isLegendHidden ? screenreaderOnly() : {};
 
     return {
       border: 0,
@@ -21,7 +23,7 @@ const Fieldset = {
         },
       },
     };
-  },
-};
+  }),
+});
 
 export default Fieldset;

--- a/src/theme/components/label.ts
+++ b/src/theme/components/label.ts
@@ -1,15 +1,17 @@
+import { defineStyleConfig, StyleFunctionProps } from "@chakra-ui/react";
+import { defineStyle } from "@chakra-ui/system";
 import { labelLegendText } from "./global";
 
-interface LabelBaseStyle {
+interface LabelBaseStyle extends StyleFunctionProps {
   isInlined: boolean;
 }
 
-const Label = {
-  baseStyle: ({ isInlined }: LabelBaseStyle) => ({
+const Label = defineStyleConfig({
+  baseStyle: defineStyle((props: LabelBaseStyle) => ({
     ...labelLegendText,
-    flex: isInlined ? "1" : null,
-    whiteSpace: isInlined ? "nowrap" : null,
-  }),
-};
+    flex: props.isInlined ? "1" : null,
+    whiteSpace: props.isInlined ? "nowrap" : null,
+  })),
+});
 
 export default Label;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1645](https://jira.nypl.org/browse/DSD-1645)

## This PR does the following:

- Updates Fieldset, Label, and FeedbackBox components to use the Chakra 2.8 updated API for their theme object.
- Form doesn't have a theme object, so I just updated its type in order to eliminate the "any".
- One thing I am noticing is that you can import some of the functions (defineStyle, defineStyleConfig, etc) from either `"@chakra-ui/system";` or `"@chakra-ui/react";`. I assume we should make this consistent throughout, but it is not as of now. 

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

- Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
