### PR TITLE
Accessibility: fixing duplicate id issue in MultiSelect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Text` component to use native Chakra responsive styles for the font sizes of the `subtitle1` and `subtitle2` variants.
 - Updates the `NewsletterSignup` component to follow NYPL recommendations and use more direct language for the email field error message.
 
+### Fixes
+
+- Removes console warnings from the `CheckboxGroup` component when a non-`Checkbox` component is passed as a child.
+
 ## Prerelease
 
 ### Adds

--- a/src/components/Checkbox/checkboxChangelogData.ts
+++ b/src/components/Checkbox/checkboxChangelogData.ts
@@ -13,7 +13,10 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Styles"],
-    notes: ["Chakra 2.8 update."],
+    affects: ["Styles", "Functionality"],
+    notes: [
+      "Removes the warning message that is logged when a non-Checkbox component is passed a child.",
+      "Chakra 2.8 update.",
+    ],
   },
 ];

--- a/src/components/CheckboxGroup/CheckboxGroup.test.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.test.tsx
@@ -520,19 +520,6 @@ describe("Checkbox", () => {
     expect(withOtherProps).toMatchSnapshot();
   });
 
-  it("should throw warning when a non-Checkbox component is used as a child", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      <CheckboxGroup labelText="wrong child!" name="wrong" id="wrong-child">
-        <p>This is wrong!</p>
-      </CheckboxGroup>
-    );
-    expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir CheckboxGroup: Only `Checkbox` components are " +
-        "allowed as children."
-    );
-  });
-
   it("passes a ref to the inner div wrapper element", () => {
     const ref = React.createRef<HTMLDivElement>();
     const { container } = render(

--- a/src/components/CheckboxGroup/CheckboxGroup.tsx
+++ b/src/components/CheckboxGroup/CheckboxGroup.tsx
@@ -7,7 +7,6 @@ import {
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
-import Checkbox from "../Checkbox/Checkbox";
 import Fieldset from "../Fieldset/Fieldset";
 import HelperErrorText, {
   HelperErrorTextType,
@@ -55,8 +54,6 @@ export interface CheckboxGroupProps {
   /** The values to programmatically update the selected `Checkbox`es. */
   value?: string[];
 }
-
-const noop = () => {};
 
 /**
  * Wrapper component to wrap `Checkbox` components. Can be displayed in a
@@ -119,18 +116,6 @@ export const CheckboxGroup: ChakraComponent<
     React.Children.map(
       children as JSX.Element,
       (child: React.ReactElement, i) => {
-        if (child.type !== Checkbox) {
-          // Special case for Storybook MDX documentation.
-          if (child.props.mdxType && child.props.mdxType === "Checkbox") {
-            noop();
-          } else {
-            console.warn(
-              "NYPL Reservoir CheckboxGroup: Only `Checkbox` components are " +
-                "allowed as children."
-            );
-          }
-        }
-
         if (child !== undefined && child !== null) {
           const newProps = {
             key: i,

--- a/src/components/CheckboxGroup/checkboxGroupChangelogData.ts
+++ b/src/components/CheckboxGroup/checkboxGroupChangelogData.ts
@@ -13,7 +13,10 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Styles"],
-    notes: ["Chakra 2.8 update."],
+    affects: ["Styles", "Functionality"],
+    notes: [
+      "Removes console warning for children elements that are not `Checkbox` components.",
+      "Chakra 2.8 update.",
+    ],
   },
 ];

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -276,7 +276,7 @@ export const visibleListItems: Story = {
         <div>
           <Heading level="h3" size="heading6" text="Default" />
           <MultiSelectStory
-            id="multi-select-id"
+            id="multi-select-id-1"
             isBlockElement
             items={withItems}
             listOverflow="expand"
@@ -286,7 +286,7 @@ export const visibleListItems: Story = {
           <Heading level="h3" size="heading6" text="Custom" />
           <MultiSelectStory
             defaultItemsVisible={8}
-            id="multi-select-id"
+            id="multi-select-id-2"
             isBlockElement
             items={withItems}
             listOverflow="expand"
@@ -299,7 +299,7 @@ export const visibleListItems: Story = {
             text="Default with Nested Items"
           />
           <MultiSelectStory
-            id="multi-select-id"
+            id="multi-select-id-3"
             isBlockElement
             items={withChildrenItems}
             listOverflow="expand"
@@ -313,7 +313,7 @@ export const visibleListItems: Story = {
 export const nestedListItems: Story = {
   render: () => (
     <MultiSelectStory
-      id="multi-select-id"
+      id="multi-select-id-4"
       isBlockElement
       isDefaultOpen={false}
       isSearchable={false}
@@ -325,7 +325,7 @@ export const nestedListItems: Story = {
 export const disabledListItems: Story = {
   render: () => (
     <MultiSelectStory
-      id="multi-select-id"
+      id="multi-select-id-5"
       isBlockElement
       isDefaultOpen={false}
       isSearchable={false}
@@ -337,7 +337,7 @@ export const disabledListItems: Story = {
 export const disabledListItemsAllChildren: Story = {
   render: () => (
     <MultiSelectStory
-      id="multi-select-id"
+      id="multi-select-id-6"
       isBlockElement
       isDefaultOpen={false}
       isSearchable={false}
@@ -349,7 +349,7 @@ export const disabledListItemsAllChildren: Story = {
 export const searchInputField: Story = {
   render: () => (
     <MultiSelectStory
-      id="multi-select-id"
+      id="multi-select-id-7"
       isBlockElement
       isDefaultOpen={false}
       isSearchable
@@ -368,13 +368,13 @@ export const isBlockElement: Story = {
           <Stack align="left" spacing="s">
             <Stack align="left">
               <MultiSelectStory
-                id="multi-select-id"
+                id="multi-select-id-8"
                 isBlockElement
                 items={withItems}
                 listOverflow="expand"
               />
               <MultiSelectStory
-                id="multi-select-id"
+                id="multi-select-id-9"
                 isBlockElement
                 items={withItems}
                 listOverflow="expand"
@@ -396,9 +396,9 @@ export const isBlockElement: Story = {
           />
           <Stack align="left" spacing="s">
             <Stack direction="row" width="100%" alignContent="stretch">
-              <MultiSelectStory id="multi-select-id" items={withItems} />
-              <MultiSelectStory id="multi-select-id" items={withItems} />
-              <MultiSelectStory id="multi-select-id" items={withItems} />
+              <MultiSelectStory id="multi-select-id-10" items={withItems} />
+              <MultiSelectStory id="multi-select-id-11" items={withItems} />
+              <MultiSelectStory id="multi-select-id-12" items={withItems} />
             </Stack>
             <Text>
               Maecenas sed diam eget risus varius blandit sit amet non magna.
@@ -436,7 +436,7 @@ export const width: Story = {
             text="full (default configuration)"
           />
           <MultiSelectStory
-            id="multi-select-id"
+            id="multi-select-id-13"
             isBlockElement
             items={withItems}
           />
@@ -444,7 +444,7 @@ export const width: Story = {
         <div>
           <Heading level="h3" size="heading6" text="fitContent" />
           <MultiSelectStory
-            id="multi-select-id"
+            id="multi-select-id-14"
             isBlockElement
             items={withItems}
             width="fitContent"
@@ -458,7 +458,7 @@ export const width: Story = {
 export const defaultOpenState: Story = {
   render: () => (
     <MultiSelectStory
-      id="multi-select-id"
+      id="multi-select-id-15"
       isBlockElement
       isDefaultOpen={true}
       items={withChildrenItems}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -183,11 +183,7 @@ export const MultiSelect: ChakraComponent<
 
       // Additional components for isSearchable
       const NoSearchResults = (): JSX.Element => {
-        return (
-          <Box id="items-not-found-text-id" marginTop="xs">
-            No options found
-          </Box>
-        );
+        return <Box marginTop="xs">No options found</Box>;
       };
 
       const onChangeSearch = (event) => {
@@ -237,7 +233,7 @@ export const MultiSelect: ChakraComponent<
           <Button
             buttonType="text"
             fontSize="desktop.button.default"
-            id="view-all-text-btn"
+            id={`view-all-text-btn-${id}`}
             onClick={toggleItemsList}
             __css={styles.viewAllButton}
           >
@@ -274,13 +270,13 @@ export const MultiSelect: ChakraComponent<
               <Checkbox
                 key={childItem.id}
                 marginInlineStart="0"
-                __css={styles.menuChildren}
                 id={childItem.id}
                 labelText={childItem.name}
                 name={childItem.name}
                 isDisabled={childItem.isDisabled}
                 isChecked={isChecked(id, childItem.id)}
                 onChange={onChange}
+                __css={styles.menuChildren}
               />
             )),
           ];
@@ -302,8 +298,8 @@ export const MultiSelect: ChakraComponent<
       /** Components for accordionData */
       const accordionLabel = (
         <Box
-          __css={selectedItemsCount > 0 ? styles.buttonTextLabel : null}
           title={buttonText}
+          __css={selectedItemsCount > 0 ? styles.buttonTextLabel : null}
         >
           {buttonText}
         </Box>
@@ -313,7 +309,7 @@ export const MultiSelect: ChakraComponent<
         <Box>
           {isSearchable && (
             <TextInput
-              id="multi-select-text-input-id"
+              id={`multi-select-text-input-${id}`}
               labelText={`Search ${buttonText}`}
               isClearable={true}
               isClearableCallback={clearSearchKeyword}
@@ -331,7 +327,7 @@ export const MultiSelect: ChakraComponent<
           ) : (
             <>
               <CheckboxGroup
-                id="multi-select-checkbox-group"
+                id={`multi-select-checkbox-group-${id}`}
                 layout="column"
                 isFullWidth
                 isRequired={false}
@@ -362,7 +358,7 @@ export const MultiSelect: ChakraComponent<
               },
             ]}
             ariaLabel={ariaLabelValue}
-            id="multi-select-accordion-id"
+            id={`multi-select-accordion-${id}`}
             isDefaultOpen={isDefaultOpen}
             isAlwaysRendered
             panelMaxHeight={listHeight}

--- a/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
+++ b/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
@@ -4,6 +4,7 @@ import Button from "../Button/Button";
 import Icon from "../Icons/Icon";
 
 export interface MultiSelectItemsCountButtonProps {
+  /** An ID string that other components can cross reference for accessibility purposes. */
   id: string;
   /** The id of the MultiSelect using this button. */
   multiSelectId: string;
@@ -13,11 +14,13 @@ export interface MultiSelectItemsCountButtonProps {
   isOpen: boolean;
   /** The selected items state (items that were checked by user). */
   selectedItemsString: string;
+  /** The number of selected items. */
   selectedItemsCount: number;
   /** The callback function for the menu toggle. */
   onMenuToggle?: () => void;
   /** The action to perform for clear/reset button of MultiSelect. */
   onClear?: () => void;
+  /** The action to perform for key down event. */
   onKeyDown?: () => void;
   /** Ref to the Accordion Button element. */
   accordianButtonRef: any;
@@ -54,7 +57,7 @@ const MultiSelectItemsCountButton = forwardRef<
 
   return (
     <Button
-      id="multi-select-button"
+      id={`ms-count-button-${multiSelectId}`}
       buttonType="pill"
       size="small"
       aria-label={selectedItemsAriaLabel}
@@ -69,7 +72,7 @@ const MultiSelectItemsCountButton = forwardRef<
       {selectedItemsCount}
       <Icon
         align="right"
-        id={`ms-${multiSelectId}-selected-items-count-icon`}
+        id={`ms-count-icon-${multiSelectId}`}
         marginLeft="xs"
         name="close"
         size="xsmall"

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -7,18 +7,18 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-id"
+    id="multi-select-accordion-multiselect-test-id"
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-id-item-0"
+        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 0 items currently selected"
         className="chakra-accordion__button css-h5m7h6"
         disabled={false}
-        id="accordion-button-multi-select-accordion-id-item-0"
+        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -38,7 +38,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
           aria-hidden={true}
           className="chakra-icon css-q3eg3a"
           focusable={false}
-          id="accordion-multi-select-accordion-id-icon-0"
+          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
           viewBox="0 0 24 24"
@@ -79,9 +79,9 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-id-item-0"
+          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-id-item-0"
+          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -89,7 +89,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
           >
             <fieldset
               className="css-1u8qly9"
-              id="multi-select-checkbox-group-checkbox-group"
+              id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
                 Multi select checkbox group label
@@ -97,7 +97,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
               <div
                 className="chakra-stack css-19s3t1h"
                 data-testid="checkbox-group"
-                id="multi-select-checkbox-group"
+                id="multi-select-checkbox-group-multiselect-test-id"
               >
                 <div
                   className="css-1xdhyk6"
@@ -532,7 +532,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                 aria-live="polite"
                 className="css-1xdhyk6"
                 data-isinvalid={false}
-                id="multi-select-checkbox-group-helperErrorText"
+                id="multi-select-checkbox-group-multiselect-test-id-helperErrorText"
               />
             </fieldset>
           </div>
@@ -550,18 +550,18 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-id"
+    id="multi-select-accordion-multiselect-test-id"
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-id-item-0"
+        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 0 items currently selected"
         className="chakra-accordion__button css-h5m7h6"
         disabled={false}
-        id="accordion-button-multi-select-accordion-id-item-0"
+        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -581,7 +581,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
           aria-hidden={true}
           className="chakra-icon css-q3eg3a"
           focusable={false}
-          id="accordion-multi-select-accordion-id-icon-0"
+          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
           viewBox="0 0 24 24"
@@ -622,9 +622,9 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-id-item-0"
+          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-id-item-0"
+          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -632,7 +632,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
           >
             <fieldset
               className="css-1u8qly9"
-              id="multi-select-checkbox-group-checkbox-group"
+              id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
                 Multi select checkbox group label
@@ -640,7 +640,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
               <div
                 className="chakra-stack css-19s3t1h"
                 data-testid="checkbox-group"
-                id="multi-select-checkbox-group"
+                id="multi-select-checkbox-group-multiselect-test-id"
               >
                 <div
                   className="css-1xdhyk6"
@@ -1075,7 +1075,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                 aria-live="polite"
                 className="css-1xdhyk6"
                 data-isinvalid={false}
-                id="multi-select-checkbox-group-helperErrorText"
+                id="multi-select-checkbox-group-multiselect-test-id-helperErrorText"
               />
             </fieldset>
           </div>
@@ -1093,18 +1093,18 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-id"
+    id="multi-select-accordion-multiselect-test-id"
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-id-item-0"
+        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 1 item currently selected"
         className="chakra-accordion__button css-h5m7h6"
         disabled={false}
-        id="accordion-button-multi-select-accordion-id-item-0"
+        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1124,7 +1124,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
           aria-hidden={true}
           className="chakra-icon css-q3eg3a"
           focusable={false}
-          id="accordion-multi-select-accordion-id-icon-0"
+          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
           viewBox="0 0 24 24"
@@ -1165,9 +1165,9 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-id-item-0"
+          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-id-item-0"
+          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -1175,7 +1175,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
           >
             <fieldset
               className="css-1u8qly9"
-              id="multi-select-checkbox-group-checkbox-group"
+              id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
                 Multi select checkbox group label
@@ -1183,7 +1183,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
               <div
                 className="chakra-stack css-19s3t1h"
                 data-testid="checkbox-group"
-                id="multi-select-checkbox-group"
+                id="multi-select-checkbox-group-multiselect-test-id"
               >
                 <div
                   className="css-1xdhyk6"
@@ -1663,7 +1663,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                 aria-live="polite"
                 className="css-1xdhyk6"
                 data-isinvalid={false}
-                id="multi-select-checkbox-group-helperErrorText"
+                id="multi-select-checkbox-group-multiselect-test-id-helperErrorText"
               />
             </fieldset>
           </div>
@@ -1675,7 +1675,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
     aria-label="remove 1 item selected from multiselect-button-text"
     className="chakra-button css-8bx9xp"
     data-testid="multi-select-close-button-testid"
-    id="multi-select-button"
+    id="ms-count-button-multiselect-test-id"
     onClick={[Function]}
     type="button"
   >
@@ -1684,7 +1684,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
       aria-hidden={true}
       className="chakra-icon css-h7dq2k"
       focusable={false}
-      id="ms-multiselect-test-id-selected-items-count-icon"
+      id="ms-count-icon-multiselect-test-id"
       role="img"
       title="Remove selected items"
       viewBox="0 0 24 24"
@@ -1723,18 +1723,18 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-id"
+    id="multi-select-accordion-multiselect-test-id"
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-id-item-0"
+        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 2 items currently selected"
         className="chakra-accordion__button css-h5m7h6"
         disabled={false}
-        id="accordion-button-multi-select-accordion-id-item-0"
+        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1754,7 +1754,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
           aria-hidden={true}
           className="chakra-icon css-q3eg3a"
           focusable={false}
-          id="accordion-multi-select-accordion-id-icon-0"
+          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
           viewBox="0 0 24 24"
@@ -1795,9 +1795,9 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-id-item-0"
+          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-id-item-0"
+          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -1805,7 +1805,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
           >
             <fieldset
               className="css-1u8qly9"
-              id="multi-select-checkbox-group-checkbox-group"
+              id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
                 Multi select checkbox group label
@@ -1813,7 +1813,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
               <div
                 className="chakra-stack css-19s3t1h"
                 data-testid="checkbox-group"
-                id="multi-select-checkbox-group"
+                id="multi-select-checkbox-group-multiselect-test-id"
               >
                 <div
                   className="css-1xdhyk6"
@@ -2290,7 +2290,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                 aria-live="polite"
                 className="css-1xdhyk6"
                 data-isinvalid={false}
-                id="multi-select-checkbox-group-helperErrorText"
+                id="multi-select-checkbox-group-multiselect-test-id-helperErrorText"
               />
             </fieldset>
           </div>
@@ -2302,7 +2302,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
     aria-label="remove 2 items selected from multiselect-button-text"
     className="chakra-button css-8bx9xp"
     data-testid="multi-select-close-button-testid"
-    id="multi-select-button"
+    id="ms-count-button-multiselect-test-id"
     onClick={[Function]}
     type="button"
   >
@@ -2311,7 +2311,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
       aria-hidden={true}
       className="chakra-icon css-h7dq2k"
       focusable={false}
-      id="ms-multiselect-test-id-selected-items-count-icon"
+      id="ms-count-icon-multiselect-test-id"
       role="img"
       title="Remove selected items"
       viewBox="0 0 24 24"


### PR DESCRIPTION
## This PR does the following:

- This came out of working on Turbine https://github.com/NYPL/nypl-ds-test-app/pull/97
- The accessibility tests don't pass because the id in the accordion and other elements are the same when multiple `MultiSelect` components are rendered on a page.
- This also removes the warning when a non-Checkbox component is passed to the CheckboxGroup component. MultiSelect does pass Checkbox components and the message _still_ gets logged. So for now it's removed.

## How has this been tested?

Locally in Storybook under the Accessibility tab for the different stories.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Fixes duplicate id issues.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
