### PR TITLE
DSD-1701: Storybook preview sizes

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -38,14 +38,14 @@ const customViewports = {
   xl: {
     name: "xl - large tablet (less than 1280)",
     styles: {
-      width: "1280px",
+      width: "1200px",
       height: "1024px",
     },
   },
   "2xl": {
     name: "desktop (greater than or equal to 1280)",
     styles: {
-      width: "1440px",
+      width: "1280px",
       height: "1024px",
     },
   },

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -15,38 +15,38 @@ import { StorybookHeading } from "./storybookComponents";
 // Custom viewport options
 const customViewports = {
   sm: {
-    name: "sm (320px)",
+    name: "sm - small mobile (less than 480)",
     styles: {
-      width: "320px",
-      height: "568px",
+      width: "390px",
+      height: "667px",
     },
   },
   md: {
-    name: "md (600px)",
+    name: "md - large mobile (less than 768) ",
     styles: {
       width: "600px",
-      height: "800px",
+      height: "715px",
     },
   },
   lg: {
-    name: "lg (960px)",
+    name: "lg - small tablet (less than 1024)",
     styles: {
       width: "960px",
-      height: "800px",
+      height: "1024px",
     },
   },
   xl: {
-    name: "xl (1280px)",
+    name: "xl - large tablet (less than 1280)",
     styles: {
       width: "1280px",
-      height: "1080px",
+      height: "1024px",
     },
   },
   "2xl": {
-    name: "2xl (1536px)",
+    name: "desktop (greater than or equal to 1280)",
     styles: {
-      width: "1536px",
-      height: "1080px",
+      width: "1440px",
+      height: "1024px",
     },
   },
 };

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the values for the breakpoints and the associated docs.
+- Updates the `viewport` preview options in Storybook to align with the Reservoir breakpoints.
 
 ## React 18 / Chakra 2.8 Release
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1701](https://jira.nypl.org/browse/DSD-1701)

## This PR does the following:

- Updates the `viewport` preview options in Storybook to align with the Reservoir breakpoints.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
