### PR TITLE
DSD-1741: Fixing checkbox's positioning so it is visible when focused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes the `Checkbox` positioning so it is visible when it is focused in a scrollable container.
+
 ## 3.1.3 (May 15, 2024)
 
 ### Adds

--- a/package-lock.json
+++ b/package-lock.json
@@ -3995,9 +3995,9 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.1.tgz",
-      "integrity": "sha512-42UH54oPZHPdRHdw6BgoBD6cg/eVTmVrFcgeRDM3jbO7uxSoipVcmcIGFcA5jmOHO5apcyvBhkSKES3fQJnu7A==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.2.tgz",
+      "integrity": "sha512-+2XpQV9LLZeanU4ZevzRnGFg2neDeKHgFLjP6YLW+tly0IvrhqT4u8enLGjLH3qeh85g19xY5rsAusfwTdn5lg==",
       "dev": true,
       "dependencies": {
         "@floating-ui/utils": "^0.2.0"
@@ -5657,18 +5657,18 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.43.4",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.43.4.tgz",
-      "integrity": "sha512-HMzeVcTbzpiVvAUOnUVOxhPGPjOlPQQjiHVZy3fsXm6D5MUiEqX0OWEuupV8Ba3LM7h1Vk8xnNghlwpCkY73UA==",
+      "version": "7.43.5",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.43.5.tgz",
+      "integrity": "sha512-ksAlwqITEe9Xps4B/LcpHxYXHPl+83wBqAORQHRBOib0cocwO0wtWMp2qr/IJ/iO47fW3eKhXq4QDqtLHPyCtg==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.28.16",
+        "@microsoft/api-extractor-model": "7.28.17",
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "4.2.1",
+        "@rushstack/node-core-library": "4.3.0",
         "@rushstack/rig-package": "0.5.2",
-        "@rushstack/terminal": "0.10.3",
-        "@rushstack/ts-command-line": "4.19.5",
+        "@rushstack/terminal": "0.10.4",
+        "@rushstack/ts-command-line": "4.20.0",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
@@ -5681,20 +5681,20 @@
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.28.16",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.16.tgz",
-      "integrity": "sha512-4/5gbW9zazr7hHHdv32QoCFDQl4vsrMOFp7g9k/uIQR2mn7AqQVN6NvNOAnFi1xwCM6X3K1BN1ZWf9ARF5hUmA==",
+      "version": "7.28.17",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.28.17.tgz",
+      "integrity": "sha512-b2AfLP33oEVtWLeNavSBRdyDa8sKlXjN4pdhBnC4HLontOtjILhL1ERAmZObF4PWSyChnnC2vjb47C9WKCFRGg==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "0.14.2",
         "@microsoft/tsdoc-config": "~0.16.1",
-        "@rushstack/node-core-library": "4.2.1"
+        "@rushstack/node-core-library": "4.3.0"
       }
     },
     "node_modules/@microsoft/api-extractor-model/node_modules/@rushstack/node-core-library": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.2.1.tgz",
-      "integrity": "sha512-jO8tR7ySxwy2c34QXSQDT9C22EfyisQruKT39FpipPOJAwKejug86eM+FL0QmkqbWGwpmfzkp3pyV71I5ZD9FA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.3.0.tgz",
+      "integrity": "sha512-JuNZ7lwaYQ4R1TugpryyWBn4lIxK+L7fF+muibFp0by5WklG22nsvH868fuBoZMLo5FqAs6WFOifNos4PJjWSA==",
       "dev": true,
       "dependencies": {
         "fs-extra": "~7.0.1",
@@ -5779,9 +5779,9 @@
       "dev": true
     },
     "node_modules/@microsoft/api-extractor/node_modules/@rushstack/node-core-library": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.2.1.tgz",
-      "integrity": "sha512-jO8tR7ySxwy2c34QXSQDT9C22EfyisQruKT39FpipPOJAwKejug86eM+FL0QmkqbWGwpmfzkp3pyV71I5ZD9FA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.3.0.tgz",
+      "integrity": "sha512-JuNZ7lwaYQ4R1TugpryyWBn4lIxK+L7fF+muibFp0by5WklG22nsvH868fuBoZMLo5FqAs6WFOifNos4PJjWSA==",
       "dev": true,
       "dependencies": {
         "fs-extra": "~7.0.1",
@@ -6894,12 +6894,12 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.10.3.tgz",
-      "integrity": "sha512-4wEPvn9bTD4cixW+FQxlCtZmVIp73gUEAFutPXDo7Nik5bqmbP+fkZcd3Zjr+hOQyyu85d6+1R1DOPcchJX5ww==",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.10.4.tgz",
+      "integrity": "sha512-U6C5NBDxC1rfJvKXgdWbMnY6i/E/SqreTTnA+jJHO4d5+Ubcl6uaAiO4rwekXYBkRnHB/RDYyvJuN1uxeizwhQ==",
       "dev": true,
       "dependencies": {
-        "@rushstack/node-core-library": "4.2.1",
+        "@rushstack/node-core-library": "4.3.0",
         "supports-color": "~8.1.1"
       },
       "peerDependencies": {
@@ -6912,9 +6912,9 @@
       }
     },
     "node_modules/@rushstack/terminal/node_modules/@rushstack/node-core-library": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.2.1.tgz",
-      "integrity": "sha512-jO8tR7ySxwy2c34QXSQDT9C22EfyisQruKT39FpipPOJAwKejug86eM+FL0QmkqbWGwpmfzkp3pyV71I5ZD9FA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-4.3.0.tgz",
+      "integrity": "sha512-JuNZ7lwaYQ4R1TugpryyWBn4lIxK+L7fF+muibFp0by5WklG22nsvH868fuBoZMLo5FqAs6WFOifNos4PJjWSA==",
       "dev": true,
       "dependencies": {
         "fs-extra": "~7.0.1",
@@ -7023,12 +7023,12 @@
       "dev": true
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.19.5",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.19.5.tgz",
-      "integrity": "sha512-0baDWdyMeB2LFHn1T8PKmy2rGclJoDruOjxwARrM4Oe66YjO9GfVZYwpM8ePdzJprWhkCnYLSxGUKJiWmUpapg==",
+      "version": "4.20.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.20.0.tgz",
+      "integrity": "sha512-X67biEL140sGKtGrtHKHXpOKfewo6Lqmj1gTQ/z8hkaNziY/450CXGLFCO+FJZDtgw5+1zplvlQOKuCYAcFUsg==",
       "dev": true,
       "dependencies": {
-        "@rushstack/terminal": "0.10.3",
+        "@rushstack/terminal": "0.10.4",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -17618,9 +17618,9 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.768",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.768.tgz",
-      "integrity": "sha512-z2U3QcvNuxdkk33YV7R1bVMNq7fL23vq3WfO5BHcqrm4TnDGReouBfYKLEFh5umoK1XACjEwp8mmnhXk2EJigw=="
+      "version": "1.4.770",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.770.tgz",
+      "integrity": "sha512-ONwOsDiVvV07CMsyH4+dEaZ9L79HMH/ODHnDS3GkIhgNqdDHJN2C18kFb0fBj0RXpQywsPJl6k2Pqg1IY4r1ig=="
     },
     "node_modules/elliptic": {
       "version": "6.5.5",

--- a/src/components/Checkbox/Checkbox.mdx
+++ b/src/components/Checkbox/Checkbox.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./checkboxChangelogData";
 
 # Checkbox
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Checkbox/Checkbox.tsx
+++ b/src/components/Checkbox/Checkbox.tsx
@@ -144,7 +144,6 @@ export const Checkbox: ChakraComponent<
             : {
                 defaultChecked: false,
               })}
-          alignItems="flex-start"
           __css={styles.base}
           {...ariaAttributes}
         >

--- a/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Checkbox renders the UI snapshot correctly 1`] = `
   id="inputID-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     onClick={[Function]}
   >
     <input
@@ -62,7 +62,7 @@ exports[`Checkbox renders the UI snapshot correctly 2`] = `
   id="checkbox-checked-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     data-checked=""
     onClick={[Function]}
   >
@@ -132,7 +132,7 @@ exports[`Checkbox renders the UI snapshot correctly 3`] = `
   id="checkbox-checked-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     data-checked=""
     onClick={[Function]}
   >
@@ -222,7 +222,7 @@ exports[`Checkbox renders the UI snapshot correctly 4`] = `
   id="checkbox-required-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     onClick={[Function]}
   >
     <input
@@ -278,7 +278,7 @@ exports[`Checkbox renders the UI snapshot correctly 5`] = `
   id="checkbox-invalid-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     data-invalid=""
     onClick={[Function]}
   >
@@ -337,7 +337,7 @@ exports[`Checkbox renders the UI snapshot correctly 6`] = `
   id="checkbox-disabled-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     data-disabled=""
     onClick={[Function]}
   >
@@ -396,7 +396,7 @@ exports[`Checkbox renders the UI snapshot correctly 7`] = `
   id="jsxLabel-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     onClick={[Function]}
   >
     <input
@@ -465,7 +465,7 @@ exports[`Checkbox renders the UI snapshot correctly 8`] = `
   id="checkbox-chakra-wrapper"
 >
   <label
-    className="chakra-checkbox css-cnetlc"
+    className="chakra-checkbox css-1t0bvx9"
     onClick={[Function]}
   >
     <input
@@ -522,7 +522,7 @@ exports[`Checkbox renders the UI snapshot correctly 9`] = `
   id="checkbox-props-wrapper"
 >
   <label
-    className="chakra-checkbox css-19e67wo"
+    className="chakra-checkbox css-1xdhyk6"
     onClick={[Function]}
   >
     <input

--- a/src/components/Checkbox/checkboxChangelogData.ts
+++ b/src/components/Checkbox/checkboxChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Sets position relative so that is it visible when focused in a scrollable container.",
+    ],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
+++ b/src/components/CheckboxGroup/__snapshots__/CheckboxGroup.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Checkbox renders the UI snapshot correctly 1`] = `
       id="column-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -72,7 +72,7 @@ exports[`Checkbox renders the UI snapshot correctly 1`] = `
       id="column-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -150,7 +150,7 @@ exports[`Checkbox renders the UI snapshot correctly 2`] = `
       id="row-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -204,7 +204,7 @@ exports[`Checkbox renders the UI snapshot correctly 2`] = `
       id="row-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -282,7 +282,7 @@ exports[`Checkbox renders the UI snapshot correctly 3`] = `
       id="noLabel-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -336,7 +336,7 @@ exports[`Checkbox renders the UI snapshot correctly 3`] = `
       id="noLabel-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -414,7 +414,7 @@ exports[`Checkbox renders the UI snapshot correctly 4`] = `
       id="helperText-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -468,7 +468,7 @@ exports[`Checkbox renders the UI snapshot correctly 4`] = `
       id="helperText-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -555,7 +555,7 @@ exports[`Checkbox renders the UI snapshot correctly 5`] = `
       id="invalidText-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -609,7 +609,7 @@ exports[`Checkbox renders the UI snapshot correctly 5`] = `
       id="invalidText-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -687,7 +687,7 @@ exports[`Checkbox renders the UI snapshot correctly 6`] = `
       id="noRequiredLabel-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -741,7 +741,7 @@ exports[`Checkbox renders the UI snapshot correctly 6`] = `
       id="noRequiredLabel-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -822,7 +822,7 @@ exports[`Checkbox renders the UI snapshot correctly 7`] = `
       id="required-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -876,7 +876,7 @@ exports[`Checkbox renders the UI snapshot correctly 7`] = `
       id="required-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -954,7 +954,7 @@ exports[`Checkbox renders the UI snapshot correctly 8`] = `
       id="invalid-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         data-invalid=""
         onClick={[Function]}
       >
@@ -1011,7 +1011,7 @@ exports[`Checkbox renders the UI snapshot correctly 8`] = `
       id="invalid-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         data-invalid=""
         onClick={[Function]}
       >
@@ -1092,7 +1092,7 @@ exports[`Checkbox renders the UI snapshot correctly 9`] = `
       id="disabled-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         data-disabled=""
         onClick={[Function]}
       >
@@ -1149,7 +1149,7 @@ exports[`Checkbox renders the UI snapshot correctly 9`] = `
       id="disabled-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         data-disabled=""
         onClick={[Function]}
       >
@@ -1230,7 +1230,7 @@ exports[`Checkbox renders the UI snapshot correctly 10`] = `
       id="jsxLabels-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -1296,7 +1296,7 @@ exports[`Checkbox renders the UI snapshot correctly 10`] = `
       id="jsxLabels-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -1386,7 +1386,7 @@ exports[`Checkbox renders the UI snapshot correctly 11`] = `
       id="chakraProps-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -1440,7 +1440,7 @@ exports[`Checkbox renders the UI snapshot correctly 11`] = `
       id="chakraProps-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -1519,7 +1519,7 @@ exports[`Checkbox renders the UI snapshot correctly 12`] = `
       id="otherProps-0-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input
@@ -1573,7 +1573,7 @@ exports[`Checkbox renders the UI snapshot correctly 12`] = `
       id="otherProps-1-wrapper"
     >
       <label
-        className="chakra-checkbox css-19e67wo"
+        className="chakra-checkbox css-1xdhyk6"
         onClick={[Function]}
       >
         <input

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -1,14 +1,15 @@
-import React, { useState, forwardRef, useRef } from "react";
 import {
   Box,
   chakra,
   ChakraComponent,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
+import React, { useState, forwardRef, useRef } from "react";
+
 import Accordion from "./../Accordion/Accordion";
 import Button from "./../Button/Button";
-import CheckboxGroup from "./../CheckboxGroup/CheckboxGroup";
 import Checkbox from "./../Checkbox/Checkbox";
+import CheckboxGroup from "./../CheckboxGroup/CheckboxGroup";
 import MultiSelectItemsCountButton from "./MultiSelectItemsCountButton";
 import TextInput from "../TextInput/TextInput";
 
@@ -30,7 +31,8 @@ export interface SelectedItems {
 export interface MultiSelectProps {
   /** The button text rendered within the MultiSelect. */
   buttonText: string;
-  /** The number of items that will be visible in the list when the component first loads. */
+  /** The number of items that will be visible in the list when the component
+   * first loads. */
   defaultItemsVisible?: number;
   /** The action to perform for the clear/reset button of individual MultiSelects. */
   onClear?: () => void;
@@ -40,9 +42,8 @@ export interface MultiSelectProps {
   onMixedStateChange?: (event: React.ChangeEvent<HTMLInputElement>) => void;
   /** An ID string that other components can cross reference for accessibility purposes. */
   id: string;
-  /** Boolean value used to control how the MultiSelect component will render within the page
-   * and interact with other DOM elements.
-   * The default value is false. */
+  /** Boolean value used to control how the MultiSelect component will render
+   * within the page and interact with other DOM elements. The default value is false. */
   isBlockElement?: boolean;
   /** Set the default open or closed state of the Multiselect. */
   isDefaultOpen?: boolean;
@@ -51,7 +52,8 @@ export interface MultiSelectProps {
   isSearchable?: boolean;
   /** The items to be rendered in the Multiselect as checkbox options. */
   items: MultiSelectItem[];
-  /** listOverflow is a property indicating how the list should handle overflow, with options limited to either "scroll" or "expand." */
+  /** listOverflow is a property indicating how the list should handle overflow,
+   * with options limited to either "scroll" or "expand." */
   listOverflow?: MultiSelectListOverflowTypes;
   /** The selected items state (items that were checked by user). */
   selectedItems: SelectedItems;
@@ -60,11 +62,11 @@ export interface MultiSelectProps {
 }
 
 /**
-  The MultiSelect component is a customizable form input that supports multiple configurations,
-  including search functionality, checkbox options, and hierarchical structure,
-  with a parent checkbox toggling all children and dynamic styling through Chakra UI.
-*/
-
+ * The MultiSelect component is a customizable form input that supports multiple
+ * configurations, including search functionality, checkbox options, and
+ * hierarchical structure, with a parent checkbox toggling all children and
+ * dynamic styling through Chakra UI.
+ */
 export const MultiSelect: ChakraComponent<
   React.ForwardRefExoticComponent<
     React.PropsWithChildren<MultiSelectProps> &
@@ -91,7 +93,8 @@ export const MultiSelect: ChakraComponent<
         ...rest
       } = props;
 
-      // Create a ref to hold a reference to the accordian button, enabling us to programmatically focus it.
+      // Create a ref to hold a reference to the accordian button, enabling us
+      // to programmatically focus it.
       const accordianButtonRef: React.RefObject<HTMLDivElement> =
         useRef<HTMLDivElement>();
       const expandToggleButtonRef: React.RefObject<HTMLButtonElement> =
@@ -135,8 +138,9 @@ export const MultiSelect: ChakraComponent<
         return false;
       };
 
-      // isAllChecked defines the isChecked status of parent checkboxes. If all child items are selected, it will turn true, otherwise it returns false.
-      // This prop is only passed to parent options.
+      // isAllChecked defines the isChecked status of parent checkboxes. If
+      // all child items are selected, it will turn true, otherwise it returns
+      // false. This prop is only passed to parent options.
       const isAllChecked = (
         multiSelectId: string,
         item: MultiSelectItem
@@ -152,7 +156,8 @@ export const MultiSelect: ChakraComponent<
         return false;
       };
 
-      // isInteterminate will return true if some child items of the parent item are selected. This prop is only passed to parent options.
+      // isInteterminate will return true if some child items of the parent
+      // item are selected. This prop is only passed to parent options.
       const isIndeterminate = (
         multiSelectId: string,
         item: MultiSelectItem
@@ -213,10 +218,9 @@ export const MultiSelect: ChakraComponent<
       };
       /** If the TextInput is cleard using the "x" button,
        * display the default options list depending on the isExpandable boolean
-       * (isExpandable is taking an account the listOverflow type and the state of
-       * the ExpandToggleButton if applicable)
+       * (isExpandable is taking an account the listOverflow type and the state
+       * of the ExpandToggleButton if applicable)
        */
-
       const clearSearchKeyword = () => {
         isExpandable ? setItemsList(defaultItemsList) : setItemsList(items);
       };

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -104,7 +104,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="dogs-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -157,7 +157,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="cats-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -210,7 +210,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="cars-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     data-disabled=""
                     onClick={[Function]}
                   >
@@ -266,7 +266,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="colors-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -319,7 +319,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="red-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     onClick={[Function]}
                   >
                     <input
@@ -372,7 +372,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="blue-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     onClick={[Function]}
                   >
                     <input
@@ -425,7 +425,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="plants-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -478,7 +478,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
                   id="furniture-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -647,7 +647,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="dogs-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -700,7 +700,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="cats-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -753,7 +753,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="cars-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     data-disabled=""
                     onClick={[Function]}
                   >
@@ -809,7 +809,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="colors-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -862,7 +862,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="red-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     onClick={[Function]}
                   >
                     <input
@@ -915,7 +915,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="blue-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     onClick={[Function]}
                   >
                     <input
@@ -968,7 +968,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="plants-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1021,7 +1021,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
                   id="furniture-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1190,7 +1190,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="dogs-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1243,7 +1243,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="cats-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1296,7 +1296,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="cars-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     data-disabled=""
                     onClick={[Function]}
                   >
@@ -1352,7 +1352,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="colors-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1436,7 +1436,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="red-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     data-checked=""
                     onClick={[Function]}
                   >
@@ -1503,7 +1503,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="blue-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     onClick={[Function]}
                   >
                     <input
@@ -1556,7 +1556,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="plants-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1609,7 +1609,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
                   id="furniture-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1820,7 +1820,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="dogs-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1873,7 +1873,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="cats-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -1926,7 +1926,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="cars-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     data-disabled=""
                     onClick={[Function]}
                   >
@@ -1982,7 +1982,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="colors-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     data-checked=""
                     onClick={[Function]}
                   >
@@ -2049,7 +2049,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="red-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     data-checked=""
                     onClick={[Function]}
                   >
@@ -2116,7 +2116,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="blue-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-1n8aert"
+                    className="chakra-checkbox css-vbxw2k"
                     data-checked=""
                     onClick={[Function]}
                   >
@@ -2183,7 +2183,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="plants-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input
@@ -2236,7 +2236,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
                   id="furniture-wrapper"
                 >
                   <label
-                    className="chakra-checkbox css-19e67wo"
+                    className="chakra-checkbox css-1xdhyk6"
                     onClick={[Function]}
                   >
                     <input

--- a/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
+++ b/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
@@ -116,7 +116,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="red-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -169,7 +169,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="blue-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -222,7 +222,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="yellow-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -388,7 +388,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="cat-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -441,7 +441,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="dog-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -494,7 +494,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="corgy-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -547,7 +547,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="german-sheperd-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -600,7 +600,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="afghan-hound-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -653,7 +653,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="rat-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -819,7 +819,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="hammer-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -872,7 +872,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="skrewdriver-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -925,7 +925,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="slottet-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -978,7 +978,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="phillips-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -1031,7 +1031,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="allen-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -1084,7 +1084,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                       id="whisk-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1267,7 +1267,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="red-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1320,7 +1320,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="blue-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1373,7 +1373,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="yellow-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1539,7 +1539,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="cat-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1592,7 +1592,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="dog-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1645,7 +1645,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="corgy-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -1698,7 +1698,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="german-sheperd-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -1751,7 +1751,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="afghan-hound-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -1804,7 +1804,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="rat-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -1970,7 +1970,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="hammer-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -2023,7 +2023,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="skrewdriver-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input
@@ -2076,7 +2076,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="slottet-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -2129,7 +2129,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="phillips-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -2182,7 +2182,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="allen-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-1n8aert"
+                        className="chakra-checkbox css-vbxw2k"
                         onClick={[Function]}
                       >
                         <input
@@ -2235,7 +2235,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                       id="whisk-wrapper"
                     >
                       <label
-                        className="chakra-checkbox css-19e67wo"
+                        className="chakra-checkbox css-1xdhyk6"
                         onClick={[Function]}
                       >
                         <input

--- a/src/theme/components/checkbox.ts
+++ b/src/theme/components/checkbox.ts
@@ -134,7 +134,11 @@ const baseStyle = definePartsStyle({
   // Style object for the Checkbox's helper text
   helperErrorText: checkboxRadioHelperErrorTextStyle,
   icon: baseStyleIcon,
-  base: checkboxRadioHoverStyles,
+  base: {
+    alignItems: "flex-start",
+    position: "relative",
+    ...checkboxRadioHoverStyles,
+  },
   control: baseStyleControl,
   label: baseStyleLabel,
 });


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1741](https://jira.nypl.org/browse/DSD-1741)

## This PR does the following:

- When tabbing through checkboxes in a scrollable container (so with a fixed height), a focused checkbox does not go into view. The suggested approach was to use the `useScrollTabIntoView` hook but when attempted, it did not make sense to introduce state to keep track of the focused element. Also, this meant we'd have to check track of user key presses for the tab press and check if a checkbox was focused. This seemed like overengineering a solution.
- After searching online, I saw this https://codepen.io/devadmin/pen/MZMjYx and natively without javascript, the expected behavior works. 
- This is not a `MultiSelect` or `Accordion` issue but rather an issue with how the `Checkbox` is positioned. Adding `position: "relative"` fixed the root of the issue.

## How has this been tested?

Review `MultiSelect`, `Accordion` (last few stories), and `CheckboxGroup` to verify that visually and functionally, everything is working as expected.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- This is an accessibility fix.

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
