### PR TITLE
DSD-1773 and DSD-1774: adding id as prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `fallbackSrc` and `onError` props to the `Image` component.
 - Adds the `fallbackSrc` and `onError` properties to the `imageProps` prop for the `Hero` component.
 - Adds the `isDarkText` prop to the `Hero` component.
+- Adds the `id` prop to the `Hero`, `HorizontalRule`, `SkeletonLoader`, `TemplateAppContainer`, and `Text` components.
+- Adds the `id` property to the `imageProps` prop object in the `Card` component.
 
 ### Updates
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -9,10 +9,10 @@ import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 # Card
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Card/Card.test.tsx
+++ b/src/components/Card/Card.test.tsx
@@ -17,6 +17,7 @@ describe("Card Accessibility", () => {
         id="cardID"
         imageProps={{
           alt: "Alt text",
+          id: "img-id",
           src: getPlaceholderImage("smaller", 0),
         }}
       >
@@ -65,6 +66,7 @@ describe("Card", () => {
       id="regularCard"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-regularCard",
         src: getPlaceholderImage("smaller", 0),
       }}
       ref={ref}
@@ -86,6 +88,7 @@ describe("Card", () => {
       id="cardWithExtendedStyles"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-cardWithExtendedStyles",
         src: getPlaceholderImage("smaller", 0),
       }}
     >
@@ -122,6 +125,7 @@ describe("Card", () => {
       id="cardWithNoCTAs"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-cardWithNoCTAs",
         src: getPlaceholderImage("smaller", 0),
       }}
     >
@@ -141,6 +145,7 @@ describe("Card", () => {
       id="cardWithNoContent"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-cardWithNoContent",
         src: getPlaceholderImage("smaller", 0),
       }}
     >
@@ -190,6 +195,7 @@ describe("Card", () => {
       id="fullclick"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-fullclick",
         src: getPlaceholderImage("smaller", 0),
       }}
       mainActionLink="http://nypl.org"
@@ -224,6 +230,7 @@ describe("Card", () => {
       id="cardID"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-cardWithRightActions",
         src: getPlaceholderImage("smaller", 0),
       }}
       isAlignedRightActions
@@ -249,6 +256,7 @@ describe("Card", () => {
       id="chakraProps"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-chakraProps",
         src: getPlaceholderImage("smaller", 0),
       }}
       p="s"
@@ -270,6 +278,7 @@ describe("Card", () => {
       id="otherProps"
       imageProps={{
         alt: "Alt text",
+        id: "img-id-otherProps",
         src: getPlaceholderImage("smaller", 0),
       }}
       data-testid="card-testid"
@@ -296,6 +305,7 @@ describe("Card", () => {
     expect(container.querySelector("h3")).toBeInTheDocument();
     expect(screen.getByText("The Card Heading")).toBeInTheDocument();
     expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute("id", "img-id-regularCard");
     expect(screen.getByText("middle column content")).toBeInTheDocument();
     expect(screen.getByText("Example CTA")).toBeInTheDocument();
   });
@@ -307,6 +317,10 @@ describe("Card", () => {
     expect(container.querySelector("h2")).toBeInTheDocument();
     expect(screen.getByText("The Card Heading")).toBeInTheDocument();
     expect(screen.getByRole("img")).toBeInTheDocument();
+    expect(screen.getByRole("img")).toHaveAttribute(
+      "id",
+      "img-id-cardWithExtendedStyles"
+    );
     expect(
       screen.getByText(/Published in New York by Random House/i)
     ).toBeInTheDocument();

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -87,6 +87,7 @@ function CardImage(
     caption,
     component,
     credit,
+    id,
     isAtEnd,
     isCentered,
     isLazy,
@@ -110,6 +111,7 @@ function CardImage(
         caption={caption}
         component={component}
         credit={credit}
+        id={id}
         isLazy={isLazy}
         size={size}
         src={src}
@@ -218,6 +220,7 @@ export const Card: ChakraComponent<
           caption: undefined,
           component: undefined,
           credit: undefined,
+          id: undefined,
           isAtEnd: false,
           isLazy: false,
           size: "default",
@@ -330,6 +333,7 @@ export const Card: ChakraComponent<
               caption={imageProps.caption}
               component={imageProps.component}
               credit={imageProps.credit}
+              id={imageProps.id}
               isAtEnd={imageProps.isAtEnd}
               isLazy={imageProps.isLazy}
               layout={layout}

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Card Renders the UI snapshot correctly 1`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-regularCard"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -64,6 +65,7 @@ exports[`Card Renders the UI snapshot correctly 2`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-cardWithExtendedStyles"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -164,6 +166,7 @@ exports[`Card Renders the UI snapshot correctly 3`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-cardWithNoCTAs"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -210,6 +213,7 @@ exports[`Card Renders the UI snapshot correctly 4`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-cardWithNoContent"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -391,6 +395,7 @@ exports[`Card Renders the UI snapshot correctly 6`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-fullclick"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -446,6 +451,7 @@ exports[`Card Renders the UI snapshot correctly 7`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-cardWithRightActions"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -508,6 +514,7 @@ exports[`Card Renders the UI snapshot correctly 8`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-chakraProps"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -559,6 +566,7 @@ exports[`Card Renders the UI snapshot correctly 9`] = `
       <img
         alt="Alt text"
         className="css-0"
+        id="img-id-otherProps"
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />

--- a/src/components/Card/cardChangelogData.ts
+++ b/src/components/Card/cardChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: ["Adds `id` to the `imageProps` prop."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -16,10 +16,10 @@ import Link from "../Link/Link";
 
 # Hero
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.2.0`    |
-| Latest            | `3.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -21,6 +21,7 @@ export const otherSubHeaderText =
   "Visit us today.";
 const imageProps = {
   alt: "Image example",
+  id: "image-example",
   src: getPlaceholderImage("smaller", 0),
 };
 
@@ -30,6 +31,7 @@ describe("Hero accessbility tests", () => {
       <Hero
         heroType="primary"
         heading={<Heading level="h1" id="a11y-hero" text="Hero Primary" />}
+        id="primary-hero"
         subHeaderText="Example Subtitle"
         backgroundImageSrc={getPlaceholderImage("smaller", 0)}
       />
@@ -687,19 +689,21 @@ describe("Hero", () => {
     expect(withOtherProps).toMatchSnapshot();
   });
 
-  it("passes a ref to the div wrapper element", () => {
+  it("passes a ref and id to the div wrapper element", () => {
     const ref = React.createRef<HTMLDivElement>();
     const { container } = render(
       <Hero
         backgroundImageSrc={getPlaceholderImage("smaller", 0)}
         heroType="primary"
         heading={<Heading level="h1" id="primary-hero" text="Hero Primary" />}
+        id="hero-id"
         ref={ref}
         subHeaderText="Example Subtitle"
       />
     );
 
     expect(container.querySelector("div")).toBe(ref.current);
+    expect(container.querySelector("#hero-id")).toBeInTheDocument();
   });
 });
 describe("Test getTextColor function (hero.ts)", () => {

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -32,7 +32,7 @@ export const heroSecondaryTypes = [
 export interface HeroImageProps
   extends Pick<
     ComponentImageProps,
-    "alt" | "fallbackSrc" | "src" | "onError"
+    "alt" | "fallbackSrc" | "id" | "src" | "onError"
   > {}
 export interface HeroProps {
   /**
@@ -57,6 +57,8 @@ export interface HeroProps {
   heading?: JSX.Element;
   /** Used to control how the `Hero` component will be rendered. */
   heroType?: HeroTypes;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
   /** Object used to create and render the `Image` component. Note that only
    * `alt`, `component`, and `src` are the available attributes to pass. If
    * `imageProps.alt` is left blank, a warning will be logged to the console and
@@ -95,8 +97,10 @@ export const Hero: ChakraComponent<
         foregroundColor,
         heading,
         heroType,
+        id,
         imageProps = {
           alt: "",
+          id: undefined,
           src: "",
         },
         isDarkText,
@@ -295,6 +299,7 @@ export const Hero: ChakraComponent<
         <Image
           alt={imageProps.alt}
           fallbackSrc={imageProps.fallbackSrc}
+          id={imageProps.id}
           onError={imageProps.onError}
           src={imageProps.src}
         />
@@ -348,6 +353,7 @@ export const Hero: ChakraComponent<
         <Box
           data-testid="hero"
           data-responsive-background-image
+          id={id}
           ref={ref}
           __css={{
             ...styles.base,

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -55,6 +55,7 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -100,6 +101,7 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -145,6 +147,7 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -190,6 +193,7 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -235,6 +239,7 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -312,6 +317,7 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -361,6 +367,7 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
         <img
           alt="Image example"
           className="css-0"
+          id="image-example"
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: ["Adds `id` prop."],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",

--- a/src/components/HorizontalRule/HorizontalRule.mdx
+++ b/src/components/HorizontalRule/HorizontalRule.mdx
@@ -9,10 +9,10 @@ import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 # HorizontalRule
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.0`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/HorizontalRule/HorizontalRule.test.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.test.tsx
@@ -14,7 +14,7 @@ describe("HorizontalRule Accessibility", () => {
 
 describe("HorizontalRule", () => {
   it("renders HorizontalRule component", () => {
-    render(<HorizontalRule />);
+    render(<HorizontalRule id="hr-id" />);
     expect(screen.getByRole("separator")).toBeInTheDocument();
   });
 
@@ -54,8 +54,9 @@ describe("HorizontalRule", () => {
 
   it("passes a ref to the hr element", () => {
     const ref = React.createRef<HTMLDivElement & HTMLHRElement>();
-    const { container } = render(<HorizontalRule ref={ref} />);
+    const { container } = render(<HorizontalRule id="hr-id" ref={ref} />);
 
     expect(container.querySelector("hr")).toBe(ref.current);
+    expect(container.querySelector("#hr-id")).toBeInTheDocument();
   });
 });

--- a/src/components/HorizontalRule/HorizontalRule.tsx
+++ b/src/components/HorizontalRule/HorizontalRule.tsx
@@ -9,6 +9,8 @@ export interface HorizontalRuleProps {
   align?: "left" | "right";
   /** ClassName you can add in addition to `horizontal-rule` */
   className?: string;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
 }
 
 export const HorizontalRule: ChakraComponent<
@@ -20,7 +22,7 @@ export const HorizontalRule: ChakraComponent<
 > = chakra(
   forwardRef<HTMLDivElement & HTMLHRElement, HorizontalRuleProps>(
     (props, ref?) => {
-      const { align, className, ...rest } = props;
+      const { align, className, id, ...rest } = props;
       const styles = useStyleConfig("HorizontalRule", { align });
 
       const finalStyles = {
@@ -33,6 +35,7 @@ export const HorizontalRule: ChakraComponent<
         <Box
           as="hr"
           className={className}
+          id={id}
           ref={ref}
           __css={finalStyles}
           {...rest}

--- a/src/components/HorizontalRule/horizontalRuleChangelogData.ts
+++ b/src/components/HorizontalRule/horizontalRuleChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: ["Adds `id` prop."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/SkeletonLoader/SkeletonLoader.mdx
+++ b/src/components/SkeletonLoader/SkeletonLoader.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # SkeletonLoader
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.17.3`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.17.3`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/SkeletonLoader/SkeletonLoader.test.tsx
+++ b/src/components/SkeletonLoader/SkeletonLoader.test.tsx
@@ -15,10 +15,11 @@ describe("SkeletonLoader Accessibility", () => {
 describe("SkeletonLoader", () => {
   it("renders default layout", () => {
     const { container } = render(
-      <SkeletonLoader className="skeleton-loader" />
+      <SkeletonLoader className="skeleton-loader" id="skeleton" />
     );
 
     expect(container.querySelector(".skeleton-loader")).toBeInTheDocument();
+    expect(container.querySelector("#skeleton")).toBeInTheDocument();
   });
 
   it("renders in the column or row layout", () => {

--- a/src/components/SkeletonLoader/SkeletonLoader.tsx
+++ b/src/components/SkeletonLoader/SkeletonLoader.tsx
@@ -26,6 +26,8 @@ export interface SkeletonLoaderProps {
   /** Optional numeric value to control the number of lines for heading
    * placeholder; default value is `1`. */
   headingSize?: number;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
   /** Optional value to control the aspect ratio of the image placeholder;
    * default value is `"square"`. */
   imageAspectRatio?: SkeletonLoaderImageRatios;
@@ -65,6 +67,7 @@ export const SkeletonLoader: ChakraComponent<
         contentSize = 3,
         headingSize = 1,
         imageAspectRatio = "square",
+        id,
         isBordered = false,
         layout = "column",
         showButton = false,
@@ -113,6 +116,7 @@ export const SkeletonLoader: ChakraComponent<
       return (
         <Box
           className={className}
+          id={id}
           ref={ref}
           __css={styles.base}
           style={{ width }}

--- a/src/components/SkeletonLoader/skeletonLoaderChangelogData.ts
+++ b/src/components/SkeletonLoader/skeletonLoaderChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: ["Adds `id` prop."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/Template/Template.mdx
+++ b/src/components/Template/Template.mdx
@@ -22,10 +22,10 @@ import Link from "../Link/Link";
 
 # Template
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.3.6`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.3.6`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Template/Template.test.tsx
+++ b/src/components/Template/Template.test.tsx
@@ -105,6 +105,7 @@ describe("TemplateAppContainer component", () => {
       <TemplateAppContainer
         aboveHeader={aboveHeader}
         header={header}
+        id="template-id"
         breakout={breakout}
         sidebar={sidebar}
         contentTop={contentTop}
@@ -114,6 +115,7 @@ describe("TemplateAppContainer component", () => {
       />
     );
     expect(container.querySelector("#mainContent")).toBeInTheDocument();
+    expect(container.querySelector("#template-id")).toBeInTheDocument();
     expect(screen.getByRole("main")).toHaveAttribute("id", "mainContent");
   });
 

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -3,7 +3,10 @@ import React, { forwardRef } from "react";
 
 import SkipNavigation from "../SkipNavigation/SkipNavigation";
 
-export interface TemplateProps {}
+export interface TemplateProps {
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
+}
 export interface TemplateHeaderProps {
   /** Flag to render an HTML header element. True by default. */
   renderHeaderElement?: boolean;
@@ -47,6 +50,8 @@ export interface TemplateAppContainerProps
   footer?: React.ReactElement;
   /** DOM that will be rendered in the `TemplateHeader` component section. */
   header?: React.ReactElement;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
   /** Render the `SkipNavigation` component or not. False by default. */
   renderSkipNavigation?: boolean;
 }
@@ -65,7 +70,7 @@ const Template: ChakraComponent<
     (props, ref?) => {
       const styles = useStyleConfig("Template", {});
       return (
-        <Box ref={ref} __css={styles} {...props}>
+        <Box id={props.id} ref={ref} __css={styles} {...props}>
           {props.children}
         </Box>
       );
@@ -306,6 +311,7 @@ export const TemplateAppContainer: ChakraComponent<
       contentTop,
       footer,
       header,
+      id,
       sidebar = "none",
       renderFooterElement = true,
       renderHeaderElement = true,
@@ -330,7 +336,7 @@ export const TemplateAppContainer: ChakraComponent<
     return (
       <>
         {renderSkipNavigation ? <SkipNavigation /> : null}
-        <Template ref={ref} {...rest}>
+        <Template id={id} ref={ref} {...rest}>
           <TemplateBreakout>
             {aboveHeaderElem}
             {(header || breakout) && (

--- a/src/components/Template/templateChangelogData.ts
+++ b/src/components/Template/templateChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: ["Adds `id` prop."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/Text/Text.mdx
+++ b/src/components/Text/Text.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./textChangelogData";
 
 # Text
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.1`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.1`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Text/Text.test.tsx
+++ b/src/components/Text/Text.test.tsx
@@ -102,9 +102,18 @@ describe("Text", () => {
     );
   });
 
+  it("passes a ref to the div wrapper element", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    const { container } = render(
+      <Text ref={ref}>Animal Crossing is all that!</Text>
+    );
+
+    expect(container.querySelectorAll("p")[0]).toBe(ref.current);
+  });
+
   it("renders the UI snapshot correctly", () => {
     const defaultText = renderer
-      .create(<Text>Animal Crossing is all that!</Text>)
+      .create(<Text id="default-text">Animal Crossing is all that!</Text>)
       .toJSON();
     const body1 = renderer
       .create(<Text size="body1">Animal Crossing is all that!</Text>)
@@ -135,7 +144,11 @@ describe("Text", () => {
       )
       .toJSON();
     const withOtherProps = renderer
-      .create(<Text data-testid="props">Animal Crossing is all that!</Text>)
+      .create(
+        <Text data-testid="props" id="html-id">
+          Animal Crossing is all that!
+        </Text>
+      )
       .toJSON();
 
     expect(defaultText).toMatchSnapshot();
@@ -148,14 +161,5 @@ describe("Text", () => {
     expect(overline2).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
-  });
-
-  it("passes a ref to the div wrapper element", () => {
-    const ref = React.createRef<HTMLDivElement>();
-    const { container } = render(
-      <Text ref={ref}>Animal Crossing is all that!</Text>
-    );
-
-    expect(container.querySelectorAll("p")[0]).toBe(ref.current);
   });
 });

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -23,6 +23,8 @@ export type TextSizes = typeof textSizesArray[number];
 export interface TextProps {
   /** Additional class name to render in the `Text` component. */
   className?: string;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
   /** Optional prop used to show bolded text */
   isBold?: boolean;
   /** Optional prop used to show itlicized text */
@@ -52,6 +54,7 @@ export const Text: ChakraComponent<
       const {
         children,
         className = "",
+        id,
         isBold,
         isItalic,
         isCapitalized,
@@ -128,6 +131,7 @@ export const Text: ChakraComponent<
       return (
         <ChakraText
           className={className}
+          id={id}
           ref={ref}
           role={role}
           sx={styles}

--- a/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Text renders the UI snapshot correctly 1`] = `
 <p
   className="chakra-text css-1xdhyk6"
+  id="default-text"
 >
   Animal Crossing is all that!
 </p>
@@ -76,6 +77,7 @@ exports[`Text renders the UI snapshot correctly 10`] = `
 <p
   className="chakra-text css-1xdhyk6"
   data-testid="props"
+  id="html-id"
 >
   Animal Crossing is all that!
 </p>

--- a/src/components/Text/textChangelogData.ts
+++ b/src/components/Text/textChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: ["Adds `id` prop."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1773](https://jira.nypl.org/browse/DSD-1773) and [DSD-1774](https://jira.nypl.org/browse/DSD-1774).

## This PR does the following:

This fixes two raised issues:
- Passes the `id` property to the `imageProps` prop object in the `Card` component.
- Adds `id` as a prop in the `Text` component.

But also went ahead and verified that all components have the `id` prop. Some did not have it so I added it for the `Hero`, `HorizontalRule`, `SkeletonLoader`, `Template`, and `Text` components.

## How has this been tested?

Unit tests.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A 

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
