### PR TITLE
DSD-1729: Adding showRowDividers prop to hide List description list  dividers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds `showRowDividers` prop to show/hide row dividers for the `List` `"dl"` variant.
+
 ## 3.1.2 (May 9, 2024)
 
 ### Adds

--- a/src/components/List/List.mdx
+++ b/src/components/List/List.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./listChangelogData";
 
 # List
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | `3.0.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.7.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -60,6 +60,10 @@ may still use this name. In the Reservoir Design System, we will use the
 To render a description list, pass in `"dl"` to the `type` prop. The optional
 `title` prop will now render above the description list element. This type of
 list renders `dt` and `dd` elements.
+
+By default, the `"dl"` description list will render row dividers between each
+`dt`/`dd` pair. To remove the row dividers, pass `false` to the
+`showRowDividers` prop.
 
 <Source
   code={`

--- a/src/components/List/List.stories.tsx
+++ b/src/components/List/List.stories.tsx
@@ -18,6 +18,7 @@ const meta: Meta<typeof List> = {
     inline: argsBooleanType(),
     listItems: { control: false },
     noStyling: argsBooleanType(),
+    showRowDividers: argsBooleanType(true),
     title: { control: { type: "text" } },
     type: {
       control: { type: "radio" },
@@ -125,6 +126,7 @@ export const WithControls: Story = {
     inline: false,
     listItems: undefined,
     noStyling: false,
+    showRowDividers: true,
     title: "Middle-Earth Peoples",
     type: "ul",
   },
@@ -152,10 +154,12 @@ export const DescriptionList: Story = {
   args: {
     id: "nypl-list2",
     noStyling: false,
+    showRowDividers: true,
     title: "Middle-Earth Peoples",
   },
   argTypes: {
     inline: { control: false },
+    showRowDividers: { control: { type: "boolean" } },
     noStyling: { control: false },
     type: { control: false },
   },

--- a/src/components/List/List.test.tsx
+++ b/src/components/List/List.test.tsx
@@ -230,6 +230,17 @@ describe("List", () => {
         />
       )
       .toJSON();
+    const descriptionWithoutDividers = renderer
+      .create(
+        <List
+          id="description"
+          type="dl"
+          title="Animal Crossing Fish"
+          showRowDividers={false}
+          listItems={fishDescriptions}
+        />
+      )
+      .toJSON();
     const withChakraPropsUnordered = renderer
       .create(
         <List
@@ -275,6 +286,7 @@ describe("List", () => {
     expect(ordered).toMatchSnapshot();
     expect(orderedNoStyling).toMatchSnapshot();
     expect(description).toMatchSnapshot();
+    expect(descriptionWithoutDividers).toMatchSnapshot();
     expect(withChakraPropsUnordered).toMatchSnapshot();
     expect(withOtherPropsUnordered).toMatchSnapshot();
     expect(withChakraPropsDescription).toMatchSnapshot();

--- a/src/components/List/List.tsx
+++ b/src/components/List/List.tsx
@@ -33,6 +33,8 @@ export interface ListProps {
   listItems?: (string | JSX.Element | DescriptionProps)[];
   /** Remove list styling. */
   noStyling?: boolean;
+  /** Show dividers between rows for the description list variant. */
+  showRowDividers?: boolean;
   /** Optional string value used to set the text for a `Heading` component, or
    * a DS Heading component that can be passed in. This title only applies to
    * to Description Lists and will render above the list. */
@@ -64,6 +66,7 @@ export const List: ChakraComponent<
       inline = false,
       listItems,
       noStyling = false,
+      showRowDividers = true,
       title,
       type = "ul",
       ...rest
@@ -71,6 +74,7 @@ export const List: ChakraComponent<
     const styles = useMultiStyleConfig("ReservoirList", {
       inline,
       noStyling,
+      showRowDividers,
       variant: type,
     });
     const finalTitle = useDSHeading({

--- a/src/components/List/__snapshots__/List.test.tsx.snap
+++ b/src/components/List/__snapshots__/List.test.tsx.snap
@@ -111,6 +111,36 @@ exports[`List Renders the UI snapshot correctly 5`] = `
 `;
 
 exports[`List Renders the UI snapshot correctly 6`] = `
+<section
+  className="css-1xdhyk6"
+  id="description"
+>
+  <h2
+    className="chakra-heading css-1xdhyk6"
+    id="description-heading"
+  >
+    Animal Crossing Fish
+  </h2>
+  <dl>
+    <dt>
+      Mahi-mahi
+    </dt>
+    <dd>
+      <p>
+        The mahi-mahi is an ocean fish known...
+      </p>
+    </dd>
+    <dt>
+      Golden trout
+    </dt>
+    <dd>
+      The golden trout is a beautifully colored fish...
+    </dd>
+  </dl>
+</section>
+`;
+
+exports[`List Renders the UI snapshot correctly 7`] = `
 <ul
   className="css-kle7zy"
   id="chakra"
@@ -130,7 +160,7 @@ exports[`List Renders the UI snapshot correctly 6`] = `
 </ul>
 `;
 
-exports[`List Renders the UI snapshot correctly 7`] = `
+exports[`List Renders the UI snapshot correctly 8`] = `
 <ul
   className="css-1xdhyk6"
   data-testid="other"
@@ -151,7 +181,7 @@ exports[`List Renders the UI snapshot correctly 7`] = `
 </ul>
 `;
 
-exports[`List Renders the UI snapshot correctly 8`] = `
+exports[`List Renders the UI snapshot correctly 9`] = `
 <section
   className="css-kle7zy"
   id="chakra"
@@ -181,7 +211,7 @@ exports[`List Renders the UI snapshot correctly 8`] = `
 </section>
 `;
 
-exports[`List Renders the UI snapshot correctly 9`] = `
+exports[`List Renders the UI snapshot correctly 10`] = `
 <section
   className="css-1xdhyk6"
   data-testid="other"

--- a/src/components/List/listChangelogData.ts
+++ b/src/components/List/listChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "New Feature",
+    affects: ["Styles"],
+    notes: [
+      "Adds `showRowDividers` prop to show/hide dividers between rows only for the description list variant.",
+    ],
+  },
+  {
     date: "2024-03-28",
     version: "3.0.1",
     type: "Update",

--- a/src/theme/components/list.ts
+++ b/src/theme/components/list.ts
@@ -30,25 +30,25 @@ export const baseListStyles = (props: ListBaseStyle = {}) => ({
   },
 });
 
-const baseHeadingStyles = {
-  borderTop: "3px solid",
+const baseHeadingStyles = (showRowDividers = true) => ({
+  borderTop: showRowDividers ? "3px solid" : "none",
   borderColor: "ui.border.default",
   margin: "0",
   padding: "var(--nypl-space-xs) 0 0",
   _dark: {
     borderColor: "dark.ui.border.default",
   },
-};
+});
 
-export const baseSectionDescriptionStyles = {
-  borderBottom: "1px solid",
+export const baseSectionDescriptionStyles = (showRowDividers = true) => ({
+  borderBottom: showRowDividers ? "1px solid" : "none",
   borderColor: "ui.border.default",
   paddingStart: "0",
-  h2: baseHeadingStyles,
+  h2: baseHeadingStyles(showRowDividers),
   _dark: {
     borderColor: "dark.ui.border.default",
   },
-};
+});
 // For specific component variants
 export const unorderedStyles = (props: ListBaseStyle = {}) => ({
   ...textMargin,
@@ -74,8 +74,8 @@ export const unorderedStyles = (props: ListBaseStyle = {}) => ({
   },
 });
 
-export const descriptionStyles = {
-  ...baseSectionDescriptionStyles,
+export const descriptionStyles = (showRowDividers = true) => ({
+  ...baseSectionDescriptionStyles(showRowDividers),
   dl: {
     display: "grid",
     gridTemplateColumns: { base: "100%", md: "max(250px) 1fr" },
@@ -83,7 +83,7 @@ export const descriptionStyles = {
     margin: "var(--nypl-space-xs) 0 0",
   },
   dt: {
-    borderTop: "1px solid",
+    borderTop: showRowDividers ? "1px solid" : "none",
     borderColor: "ui.border.default",
     color: "ui.typography.heading",
     fontWeight: "label.default",
@@ -98,19 +98,19 @@ export const descriptionStyles = {
   dd: {
     margin: "0",
     paddingBottom: "s",
-    borderTop: { base: "none", md: "1px solid" },
+    borderTop: { base: "none", md: showRowDividers ? "1px solid" : "none" },
     borderColor: { md: "ui.border.default" },
     paddingTop: { md: "s" },
     _dark: {
       borderColor: { md: "dark.ui.border.default" },
     },
   },
-};
+});
 
 const List = defineMultiStyleConfig({
   baseStyle: definePartsStyle(({ inline, noStyling }: ListBaseStyle) => ({
     base: baseListStyles({ inline, noStyling }),
-    heading: baseHeadingStyles,
+    heading: baseHeadingStyles(),
   })),
   variants: {
     ul: definePartsStyle((props) => ({
@@ -119,9 +119,10 @@ const List = defineMultiStyleConfig({
     ol: definePartsStyle({
       base: textMargin,
     }),
-    dl: definePartsStyle({
-      base: descriptionStyles,
-    }),
+    dl: ({ showRowDividers }) =>
+      definePartsStyle({
+        base: descriptionStyles(showRowDividers),
+      }),
   },
 });
 

--- a/src/theme/components/structuredContent.ts
+++ b/src/theme/components/structuredContent.ts
@@ -116,10 +116,10 @@ const StructuredContent = defineMultiStyleConfig({
           ...textMargin,
         },
         // For section, h2 in the definition list.
-        section: baseSectionDescriptionStyles,
-        dl: descriptionStyles.dl,
-        dt: descriptionStyles.dt,
-        dd: descriptionStyles.dd,
+        section: baseSectionDescriptionStyles(),
+        dl: descriptionStyles().dl,
+        dt: descriptionStyles().dt,
+        dd: descriptionStyles().dd,
         table: {
           width: "100%",
           th: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1729](https://jira.nypl.org/browse/DSD-1729)

## This PR does the following:

- Adds the `showRowDividers` prop to be able to hide horizontal row dividers for the `"dl"` `List` variant.
- The underlying style functions that were updated are also used in `StructuredContent` but this update does not apply to the `StructuredContent` component. So there is no change and does not need to be included in the changelog.
- Try it out in the "Controls" tab.

Question: @bigfishdesign13 I removed the `Heading`'s top border as well. Let me know if it should not be removed as it's technically not a row divider, but it's still a border that is part of the `List` component.

## How has this been tested?

Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
