### PR TITLE
DSD-1810: Correct Breadcrumbs DC variant svg fill 

### DIFF
--- a/src/theme/components/breadcrumb.ts
+++ b/src/theme/components/breadcrumb.ts
@@ -79,6 +79,12 @@ const digitalCollections = defineStyle({
       },
     },
   },
+  svg: {
+    fill: "ui.black",
+    _dark: {
+      fill: "ui.white",
+    },
+  },
 });
 const education = defineStyle({
   bg: "section.education.secondary",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1810](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1810).

## This PR does the following:

- Corrects Breadcrumbs `digitalCollections` variant svg fill (back arrow)

## How has this been tested?

<!--- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!--- Describe any accessibility concerns or updates that were made that should be known. -->

### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!--- This step is done AFTER creating a PR. -->
<!--- Vercel creates a static Storybook preview URL once the PR is created. -->
<!--- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.

[DSD-1810]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1810?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ