### PR TITLE
DSD-1556: better layout for Icon examples

### DIFF
--- a/src/components/Icons/Icon.mdx
+++ b/src/components/Icons/Icon.mdx
@@ -113,7 +113,7 @@ The following icons are for generic purposes. All the available icon names can
 be found in the `IconNames` type.
 
 Note: All of the examples below have been rendered with the `size` prop set to
-`xxlarge`.
+`xlarge`.
 
 <Canvas of={IconStories.AllIcons} />
 

--- a/src/components/Icons/Icon.stories.tsx
+++ b/src/components/Icons/Icon.stories.tsx
@@ -89,9 +89,10 @@ export const WithControls: Story = {
   },
 };
 
-const iconRow = (iconName, opts: any = {}) => {
-  // We'll use this setup function to render all the icons in a list item.
-  // Some icons display better with a dark background.
+const iconElement = (iconName, opts: any = {}, type: string = "grid") => {
+  // Use this setup function to render each icon packaged as a list item or
+  // wrapped in a basic div based on its intended usage. Note: some icons
+  // display better with a dark background.
   const styles: any = { display: "block" };
   const {
     size = "large",
@@ -115,7 +116,7 @@ const iconRow = (iconName, opts: any = {}) => {
     key += `-${size}`;
   }
 
-  return (
+  return type === "list" ? (
     <li
       key={key}
       style={{ marginBottom: "var(--nypl-space-l)", textAlign: "center" }}
@@ -130,35 +131,7 @@ const iconRow = (iconName, opts: any = {}) => {
       </span>
       <Text size="caption">{displayValue}</Text>
     </li>
-  );
-};
-const iconBlock = (iconName, opts: any = {}) => {
-  // We'll use this setup function to render all the icons in a list item.
-  // Some icons display better with a dark background.
-  const styles: any = { display: "block" };
-  const {
-    size = "large",
-    iconRotation = "rotate0",
-    color = "ui.black",
-    displayValue = iconName,
-  } = opts;
-  let key = iconName;
-  if (iconName.indexOf("Negative") !== -1 || color.indexOf("White") !== -1) {
-    styles.backgroundColor = "#000";
-    styles.padding = "1rem";
-  }
-  // The following is just to fix duplicate React key issues.
-  if (iconRotation !== "rotate0") {
-    key += `-${iconRotation}`;
-  }
-  if (color !== "ui.black") {
-    key += `-${color}`;
-  }
-  if (size !== "large") {
-    key += `-${size}`;
-  }
-
-  return (
+  ) : (
     <Box
       alignItems="center"
       display="flex"
@@ -178,6 +151,7 @@ const iconBlock = (iconName, opts: any = {}) => {
     </Box>
   );
 };
+
 const icons = [];
 const rotations = [];
 const colors = [];
@@ -196,7 +170,7 @@ const iconSizesValues = [
 ];
 for (const icon in iconNamesValues) {
   icons.push(
-    iconBlock(iconNamesValues[icon], {
+    iconElement(iconNamesValues[icon], {
       displayValue: iconNamesValues[icon],
       size: "xlarge",
     })
@@ -204,7 +178,7 @@ for (const icon in iconNamesValues) {
 }
 for (const iconRotation in iconRotationsValues) {
   rotations.push(
-    iconBlock("actionLightbulb", {
+    iconElement("actionLightbulb", {
       displayValue: iconRotationsValues[iconRotation],
       iconRotation: iconRotationsValues[iconRotation],
       size: "xxlarge",
@@ -213,7 +187,7 @@ for (const iconRotation in iconRotationsValues) {
 }
 for (const iconColor in iconColorsValues) {
   colors.push(
-    iconBlock("errorFilled", {
+    iconElement("errorFilled", {
       color: iconColorsValues[iconColor],
       displayValue: iconColorsValues[iconColor],
       size: "xxlarge",
@@ -222,10 +196,14 @@ for (const iconColor in iconColorsValues) {
 }
 for (const iconSize in iconSizesValues) {
   sizes.push(
-    iconRow("actionCheckCircle", {
-      displayValue: iconSizesValues[iconSize].display,
-      size: iconSizesValues[iconSize].size,
-    })
+    iconElement(
+      "actionCheckCircle",
+      {
+        displayValue: iconSizesValues[iconSize].display,
+        size: iconSizesValues[iconSize].size,
+      },
+      "list"
+    )
   );
 }
 
@@ -239,7 +217,7 @@ export const Rotations: Story = {
   render: () => allIconsTypeGrid(rotations, 4),
 };
 export const Colors: Story = {
-  render: () => allIconsTypeGrid(colors),
+  render: () => allIconsTypeGrid(colors, 4),
 };
 export const Sizes: Story = {
   render: () => allIconsType(sizes),

--- a/src/components/Icons/Icon.stories.tsx
+++ b/src/components/Icons/Icon.stories.tsx
@@ -1,8 +1,8 @@
+import { Box } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { withDesign } from "storybook-addon-designs";
 import { argsBooleanType } from "../../helpers/storybookUtils";
 
-import Heading from "../Heading/Heading";
 import Icon from "./Icon";
 import {
   iconAlignArray,
@@ -11,6 +11,8 @@ import {
   iconRotationsArray,
   iconSizesArray,
 } from "./iconVariables";
+import SimpleGrid from "../Grid/SimpleGrid";
+import Text from "../Text/Text";
 
 const meta: Meta<typeof Icon> = {
   title: "Components/Media & Icons/Icon",
@@ -118,9 +120,6 @@ const iconRow = (iconName, opts: any = {}) => {
       key={key}
       style={{ marginBottom: "var(--nypl-space-l)", textAlign: "center" }}
     >
-      <Heading level="h4" size="heading6">
-        {displayValue}
-      </Heading>
       <span style={styles}>
         <Icon
           name={iconName}
@@ -129,7 +128,54 @@ const iconRow = (iconName, opts: any = {}) => {
           color={color}
         />
       </span>
+      <Text size="caption">{displayValue}</Text>
     </li>
+  );
+};
+const iconBlock = (iconName, opts: any = {}) => {
+  // We'll use this setup function to render all the icons in a list item.
+  // Some icons display better with a dark background.
+  const styles: any = { display: "block" };
+  const {
+    size = "large",
+    iconRotation = "rotate0",
+    color = "ui.black",
+    displayValue = iconName,
+  } = opts;
+  let key = iconName;
+  if (iconName.indexOf("Negative") !== -1 || color.indexOf("White") !== -1) {
+    styles.backgroundColor = "#000";
+    styles.padding = "1rem";
+  }
+  // The following is just to fix duplicate React key issues.
+  if (iconRotation !== "rotate0") {
+    key += `-${iconRotation}`;
+  }
+  if (color !== "ui.black") {
+    key += `-${color}`;
+  }
+  if (size !== "large") {
+    key += `-${size}`;
+  }
+
+  return (
+    <Box
+      alignItems="center"
+      display="flex"
+      flexBasis="33%"
+      flexDirection="column"
+      key={key}
+    >
+      <span style={styles}>
+        <Icon
+          name={iconName}
+          size={size}
+          iconRotation={iconRotation}
+          color={color}
+        />
+      </span>
+      <Text size="caption">{displayValue}</Text>
+    </Box>
   );
 };
 const icons = [];
@@ -150,15 +196,15 @@ const iconSizesValues = [
 ];
 for (const icon in iconNamesValues) {
   icons.push(
-    iconRow(iconNamesValues[icon], {
+    iconBlock(iconNamesValues[icon], {
       displayValue: iconNamesValues[icon],
-      size: "xxlarge",
+      size: "xlarge",
     })
   );
 }
 for (const iconRotation in iconRotationsValues) {
   rotations.push(
-    iconRow("arrow", {
+    iconBlock("actionLightbulb", {
       displayValue: iconRotationsValues[iconRotation],
       iconRotation: iconRotationsValues[iconRotation],
       size: "xxlarge",
@@ -167,7 +213,7 @@ for (const iconRotation in iconRotationsValues) {
 }
 for (const iconColor in iconColorsValues) {
   colors.push(
-    iconRow("errorFilled", {
+    iconBlock("errorFilled", {
       color: iconColorsValues[iconColor],
       displayValue: iconColorsValues[iconColor],
       size: "xxlarge",
@@ -184,19 +230,20 @@ for (const iconSize in iconSizesValues) {
 }
 
 const allIconsType = (list) => <ul style={{ listStyle: "none" }}>{list}</ul>;
+const allIconsTypeGrid = (list, columns = 6) => <SimpleGrid columns={columns}>{list}</SimpleGrid>;
 
 // The following are additional Icon example Stories.
 export const Rotations: Story = {
-  render: () => allIconsType(rotations),
+  render: () => allIconsTypeGrid(rotations, 4),
 };
 export const Colors: Story = {
-  render: () => allIconsType(colors),
+  render: () => allIconsTypeGrid(colors),
 };
 export const Sizes: Story = {
   render: () => allIconsType(sizes),
 };
 export const AllIcons: Story = {
-  render: () => allIconsType(icons),
+  render: () => allIconsTypeGrid(icons),
 };
 export const CustomIcons: Story = {
   args: {

--- a/src/components/Icons/Icon.stories.tsx
+++ b/src/components/Icons/Icon.stories.tsx
@@ -230,7 +230,9 @@ for (const iconSize in iconSizesValues) {
 }
 
 const allIconsType = (list) => <ul style={{ listStyle: "none" }}>{list}</ul>;
-const allIconsTypeGrid = (list, columns = 6) => <SimpleGrid columns={columns}>{list}</SimpleGrid>;
+const allIconsTypeGrid = (list, columns = 6) => (
+  <SimpleGrid columns={columns}>{list}</SimpleGrid>
+);
 
 // The following are additional Icon example Stories.
 export const Rotations: Story = {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1556](https://jira.nypl.org/browse/DSD-1556)

## This PR does the following:

- Updates the `Icon` component story page to improve the layout of the examples.

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->
- local Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
