### PR TITLE
DSD-1649: Updates focus ring colors to be more accessible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates `Tabs` to be scrollable when the width of the tab set is greater than the viewport.
 - Updates the required comment field so it cannot be submitted when empty for the `FeedbackBox` component.
 - Updates the `Heading` component to use a custom `@media query` method to handle the responsive `font-size` styles.
-- Updates the `useNYPLBreakpoints` hook to include `isSmallerThanMedium` and `isSmallerThanDesktop`, both of which implement a desktop-first design approach.
 - Updates the `Text` component to use native Chakra responsive styles for the font sizes of the `subtitle1` and `subtitle2` variants.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the required comment field so it cannot be submitted when empty for the `FeedbackBox` component.
 - Updates the `Heading` component to use a custom `@media query` method to handle the responsive `font-size` styles.
 - Updates the `useNYPLBreakpoints` hook to include `isSmallerThanMedium` and `isSmallerThanDesktop`, both of which implement a desktop-first design approach.
+- Updates focus ring color in `Notification` and `Breadcrumbs` to match color of text.
 
 ### Fixes
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -1,16 +1,18 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 import * as BreadcrumbsStories from "./Breadcrumbs.stories";
+import { changelogData } from "./breadcrumbsChangelogData";
 import Link from "../Link/Link";
 
 <Meta of={BreadcrumbsStories} />
 
 # Breadcrumbs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.3`    |
-| Latest            | `2.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.3`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -19,6 +21,7 @@ import Link from "../Link/Link";
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
 - {<Link href="#long-titles" target="_self">Long Titles</Link>}
 - {<Link href="#color-variations" target="_self">Color Variations</Link>}
+- {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
 
@@ -73,3 +76,7 @@ The `Breadcrumbs` component background color can be set to a value of the
 background color is `"whatsOn"` (`ui.black`).
 
 <Canvas of={BreadcrumbsStories.ColorVariations} />
+
+## Changelog
+
+<ComponentChangelogTable changelogData={changelogData} />

--- a/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
+++ b/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
@@ -16,13 +16,4 @@ export const changelogData: ChangelogData[] = [
     affects: ["Styles"],
     notes: ["Updates focus ring color to match color of text."],
   },
-  {
-    date: "2023-12-07",
-    version: "2.1.3",
-    type: "Update",
-    affects: ["Accessibility", "Documentation"],
-    notes: [
-      "Updated the `notificationHeading` prop to allow JSX to render custom heading elements for accessible heading hierarchy.",
-    ],
-  },
 ];

--- a/src/components/Notification/Notification.mdx
+++ b/src/components/Notification/Notification.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./notificationChangelogData";
 
 # Notification
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `2.1.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.2`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -14,6 +14,11 @@ const blogs = {
         color: "dark.ui.typography.heading",
       },
     },
+    _focus: {
+      outline: "none",
+      ring: "2px",
+      ringColor: "ui.black",
+    },
   },
   "li:last-child": {
     ".chakra-breadcrumb__link": {
@@ -94,6 +99,11 @@ const Breadcrumb = {
       _hover: {
         color: "ui.gray.light-cool",
         textDecoration: "none",
+      },
+      _focus: {
+        outline: "none",
+        ring: "2px",
+        ringColor: "ui.white",
       },
     },
     "li:last-child": {

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -16,7 +16,7 @@ const blogs = {
         color: "dark.ui.typography.heading",
       },
     },
-    _focus: { ...customFocusColor("ui.black", "dark.section.blogs.secondary") },
+    _focus: customFocusColor("ui.black", "dark.ui.typography.body"),
   },
   "li:last-child": {
     ".chakra-breadcrumb__link": {
@@ -98,9 +98,7 @@ const Breadcrumb = {
         color: "ui.gray.light-cool",
         textDecoration: "none",
       },
-      _focus: {
-        ...customFocusColor("ui.white", "dark.ui.typography.heading"),
-      },
+      _focus: customFocusColor("ui.white", "dark.ui.typography.heading"),
     },
     "li:last-child": {
       fontWeight: { base: "breadcrumbs.default", md: "breadcrumbs.lastChild" },

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -1,3 +1,5 @@
+import { customFocusColor } from "./global";
+
 // Variant styling
 const blogs = {
   bg: "section.blogs.secondary",
@@ -14,11 +16,7 @@ const blogs = {
         color: "dark.ui.typography.heading",
       },
     },
-    _focus: {
-      outline: "none",
-      ring: "2px",
-      ringColor: "ui.black",
-    },
+    _focus: { ...customFocusColor("ui.black", "dark.section.blogs.secondary") },
   },
   "li:last-child": {
     ".chakra-breadcrumb__link": {
@@ -101,9 +99,7 @@ const Breadcrumb = {
         textDecoration: "none",
       },
       _focus: {
-        outline: "none",
-        ring: "2px",
-        ringColor: "ui.white",
+        ...customFocusColor("ui.white", "dark.ui.typography.heading"),
       },
     },
     "li:last-child": {

--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -3,6 +3,16 @@ export { screenreaderOnly, wrapperStyles } from "./globalMixins";
 
 /** Reusable component styles. */
 
+const customFocusColor = (focusColor, focusColorDark) => ({
+  boxShadow: "none",
+  outline: "2px solid",
+  outlineOffset: "2px",
+  outlineColor: focusColor,
+  zIndex: "9999",
+  _dark: {
+    outlineColor: focusColorDark,
+  },
+});
 // Used in `Select` and `TextInput`.
 const activeFocus = (darkMode = false) => ({
   boxShadow: "none",
@@ -148,6 +158,7 @@ export {
   checkboxRadioHelperErrorTextStyle,
   checkboxRadioHoverStyles,
   checkboxRadioLabelStyles,
+  customFocusColor,
   defaultElementSizes,
   labelLegendText,
   selectTextInputDisabledStyles,

--- a/src/theme/components/notification.ts
+++ b/src/theme/components/notification.ts
@@ -1,4 +1,5 @@
 import { NotificationTypes } from "../../components/Notification/Notification";
+import { customFocusColor } from "./global";
 
 interface NotificationBaseStyle {
   isCentered: boolean;
@@ -121,11 +122,7 @@ const NotificationContent = {
             color: "dark.ui.link.secondary",
           },
         },
-        _focus: {
-          outline: "none",
-          ring: "2px",
-          ringColor: "ui.black",
-        },
+        _focus: { ...customFocusColor("ui.black", "dark.ui.link.primary") },
       },
     },
   }),

--- a/src/theme/components/notification.ts
+++ b/src/theme/components/notification.ts
@@ -121,6 +121,11 @@ const NotificationContent = {
             color: "dark.ui.link.secondary",
           },
         },
+        _focus: {
+          outline: "none",
+          ring: "2px",
+          ringColor: "ui.black",
+        },
       },
     },
   }),

--- a/src/theme/components/notification.ts
+++ b/src/theme/components/notification.ts
@@ -72,6 +72,13 @@ const Notification = {
         _dark: {
           color: "dark.ui.typography.heading",
         },
+        _focus: {
+          // This pseudo-class selector is needed for overriding Chakra styles
+          [":not([disabled])"]: customFocusColor(
+            "ui.typography.heading",
+            "dark.ui.typography.heading"
+          ),
+        },
         _hover: {
           bg: "inherit",
         },
@@ -122,7 +129,7 @@ const NotificationContent = {
             color: "dark.ui.link.secondary",
           },
         },
-        _focus: { ...customFocusColor("ui.black", "dark.ui.link.primary") },
+        _focus: customFocusColor("ui.black", "dark.ui.typography.body"),
       },
     },
   }),


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1649](https://jira.nypl.org/browse/DSD-1649)

## This PR does the following:

- Updates focus ring color in `Notification` and `Breadcrumbs` to match color of text.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- Locally, in Storybook. 

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- None, this is an accessibility improvement.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
