### PR TITLE
DSD-1644: Fixes from VQA of form elms pt 1

### DIFF
--- a/src/components/DatePicker/_DatePicker.scss
+++ b/src/components/DatePicker/_DatePicker.scss
@@ -26,7 +26,7 @@
   // The left and right arrow buttons.
   .react-datepicker__navigation {
     &-icon {
-      top: 5px;
+      top: 2px;
       width: 0px;
       &::before {
         border-color: var(--nypl-colors-ui-border-default);

--- a/src/components/DatePicker/_DatePicker.scss
+++ b/src/components/DatePicker/_DatePicker.scss
@@ -118,6 +118,7 @@
       border-bottom-color: var(--nypl-colors-ui-border-default) !important;
     }
     &::after {
+      border-top-color: var(--nypl-colors-dark-ui-bg-hover) !important;
       border-bottom-color: var(--nypl-colors-dark-ui-bg-hover) !important;
     }
   }

--- a/src/theme/components/checkboxGroup.ts
+++ b/src/theme/components/checkboxGroup.ts
@@ -2,7 +2,7 @@ import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 import { checkboxRadioGroupStyles } from "./global";
 
 const { defineMultiStyleConfig, definePartsStyle } =
-  createMultiStyleConfigHelpers(["helperErrorText", "stack"]);
+  createMultiStyleConfigHelpers(["helperErrorText"]);
 
 const CheckboxGroup = defineMultiStyleConfig({
   baseStyle: definePartsStyle(({ isFullWidth = false }) => ({

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -92,6 +92,7 @@ const checkboxRadioGroupStyles = (isFullWidth = false) => ({
     marginTop: "xs",
   },
   label: {
+    display: "flex",
     width: isFullWidth ? "100%" : "fit-content",
   },
 });


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1644](https://jira.nypl.org/browse/DSD-1644).

## This PR does the following:

- The `width` property on the label was not being applied because the label was previously using `display: inline`. I am not sure why it was working before without a different display style.
- I also removed the "stack" part of CheckboxGroup because we are not using it to style. I don't think removing it broke anything as far as I could tell.
- I fixed the styling for the DatePicker's calendar triangle in dark mode. This was broken before, but Alkim just pointed it out.
- Finally, I adjusted the alignment of the DatePicker calendar's navigation arrows as they were not properly aligned with the name of the month.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

- Locally in Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
