### PR TITLE
DSD-1710: Use onClearAll  function in multi-select component

### DIFF
--- a/src/components/FilterBar/FilterBar.test.tsx
+++ b/src/components/FilterBar/FilterBar.test.tsx
@@ -72,7 +72,6 @@ const FilterBarTestComponent = ({
     onChange,
     onMixedStateChange,
     selectedItems,
-    onClear,
     onClearAll,
     isModalOpen,
     onToggle,
@@ -117,8 +116,8 @@ const FilterBarTestComponent = ({
                   multiSelect.items
                 );
               }}
-              onClear={() => {
-                onClear(multiSelect.id);
+              onClearAll={() => {
+                onClearAll();
               }}
             />
           ))}
@@ -146,7 +145,7 @@ const MultiSelectTestGroup = (multiSelectItems) => (
         defaultItemsVisible={defaultItemsVisible}
         onChange={() => null}
         onMixedStateChange={() => null}
-        onClear={() => "clear"}
+        onClearAll={() => "clearAll"}
       />
     ))}
   </MultiSelectGroup>

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -704,7 +704,7 @@ cases where managing the state of the component in the consuming app is less
 of a concern and general ease of use is prefered.
 
 The hook returns an object containing all the props and state needed to handle
-the selectedItems. That includes the functions `onChange`, `onClear`,
+the selectedItems. That includes the functions `onChange`, `onClearAll`,
 `onMixedStateChange` for handling any changes to the selection of items and the
 current state of the selection: `selectedItems`.
 

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -468,7 +468,7 @@ export const defaultOpenState: Story = {
 
 const MultiSelectWithControlsStory = (args) => {
   // Example with custom hook useMultiSelect.
-  const { onChange, onMixedStateChange, onClear, selectedItems } =
+  const { onChange, onMixedStateChange, onClearAll, selectedItems } =
     useMultiSelect();
 
   // Hack to get storybook's action tab to log state change when selectedItems state changes.
@@ -478,7 +478,7 @@ const MultiSelectWithControlsStory = (args) => {
     if (Object.keys(selectedItems).length !== 0) {
       action(actionName)(selectedItems);
     }
-    if (actionName === "onClear") {
+    if (actionName === "onClearAll") {
       action(actionName)(selectedItems);
     }
   }, [actionName, selectedItems]);
@@ -496,9 +496,9 @@ const MultiSelectWithControlsStory = (args) => {
         onMixedStateChange(e.target.id, multiSelectId, args.items);
         setActionName("onMixedStateChange");
       }}
-      onClear={() => {
-        onClear(multiSelectId);
-        setActionName("onClear");
+      onClearAll={() => {
+        onClearAll();
+        setActionName("onClearAll");
       }}
     />
   );
@@ -515,7 +515,7 @@ const MultiSelectStory = ({
   defaultItemsVisible = 5,
 }: Partial<MultiSelectProps>) => {
   // Example with custom hook useMultiSelect.
-  const { onChange, onMixedStateChange, onClear, selectedItems } =
+  const { onChange, onMixedStateChange, onClearAll, selectedItems } =
     useMultiSelect();
 
   // Hack to get storybook's action tab to log state change when selectedItems state changes.
@@ -525,7 +525,7 @@ const MultiSelectStory = ({
     if (Object.keys(selectedItems).length !== 0) {
       action(actionName)(selectedItems);
     }
-    if (actionName === "onClear") {
+    if (actionName === "onClearAll") {
       action(actionName)(selectedItems);
     }
   }, [actionName, selectedItems]);
@@ -550,9 +550,9 @@ const MultiSelectStory = ({
         onMixedStateChange(e.target.id, id, items);
         setActionName("onMixedStateChange");
       }}
-      onClear={() => {
-        onClear(id);
-        setActionName("onClear");
+      onClearAll={() => {
+        onClearAll();
+        setActionName("onClearAll");
       }}
     />
   );

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -51,7 +51,7 @@ const MultiSelectTestComponent = ({
     onMixedStateChange,
     selectedItems,
     setSelectedItems,
-    onClear,
+    onClearAll,
   } = useMultiSelect();
 
   useEffect(() => {
@@ -73,7 +73,7 @@ const MultiSelectTestComponent = ({
       onMixedStateChange={(e) => {
         onMixedStateChange(e.target.id, multiSelectId, items);
       }}
-      onClear={() => onClear(multiSelectId)}
+      onClearAll={() => onClearAll()}
     />
   );
 };
@@ -94,7 +94,7 @@ describe("MultiSelect Accessibility", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -128,7 +128,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(container.querySelector("#multiselect-test-id")).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.getByText("Multiselect button text").textContent);
@@ -165,7 +165,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.queryByRole("checkbox")).toBeNull();
@@ -183,7 +183,7 @@ describe("MultiSelect", () => {
         items={disabledItems}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.getByRole("button").getAttribute("aria-expanded")).toEqual(
@@ -209,7 +209,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.getByRole("button").getAttribute("aria-expanded")).toEqual(
@@ -231,7 +231,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.getAllByRole("checkbox")).toHaveLength(8);
@@ -254,7 +254,7 @@ describe("MultiSelect", () => {
         isDefaultOpen={true}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.getAllByRole("checkbox")).toHaveLength(8);
@@ -275,7 +275,7 @@ describe("MultiSelect", () => {
         isBlockElement={false}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
 
@@ -340,7 +340,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     // Open multiselect menu.
@@ -361,7 +361,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     userEvent.click(screen.queryByRole("checkbox", { name: /dogs/i }));
@@ -393,7 +393,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
 
@@ -414,7 +414,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.queryAllByRole("checkbox")).toHaveLength(8);
@@ -483,7 +483,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onMixedStateChange={() => null}
         onChange={() => null}
-        onClear={() => null}
+        onClearAll={() => null}
       />
     );
     expect(screen.getByLabelText("Colors")).toBeChecked();
@@ -539,7 +539,7 @@ describe("MultiSelect", () => {
           isBlockElement={false}
           selectedItems={selectedTestItems}
           onChange={() => null}
-          onClear={() => null}
+          onClearAll={() => null}
         />
       )
       .toJSON();
@@ -556,7 +556,7 @@ describe("MultiSelect", () => {
           isDefaultOpen={true}
           selectedItems={selectedTestItems}
           onChange={() => null}
-          onClear={() => null}
+          onClearAll={() => null}
         />
       )
       .toJSON();
@@ -575,7 +575,7 @@ describe("MultiSelect", () => {
           selectedItems={selectedTestItems}
           onMixedStateChange={() => null}
           onChange={() => null}
-          onClear={() => null}
+          onClearAll={() => null}
         />
       )
       .toJSON();
@@ -596,7 +596,7 @@ describe("MultiSelect", () => {
           selectedItems={selectedTestItems}
           onMixedStateChange={() => null}
           onChange={() => null}
-          onClear={() => null}
+          onClearAll={() => null}
         />
       )
       .toJSON();

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -94,6 +94,8 @@ export const MultiSelect: ChakraComponent<
       // Create a ref to hold a reference to the accordian button, enabling us to programmatically focus it.
       const accordianButtonRef: React.RefObject<HTMLDivElement> =
         useRef<HTMLDivElement>();
+      const buttonRef: React.RefObject<HTMLButtonElement> =
+        useRef<HTMLButtonElement>();
 
       const MINIMUM_ITEMS_LIST_HEIGHT = "215px";
       const MAXIMUM_ITEMS_LIST_HEIGHT = "270px";
@@ -222,6 +224,11 @@ export const MultiSelect: ChakraComponent<
       /** Toggle for listOverflow = "expand" */
       const toggleItemsList = () => {
         setIsExpandable((prevProp) => !prevProp);
+        setTimeout(() => {
+          if (buttonRef.current) {
+            buttonRef.current.focus(); // Set focus after expansion
+          }
+        }, 1);
       };
 
       React.useEffect(() => {
@@ -234,6 +241,7 @@ export const MultiSelect: ChakraComponent<
             buttonType="text"
             fontSize="desktop.button.default"
             id={`view-all-text-btn-${id}`}
+            ref={buttonRef}
             onClick={toggleItemsList}
             __css={styles.viewAllButton}
           >

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -94,7 +94,7 @@ export const MultiSelect: ChakraComponent<
       // Create a ref to hold a reference to the accordian button, enabling us to programmatically focus it.
       const accordianButtonRef: React.RefObject<HTMLDivElement> =
         useRef<HTMLDivElement>();
-      const buttonRef: React.RefObject<HTMLButtonElement> =
+      const expandToggleButtonRef: React.RefObject<HTMLButtonElement> =
         useRef<HTMLButtonElement>();
 
       const MINIMUM_ITEMS_LIST_HEIGHT = "215px";
@@ -225,8 +225,8 @@ export const MultiSelect: ChakraComponent<
       const toggleItemsList = () => {
         setIsExpandable((prevProp) => !prevProp);
         setTimeout(() => {
-          if (buttonRef.current) {
-            buttonRef.current.focus(); // Set focus after expansion
+          if (expandToggleButtonRef.current) {
+            expandToggleButtonRef.current.focus(); // Set focus after expansion
           }
         }, 1); // Ensure focus logic runs after state update
       };
@@ -241,7 +241,7 @@ export const MultiSelect: ChakraComponent<
             buttonType="text"
             fontSize="desktop.button.default"
             id={`view-all-text-btn-${id}`}
-            ref={buttonRef}
+            ref={expandToggleButtonRef}
             onClick={toggleItemsList}
             __css={styles.viewAllButton}
           >

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -228,7 +228,7 @@ export const MultiSelect: ChakraComponent<
           if (buttonRef.current) {
             buttonRef.current.focus(); // Set focus after expansion
           }
-        }, 1);
+        }, 1); // Ensure focus logic runs after state update
       };
 
       React.useEffect(() => {

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -33,7 +33,7 @@ export interface MultiSelectProps {
   /** The number of items that will be visible in the list when the component first loads. */
   defaultItemsVisible?: number;
   /** The action to perform for clear/reset button of MultiSelect. */
-  onClear?: () => void;
+  onClearAll?: () => void;
   /** The action to perform on the checkbox's onChange function. */
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** The action to perform for a mixed state checkbox (parent checkbox). */
@@ -84,7 +84,7 @@ export const MultiSelect: ChakraComponent<
         listOverflow = "scroll",
         buttonText,
         onChange,
-        onClear,
+        onClearAll,
         onMixedStateChange,
         selectedItems,
         width = "full",
@@ -374,7 +374,7 @@ export const MultiSelect: ChakraComponent<
               isOpen={isDefaultOpen}
               selectedItemsString={selectedItemsString}
               selectedItemsCount={selectedItemsCount}
-              onClear={onClear}
+              onClearAll={onClearAll}
               accordianButtonRef={accordianButtonRef}
             />
           )}

--- a/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
+++ b/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
@@ -19,7 +19,7 @@ export interface MultiSelectItemsCountButtonProps {
   /** The callback function for the menu toggle. */
   onMenuToggle?: () => void;
   /** The action to perform for clear/reset button of MultiSelect. */
-  onClear?: () => void;
+  onClearAll?: () => void;
   /** The action to perform for key down event. */
   onKeyDown?: () => void;
   /** Ref to the Accordion Button element. */
@@ -42,7 +42,7 @@ const MultiSelectItemsCountButton = forwardRef<
     multiSelectId,
     multiSelectLabelText,
     accordianButtonRef,
-    onClear,
+    onClearAll,
     selectedItemsString,
     selectedItemsCount,
   } = props;
@@ -63,7 +63,7 @@ const MultiSelectItemsCountButton = forwardRef<
       aria-label={selectedItemsAriaLabel}
       data-testid="multi-select-close-button-testid"
       onClick={() => {
-        onClear();
+        onClearAll();
         // Set focus on the Accordion Button when close the selected items count button.
         accordianButtonRef.current?.focus();
       }}

--- a/src/components/MultiSelectGroup/MultiSelectGroup.md
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.md
@@ -56,7 +56,7 @@ cases where managing the state of the component in the consuming app is less
 of a concern and general ease of use is prefered.
 
 The hook returns an object containing all the props and state needed to handle
-the selectedItems. That includes the functions `onChange`, `onClear`, `onClearAll`,
+the selectedItems. That includes the functions `onChange`, `onClearAll`,
 `onMixedStateChange` for handling any changes to the selection of items and the
 current state of the selection: `selectedItems`. Additionally it returns
 `setSelectedItems` for setting an initial state of `selectedItems` or manipulate

--- a/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
@@ -76,7 +76,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClear={() => "clear"}
+            onClearAll={() => "clearAll"}
           />
         ))}
       </MultiSelectGroup>
@@ -104,7 +104,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClear={() => "clear"}
+            onClearAll={() => "clearall"}
           />
         ))}
       </MultiSelectGroup>
@@ -132,7 +132,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClear={() => "clear"}
+            onClearAll={() => "clearAll"}
           />
         ))}
       </MultiSelectGroup>
@@ -161,7 +161,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClear={() => "clear"}
+            onClearAll={() => "clearAll"}
           />
         ))}
       </MultiSelectGroup>
@@ -210,7 +210,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
               buttonText="MultiSelect"
               defaultItemsVisible={defaultItemsVisible}
               onChange={handleChangeMock}
-              onClear={() => "clear"}
+              onClearAll={() => "clearAll"}
             />
           ))}
         </MultiSelectGroup>
@@ -237,7 +237,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
               buttonText="MultiSelect"
               defaultItemsVisible={defaultItemsVisible}
               onChange={handleChangeMock}
-              onClear={() => "clear"}
+              onClearAll={() => "clearAll"}
             />
           ))}
         </MultiSelectGroup>

--- a/src/theme/components/multiSelect.ts
+++ b/src/theme/components/multiSelect.ts
@@ -110,6 +110,7 @@ const MultiSelect = defineMultiStyleConfig({
       },
       ".chakra-collapse": {
         bgColor: "ui.bg.page",
+        overflow: "unset !important",
         borderTopWidth: "1px",
         marginTop: "-1px",
         position: isBlockElement ? null : "absolute",

--- a/src/theme/components/multiSelectItemsCountButton.ts
+++ b/src/theme/components/multiSelectItemsCountButton.ts
@@ -18,6 +18,7 @@ const MultiSelectItemsCountButton = defineStyleConfig({
     top: { base: "12px", md: "10px" },
     width: "46px",
     zIndex: 10000,
+    py: 'xxxs',
     _hover: {
       borderColor: isOpen ? "ui.gray.xx-dark" : "ui.border.hover",
     },


### PR DESCRIPTION
Fixes JIRA ticket xxx

## This PR does the following:

- Used onClearAll function in multiSelect component instead of onClear.
- Updated onClearAll function in multiSelectGroup and FilterBar.
- Fixed focus issue when click on the ViewAll button.
- Fixed scroll issue when isBlockElement flag is false.

## How has this been tested?
Local and storybook

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.
