### PR TITLE
MultiSelect onClear function

### DIFF
--- a/src/components/FilterBar/FilterBar.test.tsx
+++ b/src/components/FilterBar/FilterBar.test.tsx
@@ -72,6 +72,7 @@ const FilterBarTestComponent = ({
     onChange,
     onMixedStateChange,
     selectedItems,
+    onClear,
     onClearAll,
     isModalOpen,
     onToggle,
@@ -116,8 +117,8 @@ const FilterBarTestComponent = ({
                   multiSelect.items
                 );
               }}
-              onClearAll={() => {
-                onClearAll();
+              onClear={() => {
+                onClear(multiSelect.id);
               }}
             />
           ))}
@@ -145,7 +146,7 @@ const MultiSelectTestGroup = (multiSelectItems) => (
         defaultItemsVisible={defaultItemsVisible}
         onChange={() => null}
         onMixedStateChange={() => null}
-        onClearAll={() => "clearAll"}
+        onClear={() => "onClear"}
       />
     ))}
   </MultiSelectGroup>

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -27,6 +27,7 @@ import { changelogData } from "./multiSelectChangelogData";
 - {<Link href="#block-element-or-float" target="_self">Block Element or Float</Link>}
 - {<Link href="#width" target="_self">Width</Link>}
 - {<Link href="#default-open-state" target="_self">Default Open State</Link>}
+- {<Link href="#multiselect-in-a-group" target="_self">MultiSelect in a Group</Link>}
 - {<Link href="#controlling-state-using-selecteditems-and-onchange-prop" target="_self">Controlling state using selectedItems and onChange prop</Link>}
 - {<Link href="#multiselect-nextjs-routing-implementation" target="_self">MultiSelect NextJS routing implementation</Link>}
 - {<Link href="#usemultiselect-hook" target="_self">useMultiSelect hook</Link>}
@@ -576,11 +577,19 @@ state by default.
 ## MultiSelect in a Group
 
 When using the `MultiSelect` component in a group, it is recommended to use the
-`useMultiSelect` hook to manage the state of all the components. The `onClearAll`
-function prop is available to use but it is recommended to use the `onClear`
-function to let the hook control the state of individual `MultiSelect` components.
-This allows the "clear" button to clear all the selected checkboxes in individual
-`MultiSelect` components without affect the rest in the same group.
+`useMultiSelect` hook to manage the state of all the `MultiSelect` components.
+
+The `useMultiSelect` hook provides an `onClear` function that should be used to
+clear all the selected checkboxes in individual `MultiSelect` components. This
+function should be passed to the `onClear` prop and is invoked through the
+"clear" button in the `MultiSelect` component.
+
+The `useMultiSelect` hook also provides an `onClearAll` function that can be
+used to clear all the selected checkboxes across all `MultiSelect` components.
+The `MultiSelect` component does _NOT_ have an `onClearAll` prop. Instead, the
+`onClearAll` function should be invoked in a separate button or action.
+Alternatively, use the `MultiSelectGroup` or `FilterBar` (name TBD) components
+in future releases.
 
 **IMPORTANT**: Make sure to give each `MultiSelect` component a unique `id`.
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -573,6 +573,59 @@ state by default.
   language="jsx"
 />
 
+## MultiSelect in a Group
+
+When using the `MultiSelect` component in a group, it is recommended to use the
+`useMultiSelect` hook to manage the state of all the components. The `onClearAll`
+function prop is available to use but it is recommended to use the `onClear`
+function to let the hook control the state of individual `MultiSelect` components.
+This allows the "clear" button to clear all the selected checkboxes in individual
+`MultiSelect` components without affect the rest in the same group.
+
+**IMPORTANT**: Make sure to give each `MultiSelect` component a unique `id`.
+
+<Canvas of={MultiSelectStories.InAGroup} />
+
+<Source
+  code={`
+import { MultiSelect, useMultiSelect } from "@nypl/design-system-react-components";
+// ...
+function MultiSelectGroupExample() {
+  // Example with custom hook useMultiSelect.
+  const { onChange, onMixedStateChange, onClear, selectedItems } =
+    useMultiSelect();
+  return (
+    <HStack>
+      <MultiSelect
+        buttonText="MultiSelect"
+        id="ms-group-1"
+        items={items}
+        selectedItems={selectedItems}
+        width="fitContent"
+        onChange={(e) => {
+          onChange(e.target.id, "ms-group-1");
+          setActionName("onChange");
+        }}
+        onMixedStateChange={(e) => {
+          onMixedStateChange(e.target.id, "ms-group-1", items);
+          setActionName("onMixedStateChange");
+        }}
+        onClear={() => {
+          onClear("ms-group-1");
+          setActionName("onClear");
+        }}
+      />
+      <MultiSelect
+        id="ms-group-2"
+        // ...
+      />
+    </HStack>
+  );
+}
+`}
+  language="jsx"
+/>
+
 ## Controlling State Using selectedItems and onChange Props
 
 The `MultiSelect` component does not store its state internally. It expects a
@@ -704,9 +757,9 @@ cases where managing the state of the component in the consuming app is less
 of a concern and general ease of use is prefered.
 
 The hook returns an object containing all the props and state needed to handle
-the selectedItems. That includes the functions `onChange`, `onClearAll`,
-`onMixedStateChange` for handling any changes to the selection of items and the
-current state of the selection: `selectedItems`.
+the selectedItems. That includes the functions `onChange`, `onClear`,
+`onClearAll`, `onMixedStateChange` for handling any changes to the selection of
+items and the current state of the selection: `selectedItems`.
 
 Find the full documentation under [useMultiSelect](../?path=/docs/hooks-usemultiselect--docs).
 

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -11,6 +11,7 @@ import MultiSelect, {
 import Text from "../Text/Text";
 import useMultiSelect from "../../hooks/useMultiSelect";
 import { HStack, Stack } from "@chakra-ui/react";
+import Button from "../Button/Button";
 
 const withItems = [
   {
@@ -565,7 +566,7 @@ const MultiSelectStory = ({
 // TODO: Replace with MultiSelectGroup once that component is done.
 const MultiSelecGroupStory = ({ items }: Partial<MultiSelectProps>) => {
   // Example with custom hook useMultiSelect.
-  const { onChange, onMixedStateChange, onClear, selectedItems } =
+  const { onChange, onMixedStateChange, onClear, onClearAll, selectedItems } =
     useMultiSelect();
 
   // Hack to get storybook's action tab to log state change when selectedItems state changes.
@@ -640,6 +641,9 @@ const MultiSelecGroupStory = ({ items }: Partial<MultiSelectProps>) => {
           setActionName("onClear");
         }}
       />
+      <Button id="clear-all" onClick={() => onClearAll()}>
+        Clear All
+      </Button>
     </HStack>
   );
 };

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -10,7 +10,7 @@ import MultiSelect, {
 } from "./MultiSelect";
 import Text from "../Text/Text";
 import useMultiSelect from "../../hooks/useMultiSelect";
-import { Stack } from "@chakra-ui/react";
+import { HStack, Stack } from "@chakra-ui/react";
 
 const withItems = [
   {
@@ -466,9 +466,13 @@ export const defaultOpenState: Story = {
   ),
 };
 
+export const InAGroup: Story = {
+  render: () => <MultiSelecGroupStory items={withItems} />,
+};
+
 const MultiSelectWithControlsStory = (args) => {
   // Example with custom hook useMultiSelect.
-  const { onChange, onMixedStateChange, onClearAll, selectedItems } =
+  const { onChange, onMixedStateChange, onClear, selectedItems } =
     useMultiSelect();
 
   // Hack to get storybook's action tab to log state change when selectedItems state changes.
@@ -478,7 +482,7 @@ const MultiSelectWithControlsStory = (args) => {
     if (Object.keys(selectedItems).length !== 0) {
       action(actionName)(selectedItems);
     }
-    if (actionName === "onClearAll") {
+    if (actionName === "onClear") {
       action(actionName)(selectedItems);
     }
   }, [actionName, selectedItems]);
@@ -496,9 +500,9 @@ const MultiSelectWithControlsStory = (args) => {
         onMixedStateChange(e.target.id, multiSelectId, args.items);
         setActionName("onMixedStateChange");
       }}
-      onClearAll={() => {
-        onClearAll();
-        setActionName("onClearAll");
+      onClear={() => {
+        onClear(multiSelectId);
+        setActionName("onClear");
       }}
     />
   );
@@ -515,7 +519,7 @@ const MultiSelectStory = ({
   defaultItemsVisible = 5,
 }: Partial<MultiSelectProps>) => {
   // Example with custom hook useMultiSelect.
-  const { onChange, onMixedStateChange, onClearAll, selectedItems } =
+  const { onChange, onMixedStateChange, onClear, selectedItems } =
     useMultiSelect();
 
   // Hack to get storybook's action tab to log state change when selectedItems state changes.
@@ -525,7 +529,7 @@ const MultiSelectStory = ({
     if (Object.keys(selectedItems).length !== 0) {
       action(actionName)(selectedItems);
     }
-    if (actionName === "onClearAll") {
+    if (actionName === "onClear") {
       action(actionName)(selectedItems);
     }
   }, [actionName, selectedItems]);
@@ -550,10 +554,92 @@ const MultiSelectStory = ({
         onMixedStateChange(e.target.id, id, items);
         setActionName("onMixedStateChange");
       }}
-      onClearAll={() => {
-        onClearAll();
-        setActionName("onClearAll");
+      onClear={() => {
+        onClear(id);
+        setActionName("onClear");
       }}
     />
+  );
+};
+
+// TODO: Replace with MultiSelectGroup once that component is done.
+const MultiSelecGroupStory = ({ items }: Partial<MultiSelectProps>) => {
+  // Example with custom hook useMultiSelect.
+  const { onChange, onMixedStateChange, onClear, selectedItems } =
+    useMultiSelect();
+
+  // Hack to get storybook's action tab to log state change when selectedItems state changes.
+  const [actionName, setActionName] = useState("");
+
+  useEffect(() => {
+    if (Object.keys(selectedItems).length !== 0) {
+      action(actionName)(selectedItems);
+    }
+    if (actionName === "onClear") {
+      action(actionName)(selectedItems);
+    }
+  }, [actionName, selectedItems]);
+
+  return (
+    <HStack minHeight="300px" alignItems="baseline">
+      <MultiSelect
+        buttonText="MultiSelect"
+        id="ms-group-1"
+        isBlockElement
+        items={items}
+        selectedItems={selectedItems}
+        width="fitContent"
+        onChange={(e) => {
+          onChange(e.target.id, "ms-group-1");
+          setActionName("onChange");
+        }}
+        onMixedStateChange={(e) => {
+          onMixedStateChange(e.target.id, "ms-group-1", items);
+          setActionName("onMixedStateChange");
+        }}
+        onClear={() => {
+          onClear("ms-group-1");
+          setActionName("onClear");
+        }}
+      />
+      <MultiSelect
+        buttonText="MultiSelect"
+        id="ms-group-2"
+        items={items}
+        selectedItems={selectedItems}
+        width="fitContent"
+        onChange={(e) => {
+          onChange(e.target.id, "ms-group-2");
+          setActionName("onChange");
+        }}
+        onMixedStateChange={(e) => {
+          onMixedStateChange(e.target.id, "ms-group-2", items);
+          setActionName("onMixedStateChange");
+        }}
+        onClear={() => {
+          onClear("ms-group-2");
+          setActionName("onClear");
+        }}
+      />
+      <MultiSelect
+        buttonText="MultiSelect"
+        id="ms-group-3"
+        items={items}
+        selectedItems={selectedItems}
+        width="fitContent"
+        onChange={(e) => {
+          onChange(e.target.id, "ms-group-3");
+          setActionName("onChange");
+        }}
+        onMixedStateChange={(e) => {
+          onMixedStateChange(e.target.id, "ms-group-3", items);
+          setActionName("onMixedStateChange");
+        }}
+        onClear={() => {
+          onClear("ms-group-3");
+          setActionName("onClear");
+        }}
+      />
+    </HStack>
   );
 };

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -51,7 +51,7 @@ const MultiSelectTestComponent = ({
     onMixedStateChange,
     selectedItems,
     setSelectedItems,
-    onClearAll,
+    onClear,
   } = useMultiSelect();
 
   useEffect(() => {
@@ -73,7 +73,7 @@ const MultiSelectTestComponent = ({
       onMixedStateChange={(e) => {
         onMixedStateChange(e.target.id, multiSelectId, items);
       }}
-      onClearAll={() => onClearAll()}
+      onClear={() => onClear(multiSelectId)}
     />
   );
 };
@@ -94,7 +94,7 @@ describe("MultiSelect Accessibility", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -128,7 +128,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(container.querySelector("#multiselect-test-id")).toBeInTheDocument();
@@ -146,7 +146,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.getByText("Multiselect button text").textContent);
@@ -165,7 +165,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.queryByRole("checkbox")).toBeNull();
@@ -183,7 +183,7 @@ describe("MultiSelect", () => {
         items={disabledItems}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.getByRole("button").getAttribute("aria-expanded")).toEqual(
@@ -209,7 +209,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.getByRole("button").getAttribute("aria-expanded")).toEqual(
@@ -231,7 +231,7 @@ describe("MultiSelect", () => {
         items={items}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.getAllByRole("checkbox")).toHaveLength(8);
@@ -254,7 +254,7 @@ describe("MultiSelect", () => {
         isDefaultOpen={true}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.getAllByRole("checkbox")).toHaveLength(8);
@@ -275,7 +275,7 @@ describe("MultiSelect", () => {
         isBlockElement={false}
         selectedItems={selectedTestItems}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
 
@@ -340,7 +340,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     // Open multiselect menu.
@@ -361,7 +361,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     userEvent.click(screen.queryByRole("checkbox", { name: /dogs/i }));
@@ -393,7 +393,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
 
@@ -414,7 +414,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onChange={onChangeMock}
         onMixedStateChange={onMixedStateChangeMock}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.queryAllByRole("checkbox")).toHaveLength(8);
@@ -483,7 +483,7 @@ describe("MultiSelect", () => {
         selectedItems={selectedTestItems}
         onMixedStateChange={() => null}
         onChange={() => null}
-        onClearAll={() => null}
+        onClear={() => null}
       />
     );
     expect(screen.getByLabelText("Colors")).toBeChecked();
@@ -539,7 +539,7 @@ describe("MultiSelect", () => {
           isBlockElement={false}
           selectedItems={selectedTestItems}
           onChange={() => null}
-          onClearAll={() => null}
+          onClear={() => null}
         />
       )
       .toJSON();
@@ -556,7 +556,7 @@ describe("MultiSelect", () => {
           isDefaultOpen={true}
           selectedItems={selectedTestItems}
           onChange={() => null}
-          onClearAll={() => null}
+          onClear={() => null}
         />
       )
       .toJSON();
@@ -575,7 +575,7 @@ describe("MultiSelect", () => {
           selectedItems={selectedTestItems}
           onMixedStateChange={() => null}
           onChange={() => null}
-          onClearAll={() => null}
+          onClear={() => null}
         />
       )
       .toJSON();
@@ -596,7 +596,7 @@ describe("MultiSelect", () => {
           selectedItems={selectedTestItems}
           onMixedStateChange={() => null}
           onChange={() => null}
-          onClearAll={() => null}
+          onClear={() => null}
         />
       )
       .toJSON();

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -34,8 +34,6 @@ export interface MultiSelectProps {
   defaultItemsVisible?: number;
   /** The action to perform for the clear/reset button of individual MultiSelects. */
   onClear?: () => void;
-  /** The action to perform for clear/reset button for multiple MultiSelect components. */
-  onClearAll?: () => void;
   /** The action to perform on the checkbox's onChange function. */
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** The action to perform for a mixed state checkbox (parent checkbox). */
@@ -87,7 +85,6 @@ export const MultiSelect: ChakraComponent<
         buttonText,
         onChange,
         onClear,
-        onClearAll,
         onMixedStateChange,
         selectedItems,
         width = "full",
@@ -386,7 +383,6 @@ export const MultiSelect: ChakraComponent<
               selectedItemsString={selectedItemsString}
               selectedItemsCount={selectedItemsCount}
               onClear={onClear}
-              onClearAll={onClearAll}
               accordianButtonRef={accordianButtonRef}
             />
           )}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -32,7 +32,9 @@ export interface MultiSelectProps {
   buttonText: string;
   /** The number of items that will be visible in the list when the component first loads. */
   defaultItemsVisible?: number;
-  /** The action to perform for clear/reset button of MultiSelect. */
+  /** The action to perform for the clear/reset button of individual MultiSelects. */
+  onClear?: () => void;
+  /** The action to perform for clear/reset button for multiple MultiSelect components. */
   onClearAll?: () => void;
   /** The action to perform on the checkbox's onChange function. */
   onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -84,6 +86,7 @@ export const MultiSelect: ChakraComponent<
         listOverflow = "scroll",
         buttonText,
         onChange,
+        onClear,
         onClearAll,
         onMixedStateChange,
         selectedItems,
@@ -382,6 +385,7 @@ export const MultiSelect: ChakraComponent<
               isOpen={isDefaultOpen}
               selectedItemsString={selectedItemsString}
               selectedItemsCount={selectedItemsCount}
+              onClear={onClear}
               onClearAll={onClearAll}
               accordianButtonRef={accordianButtonRef}
             />

--- a/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
+++ b/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
@@ -18,7 +18,9 @@ export interface MultiSelectItemsCountButtonProps {
   selectedItemsCount: number;
   /** The callback function for the menu toggle. */
   onMenuToggle?: () => void;
-  /** The action to perform for clear/reset button of MultiSelect. */
+  /** The action to perform for the clear/reset button of individual MultiSelects. */
+  onClear?: () => void;
+  /** The action to perform for clear/reset button for multiple MultiSelect components. */
   onClearAll?: () => void;
   /** The action to perform for key down event. */
   onKeyDown?: () => void;
@@ -42,6 +44,7 @@ const MultiSelectItemsCountButton = forwardRef<
     multiSelectId,
     multiSelectLabelText,
     accordianButtonRef,
+    onClear,
     onClearAll,
     selectedItemsString,
     selectedItemsCount,
@@ -63,7 +66,8 @@ const MultiSelectItemsCountButton = forwardRef<
       aria-label={selectedItemsAriaLabel}
       data-testid="multi-select-close-button-testid"
       onClick={() => {
-        onClearAll();
+        onClear && onClear();
+        onClearAll && onClearAll();
         // Set focus on the Accordion Button when close the selected items count button.
         accordianButtonRef.current?.focus();
       }}

--- a/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
+++ b/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
@@ -20,8 +20,6 @@ export interface MultiSelectItemsCountButtonProps {
   onMenuToggle?: () => void;
   /** The action to perform for the clear/reset button of individual MultiSelects. */
   onClear?: () => void;
-  /** The action to perform for clear/reset button for multiple MultiSelect components. */
-  onClearAll?: () => void;
   /** The action to perform for key down event. */
   onKeyDown?: () => void;
   /** Ref to the Accordion Button element. */
@@ -45,7 +43,6 @@ const MultiSelectItemsCountButton = forwardRef<
     multiSelectLabelText,
     accordianButtonRef,
     onClear,
-    onClearAll,
     selectedItemsString,
     selectedItemsCount,
   } = props;
@@ -67,7 +64,6 @@ const MultiSelectItemsCountButton = forwardRef<
       data-testid="multi-select-close-button-testid"
       onClick={() => {
         onClear && onClear();
-        onClearAll && onClearAll();
         // Set focus on the Accordion Button when close the selected items count button.
         accordianButtonRef.current?.focus();
       }}

--- a/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.test.tsx
@@ -76,7 +76,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClearAll={() => "clearAll"}
+            onClear={() => "onClear"}
           />
         ))}
       </MultiSelectGroup>
@@ -104,7 +104,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClearAll={() => "clearall"}
+            onClear={() => "onClear"}
           />
         ))}
       </MultiSelectGroup>
@@ -132,7 +132,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClearAll={() => "clearAll"}
+            onClear={() => "onClear"}
           />
         ))}
       </MultiSelectGroup>
@@ -161,7 +161,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
             buttonText="MultiSelect"
             defaultItemsVisible={defaultItemsVisible}
             onChange={handleChangeMock}
-            onClearAll={() => "clearAll"}
+            onClear={() => "onClear"}
           />
         ))}
       </MultiSelectGroup>
@@ -210,7 +210,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
               buttonText="MultiSelect"
               defaultItemsVisible={defaultItemsVisible}
               onChange={handleChangeMock}
-              onClearAll={() => "clearAll"}
+              onClear={() => "onClear"}
             />
           ))}
         </MultiSelectGroup>
@@ -237,7 +237,7 @@ describe.skip("MulitSelectGroup Accessibility", () => {
               buttonText="MultiSelect"
               defaultItemsVisible={defaultItemsVisible}
               onChange={handleChangeMock}
-              onClearAll={() => "clearAll"}
+              onClear={() => "onClear"}
             />
           ))}
         </MultiSelectGroup>


### PR DESCRIPTION
## This PR does the following:

- It turns out that `onClear` is very different than `onClearAll` and both are needed for separate situations. We've been using `onClearAll` incorrectly and this update adds back the `onClear` and gives an example of how it should be used.
- This makes it so that when multiple `MultiSelect` components are used in a single `useMultiSelect` hook, that clicking on the "clear" button won't clear the state for _all_ `MultiSelect` but instead just each individual one.

## How has this been tested?

Locally in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
