### PR TITLE
DSD-1742: Fixing z-index issue on MultiSelect selected items count button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Fixes
 
 - Fixes the desktop styling flicker in the `ButtonGroup` component.
+- Fixes the z-index issue in the `MultiSelect` component's selected item button.
 
 ## 3.1.2 (May 9, 2024)
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./multiSelectChangelogData";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `3.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.4.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,10 +1,11 @@
-import React, { useState, forwardRef, useRef } from "react";
 import {
   Box,
   chakra,
   ChakraComponent,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
+import React, { useState, forwardRef, useRef } from "react";
+
 import Accordion from "./../Accordion/Accordion";
 import Button from "./../Button/Button";
 import CheckboxGroup from "./../CheckboxGroup/CheckboxGroup";

--- a/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
+++ b/src/components/MultiSelect/MultiSelectItemsCountButton.tsx
@@ -1,5 +1,6 @@
-import React, { forwardRef } from "react";
-import { useMultiStyleConfig } from "@chakra-ui/react";
+import { useStyleConfig } from "@chakra-ui/react";
+import { forwardRef } from "react";
+
 import Button from "../Button/Button";
 import Icon from "../Icons/Icon";
 
@@ -50,9 +51,8 @@ const MultiSelectItemsCountButton = forwardRef<
   // Sets the selected items count on the menu button.
   let selectedItemsAriaLabel = `remove ${selectedItemsCount} ${selectedItemsString} selected from ${multiSelectLabelText}`;
 
-  const styles = useMultiStyleConfig("MultiSelectItemsCountButton", {
+  const styles = useStyleConfig("MultiSelectItemsCountButton", {
     isOpen,
-    hasSelectedItems: selectedItemsCount,
   });
 
   return (
@@ -64,7 +64,8 @@ const MultiSelectItemsCountButton = forwardRef<
       data-testid="multi-select-close-button-testid"
       onClick={() => {
         onClear && onClear();
-        // Set focus on the Accordion Button when close the selected items count button.
+        // Set focus on the Accordion Button when close the
+        // selected items count button.
         accordianButtonRef.current?.focus();
       }}
       __css={styles}

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Styles"],
+    notes: ["Fixes the z-index value in the small selected items button."],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",

--- a/src/theme/components/multiSelect.ts
+++ b/src/theme/components/multiSelect.ts
@@ -81,7 +81,7 @@ const MultiSelect = defineMultiStyleConfig({
         position: "relative",
         width: width === "full" ? "100%" : { base: "100%", md: "fit-content" },
         overflow: "hidden",
-        zIndex: 1,
+        zIndex: 10000,
         div: {
           overflow: "hidden",
           textOverflow: "ellipsis",
@@ -114,7 +114,7 @@ const MultiSelect = defineMultiStyleConfig({
         borderTopWidth: "1px",
         marginTop: "-1px",
         position: isBlockElement ? null : "absolute",
-        zIndex: 2,
+        zIndex: 10001,
         ...multiSelectWidths[width],
       },
       ".chakra-accordion__panel": {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1742](https://jira.nypl.org/browse/DSD-1742)

## This PR does the following:

- Fixes the selected item count button's z-index issue.

## How has this been tested?

Storybook, specifically check the layout patterns Story in the `MultiSelectGroup` for a better example where various `MultiSelect` components overlap.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
