### PR TITLE
DSD-1761: placeholder value for MultiSelect search field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the placeholder value for the search field within the `MultiSelect` component.
+
 ## 3.1.0 (April 11, 2024)
 
 ### Adds

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./multiSelectChangelogData";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.4.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -321,7 +321,7 @@ export const MultiSelect: ChakraComponent<
               labelText={`Search ${buttonText}`}
               isClearable={true}
               isClearableCallback={clearSearchKeyword}
-              placeholder={`Search`}
+              placeholder="Search"
               onChange={onChangeSearch}
               showLabel={false}
               showRequiredLabel={false}

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -321,7 +321,7 @@ export const MultiSelect: ChakraComponent<
               labelText={`Search ${buttonText}`}
               isClearable={true}
               isClearableCallback={clearSearchKeyword}
-              placeholder={`Search for options`}
+              placeholder={`Search`}
               onChange={onChangeSearch}
               showLabel={false}
               showRequiredLabel={false}

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Updated the placeholder value for the search field."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1761](https://jira.nypl.org/browse/DSD-1761)

## This PR does the following:

- Updates the placeholder value for the search field within the `MultiSelect` component.

NOTE: We are shortening the placeholder text because the original "Search for options" placeholder value is long enough to get cut off when multiple `MultiSelect` components are used in a `MultiSelectGroup` component row layout.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
