### PR TITLE
DSD-1685: Github Action tag/release fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,9 @@ jobs:
       - name: Tag
         id: autotagger
         uses: butlerlogic/action-autotag@stable
-        with:
+        env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
           strategy: package
           tag_prefix: v
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       # the tag will match the package.json version (eg. v1.0.0)
       - name: Tag
         id: autotagger
-        uses: butlerlogic/action-autotag@stable
+        uses: butlerlogic/action-autotag@1.1.2
         env:
           GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates how links are styled within the `Heading` component.
 
+### Fixes
+
+- Fixes broken Github Action for release tags.
+
 ## 3.1.5 (June 6, 2024)
 
 ### Adds


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1685](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1685)

## This PR does the following:

- I think this should be enough to fix the issue we keep encountering. The `GITHUB_TOKEN` value is not read because it's not an accepted value in under the "with" property.

## How has this been tested?

Not yet, not until the next release.

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
