### PR TITLE
DSD-1795: Breadcrumbs Digital Collections variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds Storybook interaction tests for `CheckboxGroup`, `DatePicker`, and `Slider` components.
+- Adds `digitalCollections` color variant to `Breadcrumbs` component.
 
 ### Updates
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Breadcrumbs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.3`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.3`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -98,6 +98,15 @@ export const ColorVariations: Story = {
       </Box>
       <Box>
         <Heading level="h3" size="heading6">
+          Digital Collections
+        </Heading>
+        <Breadcrumbs
+          breadcrumbsData={breadcrumbsData}
+          breadcrumbsType="digitalCollections"
+        />
+      </Box>
+      <Box>
+        <Heading level="h3" size="heading6">
           Education
         </Heading>
         <Breadcrumbs
@@ -130,15 +139,6 @@ export const ColorVariations: Story = {
         <Breadcrumbs
           breadcrumbsData={breadcrumbsData}
           breadcrumbsType="whatsOn"
-        />
-      </Box>
-      <Box>
-        <Heading level="h3" size="heading6">
-          Digital Collections
-        </Heading>
-        <Breadcrumbs
-          breadcrumbsData={breadcrumbsData}
-          breadcrumbsType="digitalCollections"
         />
       </Box>
     </VStack>

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -132,6 +132,15 @@ export const ColorVariations: Story = {
           breadcrumbsType="whatsOn"
         />
       </Box>
+      <Box>
+        <Heading level="h3" size="heading6">
+          Digital Collections
+        </Heading>
+        <Breadcrumbs
+          breadcrumbsData={breadcrumbsData}
+          breadcrumbsType="digitalCollections"
+        />
+      </Box>
     </VStack>
   ),
 };

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -21,6 +21,7 @@ export const breadcrumbTypeArray = [
   "locations",
   "research",
   "whatsOn",
+  "digitalCollections",
 ] as const;
 export type BreadcrumbsTypes = typeof breadcrumbTypeArray[number];
 export interface BreadcrumbsDataProps {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -17,11 +17,11 @@ export const breadcrumbTypeArray = [
   "booksAndMore",
   "brand",
   "connect",
+  "digitalCollections",
   "education",
   "locations",
   "research",
   "whatsOn",
-  "digitalCollections",
 ] as const;
 export type BreadcrumbsTypes = typeof breadcrumbTypeArray[number];
 export interface BreadcrumbsDataProps {

--- a/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
+++ b/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Adds `digitalCollections` color variant."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -74,6 +74,14 @@ const whatsOn = defineStyle({
     bg: "dark.section.whats-on.secondary",
   },
 });
+const digitalCollections = defineStyle({
+  bg: "ui.gray.light-cool",
+  color: "ui.black",
+  _dark: {
+    bg: "ui.gray.xx-dark",
+    color: "ui.white",
+  },
+});
 
 const Breadcrumb = defineStyleConfig({
   baseStyle: defineStyle({
@@ -151,6 +159,7 @@ const Breadcrumb = defineStyleConfig({
     locations,
     research,
     whatsOn,
+    digitalCollections,
   },
 });
 

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -79,7 +79,28 @@ const digitalCollections = defineStyle({
   color: "ui.black",
   _dark: {
     bg: "ui.gray.xx-dark",
-    color: "ui.white",
+  },
+  a: {
+    _hover: {
+      color: "ui.gray.xx-dark",
+    },
+    _dark: {
+      _hover: {
+        color: "ui.white",
+      },
+    },
+  },
+  "li:last-child": {
+    ".chakra-breadcrumb__link": {
+      _hover: {
+        color: "ui.gray.xx-dark",
+      },
+      _dark: {
+        _hover: {
+          color: "ui.white",
+        },
+      },
+    },
   },
 });
 

--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -50,6 +50,36 @@ const connect = defineStyle({
     bg: "dark.section.connect.secondary",
   },
 });
+const digitalCollections = defineStyle({
+  bg: "ui.gray.light-cool",
+  color: "ui.black",
+  _dark: {
+    bg: "ui.gray.xx-dark",
+  },
+  a: {
+    _hover: {
+      color: "ui.gray.xx-dark",
+    },
+    _dark: {
+      _hover: {
+        color: "ui.white",
+      },
+    },
+    _focus: customFocusColor("ui.black", "dark.ui.typography.body"),
+  },
+  "li:last-child": {
+    ".chakra-breadcrumb__link": {
+      _hover: {
+        color: "ui.gray.xx-dark",
+      },
+      _dark: {
+        _hover: {
+          color: "ui.white",
+        },
+      },
+    },
+  },
+});
 const education = defineStyle({
   bg: "section.education.secondary",
   _dark: {
@@ -72,35 +102,6 @@ const whatsOn = defineStyle({
   bg: "section.whats-on.secondary",
   _dark: {
     bg: "dark.section.whats-on.secondary",
-  },
-});
-const digitalCollections = defineStyle({
-  bg: "ui.gray.light-cool",
-  color: "ui.black",
-  _dark: {
-    bg: "ui.gray.xx-dark",
-  },
-  a: {
-    _hover: {
-      color: "ui.gray.xx-dark",
-    },
-    _dark: {
-      _hover: {
-        color: "ui.white",
-      },
-    },
-  },
-  "li:last-child": {
-    ".chakra-breadcrumb__link": {
-      _hover: {
-        color: "ui.gray.xx-dark",
-      },
-      _dark: {
-        _hover: {
-          color: "ui.white",
-        },
-      },
-    },
   },
 });
 
@@ -176,11 +177,11 @@ const Breadcrumb = defineStyleConfig({
     booksAndMore,
     brand,
     connect,
+    digitalCollections,
     education,
     locations,
     research,
     whatsOn,
-    digitalCollections,
   },
 });
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1795](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1795).

## This PR does the following:

- Adds the `digitalCollections` color variant for `Breadcrumbs` component

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->


### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1795]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1795?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ