### PR TITLE
DSD-1565: Fixing a breadcrumbs test to have the appropriate type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes a `Breadcrumbs` snapshot test that was duplicated and now has the appropriate `"locations"` variant.
+
 ## 3.1.2 (May 9, 2024)
 
 ### Adds

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import { axe } from "jest-axe";
-import * as React from "react";
+import { createRef } from "react";
 import renderer from "react-test-renderer";
 
 import Breadcrumbs from "./Breadcrumbs";
@@ -92,7 +92,7 @@ describe("Breadcrumbs", () => {
   it("passes a ref to the nav wrapper element", () => {
     // It's okay to use this type even though the rendered element is
     // a `nav` since Chakra internally generates the necessary DOM.
-    const ref = React.createRef<HTMLDivElement>();
+    const ref = createRef<HTMLDivElement>();
     const { container } = render(
       <Breadcrumbs breadcrumbsData={breadcrumbsData} ref={ref} />
     );
@@ -130,7 +130,7 @@ describe("Breadcrumbs Snapshot", () => {
       .create(
         <Breadcrumbs
           breadcrumbsData={breadcrumbsData}
-          breadcrumbsType="blogs"
+          breadcrumbsType="locations"
           id="breadcrumbs-test"
         />
       )


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1565](https://jira.nypl.org/browse/DSD-1565)

## This PR does the following:

- There was a duplicate snapshot test for the `Breadcrumbs` component that used the same type value. It was updated to use the "locations" variant type.

## How has this been tested?

Local tests.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
