### PR TITLE
DSD-1673: FeedbackBox form fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the required comment field so it cannot be submitted when empty for the `FeedbackBox` component.
+
+### Fixes
+
+- Fixes the focus ring style for the open button in the `FeedbackBox` component.
+- Forcibly focuses on the open button when the `FeedbackBox` form is closed to ensure focus is not lost.
+
 ## 2.1.4 (January 4, 2024)
 
 ### Adds

--- a/src/components/FeedbackBox/FeedbackBox.test.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.test.tsx
@@ -106,6 +106,26 @@ describe("FeedbackBox", () => {
     ).toBeInTheDocument();
   });
 
+  it("sets the invalid state for the comment field if it is empty when submitted", () => {
+    render(
+      <FeedbackBox
+        onSubmit={onSubmit}
+        showCategoryField
+        showEmailField
+        title="Help and Feedback"
+      />
+    );
+
+    const button = screen.getByRole("button", { name: "Help and Feedback" });
+
+    button.click();
+
+    const submit = screen.getByRole("button", { name: "Submit" });
+    submit.click();
+
+    expect(screen.getByText(/please fill out this field/i)).toBeInTheDocument();
+  });
+
   it("renders optional additional description text", () => {
     render(
       <FeedbackBox

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -22,7 +22,7 @@ import Notification from "../Notification/Notification";
 import Radio from "../Radio/Radio";
 import RadioGroup from "../RadioGroup/RadioGroup";
 import Text from "../Text/Text";
-import TextInput from "../TextInput/TextInput";
+import TextInput, { TextInputRefType } from "../TextInput/TextInput";
 import useStateWithDependencies from "../../hooks/useStateWithDependencies";
 import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 import useFeedbackBoxReducer from "./useFeedbackBoxReducer";
@@ -129,6 +129,7 @@ export const FeedbackBox = chakra(
       const finalOnClose = onClose ? onClose : disclosure.onClose;
       const focusRef = useRef<HTMLDivElement>();
       const openButtonRef = useRef<HTMLButtonElement>();
+      const commentInputRef = useRef<TextInputRefType>();
       const styles = useMultiStyleConfig("FeedbackBox", {});
       const isFormView = viewType === "form";
       const isConfirmationView = viewType === "confirmation";
@@ -164,6 +165,7 @@ export const FeedbackBox = chakra(
 
         // Set the invalid state if the comment text field is empty.
         if (submittedValues.comment.length === 0) {
+          commentInputRef?.current?.focus();
           setFinalIsInvalidComment(true);
           return;
         }
@@ -368,6 +370,7 @@ export const FeedbackBox = chakra(
                         )}
                         <FormField width="100%">
                           <TextInput
+                            defaultValue={state.comment}
                             helperText={`${
                               maxCommentCharacters - state.comment.length
                             } characters remaining`}
@@ -380,8 +383,8 @@ export const FeedbackBox = chakra(
                             name={`${id}-comment`}
                             onChange={(e) => setComment(e.target.value)}
                             placeholder="Enter your question or feedback here"
+                            ref={commentInputRef}
                             type="textarea"
-                            defaultValue={state.comment}
                           />
                         </FormField>
                         {showEmailField && (

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -11,7 +11,7 @@ import {
   useMultiStyleConfig,
   VStack,
 } from "@chakra-ui/react";
-import React, { forwardRef, useEffect, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 
 import Button from "../Button/Button";
 import ButtonGroup from "../ButtonGroup/ButtonGroup";
@@ -114,6 +114,8 @@ export const FeedbackBox = chakra(
       // update if the consuming app updates it, based on API
       // success and failure responses.
       const [viewType, setViewType] = useStateWithDependencies(view);
+      const [finalIsInvalidComment, setFinalIsInvalidComment] =
+        useStateWithDependencies(isInvalidComment);
       const [isSubmitted, setIsSubmitted] = useState<boolean>(false);
       // Helps keep track of form field state values.
       const { state, setCategory, setComment, setEmail, clearValues } =
@@ -126,6 +128,7 @@ export const FeedbackBox = chakra(
       const finalOnOpen = onOpen ? onOpen : disclosure.onOpen;
       const finalOnClose = onClose ? onClose : disclosure.onClose;
       const focusRef = useRef<HTMLDivElement>();
+      const openButtonRef = useRef<HTMLButtonElement>();
       const styles = useMultiStyleConfig("FeedbackBox", {});
       const isFormView = viewType === "form";
       const isConfirmationView = viewType === "confirmation";
@@ -145,6 +148,12 @@ export const FeedbackBox = chakra(
         finalOnClose();
         setViewType("form");
         clearValues();
+        setFinalIsInvalidComment(false);
+
+        // Leave some time after closing before focusing on the open button.
+        setTimeout(() => {
+          openButtonRef?.current?.focus();
+        }, 250);
       };
       const internalOnSubmit = (e) => {
         e.preventDefault();
@@ -152,7 +161,15 @@ export const FeedbackBox = chakra(
         if (hiddenFields) {
           submittedValues = { ...submittedValues, ...hiddenFields };
         }
+
+        // Set the invalid state if the comment text field is empty.
+        if (submittedValues.comment.length === 0) {
+          setFinalIsInvalidComment(true);
+          return;
+        }
+
         onSubmit && onSubmit(submittedValues);
+        setFinalIsInvalidComment(false);
         setIsSubmitted(true);
       };
       const notificationElement =
@@ -263,14 +280,19 @@ export const FeedbackBox = chakra(
 
       return (
         <Box className={className} id={id} ref={ref} sx={styles} {...rest}>
-          <Button id="open" onClick={finalOnOpen} sx={styles.openButton}>
+          <Button
+            id="open"
+            onClick={finalOnOpen}
+            sx={styles.openButton}
+            ref={openButtonRef}
+          >
             {title}
           </Button>
 
           <Drawer
             blockScrollOnMount={false}
             isOpen={finalIsOpen}
-            onClose={finalOnClose}
+            onClose={closeAndResetForm}
             placement="bottom"
           >
             {/* Adds the opaque background. */}
@@ -280,7 +302,7 @@ export const FeedbackBox = chakra(
               <Button
                 buttonType="text"
                 id="close-btn"
-                onClick={finalOnClose}
+                onClick={closeAndResetForm}
                 sx={styles.closeButton}
               >
                 <Icon color="ui.black" name="minus" size="medium" />
@@ -352,9 +374,8 @@ export const FeedbackBox = chakra(
                             id={`${id}-comment`}
                             invalidText="Please fill out this field."
                             isDisabled={isSubmitted}
-                            isInvalid={isInvalidComment}
-                            isRequired
-                            labelText="Comment"
+                            isInvalid={finalIsInvalidComment}
+                            labelText="Comment (Required)"
                             maxLength={maxCommentCharacters}
                             name={`${id}-comment`}
                             onChange={(e) => setComment(e.target.value)}

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -375,7 +375,7 @@ export const FeedbackBox = chakra(
                               maxCommentCharacters - state.comment.length
                             } characters remaining`}
                             id={`${id}-comment`}
-                            invalidText="Please fill out this field."
+                            invalidText="There was a problem. Please fill out this field."
                             isDisabled={isSubmitted}
                             isInvalid={finalIsInvalidComment}
                             labelText="Comment (Required)"
@@ -391,7 +391,7 @@ export const FeedbackBox = chakra(
                           <FormField width="100%">
                             <TextInput
                               id={`${id}-email`}
-                              invalidText="Please enter a valid email address."
+                              invalidText="There was a problem. Please enter a valid email address."
                               isDisabled={isSubmitted}
                               isInvalid={isInvalidEmail}
                               labelText="Email"

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -13,8 +13,11 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Accessibility"],
-    notes: ["Updates the focus ring style for the open button.."],
+    affects: ["Accessibility", "Functionality"],
+    notes: [
+      "Updates the focus ring style for the open button.",
+      "Fixes..........",
+    ],
   },
   {
     date: "2023-10-26",

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -16,7 +16,8 @@ export const changelogData: ChangelogData[] = [
     affects: ["Accessibility", "Functionality"],
     notes: [
       "Updates the focus ring style for the open button.",
-      "Fixes..........",
+      "Updates the required comment field so it cannot be submitted when empty.",
+      "Forcibly focuses on the open button when the form is closed.",
     ],
   },
   {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1673](https://jira.nypl.org/browse/DSD-1673)

## This PR does the following:

Fixes two accessibility issues:
- Removes the `required` (through the DS `isRequired` prop) so that the native HTML validation popup does not display. Instead, if the form is submitted with an empty "Comment" field, then it will set the invalid state. This requires an update to keeping the invalid state within the component.

![Screen Shot 2024-01-24 at 3 24 47 PM](https://github.com/NYPL/nypl-design-system/assets/1280564/ef21303e-419d-47d3-9132-ceb522eddd50)

- Forcibly focuses on the open button when the form is closed. This feature worked before but when it was implemented and rendered in various apps, the feature broke. It could be because of how different apps rerender but it's not clear what the issue is. This update will work in Storybook but we need to test the release candidate in Turbine to verify.

## How has this been tested?

Storybook locally.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Fixes issues Clare found while testing in the DC Facelift app.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
