### PR TITLE
Bug fix: zindex click issue on MultiSelect count button

### DIFF
--- a/src/theme/components/multiSelectItemsCountButton.ts
+++ b/src/theme/components/multiSelectItemsCountButton.ts
@@ -19,6 +19,11 @@ const MultiSelectItemsCountButton = defineStyleConfig({
     width: "46px",
     zIndex: 10000,
     py: "xxxs",
+    _focus: {
+      // Give the count button a higher index so it can be
+      // activated when it is focused.
+      zIndex: "10001 !important",
+    },
     _hover: {
       borderColor: isOpen ? "ui.gray.xx-dark" : "ui.border.hover",
     },


### PR DESCRIPTION
This was found in QA reviewing ticket [DSD-1741](https://jira.nypl.org/browse/DSD-1741).

Updates the z-index when the `MultiSelect` count button is focused so it can be clicked/selected.