### PR TITLE
DSD-1659: docs for Link component "Visited State Patterns"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds docs for `"Visited State Patterns"` to the `Link` component story page.
+
 ## 3.1.0 (April 11, 2024)
 
 ### Adds

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -22,6 +22,7 @@ import * as LinkStories from "./Link.stories";
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
+- {<Link href="#visited-state-patterns" target="_self">Visited State Patterns</Link>}
 - {<Link href="#all-link-types" target="_self">All Link Types</Link>}
 - {<Link href="#links-with-icons" target="_self">Links With Icons</Link>}
 - {<Link href="#anchor-element-rendering" target="_self">Anchor Element Rendering</Link>}
@@ -73,6 +74,38 @@ Resources:
 - [Yale Usability & Web Accessibility Links](https://usability.yale.edu/web-accessibility/articles/links)
 - [WebAIM: Invisible Content Just for Screen Reader Users](https://webaim.org/techniques/css/invisiblecontent/)
 - [IANA: Link Relation Types](https://www.iana.org/assignments/link-relations/link-relations.xhtml)
+
+## Visited State Patterns
+
+To improve accessibility, the `Link` component by default will render `visited`
+state styles when a link's `href` value matches an entry in a browser's history
+log. In simple terms, a text link will be purple after a user has clicked on it.
+
+The `visited` state styles are most relevant for links within a standard block
+of text, but the `visited` state color change may not be applicable for all
+links. For example, links in main navigation areas (i.e. header or footer) or
+links in a list format may be more effective with standardized styles and
+consistent color throughout.
+
+In cases where the `visited` state styles are not appropriate, the `Link`
+component's `hasVisitedState` prop should be set to `false`. When this is done,
+the `Link` component will not render the default purple `visited` state color
+after a user has clicked on a text link. Rather, the `Link` component will use
+the default NYPL link blue or whatever custom color has been applied to the
+component.
+
+<Source
+  code={`
+<Link
+  hasVisitedState={false}
+  href="https://nypl.org"
+  type="action"
+>
+  NYPL Website
+</Link>
+`}
+  language="jsx"
+/>
 
 ## All Link Types
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1659](https://jira.nypl.org/browse/DSD-1659)

## This PR does the following:

- Adds docs for `"Visited State Patterns"` to the `Link` component story page.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
