### PR TITLE
DSd-1735: Exporting helper chakra functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Exports `useMediaQuery` and `chakra` from Chakra UI.
+
 ## 3.1.2 (May 9, 2024)
 
 ### Adds

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import "./styles.scss";
 export {
   Box,
   Center,
+  chakra,
   Circle,
   ColorModeScript,
   cookieStorageManager,
@@ -21,6 +22,7 @@ export {
   useColorMode,
   useColorModeValue,
   useStyleConfig,
+  useMediaQuery,
   useMultiStyleConfig,
   VStack,
 } from "@chakra-ui/react";


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1735](https://jira.nypl.org/browse/DSD-1735)

## This PR does the following:

- Exports `chakra` and `useMediaQuery` chakra functions. Some consuming apps (such as the Header app) use these helper functions.

## How has this been tested?

N/A

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
