### PR TITLE
DSD-1636: React18 QA fixes for Basic Elements components

### DIFF
--- a/src/components/FeaturedContent/FeaturedContent.stories.tsx
+++ b/src/components/FeaturedContent/FeaturedContent.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof FeaturedContent> = {
     isFullWidth: {
       table: { defaultValue: { summary: false } },
     },
-    imageProps: { disable: false },
+    imageProps: { disable: true },
     "imageProps.alt": {
       control: { type: "text" },
       table: { defaultValue: { summary: "" } },
@@ -54,14 +54,24 @@ export const WithControls: Story = {
     className: undefined,
     id: "FeaturedContent-id",
     imageProps: undefined,
-    "imageProps.alt": undefined,
-    "imageProps.src": undefined,
-    isFullWidth: false,
+    "imageProps.alt": "Alt text",
+    "imageProps.position": "end",
+    "imageProps.src": "//placekitten.com/600/600",
+    "imageProps.width": "default",
+    isFullWidth: undefined,
     textContent: undefined,
   },
   render: (args) => (
     <FeaturedContent
-      {...args}
+      // {...args}
+      id={args["id"]}
+      imageProps={{
+        alt: args["imageProps.alt"],
+        position: args["imageProps.position"],
+        src: args["imageProps.src"],
+        width: args["imageProps.width"],
+      }}
+      isFullWidth={args["isFullWidth"]}
       textContent={
         <div>
           <Heading level="h2" overline="Featured">
@@ -75,12 +85,6 @@ export const WithControls: Story = {
           <Button id="test"> Discover more </Button>
         </div>
       }
-      imageProps={{
-        alt: args["imageProps.alt"],
-        width: args["imageProps.width"],
-        position: args["imageProps.position"],
-        src: args["imageProps.src"],
-      }}
     />
   ),
   parameters: {

--- a/src/theme/components/link.ts
+++ b/src/theme/components/link.ts
@@ -32,6 +32,11 @@ export const baseLinkStyles = {
     textDecoration: "underline",
     textDecorationStyle: "dotted",
     textDecorationThickness: "1px",
+    // The dark mode hover color is not being picked up properly down stream, so
+    // it is being explicitly added here.
+    _dark: {
+      color: "dark.ui.link.secondary",
+    },
   },
 };
 
@@ -124,6 +129,11 @@ const buttonPrimary = definePartsStyle(
         textDecoration: "underline",
         textDecorationStyle: "dotted !important",
         textDecorationThickness: "1px !important",
+        // The dark mode hover color is not being picked up properly down stream, so
+        // it is being explicitly added here.
+        _dark: {
+          color: "ui.gray.xxx-dark",
+        },
       },
       _visited: hasVisitedState
         ? {
@@ -170,6 +180,11 @@ const buttonPill = definePartsStyle(
         textDecoration: "underline",
         textDecorationStyle: "dotted !important",
         textDecorationThickness: "1px !important",
+        // The dark mode hover color is not being picked up properly down stream, so
+        // it is being explicitly added here.
+        _dark: {
+          color: "dark.ui.typography.heading",
+        },
       },
       _visited: hasVisitedState
         ? {
@@ -193,6 +208,11 @@ const buttonCallout = definePartsStyle(
         textDecoration: "underline",
         textDecorationStyle: "dotted !important",
         textDecorationThickness: "1px !important",
+        // The dark mode hover color is not being picked up properly down stream, so
+        // it is being explicitly added here.
+        _dark: {
+          color: "ui.white",
+        },
       },
       _visited: hasVisitedState
         ? {
@@ -216,6 +236,11 @@ const buttonNoBrand = definePartsStyle(
         textDecoration: "underline",
         textDecorationStyle: "dotted !important",
         textDecorationThickness: "1px !important",
+        // The dark mode hover color is not being picked up properly down stream, so
+        // it is being explicitly added here.
+        _dark: {
+          color: "ui.white",
+        },
       },
       _visited: hasVisitedState
         ? {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1636](https://jira.nypl.org/browse/DSD-1636)

## This PR does the following:

- Added explicit color attributes for `Link` component.  The base styles were not getting picked up in the `Card` component.
- Updated the `args` for the `FeaturedContent` `With Docs` story.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
