### PR TITLE
DSD-1772: Fixing Table issue where headings rendered twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes an issue with the `Table` component where it rendered the headings twice until the component loaded and applied the desktop styles. This was done by adding inline responsive styles and removing the use of the `useWindowSize` hook.
+
 ## 3.1.1 (April 25, 2024)
 
 ### Adds

--- a/src/components/Table/Table.mdx
+++ b/src/components/Table/Table.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./tableChangelogData";
 
 # Table
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.9`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.9`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Table/Table.test.tsx
+++ b/src/components/Table/Table.test.tsx
@@ -116,9 +116,12 @@ describe("Table", () => {
       />
     );
 
-    expect(screen.getByText("First Name")).toBeInTheDocument();
-    expect(screen.getByText("Last Name")).toBeInTheDocument();
-    expect(screen.getByText("Nick Name")).toBeInTheDocument();
+    // The `Table` renders two set of headers, but the second set
+    // in the body is hidden on desktop and visible on mobile.
+    // For this test, we only want to check the first set of headers.
+    expect(screen.getAllByText("First Name")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Last Name")[0]).toBeInTheDocument();
+    expect(screen.getAllByText("Nick Name")[0]).toBeInTheDocument();
   });
 
   it("renders table data", () => {

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   chakra,
   Table as ChakraTable,
   TableCaption as ChakraTableCaption,
@@ -11,7 +12,6 @@ import {
   ChakraComponent,
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
-import useWindowSize from "../../hooks/useWindowSize";
 
 interface CustomColors {
   backgroundColor?: string;
@@ -79,10 +79,6 @@ export const Table: ChakraComponent<
         useRowHeaders,
       });
 
-      // Based on --nypl-breakpoint-medium
-      const breakpointMedium = 600;
-      const windowDimensions = useWindowSize();
-
       const tableCaption = titleText && (
         <ChakraTableCaption>{titleText}</ChakraTableCaption>
       );
@@ -132,16 +128,14 @@ export const Table: ChakraComponent<
           }
         }
 
-        const cellContent = (key: number, column: string | JSX.Element) => {
-          return windowDimensions.width <= breakpointMedium ? (
-            <>
-              <span>{columnHeaders[key]}</span>
-              <span>{column}</span>
-            </>
-          ) : (
-            column
-          );
-        };
+        const cellContent = (key: number, column: string | JSX.Element) => (
+          <>
+            <Box as="span" display={{ base: "block", md: "none" }}>
+              {columnHeaders[key]}
+            </Box>
+            <span>{column}</span>
+          </>
+        );
 
         return (
           <ChakraTbody>

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -64,7 +64,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -74,7 +76,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -84,7 +88,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -94,7 +100,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -104,7 +112,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -114,7 +124,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -124,7 +136,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -138,7 +152,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -148,7 +164,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -158,7 +176,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -168,7 +188,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -178,7 +200,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -188,7 +212,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -198,7 +224,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -212,7 +240,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -222,7 +252,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -232,7 +264,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -242,7 +276,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -252,7 +288,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -262,7 +300,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -272,7 +312,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -286,7 +328,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -296,7 +340,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -306,7 +352,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -316,7 +364,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -326,7 +376,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -336,7 +388,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -346,7 +400,9 @@ exports[`Table renders the UI snapshot correctly 1`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -427,115 +483,86 @@ exports[`Table renders the UI snapshot correctly 2`] = `
       <td
         className="css-0"
       >
-        Tom
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Tom
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Nook
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Nook
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Tanukichi
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Tanukichi
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Main Street
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Main Street
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        23458
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          23458
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
-      </td>
-    </tr>
-    <tr
-      className="css-0"
-    >
-      <td
-        className="css-0"
-      >
-        Isabelle
-      </td>
-      <td
-        className="css-0"
-      >
-        -
-      </td>
-      <td
-        className="css-0"
-      >
-        Shizue
-      </td>
-      <td
-        className="css-0"
-      >
-        Walnut Street
-      </td>
-      <td
-        className="css-0"
-      >
-        New York
-      </td>
-      <td
-        className="css-0"
-      >
-        23458
-      </td>
-      <td
-        className="css-0"
-      >
-        NY
-      </td>
-    </tr>
-    <tr
-      className="css-0"
-    >
-      <td
-        className="css-0"
-      >
-        K.K.
-      </td>
-      <td
-        className="css-0"
-      >
-        Slider
-      </td>
-      <td
-        className="css-0"
-      >
-        Totakeke
-      </td>
-      <td
-        className="css-0"
-      >
-        Niper Place
-      </td>
-      <td
-        className="css-0"
-      >
-        New York
-      </td>
-      <td
-        className="css-0"
-      >
-        98765
-      </td>
-      <td
-        className="css-0"
-      >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
     <tr
@@ -544,37 +571,262 @@ exports[`Table renders the UI snapshot correctly 2`] = `
       <td
         className="css-0"
       >
-        Sonny
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Isabelle
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Resetti
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          -
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Risetto san
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Shizue
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Village Road
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Walnut Street
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        09873
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          23458
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
+      </td>
+    </tr>
+    <tr
+      className="css-0"
+    >
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          K.K.
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Slider
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Totakeke
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Niper Place
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          98765
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
+      </td>
+    </tr>
+    <tr
+      className="css-0"
+    >
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Sonny
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Resetti
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Risetto san
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Village Road
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          09873
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
   </tbody>
@@ -650,7 +902,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -660,7 +914,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -670,7 +926,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -680,7 +938,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -690,7 +950,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -700,7 +962,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -710,7 +974,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -724,7 +990,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -734,7 +1002,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -744,7 +1014,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -754,7 +1026,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -764,7 +1038,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -774,7 +1050,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -784,7 +1062,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -798,7 +1078,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -808,7 +1090,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -818,7 +1102,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -828,7 +1114,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -838,7 +1126,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -848,7 +1138,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -858,7 +1150,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -872,7 +1166,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -882,7 +1178,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -892,7 +1190,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -902,7 +1202,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -912,7 +1214,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -922,7 +1226,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -932,7 +1238,9 @@ exports[`Table renders the UI snapshot correctly 3`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1014,37 +1322,86 @@ exports[`Table renders the UI snapshot correctly 4`] = `
         className="css-0"
         scope="row"
       >
-        Tom
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Tom
+        </span>
       </th>
       <td
         className="css-0"
       >
-        Nook
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Nook
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Tanukichi
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Tanukichi
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Main Street
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Main Street
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        23458
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          23458
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
     <tr
@@ -1054,37 +1411,86 @@ exports[`Table renders the UI snapshot correctly 4`] = `
         className="css-0"
         scope="row"
       >
-        Isabelle
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Isabelle
+        </span>
       </th>
       <td
         className="css-0"
       >
-        -
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          -
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Shizue
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Shizue
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Walnut Street
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Walnut Street
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        23458
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          23458
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
     <tr
@@ -1094,37 +1500,86 @@ exports[`Table renders the UI snapshot correctly 4`] = `
         className="css-0"
         scope="row"
       >
-        K.K.
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          K.K.
+        </span>
       </th>
       <td
         className="css-0"
       >
-        Slider
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Slider
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Totakeke
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Totakeke
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Niper Place
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Niper Place
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        98765
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          98765
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
     <tr
@@ -1134,37 +1589,86 @@ exports[`Table renders the UI snapshot correctly 4`] = `
         className="css-0"
         scope="row"
       >
-        Sonny
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Sonny
+        </span>
       </th>
       <td
         className="css-0"
       >
-        Resetti
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Resetti
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Risetto san
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Risetto san
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Village Road
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Village Road
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        09873
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          09873
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
   </tbody>
@@ -1241,7 +1745,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
         className="css-0"
         scope="row"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1251,7 +1757,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1261,7 +1769,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1271,7 +1781,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -1281,7 +1793,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -1291,7 +1805,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -1301,7 +1817,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1316,7 +1834,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
         className="css-0"
         scope="row"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1326,7 +1846,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1336,7 +1858,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1346,7 +1870,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -1356,7 +1882,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -1366,7 +1894,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -1376,7 +1906,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1391,7 +1923,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
         className="css-0"
         scope="row"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1401,7 +1935,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1411,7 +1947,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1421,7 +1959,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -1431,7 +1971,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -1441,7 +1983,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -1451,7 +1995,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1466,7 +2012,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
         className="css-0"
         scope="row"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1476,7 +2024,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1486,7 +2036,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1496,7 +2048,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -1506,7 +2060,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -1516,7 +2072,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -1526,7 +2084,9 @@ exports[`Table renders the UI snapshot correctly 5`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1602,115 +2162,86 @@ exports[`Table renders the UI snapshot correctly 6`] = `
       <td
         className="css-0"
       >
-        Tom
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Tom
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Nook
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Nook
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Tanukichi
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Tanukichi
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Main Street
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Main Street
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        23458
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          23458
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
-      </td>
-    </tr>
-    <tr
-      className="css-0"
-    >
-      <td
-        className="css-0"
-      >
-        Isabelle
-      </td>
-      <td
-        className="css-0"
-      >
-        -
-      </td>
-      <td
-        className="css-0"
-      >
-        Shizue
-      </td>
-      <td
-        className="css-0"
-      >
-        Walnut Street
-      </td>
-      <td
-        className="css-0"
-      >
-        New York
-      </td>
-      <td
-        className="css-0"
-      >
-        23458
-      </td>
-      <td
-        className="css-0"
-      >
-        NY
-      </td>
-    </tr>
-    <tr
-      className="css-0"
-    >
-      <td
-        className="css-0"
-      >
-        K.K.
-      </td>
-      <td
-        className="css-0"
-      >
-        Slider
-      </td>
-      <td
-        className="css-0"
-      >
-        Totakeke
-      </td>
-      <td
-        className="css-0"
-      >
-        Niper Place
-      </td>
-      <td
-        className="css-0"
-      >
-        New York
-      </td>
-      <td
-        className="css-0"
-      >
-        98765
-      </td>
-      <td
-        className="css-0"
-      >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
     <tr
@@ -1719,37 +2250,262 @@ exports[`Table renders the UI snapshot correctly 6`] = `
       <td
         className="css-0"
       >
-        Sonny
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Isabelle
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Resetti
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          -
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Risetto san
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Shizue
+        </span>
       </td>
       <td
         className="css-0"
       >
-        Village Road
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Walnut Street
+        </span>
       </td>
       <td
         className="css-0"
       >
-        New York
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
       </td>
       <td
         className="css-0"
       >
-        09873
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          23458
+        </span>
       </td>
       <td
         className="css-0"
       >
-        NY
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
+      </td>
+    </tr>
+    <tr
+      className="css-0"
+    >
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          K.K.
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Slider
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Totakeke
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Niper Place
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          98765
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
+      </td>
+    </tr>
+    <tr
+      className="css-0"
+    >
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          First Name
+        </span>
+        <span>
+          Sonny
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Resetti
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Nick Name
+        </span>
+        <span>
+          Risetto san
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Address1
+        </span>
+        <span>
+          Village Road
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          City
+        </span>
+        <span>
+          New York
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Zipcode
+        </span>
+        <span>
+          09873
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          State
+        </span>
+        <span>
+          NY
+        </span>
       </td>
     </tr>
   </tbody>
@@ -1821,7 +2577,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1831,7 +2589,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1841,7 +2601,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1851,7 +2613,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -1861,7 +2625,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -1871,7 +2637,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -1881,7 +2649,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1895,7 +2665,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1905,7 +2677,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1915,7 +2689,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1925,7 +2701,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -1935,7 +2713,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -1945,7 +2725,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -1955,7 +2737,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -1969,7 +2753,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -1979,7 +2765,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -1989,7 +2777,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -1999,7 +2789,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -2009,7 +2801,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -2019,7 +2813,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -2029,7 +2825,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -2043,7 +2841,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           First Name
         </span>
         <span>
@@ -2053,7 +2853,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Last Name
         </span>
         <span>
@@ -2063,7 +2865,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Nick Name
         </span>
         <span>
@@ -2073,7 +2877,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Address1
         </span>
         <span>
@@ -2083,7 +2889,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           City
         </span>
         <span>
@@ -2093,7 +2901,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           Zipcode
         </span>
         <span>
@@ -2103,7 +2913,9 @@ exports[`Table renders the UI snapshot correctly 7`] = `
       <td
         className="css-0"
       >
-        <span>
+        <span
+          className="css-dsyim5"
+        >
           State
         </span>
         <span>
@@ -2155,26 +2967,47 @@ exports[`Table renders the UI snapshot correctly 8`] = `
       <td
         className="css-0"
       >
-        Tom
-      </td>
-      <td
-        className="css-0"
-      >
-        Nook
-      </td>
-      <td
-        className="css-0"
-      >
-        <div
-          className="css-0"
+        <span
+          className="css-dsyim5"
         >
-          <img
-            alt="Tom Nook"
+          First Name
+        </span>
+        <span>
+          Tom
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Nook
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Avatar
+        </span>
+        <span>
+          <div
             className="css-0"
-            onError={[Function]}
-            src="https://play.nintendo.com/images/AC_Tom_FRYtwIN.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
-          />
-        </div>
+          >
+            <img
+              alt="Tom Nook"
+              className="css-0"
+              onError={[Function]}
+              src="https://play.nintendo.com/images/AC_Tom_FRYtwIN.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
+            />
+          </div>
+        </span>
       </td>
     </tr>
     <tr
@@ -2183,26 +3016,45 @@ exports[`Table renders the UI snapshot correctly 8`] = `
       <td
         className="css-0"
       >
-        Isabelle
-      </td>
-      <td
-        className="css-0"
-      >
-        -
-      </td>
-      <td
-        className="css-0"
-      >
-        <div
-          className="css-0"
+        <span
+          className="css-dsyim5"
         >
-          <img
-            alt="Isabelle"
+          First Name
+        </span>
+        <span>
+          Isabelle
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          -
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        />
+        <span>
+          <div
             className="css-0"
-            onError={[Function]}
-            src="https://play.nintendo.com/images/AC_Isabelle_7XU6aGu.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
-          />
-        </div>
+          >
+            <img
+              alt="Isabelle"
+              className="css-0"
+              onError={[Function]}
+              src="https://play.nintendo.com/images/AC_Isabelle_7XU6aGu.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
+            />
+          </div>
+        </span>
       </td>
     </tr>
     <tr
@@ -2211,26 +3063,45 @@ exports[`Table renders the UI snapshot correctly 8`] = `
       <td
         className="css-0"
       >
-        K.K.
-      </td>
-      <td
-        className="css-0"
-      >
-        Slider
-      </td>
-      <td
-        className="css-0"
-      >
-        <div
-          className="css-0"
+        <span
+          className="css-dsyim5"
         >
-          <img
-            alt="K.K Slider"
+          First Name
+        </span>
+        <span>
+          K.K.
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        >
+          Last Name
+        </span>
+        <span>
+          Slider
+        </span>
+      </td>
+      <td
+        className="css-0"
+      >
+        <span
+          className="css-dsyim5"
+        />
+        <span>
+          <div
             className="css-0"
-            onError={[Function]}
-            src="https://play.nintendo.com/images/AC_KK_jh4yj5t.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
-          />
-        </div>
+          >
+            <img
+              alt="K.K Slider"
+              className="css-0"
+              onError={[Function]}
+              src="https://play.nintendo.com/images/AC_KK_jh4yj5t.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
+            />
+          </div>
+        </span>
       </td>
     </tr>
   </tbody>

--- a/src/components/Table/tableChangelogData.ts
+++ b/src/components/Table/tableChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Adds inline responsive styles and removes the use of the useWindowSize hook.",
+    ],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1772](https://jira.nypl.org/browse/DSD-1772)

## This PR does the following:

- This issue was caught in the Research Catalog. Check the tables for each search result: http://qa-www.nypl.org/research/research-catalog/search?q=shakespeare
- This component used the `useWindowSize` hook which was used to conditionally render headings in the body for the mobile view. This cause a flash while the correct style was applied. The problem with this is that it depends on javascript to load. So, the mobile view rendered the mobile headings on desktop, once the component loaded it called the `useWindowSize` hook, then it conditionally removed the mobile headings on desktop. 
- This removes the `useWindowSize` hook and applies the styles through Chakra's responsive inline styles.

## How has this been tested?

In Storybook.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
