### PR TITLE
DSD-1611: better error message for NewsletterSignup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the base `Modal` component to use the `useDSHeading` hook internally to render a DS Heading for the `headingText` prop.
 - Updates the `Heading` component to use native Chakra responsive styles to handle the font sizes of the component's internal `heading`, `overline` and `subtitle` elements. This also resolves the flashing font size bug that is most noticeable on slower internet connections.
 - Updates the `Text` component to use native Chakra responsive styles for the font sizes of the `subtitle1` and `subtitle2` variants.
-- Updates the `NewsletterSignup` component to following NYPL recommendations and use more direct language for the email field error message.
+- Updates the `NewsletterSignup` component to follow NYPL recommendations and use more direct language for the email field error message.
 
 ## Prerelease
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the base `Modal` component to use the `useDSHeading` hook internally to render a DS Heading for the `headingText` prop.
 - Updates the `Heading` component to use native Chakra responsive styles to handle the font sizes of the component's internal `heading`, `overline` and `subtitle` elements. This also resolves the flashing font size bug that is most noticeable on slower internet connections.
 - Updates the `Text` component to use native Chakra responsive styles for the font sizes of the `subtitle1` and `subtitle2` variants.
+- Updates the `NewsletterSignup` component to following NYPL recommendations and use more direct language for the email field error message.
 
 ## Prerelease
 

--- a/src/components/NewsletterSignup/NewsletterSignup.mdx
+++ b/src/components/NewsletterSignup/NewsletterSignup.mdx
@@ -12,7 +12,6 @@ import { changelogData } from "./newsletterSignupChangelogData";
 | Component Version | DS Version   |
 | ----------------- | ------------ |
 | Added             | `2.1.0`      |
-| Added             | `2.1.3`      |
 | Latest            | `Prerelease` |
 
 ## Table of Contents

--- a/src/components/NewsletterSignup/NewsletterSignup.tsx
+++ b/src/components/NewsletterSignup/NewsletterSignup.tsx
@@ -165,7 +165,7 @@ export const NewsletterSignup: ChakraComponent<
                     id="email-input"
                     isDisabled={view === "submitting"}
                     isRequired
-                    invalidText="Please enter a valid email address."
+                    invalidText="There was a problem. Please enter a valid email address."
                     isInvalid={isInvalidEmail}
                     labelText="Email Address"
                     helperText={formHelperText}

--- a/src/components/NewsletterSignup/__snapshots__/NewsletterSignup.test.tsx.snap
+++ b/src/components/NewsletterSignup/__snapshots__/NewsletterSignup.test.tsx.snap
@@ -1733,7 +1733,7 @@ exports[`NewsletterSignup Snapshots Renders the bad email UI snapshot correctly 
                 className="css-0"
                 dangerouslySetInnerHTML={
                   {
-                    "__html": "Please enter a valid email address.",
+                    "__html": "There was a problem. Please enter a valid email address.",
                   }
                 }
               />

--- a/src/components/NewsletterSignup/newsletterSignupChangelogData.ts
+++ b/src/components/NewsletterSignup/newsletterSignupChangelogData.ts
@@ -13,8 +13,11 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Styles"],
-    notes: ["Chakra 2.8 update."],
+    affects: ["Styles", "Functionality"],
+    notes: [
+      "Chakra 2.8 update.",
+      "Updated the email field error message to following NYPL recommendations and use more direct language.",
+    ],
   },
   {
     date: "2023-12-07",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1611](https://jira.nypl.org/browse/DSD-1611)

## This PR does the following:

- Updates the `NewsletterSignup` component to follow NYPL recommendations and use more direct language for the email field error message.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
