### PR TITLE
DSD-1705: remove legacy media queries in Heading

### DIFF
--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -17,75 +17,49 @@ const { defineMultiStyleConfig, definePartsStyle } =
 export const headings = {
   one: definePartsStyle({
     base: {
+      fontSize: "heading.primary", // var(--nypl-fontSizes-4);
       fontWeight: "heading.primary",
       letterSpacing: "0",
       lineHeight: "1.1",
       ...margins,
       width: "auto",
-      a: { textUnderlineOffset: "4px" },
-      "@media (min-width: 0px)": {
-        fontSize: "heading.primary", // var(--nypl-fontSizes-4);
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "heading.primary", // var(--nypl-fontSizes-4);
-      },
     },
   }),
   two: definePartsStyle({
     base: {
+      fontSize: "heading.secondary", // var(--nypl-fontSizes-3);
       fontWeight: "heading.secondary",
       lineHeight: "1.25",
       ...margins,
       width: "auto",
       a: { textUnderlineOffset: "3px" },
-      "@media (min-width: 0px)": {
-        fontSize: "heading.secondary", // var(--nypl-fontSizes-3);
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "heading.secondary", // var(--nypl-fontSizes-3);
-      },
     },
   }),
   three: definePartsStyle({
     base: {
+      fontSize: "heading.tertiary", // var(--nypl-fontSizes-2);
       fontWeight: "heading.tertiary",
       lineHeight: "1.25",
       ...margins,
       width: "auto",
-      "@media (min-width: 0px)": {
-        fontSize: "heading.tertiary", // var(--nypl-fontSizes-2);
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "heading.tertiary", // var(--nypl-fontSizes-2);
-      },
     },
   }),
   four: definePartsStyle({
     base: {
+      fontSize: "heading.callout", // var(--nypl-fontSizes-1);
       fontWeight: "heading.callout",
       lineHeight: "1.15",
       ...margins,
       width: "auto",
-      "@media (min-width: 0px)": {
-        fontSize: "heading.callout", // var(--nypl-fontSizes-1);
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "heading.callout", // var(--nypl-fontSizes-1);
-      },
     },
   }),
   fallback: definePartsStyle({
     base: {
+      fontSize: "1", // var(--nypl-fontSizes-1);
       fontWeight: "regular",
       lineHeight: "1.15",
       ...margins,
       width: "auto",
-      "@media (min-width: 0px)": {
-        fontSize: "1", // var(--nypl-fontSizes-1);
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "1", // var(--nypl-fontSizes-1);
-      },
     },
   }),
   display1: definePartsStyle({
@@ -99,12 +73,6 @@ export const headings = {
       lineHeight: "1.10",
       width: "auto",
       a: { textUnderlineOffset: "7px" },
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.display1",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.display1",
-      },
     },
   }),
   heading1: definePartsStyle({
@@ -118,12 +86,6 @@ export const headings = {
       lineHeight: "1.15",
       width: "auto",
       a: { textUnderlineOffset: "6px" },
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.heading1",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.heading1",
-      },
     },
   }),
   heading2: definePartsStyle({
@@ -137,12 +99,6 @@ export const headings = {
       lineHeight: "1.20",
       width: "auto",
       a: { textUnderlineOffset: "5px" },
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.heading2",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.heading2",
-      },
     },
   }),
   heading3: definePartsStyle({
@@ -156,12 +112,6 @@ export const headings = {
       lineHeight: "1.25",
       width: "auto",
       a: { textUnderlineOffset: "4px" },
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.heading3",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.heading3",
-      },
     },
   }),
   heading4: definePartsStyle({
@@ -175,12 +125,6 @@ export const headings = {
       lineHeight: "1.30",
       width: "auto",
       a: { textUnderlineOffset: "3px" },
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.heading4",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.heading4",
-      },
     },
   }),
   heading5: definePartsStyle({
@@ -193,12 +137,6 @@ export const headings = {
       letterSpacing: "0",
       lineHeight: "1.35",
       width: "auto",
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.heading5",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.heading4",
-      },
     },
   }),
   heading6: definePartsStyle({
@@ -211,12 +149,6 @@ export const headings = {
       letterSpacing: "0",
       lineHeight: "1.40",
       width: "auto",
-      "@media (min-width: 0px)": {
-        fontSize: "mobile.heading.heading6",
-      },
-      "@media (min-width: 600px)": {
-        fontSize: "desktop.heading.heading6",
-      },
     },
   }),
 };

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -23,6 +23,7 @@ export const headings = {
       lineHeight: "1.1",
       ...margins,
       width: "auto",
+      a: { textUnderlineOffset: "4px" },
     },
   }),
   two: definePartsStyle({


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1705](https://jira.nypl.org/browse/DSD-1705)

## This PR does the following:

- Updates the `Heading` styles to remove the legacy media queries that were added to handle the responsive font sizes in the `React 17` iteration of the DS.
- NOTE: no updates for the CHANGELOG becuse this is a correction of updates that were made previously.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
