### PR TITLE
DSD-1777: Fixing the desktop styling flicker in ButtonGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes the desktop styling flicker in the `ButtonGroup` component.
+
 ## 3.1.2 (May 9, 2024)
 
 ### Adds

--- a/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/src/components/ButtonGroup/ButtonGroup.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # ButtonGroup
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.28.0`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.28.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -8,7 +8,6 @@ import React, { forwardRef } from "react";
 
 import Button from "../Button/Button";
 import { LayoutTypes } from "../../helpers/types";
-import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 export const buttonGroupWidthsArray = ["default", "full"] as const;
 export type ButtonGroupWidths = typeof buttonGroupWidthsArray[number];
@@ -52,11 +51,8 @@ export const ButtonGroup: ChakraComponent<
         ...rest
       } = props;
       const newChildren: JSX.Element[] = [];
-      const { isLargerThanMobile } = useNYPLBreakpoints();
-      const finalLayout = isLargerThanMobile ? layout : "column";
-      const finalButtonWidth = isLargerThanMobile ? buttonWidth : "full";
       const styles = useStyleConfig("ButtonGroup", {
-        buttonWidth: finalButtonWidth,
+        buttonWidth: buttonWidth,
       });
 
       React.Children.map(
@@ -86,7 +82,7 @@ export const ButtonGroup: ChakraComponent<
       return (
         <Stack
           className={className}
-          direction={finalLayout}
+          direction={{ base: "column", md: layout }}
           id={id}
           ref={ref}
           // Always set the spacing to "8px".

--- a/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.tsx.snap
+++ b/src/components/ButtonGroup/__snapshots__/ButtonGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 1`] = `
 <div
-  className="chakra-stack css-9yqc00"
+  className="chakra-stack css-11okbqf"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -23,7 +23,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 1`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 2`] = `
 <div
-  className="chakra-stack css-sg7sn5"
+  className="chakra-stack css-11okbqf"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -44,7 +44,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 2`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 3`] = `
 <div
-  className="chakra-stack css-9yqc00"
+  className="chakra-stack css-1mha6zh"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -65,7 +65,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 3`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 4`] = `
 <div
-  className="chakra-stack css-1qooc78"
+  className="chakra-stack css-apzk22"
 >
   <button
     className="chakra-button css-1xdhyk6"
@@ -86,7 +86,7 @@ exports[`ButtonGroup Snapshot renders the UI snapshot correctly 4`] = `
 
 exports[`ButtonGroup Snapshot renders the UI snapshot correctly 5`] = `
 <div
-  className="chakra-stack css-9yqc00"
+  className="chakra-stack css-11okbqf"
   data-testid="testid"
 >
   <button

--- a/src/components/ButtonGroup/buttonGroupChangelogData.ts
+++ b/src/components/ButtonGroup/buttonGroupChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Fixes desktop flicker issue where the mobile view was briefly displayed before the desktop styles were applied.",
+    ],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/theme/components/buttonGroup.ts
+++ b/src/theme/components/buttonGroup.ts
@@ -3,7 +3,10 @@ import { defineStyle } from "@chakra-ui/system";
 
 const ButtonGroup = defineStyleConfig({
   baseStyle: defineStyle(({ buttonWidth }) => ({
-    width: buttonWidth === "default" ? "fit-content" : "100%",
+    width: {
+      base: "100%",
+      md: buttonWidth === "default" ? "fit-content" : "100%",
+    },
     button: {
       flexGrow: buttonWidth === "default" ? undefined : "1",
     },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1777](https://jira.nypl.org/browse/DSD-1777)

## This PR does the following:

- Fixes the styling flicker for the `ButtonGroup` component. The mobile styles flickers right before the desktop styles were applied.

## How has this been tested?

Storybook and comparing against prod.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
