### PR TITLE
DSD-1764: Extending Heading prop interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `Heading` component to allow more HTML attributes as props.
+
 ## 3.1.1 (April 25, 2024)
 
 ### Adds

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./headingChangelogData";
 
 # Heading
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -40,6 +40,15 @@ describe("Heading", () => {
     expect(screen.getByText("Heading 2")).toBeInTheDocument();
   });
 
+  it("allows HTML heading attributes as props", () => {
+    render(
+      <Heading id="h1" tabIndex={0}>
+        Heading 2
+      </Heading>
+    );
+    expect(screen.getByRole("heading")).toHaveAttribute("tabindex", "0");
+  });
+
   it("renders the default level two if no `level` prop is passed", () => {
     render(<Heading id="h2">Heading 2</Heading>);
     expect(screen.getByRole("heading", { level: 2 })).toBeInTheDocument();

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -4,6 +4,7 @@ import {
   ChakraComponent,
   Heading as ChakraHeading,
   useMultiStyleConfig,
+  HeadingProps as ChakraHeadingProps,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
@@ -41,7 +42,7 @@ export const headingLevelsArray = [
 export type HeadingSizes = typeof headingSizesArray[number];
 export type HeadingLevels = typeof headingLevelsArray[number];
 
-export interface HeadingProps {
+export interface HeadingProps extends ChakraHeadingProps {
   /** Optional className that appears in addition to `heading` */
   className?: string;
   /** Optional ID that other components can cross reference for accessibility

--- a/src/components/Heading/headingChangelogData.ts
+++ b/src/components/Heading/headingChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Extends prop type to allow heading HTML attributes."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1764](https://jira.nypl.org/browse/DSD-1764)

## This PR does the following:

- Extends the prop interface for the `Heading` component.
- This issue was found in the Research Catalog where devs needed to pass the `tabIndex` prop but it threw a ts error:
  - https://github.com/NYPL/research-catalog/blob/6920382982806ccae7c208745b739e94995e7d7b/pages/search/index.tsx#L168
  - https://github.com/NYPL/research-catalog/blob/6920382982806ccae7c208745b739e94995e7d7b/pages/search/index.tsx#L221

@charmingduchess  just FYI.

## How has this been tested?

Through unit tests and checking the linter.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- Will help in some scenarios where the Heading needs to be programmatically focused.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
