### PR TITLE
DSD-1632: Tabs left/right scrolling 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates `Tabs` to be scrollable when the width of the tab set is greater than the viewport.
+
 ## 2.1.4 (January 4, 2024)
 
 ### Adds

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -2,6 +2,8 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import * as TabsStories from "./Tabs.stories";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./tabsChangelogData";
 
 <Meta of={TabsStories} />
 
@@ -19,9 +21,11 @@ import Link from "../Link/Link";
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#composing-with-a-data-object" target="_self">Composing with a Data Object</Link>}
 - {<Link href="#responsive-mobile-carousel" target="_self">Responsive Mobile Carousel</Link>}
+- {<Link href="#scrollable-desktop-tab-set" target="_self">Scrollable Desktop Tab Set</Link>}
 - {<Link href="#callback-event-function" target="_self">Callback Event Function</Link>}
 - {<Link href="#url-hash-option" target="_self">URL Hash Option</Link>}
 - {<Link href="#children-components" target="_self">Children Components</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -127,6 +131,15 @@ the <Link href="#children-components" target="_self">Children Components</Link> 
 
 To view and test this in Storybook, go to the "Canvas" tab and change the
 viewport in the Storybook toolbar at the top of the page.
+
+## Scrollable Desktop Tab Set
+
+For desktop viewports (600px and greater), the full tab set scrolls left/right when
+the width of the tab set is greater than the width of the viewport.
+
+To scroll horizontally, use the `shift + scroll wheel` combination.
+
+<Canvas of={TabsStories.ExtendedTabSetExample} />
 
 ## Callback Event Function
 
@@ -235,3 +248,7 @@ import {
 />
 
 <Canvas of={TabsStories.ChildrenComponents} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Tabs/Tabs.stories.tsx
+++ b/src/components/Tabs/Tabs.stories.tsx
@@ -49,6 +49,27 @@ const animalCrossingData = [
   },
 ];
 
+const extraACData = [
+  {
+    label: "Filbert",
+    content:
+      "<strong>Filbert</strong> is a lazy squirrel villager in the Animal Crossing " +
+      "series. His name, like most of his species, comes from a type of nut. In " +
+      "this case, his name comes from an edible type of hazelnut. He has made an " +
+      "appearance in every Animal Crossing game to date. He is the only lazy " +
+      "squirrel villager in the series so far. His initial catchphrase could be " +
+      "based on the fact that squirrels usually appear to have buck teeth. He " +
+      "has the nature hobby.",
+  },
+  {
+    label: "Timmy and Tommy",
+    content:
+      "<strong>Timothy</strong> (better known as Timmy) and <strong>Thomas</strong> " +
+      "(more often known as Tommy) are the twin apprentices of Tom Nook, the tanuki " +
+      "who runs the town's store. Their last names are said to be Nook.",
+  },
+];
+
 const meta: Meta<typeof Tabs> = {
   title: "Components/Overlays & Switchers/Tabs",
   component: Tabs,
@@ -94,6 +115,10 @@ export const WithControls: Story = {
 // The following are additional Tabs example Stories.
 const onChange = (value) => {
   window.alert(`Tab index selected was ${value}`);
+};
+
+export const ExtendedTabSetExample: Story = {
+  render: () => <Tabs tabsData={[...animalCrossingData, ...extraACData]} />,
 };
 
 export const CallbackEventFunction: Story = {

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -137,6 +137,7 @@ describe("Tabs", () => {
   });
 
   it("switches between tabs", () => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
     render(<Tabs tabsData={animalCrossing} />);
     const isabelleTab = getTabByName("Isabelle");
     const kkSliderTab = getTabByName("K.K. Slider");

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -156,7 +156,7 @@ export const Tabs = chakra(
         useHash = false,
         ...rest
       } = props;
-      const [tabIndex, setTabIndex] = useState(0);
+      const [tabIndex, setTabIndex] = useState(defaultIndex);
       const styles = useMultiStyleConfig("Tabs", {});
       // Just an estimate of the tab width for the mobile carousel.
       const initTabWidth = 65;

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -8,12 +8,13 @@ import {
   Tabs as ChakraTabs,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useState } from "react";
 
 import Button from "../Button/Button";
 import Icon from "../Icons/Icon";
 import useCarouselStyles from "../../hooks/useCarouselStyles";
 import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
+import useScrollTabIntoView from "../../hooks/useScrollTabIntoView";
 
 // Internal interface used for rendering `Tabs` tab and panel
 // elements, either from data or from children.
@@ -155,6 +156,7 @@ export const Tabs = chakra(
         useHash = false,
         ...rest
       } = props;
+      const [tabIndex, setTabIndex] = useState(0);
       const styles = useMultiStyleConfig("Tabs", {});
       // Just an estimate of the tab width for the mobile carousel.
       const initTabWidth = 65;
@@ -233,13 +235,20 @@ export const Tabs = chakra(
         );
       }
 
+      const tablistRef = useScrollTabIntoView(tabIndex);
+
       return (
         <ChakraTabs
           defaultIndex={defaultIndex}
           id={id}
           // The following lazy loads each panel whenever it is needed.
           isLazy
-          onChange={onChange}
+          onChange={(index) => {
+            if (onChange !== undefined) {
+              onChange(index);
+            }
+            setTabIndex(index);
+          }}
           ref={ref}
           variant="enclosed"
           {...rest}
@@ -254,7 +263,9 @@ export const Tabs = chakra(
           >
             {previousButton}
             <Box __css={styles.carouselParent}>
-              <Box {...carouselStyle}>{tabs}</Box>
+              <Box {...carouselStyle} ref={tablistRef}>
+                {tabs}
+              </Box>
             </Box>
             {nextButton}
           </Box>

--- a/src/components/Tabs/tabsChangelogData.ts
+++ b/src/components/Tabs/tabsChangelogData.ts
@@ -1,0 +1,21 @@
+/** This data is used to populate the ComponentChangelogTable component.
+ *
+ * date: string (when adding new entry during development, set value as "Prerelease")
+ * version: string (when adding new entry during development, set value as "Prerelease")
+ * type: "Bug Fix" | "New Feature" | "Update";
+ * affects: array["Accessibility" | "Documentation" | "Functionality" | "Styles"];
+ * notes: array (will render as a bulleted list, add one array element for each list element)
+ */
+import { ChangelogData } from "../../utils/ComponentChangelogTable";
+
+export const changelogData: ChangelogData[] = [
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Accessibility", "Documentation"],
+    notes: [
+      "Updates tab set to be scrollable when the width of the tab set is greater than the viewport",
+    ],
+  },
+];

--- a/src/hooks/useScrollTabIntoView.ts
+++ b/src/hooks/useScrollTabIntoView.ts
@@ -1,0 +1,17 @@
+import React, { useEffect, useRef } from "react";
+
+export const useScrollTabIntoView = (index: number) => {
+  const tablistRef = useRef<HTMLDivElement>();
+
+  useEffect(() => {
+    const selectedTab = tablistRef?.current?.querySelector(
+      "[role=tab][aria-selected=true]"
+    );
+    // scroll only horizontally
+    selectedTab?.scrollIntoView({ block: "nearest" });
+  }, [index]);
+
+  return tablistRef;
+};
+
+export default useScrollTabIntoView;

--- a/src/hooks/useScrollTabIntoView.ts
+++ b/src/hooks/useScrollTabIntoView.ts
@@ -1,5 +1,11 @@
 import React, { useEffect, useRef } from "react";
 
+/**
+ * DS internal helper hook for the Tabs component to scroll
+ * the selected tab into view using useEffect and querySelector.
+ *
+ * Returns a ref for the TabList component.
+ */
 export const useScrollTabIntoView = (index: number) => {
   const tablistRef = useRef<HTMLDivElement>();
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,7 +166,6 @@ export { default as useCloseDropDown } from "./hooks/useCloseDropDown";
 // export { default as useMultiSelect } from "./hooks/useMultiSelect";
 export { default as useNYPLBreakpoints } from "./hooks/useNYPLBreakpoints";
 export { default as useNYPLTheme } from "./hooks/useNYPLTheme";
-export { default as useScrollTabIntoView } from "./hooks/useScrollTabIntoView";
 export { default as useWindowSize } from "./hooks/useWindowSize";
 export { default as VideoPlayer } from "./components/VideoPlayer/VideoPlayer";
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -166,6 +166,7 @@ export { default as useCloseDropDown } from "./hooks/useCloseDropDown";
 // export { default as useMultiSelect } from "./hooks/useMultiSelect";
 export { default as useNYPLBreakpoints } from "./hooks/useNYPLBreakpoints";
 export { default as useNYPLTheme } from "./hooks/useNYPLTheme";
+export { default as useScrollTabIntoView } from "./hooks/useScrollTabIntoView";
 export { default as useWindowSize } from "./hooks/useWindowSize";
 export { default as VideoPlayer } from "./components/VideoPlayer/VideoPlayer";
 export type {

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -119,7 +119,12 @@ const carouselParent = {
   paddingTop: { base: "4px", md: "0" },
   right: { base: "52px", md: "auto" },
   top: { base: "4px", md: "0" },
-  overflowX: { base: "hidden", md: "visible" },
+  scrollbarWidth: "none",
+  "::-webkit-scrollbar": {
+    display: "none",
+  },
+  overflowY: "hidden",
+  overflowX: { base: "hidden", md: "scroll" },
 };
 
 const CustomTabs = {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1632](https://jira.nypl.org/browse/DSD-1632).

## This PR does the following:

- Updates `Tabs` component to be scrollable when the width of the tab set is greater than the width of the viewport.

## How has this been tested?

Locally on storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
