### PR TITLE
Prep for Release v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+## 3.2.0 (July 25, 2024)
+
 ### Adds
 
 - Adds the `FilterBarInline` component.
@@ -17,6 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates Storybook and related npm packages to version `8.1.11`. Does not affect any DS component.
+- Updates the `Banner`, `Button`, `ButtonGroup`, `DatePicker`, `FeaturedContent`, `FeedbackBox`, `Fieldset`, `HelperErrorText`, `Label`, `SkipNavigation`, and `StyledList` components to export all types and prop interfaces.
 
 ## 3.1.7 (July 3, 2024)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/design-system-react-components",
-      "version": "3.1.7",
+      "version": "3.2.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/react": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "3.1.7",
+  "version": "3.2.0",
   "description": "NYPL Reservoir Design System React Components",
   "repository": {
     "type": "git",

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./bannerChangelogData";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `3.1.0`    |
-| Latest            | `3.1.1`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `BannerProps` interface."],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",

--- a/src/components/Button/Button.mdx
+++ b/src/components/Button/Button.mdx
@@ -12,7 +12,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `3.1.1`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/Button/buttonChangelogData.ts
+++ b/src/components/Button/buttonChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `ButtonProps` interface."],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",

--- a/src/components/ButtonGroup/ButtonGroup.mdx
+++ b/src/components/ButtonGroup/ButtonGroup.mdx
@@ -12,7 +12,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.28.0`   |
-| Latest            | `3.1.3`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/ButtonGroup/buttonGroupChangelogData.ts
+++ b/src/components/ButtonGroup/buttonGroupChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `ButtonGroupProps` interface."],
+  },
+  {
     date: "2024-05-15",
     version: "3.1.3",
     type: "Update",

--- a/src/components/DatePicker/DatePicker.mdx
+++ b/src/components/DatePicker/DatePicker.mdx
@@ -13,7 +13,7 @@ import Table from "../Table/Table";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.24.0`   |
-| Latest            | `3.1.7`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/DatePicker/datePickerChangelogData.ts
+++ b/src/components/DatePicker/datePickerChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `CustomTextInputProps` interface."],
+  },
+  {
     date: "2024-07-03",
     version: "3.1.7",
     type: "Update",

--- a/src/components/FeaturedContent/FeaturedContent.mdx
+++ b/src/components/FeaturedContent/FeaturedContent.mdx
@@ -11,7 +11,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `2.1.0`    |
-| Latest            | `3.1.1`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/FeaturedContent/featuredContentChangelogData.ts
+++ b/src/components/FeaturedContent/featuredContentChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `FeaturedContentWidthType` and `FeaturedContentPositionType` types and the `FeaturedContentImageProps` interface."],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",

--- a/src/components/FeaturedContent/featuredContentChangelogData.ts
+++ b/src/components/FeaturedContent/featuredContentChangelogData.ts
@@ -14,7 +14,9 @@ export const changelogData: ChangelogData[] = [
     version: "3.2.0",
     type: "Update",
     affects: ["Functionality"],
-    notes: ["Exports the `FeaturedContentWidthType` and `FeaturedContentPositionType` types and the `FeaturedContentImageProps` interface."],
+    notes: [
+      "Exports the `FeaturedContentWidthType` and `FeaturedContentPositionType` types and the `FeaturedContentImageProps` interface.",
+    ],
   },
   {
     date: "2024-04-25",

--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -12,7 +12,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `1.3.0`    |
-| Latest            | `3.1.7`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `FeedbackBoxProps` interface."],
+  },
+  {
     date: "2024-07-03",
     version: "3.1.7",
     type: "Update",

--- a/src/components/Fieldset/Fieldset.mdx
+++ b/src/components/Fieldset/Fieldset.mdx
@@ -12,7 +12,7 @@ import { Link } from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.25.3`   |
-| Latest            | `3.0.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/Fieldset/fieldsetChangelogData.ts
+++ b/src/components/Fieldset/fieldsetChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `FieldsetProps` interface."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/FilterBarInline/FilterBarInline.mdx
+++ b/src/components/FilterBarInline/FilterBarInline.mdx
@@ -8,10 +8,10 @@ import Link from "../Link/Link";
 
 # FilterBarInline
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `Prerelease` |
-| Latest            | `Prerelease` |
+| Component Version | DS Version |
+| ----------------- | ---------- |
+| Added             | `3.2.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/FilterBarInline/filterBarInlineChangelogData.ts
+++ b/src/components/FilterBarInline/filterBarInlineChangelogData.ts
@@ -10,8 +10,8 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "Prerelease",
-    version: "Prerelease",
+    date: "2024-07-25",
+    version: "3.2.0",
     type: "New Feature",
     affects: ["Accessibility", "Documentation", "Functionality", "Styles"],
     notes: ["Adds FilterBarInline component."],

--- a/src/components/HelperErrorText/HelperErrorText.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.mdx
@@ -12,7 +12,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `3.0.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/HelperErrorText/helperErrorTextChangelogData.ts
+++ b/src/components/HelperErrorText/helperErrorTextChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `HelperErrorTextProps` interface."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/Label/Label.mdx
+++ b/src/components/Label/Label.mdx
@@ -12,7 +12,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.10`   |
-| Latest            | `3.0.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/Label/labelChangelogData.ts
+++ b/src/components/Label/labelChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `LabelProps` interface."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/NewsletterSignup/NewsletterSignup.mdx
+++ b/src/components/NewsletterSignup/NewsletterSignup.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./newsletterSignupChangelogData";
 
 # NewsletterSignup
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `2.1.0`      |
-| Latest            | `Prerelease` |
+| Component Version | DS Version |
+| ----------------- | ---------- |
+| Added             | `2.1.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/NewsletterSignup/newsletterSignupChangelogData.ts
+++ b/src/components/NewsletterSignup/newsletterSignupChangelogData.ts
@@ -10,8 +10,8 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "Prerelease",
-    version: "Prerelease",
+    date: "2024-07-25",
+    version: "3.2.0",
     type: "Update",
     affects: ["Functionality"],
     notes: [

--- a/src/components/SkipNavigation/SkipNavigation.mdx
+++ b/src/components/SkipNavigation/SkipNavigation.mdx
@@ -12,7 +12,7 @@ import Link from "../Link/Link";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.28.0`   |
-| Latest            | `3.0.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/SkipNavigation/skipNavigationChangelogData.ts
+++ b/src/components/SkipNavigation/skipNavigationChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `SkipNavigationProps` interface."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/SocialMediaLinks/SocialMediaLinks.mdx
+++ b/src/components/SocialMediaLinks/SocialMediaLinks.mdx
@@ -9,10 +9,10 @@ import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 # SocialMediaLinks
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `2.0.0`      |
-| Latest            | `Prerelease` |
+| Component Version | DS Version |
+| ----------------- | ---------- |
+| Added             | `2.0.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/SocialMediaLinks/socialMediaLinksChangelogData.ts
+++ b/src/components/SocialMediaLinks/socialMediaLinksChangelogData.ts
@@ -10,8 +10,8 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "Prerelease",
-    version: "Prerelease",
+    date: "2024-07-25",
+    version: "3.2.0",
     type: "Update",
     affects: ["Functionality"],
     notes: ["Refined the component with updated props."],

--- a/src/components/StyledList/StyledList.mdx
+++ b/src/components/StyledList/StyledList.mdx
@@ -13,7 +13,7 @@ import { changelogData } from "./styledListChangelogData";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `1.3.0`    |
-| Latest            | `3.0.0`    |
+| Latest            | `3.2.0`    |
 
 ## Table of Contents
 

--- a/src/components/StyledList/styledListChangelogData.ts
+++ b/src/components/StyledList/styledListChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-25",
+    version: "3.2.0",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Exports the `StyledListTextSizes` type."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",


### PR DESCRIPTION
## This PR does the following:

- Prep for Release `v3.2.0`

NOTE: Due to a last minute CHANGELOG addition, quite a few files needed to be updated to reflect the related updates (i.e. `Lastest Version` values and component changelogs).