### PR TITLE
Exporting helpers from Chakra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Heading` component to use native Chakra responsive styles to handle the font sizes of the component's internal `heading`, `overline` and `subtitle` elements. This also resolves the flashing font size bug that is most noticeable on slower internet connections.
 - Updates the `Text` component to use native Chakra responsive styles for the font sizes of the `subtitle1` and `subtitle2` variants.
 - Updates the `NewsletterSignup` component to follow NYPL recommendations and use more direct language for the email field error message.
+- Updates the default export to include `FocusLock`, `useStyleConfig`, and `useMultiStyleConfig` from Chakra UI.
+- Updates the default export to include the test helper "MatchMedia".
 
 ## Prerelease
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export {
   ColorModeScript,
   cookieStorageManager,
   cookieStorageManagerSSR,
+  FocusLock,
   Flex,
   Grid,
   GridItem,
@@ -19,6 +20,8 @@ export {
   Stack,
   useColorMode,
   useColorModeValue,
+  useStyleConfig,
+  useMultiStyleConfig,
   VStack,
 } from "@chakra-ui/react";
 export { default as Accordion } from "./components/Accordion/Accordion";
@@ -88,6 +91,7 @@ export { default as List } from "./components/List/List";
 export type { DescriptionProps, ListTypes } from "./components/List/List";
 export { default as Logo } from "./components/Logo/Logo";
 export type { LogoNames, LogoSizes } from "./components/Logo/Logo";
+export { default as MatchMedia } from "../src/__tests__/mediaMatchMock";
 export { default as Menu } from "./components/Menu/Menu";
 export type {
   ListItemsData,


### PR DESCRIPTION
## This PR does the following:

- Found out while testing the new version in the Header app that we need to export a few more helpers. This exports `FocusLock` which is now part of Chakra in 2.8, as well as `useStyleConfig` and `useMultiStyleConfig` for apps that need to create their own theme object (like the Header).
- This also exports the helper for the MatchMedia object.

## How has this been tested?

N/A will be tested in a release candidate.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
