### PR TITLE
DSD-1717: Update list bullet color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the `"editorMode"` option (pencil) to the `Icon` component.
+- Updates the `ul` bullet color in the `List` component.
 
 ## 3.0.0 (March 14, 2024) React 18 / Chakra 2.8
 

--- a/src/components/List/List.mdx
+++ b/src/components/List/List.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./listChangelogData";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.7.0`    |
-| Latest            | `3.0.0`    |
+| Latest            | Prerelease |
 
 ## Table of Contents
 

--- a/src/components/List/List.mdx
+++ b/src/components/List/List.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./listChangelogData";
 
 # List
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | Prerelease |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.7.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/List/listChangelogData.ts
+++ b/src/components/List/listChangelogData.ts
@@ -10,7 +10,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "2024-03-26",
+    date: "Prerelease",
     version: "3.0.0",
     type: "Update",
     affects: ["Styles", "Accessibility"],

--- a/src/components/List/listChangelogData.ts
+++ b/src/components/List/listChangelogData.ts
@@ -13,6 +13,13 @@ export const changelogData: ChangelogData[] = [
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",
+    affects: ["Styles", "Accessibility"],
+    notes: ["List <ul> bullet color updated."],
+  },
+  {
+    date: "2024-03-14",
+    version: "3.0.0",
+    type: "Update",
     affects: ["Styles"],
     notes: ["Chakra 2.8 update."],
   },

--- a/src/components/List/listChangelogData.ts
+++ b/src/components/List/listChangelogData.ts
@@ -10,7 +10,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "2024-03-14",
+    date: "2024-03-26",
     version: "3.0.0",
     type: "Update",
     affects: ["Styles", "Accessibility"],

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -55,7 +55,7 @@ export const unorderedStyles = (props: ListBaseStyle = {}) => ({
   listStyle: "none",
   li: {
     _before: {
-      color: "ui.gray.medium",
+      color: "ui.border.hover",
       // \2022 is the CSS Code/unicode for a bullet.
       content: props.noStyling ? "unset" : `"\\2022"`,
       // Needed to add space between the bullet and the text.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1717](https://jira.nypl.org/browse/DSD-1717).

## This PR does the following:
- Updates `ul` list bullets to use the `"ui.border.hover"` design token

## How has this been tested?

Locally, Storybook.

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Now compliant with a11y color contrast

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
