### PR TITLE
DSD-1331: Menu initial focus

### DIFF
--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -13,7 +13,7 @@ import {
 } from "@chakra-ui/react";
 import Icon, { IconNames } from "../Icons/Icon";
 import Image from "../Image/Image";
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef, useRef, useState } from "react";
 import { SectionTypes } from "../../helpers/types";
 
 export interface MenuProps {
@@ -249,6 +249,7 @@ export const Menu: ChakraComponent<
               isFocusable={true}
               data-testid={isSelected ? "selected-item" : ""}
               onClick={() => handleSelect(item.id, item.onClick)}
+              ref={isSelected ? initialRef : null}
               sx={{
                 ...styles.actionItem,
                 ...(isSelected && styles.selected),
@@ -270,9 +271,14 @@ export const Menu: ChakraComponent<
           return [...lst, menuItem];
         }, []);
 
+      const initialRef = useRef();
       return (
         <Box ref={ref}>
-          <ChakraMenu id={id} autoSelect={false} {...rest}>
+          <ChakraMenu
+            id={id}
+            initialFocusRef={selected ? initialRef : null}
+            {...rest}
+          >
             {({ isOpen }) => (
               <Flex
                 flexDirection={


### PR DESCRIPTION
Resolves JIRA ticket [DSD-1331](https://jira.nypl.org/browse/DSD-1331).

## This PR does the following:
- Adds an initial reference to the first item of the menu list OR the selected item, allowing the `Esc` key to close the menu

## How has this been tested?

Locally, Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Previously, `Esc` key did not close the menu unless user hovered over a menu item, because focus remained on the menu button


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
