### PR TITLE
DSD-1641: Updating Accordion, Modal, Tabs, and Tooltip to Chakra 2.8 API

### DIFF
--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./accordionChangelogData";
 
 import * as AccordionStories from "./Accordion.stories";
 import Link from "../Link/Link";
@@ -7,10 +9,10 @@ import Link from "../Link/Link";
 
 # Accordion
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -19,6 +21,7 @@ import Link from "../Link/Link";
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#faq-example" target="_self">FAQ Example</Link>}
 - {<Link href="#example-with-panelmaxheight-prop" target="_self">Example with panelMaxHeight Prop</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -220,3 +223,7 @@ of the content when it is closed. Click on subjects inside both `Accordion`s and
 toggle them closed and opened to see the difference.
 
 <Canvas of={AccordionStories.IsAlwaysRendered} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -1,6 +1,7 @@
 import { VStack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
+import { argsBooleanType } from "../../helpers/storybookUtils";
 
 import { Accordion, AccordionDataProps } from "./Accordion";
 import Card, { CardHeading, CardContent } from "../Card/Card";
@@ -140,8 +141,8 @@ const meta: Meta<typeof Accordion> = {
       },
     },
     id: { control: false },
-    isDefaultOpen: { table: { defaultValue: { summary: false } } },
-    isAlwaysRendered: { table: { defaultValue: { summary: false } } },
+    isDefaultOpen: argsBooleanType(),
+    isAlwaysRendered: argsBooleanType(),
     panelMaxHeight: { control: { type: "text" } },
   },
 };

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -184,10 +184,9 @@ const getElementsFromData = (
  */
 export const Accordion: ChakraComponent<
   React.ForwardRefExoticComponent<
-    React.PropsWithChildren<AccordionProps> &
-      React.RefAttributes<HTMLDivElement>
+    AccordionProps & React.RefAttributes<HTMLDivElement>
   >,
-  React.PropsWithChildren<AccordionProps>
+  AccordionProps
 > = chakra(
   forwardRef<HTMLDivElement, AccordionProps>((props, ref?) => {
     const {

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   chakra,
   useColorMode,
+  ChakraComponent,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
@@ -181,7 +182,13 @@ const getElementsFromData = (
  * Accordion component that shows content on toggle. Can be used to display
  * multiple accordion items together.
  */
-export const Accordion: React.FC<any> = chakra(
+export const Accordion: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<AccordionProps> &
+      React.RefAttributes<HTMLDivElement>
+  >,
+  React.PropsWithChildren<AccordionProps>
+> = chakra(
   forwardRef<HTMLDivElement, AccordionProps>((props, ref?) => {
     const {
       accordionData,

--- a/src/components/Accordion/accordionChangelogData.ts
+++ b/src/components/Accordion/accordionChangelogData.ts
@@ -1,0 +1,19 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Chakra 2.8 update."],
+  },
+];

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./modalChangelogData";
 
 import * as ModalStories from "./Modal.stories";
 import { ModalTrigger, useModal } from "./Modal";
@@ -8,10 +10,10 @@ import Link from "../Link/Link";
 
 # Modal
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -24,6 +26,7 @@ import Link from "../Link/Link";
 - {<Link href="#usemodal" target="_self">useModal</Link>}
 - {<Link href="#usemodal-component-props" target="_self">useModal Component Props</Link>}
 - {<Link href="#content-window-scrolling" target="_self">Content Window Scrolling</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -206,3 +209,7 @@ scroll while the `Modal`'s header and footer still stay static. Check the
 example below with a lot of content inside the `Modal`.
 
 <Canvas of={ModalStories.ContentWindowScrolling} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -8,6 +8,7 @@ import {
   ModalBody,
   ModalCloseButton,
   useDisclosure,
+  ChakraComponent,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
@@ -32,7 +33,13 @@ export interface ModalProps {
   modalProps: BaseModalProps;
 }
 
-const BaseModal: React.FC<any> = chakra(
+export const BaseModal: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<BaseModalProps> &
+      React.RefAttributes<HTMLButtonElement>
+  >,
+  React.PropsWithChildren<BaseModalProps>
+> = chakra(
   ({
     bodyContent,
     closeButtonLabel = "Close",
@@ -81,7 +88,12 @@ const BaseModal: React.FC<any> = chakra(
  * internal `Modal` component. Note that props to update the internal `Modal`
  * component are passed through to the `modalProps` prop.
  */
-export const ModalTrigger: React.FC<any> = chakra(
+export const ModalTrigger: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<ModalProps> & React.RefAttributes<HTMLButtonElement>
+  >,
+  React.PropsWithChildren<ModalProps>
+> = chakra(
   forwardRef<HTMLButtonElement, React.PropsWithChildren<ModalProps>>(
     ({ buttonText, id, modalProps, ...rest }, ref?) => {
       const { isOpen, onOpen, onClose } = useDisclosure();

--- a/src/components/Modal/modalChangelogData.ts
+++ b/src/components/Modal/modalChangelogData.ts
@@ -1,0 +1,19 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Chakra 2.8 update."],
+  },
+];

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./tabsChangelogData";
 
 import * as TabsStories from "./Tabs.stories";
 import Link from "../Link/Link";
@@ -7,10 +9,10 @@ import Link from "../Link/Link";
 
 # Tabs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -22,6 +24,7 @@ import Link from "../Link/Link";
 - {<Link href="#callback-event-function" target="_self">Callback Event Function</Link>}
 - {<Link href="#url-hash-option" target="_self">URL Hash Option</Link>}
 - {<Link href="#children-components" target="_self">Children Components</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -235,3 +238,7 @@ import {
 />
 
 <Canvas of={TabsStories.ChildrenComponents} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 
 import Tabs, { TabList, Tab, TabPanels, TabPanel } from "./Tabs";
+import { argsBooleanType } from "../../helpers/storybookUtils";
 
 const animalCrossingData = [
   {
@@ -61,9 +62,7 @@ const meta: Meta<typeof Tabs> = {
     id: { control: false },
     onChange: { control: false },
     tabsData: { control: false },
-    useHash: {
-      table: { defaultValue: { summary: false } },
-    },
+    useHash: argsBooleanType(),
   },
 };
 

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -7,6 +7,7 @@ import {
   TabPanel,
   Tabs as ChakraTabs,
   useMultiStyleConfig,
+  ChakraComponent,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
@@ -143,7 +144,12 @@ const getElementsFromChildren = (children): TabPanelProps => {
  * Renders Chakra's `Tab` component with specific variants, props,
  * and controlled styling.
  */
-export const Tabs: React.FC<any> = chakra(
+export const Tabs: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<TabsProps> & React.RefAttributes<HTMLDivElement>
+  >,
+  React.PropsWithChildren<TabsProps>
+> = chakra(
   forwardRef<HTMLDivElement, React.PropsWithChildren<TabsProps>>(
     (props, ref?) => {
       const {

--- a/src/components/Tabs/tabsChangelogData.ts
+++ b/src/components/Tabs/tabsChangelogData.ts
@@ -1,0 +1,19 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Chakra 2.8 update."],
+  },
+];

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -1,4 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./tooltipChangelogData";
 
 import * as TooltipStories from "./Tooltip.stories";
 import Link from "../Link/Link";
@@ -7,10 +9,10 @@ import Link from "../Link/Link";
 
 # Tooltip
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.1.0`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -18,6 +20,7 @@ import Link from "../Link/Link";
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#examples" target="_self">Examples</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -92,3 +95,7 @@ By default, the `Tooltip` is not shown for a disabled `Button`. To show the `Too
 on a disabled `Button`, pass the `shouldWrapChildren` prop.
 
 <Canvas of={TooltipStories.DisablingTooltipButton} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Tooltip/Tooltip.stories.tsx
+++ b/src/components/Tooltip/Tooltip.stories.tsx
@@ -12,6 +12,7 @@ import SimpleGrid from "../Grid/SimpleGrid";
 import Text from "../Text/Text";
 import Toggle from "../Toggle/Toggle";
 import Tooltip from "./Tooltip";
+import { argsBooleanType } from "../../helpers/storybookUtils";
 
 const meta: Meta<typeof Tooltip> = {
   title: "Components/Overlays & Switchers/Tooltip",
@@ -21,12 +22,8 @@ const meta: Meta<typeof Tooltip> = {
     children: { control: false },
     className: { control: false },
     id: { control: false },
-    isDisabled: {
-      table: { defaultValue: { summary: false } },
-    },
-    shouldWrapChildren: {
-      table: { defaultValue: { summary: false } },
-    },
+    isDisabled: argsBooleanType(),
+    shouldWrapChildren: argsBooleanType(),
   },
 };
 

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -2,7 +2,7 @@ import React, { forwardRef } from "react";
 import {
   chakra,
   Tooltip as ChakraTooltip,
-  useMultiStyleConfig,
+  useStyleConfig,
   ChakraComponent,
 } from "@chakra-ui/react";
 import Icon from "../Icons/Icon";
@@ -60,7 +60,7 @@ export const Tooltip: ChakraComponent<
       children
     );
 
-    const styles = useMultiStyleConfig("Tooltip", {});
+    const styles = useStyleConfig("Tooltip", {});
 
     return (
       <ChakraTooltip

--- a/src/components/Tooltip/Tooltip.tsx
+++ b/src/components/Tooltip/Tooltip.tsx
@@ -3,6 +3,7 @@ import {
   chakra,
   Tooltip as ChakraTooltip,
   useMultiStyleConfig,
+  ChakraComponent,
 } from "@chakra-ui/react";
 import Icon from "../Icons/Icon";
 import Image from "../Image/Image";
@@ -23,7 +24,12 @@ export interface TooltipProps {
   shouldWrapChildren?: boolean;
 }
 
-export const Tooltip: React.FC<any> = chakra(
+export const Tooltip: ChakraComponent<
+  React.ForwardRefExoticComponent<
+    React.PropsWithChildren<TooltipProps> & React.RefAttributes<HTMLDivElement>
+  >,
+  React.PropsWithChildren<TooltipProps>
+> = chakra(
   forwardRef<HTMLDivElement, TooltipProps>((props, ref?) => {
     const {
       children,

--- a/src/components/Tooltip/tooltipChangelogData.ts
+++ b/src/components/Tooltip/tooltipChangelogData.ts
@@ -1,0 +1,19 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Chakra 2.8 update."],
+  },
+];

--- a/src/theme/components/accordion.ts
+++ b/src/theme/components/accordion.ts
@@ -1,3 +1,8 @@
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+
+const { defineMultiStyleConfig, definePartsStyle } =
+  createMultiStyleConfigHelpers(["container", "button", "panel"]);
+
 const containerStyles = {
   border: "none",
   width: "100%",
@@ -27,13 +32,12 @@ const panelStyles = {
   },
 };
 
-const Accordion = {
-  parts: ["container", "button", "panel"],
-  baseStyle: {
+const Accordion = defineMultiStyleConfig({
+  baseStyle: definePartsStyle({
     container: containerStyles,
     button: buttonStyles,
     panel: panelStyles,
-  },
-};
+  }),
+});
 
 export default Accordion;

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -1,5 +1,7 @@
-const Modal = {
-  parts: [
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+
+const { defineMultiStyleConfig, definePartsStyle } =
+  createMultiStyleConfigHelpers([
     "header",
     "overlay",
     "dialogContainer",
@@ -7,8 +9,10 @@ const Modal = {
     "closeButton",
     "body",
     "footer",
-  ],
-  baseStyle: {
+  ]);
+
+const Modal = defineMultiStyleConfig({
+  baseStyle: definePartsStyle({
     dialog: {
       _dark: {
         bg: "dark.ui.bg.default",
@@ -30,7 +34,7 @@ const Modal = {
         color: "dark.ui.typography.body",
       },
     },
-  },
-};
+  }),
+});
 
 export default Modal;

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -1,3 +1,20 @@
+import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+
+// root, tablist, tab, tabpanel, and tabpanels are existing keys which are extended but
+// buttonArrows, tablistWrapper, and carouselParent are custom elements
+// in the `Tabs` component.
+const { defineMultiStyleConfig, definePartsStyle } =
+  createMultiStyleConfigHelpers([
+    "root",
+    "tab",
+    "tabpanels",
+    "tabpanel",
+    "tablist",
+    "buttonArrows",
+    "tablistWrapper",
+    "carouselParent",
+  ]);
+
 const tablist = {
   borderColor: "ui.black",
 };
@@ -122,24 +139,25 @@ const carouselParent = {
   overflowX: { base: "hidden", md: "visible" },
 };
 
-const CustomTabs = {
+const CustomTabs = defineMultiStyleConfig({
   // tablist, tab, and tabpanels are existing keys which are extended but
   // buttonArrows, tablistWrapper, and carouselParent are custom elements
   // in the `Tabs` component.
-  parts: ["buttonArrows", "tablistWrapper", "carouselParent"],
-  baseStyle: {
+  baseStyle: definePartsStyle({
+    tabpanel: {},
+    root: {},
+    tabpanels,
     tablist,
     tab,
     // Only display the previous/next arrow buttons on mobile.
     buttonArrows,
     // To better align the mobile arrow buttons with the tablist.
     tablistWrapper,
-    tabpanels,
     carouselParent,
-  },
+  }),
   defaultProps: {
     colorScheme: "ui.black",
   },
-};
+});
 
 export default CustomTabs;

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -1,9 +1,11 @@
 import { cssVar } from "@chakra-ui/theme-tools";
+import { defineStyleConfig } from "@chakra-ui/react";
+import { defineStyle } from "@chakra-ui/system";
 
 const $bg = cssVar("tooltip-bg");
 
-const Tooltip = {
-  baseStyle: {
+const Tooltip = defineStyleConfig({
+  baseStyle: defineStyle({
     [$bg.variable]: "colors.ui.gray.xx-dark",
     borderRadius: "4px",
     boxShadow: "none",
@@ -17,7 +19,7 @@ const Tooltip = {
       [$bg.variable]: "colors.ui.gray.x-dark",
       color: "dark.ui.typography.heading",
     },
-  },
-};
+  }),
+});
 
 export default Tooltip;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1641](https://jira.nypl.org/browse/DSD-1641)

## This PR does the following:
- Updates accordion, modal, tabs, and tooltip components to Chakra 2.8 API
- Adds changelogs for all 4
- Tooltip used `useMultiStyleConfig` but I think it's single part, so updated `Tooltip.tsx` and `tooltip.ts` to `useStyleConfig`

## How has this been tested?

Locally, Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.
