### PR TITLE
DSD-1750: Select interaction tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the following npm packages: `jest-transformer-svg`, `@storybook/addon-designs`, and `@storybook/test`.
+- Adds Storybook interaction tests for `Select`.
 
 ## 3.1.4 (May 23, 2024)
 

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -1,5 +1,4 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as SelectStories from "./Select.stories";
 import Link from "../Link/Link";

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -8,10 +8,10 @@ import { changelogData } from "./selectChangelogData";
 
 # Select
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | `3.1.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.7.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -6,7 +6,7 @@ import Button from "../Button/Button";
 import Form, { FormField } from "../Form/Form";
 import Select, { labelPositionsArray, selectTypesArray } from "./Select";
 import { argsBooleanType } from "../../helpers/storybookUtils";
-import { userEvent, within } from "@storybook/test";
+import { expect, userEvent, within } from "@storybook/test";
 
 const meta: Meta<typeof Select> = {
   title: "Components/Form Elements/Select",
@@ -86,7 +86,19 @@ export const WithControls: Story = {
   play: async ({ canvasElement }) => {
     const screen = within(canvasElement);
     const select = screen.getByRole("combobox");
+
     await userEvent.selectOptions(select, "green");
+    expect(
+      (screen.getByText("Green") as HTMLOptionElement).selected
+    ).toBeTruthy();
+
+    await userEvent.selectOptions(select, "black");
+    expect(
+      (screen.getByText("Black") as HTMLOptionElement).selected
+    ).toBeTruthy();
+    expect(
+      (screen.getByText("Green") as HTMLOptionElement).selected
+    ).toBeFalsy();
   },
 };
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -6,6 +6,7 @@ import Button from "../Button/Button";
 import Form, { FormField } from "../Form/Form";
 import Select, { labelPositionsArray, selectTypesArray } from "./Select";
 import { argsBooleanType } from "../../helpers/storybookUtils";
+import { userEvent, within } from "@storybook/test";
 
 const meta: Meta<typeof Select> = {
   title: "Components/Form Elements/Select",
@@ -81,6 +82,14 @@ export const WithControls: Story = {
       url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Master?node-id=11895%3A549",
     },
     jest: ["Select.test.tsx"],
+  },
+  play: async ({ canvasElement }) => {
+    const screen = within(canvasElement);
+    const select = screen.getByRole("combobox");
+    await userEvent.selectOptions(select, "green");
+
+    await userEvent.click(screen.getByRole("combobox"));
+    userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
   },
 };
 

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -87,9 +87,6 @@ export const WithControls: Story = {
     const screen = within(canvasElement);
     const select = screen.getByRole("combobox");
     await userEvent.selectOptions(select, "green");
-
-    await userEvent.click(screen.getByRole("combobox"));
-    userEvent.keyboard("{ArrowDown}{ArrowDown}{Enter}");
   },
 };
 

--- a/src/components/Select/selectChangelogData.ts
+++ b/src/components/Select/selectChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Adds interaction tests for the Controls story."],
+  },
+  {
     date: "2024-04-11",
     version: "3.1.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1750](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1750).

## This PR does the following:

- Adds a test that selects an option (with mouse)
- **See https://github.com/testing-library/user-event/issues/786– looks like there's a standing issue in Testing Library with keyboard inputs to dropdowns, none of the keyboard events I tried seemed to change the state of the select

## How has this been tested?

Locally, in Storybook

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
