### PR TITLE
DSD-1718: Modal heading size update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds the `"editorMode"` option (pencil) to the `Icon` component.
 
+### Updates
+
+- Updates default heading size to `heading4` on Modal component.
+
 ## 3.0.0 (March 14, 2024) React 18 / Chakra 2.8
 
 ### Adds

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -25,6 +25,7 @@ import Link from "../Link/Link";
 - {<Link href="#modaltrigger-component-props" target="_self">ModalTrigger Component Props</Link>}
 - {<Link href="#usemodal" target="_self">useModal</Link>}
 - {<Link href="#usemodal-component-props" target="_self">useModal Component Props</Link>}
+- {<Link href="#default-heading-text" target="_self">Default Heading Text</Link>}
 - {<Link href="#custom-heading-text" target="_self">Custom Heading Text</Link>}
 - {<Link href="#content-window-scrolling" target="_self">Content Window Scrolling</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
@@ -222,10 +223,16 @@ export const ModalStory = (args) => {
 
 <ArgTypes of={ModalStories.useModalStory} />
 
+## Default Heading Text
+
+By default, the `Modal` component will render a DS level `h2` and size `h4` `Heading` component when
+a string is passed to the `headingText` prop.
+
+<Canvas of={ModalStories.DefaultHeading} />
+
 ## Custom Heading Text
 
-By default, the `Modal` component will render a DS h2 `Heading` component when
-a string is passed to the `headingText` prop. However, a custom heading can be
+However, a custom heading can be
 passed to the `headingText` property. This can be useful when you want to add
 additional elements to the heading, such as an icon, or to set the level to
 something other than an `h2`.

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -10,10 +10,10 @@ import Link from "../Link/Link";
 
 # Modal
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -218,6 +218,27 @@ const scrollModalProps = {
   headingText: "Modal Heading Text",
 };
 
+const defaultHeadingModalProps = {
+  bodyContent: (
+    <p>
+      The heading of this modal is level "h2" and size "heading4", since no
+      custom heading element has been passed in.
+    </p>
+  ),
+  closeButtonLabel: "Close Button",
+  headingText: "Default Heading",
+};
+
+export const DefaultHeading: Story = {
+  render: () => (
+    <ModalTrigger
+      buttonText="Button Text"
+      id="modal-scrolling"
+      modalProps={defaultHeadingModalProps}
+    />
+  ),
+};
+
 export const ContentWindowScrolling: Story = {
   render: () => (
     <ModalTrigger

--- a/src/components/Modal/Modal.test.tsx
+++ b/src/components/Modal/Modal.test.tsx
@@ -103,7 +103,7 @@ describe("ModalTrigger", () => {
         modalProps={{
           bodyContent: "body text",
           closeButtonLabel: "Close Button",
-          headingText: <Heading level="h4">Modal Heading Text</Heading>,
+          headingText: <Heading level="h3">Modal Heading Text</Heading>,
           onClose: () => {
             console.log("custom close");
           },
@@ -114,8 +114,33 @@ describe("ModalTrigger", () => {
     const openButton = screen.getByText("Button Text");
     openButton.click();
 
-    expect(screen.getByRole("heading", { level: 4 })).toHaveTextContent(
+    expect(screen.getByRole("heading", { level: 3 })).toHaveTextContent(
       "Modal Heading Text"
+    );
+  });
+
+  it("renders default heading with expected size", () => {
+    render(
+      <ModalTrigger
+        buttonText="Button Text"
+        id="modal-trigger"
+        modalProps={{
+          bodyContent: "body text",
+          closeButtonLabel: "Close Button",
+          headingText: "Modal Heading Text",
+          onClose: () => {
+            console.log("custom close");
+          },
+        }}
+      />
+    );
+
+    const openButton = screen.getByText("Button Text");
+    openButton.click();
+
+    expect(screen.getByRole("heading", { level: 2 })).toHaveStyle(
+      //var(--nypl-fontSizes-mobile-heading-heading4) = 1.5em
+      "font-size: 1.5em"
     );
   });
 

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -67,6 +67,7 @@ export const BaseModal: ChakraComponent<
     const finalTitle = useDSHeading({
       title: headingText,
       id,
+      //headingSize: "heading4",
     });
 
     return (

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -67,7 +67,7 @@ export const BaseModal: ChakraComponent<
     const finalTitle = useDSHeading({
       title: headingText,
       id,
-      //headingSize: "heading4",
+      headingSize: "heading4",
     });
 
     return (

--- a/src/components/Modal/modalChangelogData.ts
+++ b/src/components/Modal/modalChangelogData.ts
@@ -10,7 +10,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "2024-03-26",
+    date: "Prerelease",
     version: "3.0.0",
     type: "Update",
     affects: ["Styles"],

--- a/src/components/Modal/modalChangelogData.ts
+++ b/src/components/Modal/modalChangelogData.ts
@@ -11,10 +11,10 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 export const changelogData: ChangelogData[] = [
   {
     date: "Prerelease",
-    version: "3.0.0",
+    version: "Prerelease",
     type: "Update",
     affects: ["Styles"],
-    notes: ["Sets default heading size to 'heading4' for Modal header."],
+    notes: ["Sets default heading size to 'heading4' for `Modal` header."],
   },
   {
     date: "2024-03-14",

--- a/src/components/Modal/modalChangelogData.ts
+++ b/src/components/Modal/modalChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-03-26",
+    version: "3.0.0",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Sets default heading size to 'heading4' for Modal header."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/hooks/useDSHeading.tsx
+++ b/src/hooks/useDSHeading.tsx
@@ -1,12 +1,12 @@
+import { HeadingProps, Heading } from "../components/Heading/Heading";
 import React from "react";
-
-import Heading from "../components/Heading/Heading";
 
 interface UseDSHeadingProps {
   title: string | JSX.Element;
   id?: string;
   customDefaultHeading?: string | JSX.Element;
   additionalStyles?: { [key: string]: any };
+  headingSize?: HeadingProps["size"];
 }
 
 const headingList = ["h1", "h2", "h3", "h4", "h5", "h6"];
@@ -21,6 +21,7 @@ function useDSHeading({
   id = "",
   customDefaultHeading,
   additionalStyles,
+  headingSize,
 }: UseDSHeadingProps) {
   const headingID = id ? `${id}-heading` : undefined;
   let updatedTitle: null | JSX.Element | string = null;
@@ -29,7 +30,7 @@ function useDSHeading({
     if (typeof title === "string") {
       // Use the DS default h2 heading element if the title is a string.
       updatedTitle = (
-        <Heading id={headingID} __css={additionalStyles}>
+        <Heading size={headingSize} id={headingID} __css={additionalStyles}>
           {title}
         </Heading>
       );

--- a/src/theme/components/modal.ts
+++ b/src/theme/components/modal.ts
@@ -20,10 +20,6 @@ const Modal = defineMultiStyleConfig({
     },
     header: {
       color: "ui.typography.heading",
-      fontSize: {
-        base: "mobile.heading.heading4",
-        md: "desktop.heading.heading4",
-      },
       fontWeight: "medium",
       _dark: {
         color: "dark.ui.typography.heading",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1718](https://jira.nypl.org/browse/DSD-1718)

## This PR does the following:
- Adds optional `headingSize` prop to `useDSHeading` hook
- Updates modal default heading size to `heading4`

## How has this been tested?

Locally, Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.
