### PR TITLE
DSD-1632: QA fix - update padding to fix focus outline 

### DIFF
--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -113,12 +113,12 @@ const tabpanels = {
 const carouselParent = {
   position: { base: "absolute", md: "relative" },
   left: { base: "50px", md: "auto" },
-  paddingBottom: { base: "5px", md: "0" },
-  paddingStart: { base: "4px", md: "0" },
-  paddingEnd: "0",
-  paddingTop: { base: "4px", md: "0" },
-  right: { base: "52px", md: "auto" },
-  top: { base: "4px", md: "0" },
+  paddingBottom: { base: "5px", md: "4px" },
+  paddingStart: "4px",
+  paddingEnd: "4px",
+  paddingTop: { base: "4px" },
+  right: { base: "52px", md: "4px" },
+  top: { base: "4px" },
   scrollbarWidth: "none",
   "::-webkit-scrollbar": {
     display: "none",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1632](https://jira.nypl.org/browse/DSD-1632)

## This PR does the following:

- Update padding to fix the focus outline around tabs. This issue is a result of changing `overflow-x` from `visible` to `scroll`, which causes the inner content to be clipped by the parent.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
Locally on storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
