### PR TITLE
DSD-1782 - Allow HTML passed as string in Banner content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates Banner component to allow for HTML content in the `content` prop when passed as a string.
+
 ## 3.2.0 (July 25, 2024)
 
 ### Adds

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -25,7 +25,7 @@ import { changelogData } from "./bannerChangelogData";
 - {<Link href="#with-html-content" target="_self">With HTML Content</Link>}
 - {<Link href="#custom-color" target="_self">Custom Color</Link>}
 - {<Link href="#dismissible" target="_self">Dismissible</Link>}
-- {<Link href="#string-content-with-html" target="_self">With HTML content passed as string</Link>}
+- {<Link href="#with-html-content-passed-as-string" target="_self">With HTML content passed as string</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -239,6 +239,16 @@ renders once.
 
 HTML content passed as a string is rendered as HTML, useful in cases where HTML content is stored in an environment variable or from other sources where the content is stored as strings.
 
+<Source
+  code={`
+<Banner
+  heading="Standard Banner with HTML content passed as string"
+  content="<p>Cras mattis consectetur purus sit amet fermentum. Maecenas faucibus mollis interdum.</p><p>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. <b>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus</b>. <a href='#'>This is a link</a>.</p>"
+/>
+`}
+  language="tsx"
+/>
+
 <Canvas of={BannerStories.StringContentWithHTML} />
 
 ## Changelog

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -237,7 +237,7 @@ renders once.
 
 ## With HTML content passed as string
 
-HTML content passed as a string is rendered as HTML, useful in cases where HTML content is stored in an environment variable.
+HTML content passed as a string is rendered as HTML, useful in cases where HTML content is stored in an environment variable or from other sources where the content is stored as strings.
 
 <Canvas of={BannerStories.StringContentWithHTML} />
 

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./bannerChangelogData";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `3.1.0`    |
-| Latest            | `3.2.0`    |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -22,9 +22,10 @@ import { changelogData } from "./bannerChangelogData";
 - {<Link href="#variants" target="_self">Variants</Link>}
 - {<Link href="#banner-heading" target="_self">Banner Heading</Link>}
 - {<Link href="#banner-icon" target="_self">Banner Icon</Link>}
+- {<Link href="#with-html-content" target="_self">With HTML Content</Link>}
 - {<Link href="#custom-color" target="_self">Custom Color</Link>}
 - {<Link href="#dismissible" target="_self">Dismissible</Link>}
-- {<Link href="#string-content-with-html" target="_self">String content with HTML</Link>}
+- {<Link href="#string-content-with-html" target="_self">With HTML content passed as string</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
@@ -234,7 +235,7 @@ renders once.
 
 <Canvas of={BannerStories.Dismissible} />
 
-## String Content with HTML
+## With HTML content passed as string
 
 HTML content passed as a string is rendered as HTML, useful in cases where HTML content is stored in an environment variable.
 

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -22,9 +22,9 @@ import { changelogData } from "./bannerChangelogData";
 - {<Link href="#variants" target="_self">Variants</Link>}
 - {<Link href="#banner-heading" target="_self">Banner Heading</Link>}
 - {<Link href="#banner-icon" target="_self">Banner Icon</Link>}
-- {<Link href="#with-html-content" target="_self">With HTML Content</Link>}
 - {<Link href="#custom-color" target="_self">Custom Color</Link>}
 - {<Link href="#dismissible" target="_self">Dismissible</Link>}
+- {<Link href="#string-content-with-html" target="_self">String content with HTML</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
@@ -233,6 +233,12 @@ clicked, the `Banner` will be removed from the DOM, therefore it only
 renders once.
 
 <Canvas of={BannerStories.Dismissible} />
+
+## String Content with HTML
+
+HTML content passed as a string is rendered as HTML, useful in cases where HTML content is stored in an environment variable.
+
+<Canvas of={BannerStories.StringContentWithHTML} />
 
 ## Changelog
 

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -396,3 +396,12 @@ export const Dismissible: Story = {
     />
   ),
 };
+export const StringContentWithHTML: Story = {
+  render: () => (
+    <Banner
+      content={"<p>HTML content passed as a <em>string</em> is rendered as <strong>HTML</strong>, useful in cases where HTML content is stored in an environment variable.</p>"}
+      heading="String content with HTML"
+      type="neutral"
+    />
+  ),
+};

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -400,7 +400,7 @@ export const StringContentWithHTML: Story = {
   render: () => (
     <Banner
       content={
-        "<p>HTML content passed as a <em>string</em> is rendered as <strong>HTML</strong>, useful in cases where HTML content is stored in an environment variable.</p>"
+        "<p>Cras mattis consectetur purus sit amet fermentum. Maecenas faucibus mollis interdum.</p><p>Morbi leo risus, porta ac consectetur ac, vestibulum at eros. <b>Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus</b>. <a href='#'>This is a link</a>.</p>"
       }
       heading="String content with HTML"
       type="neutral"

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -399,7 +399,9 @@ export const Dismissible: Story = {
 export const StringContentWithHTML: Story = {
   render: () => (
     <Banner
-      content={"<p>HTML content passed as a <em>string</em> is rendered as <strong>HTML</strong>, useful in cases where HTML content is stored in an environment variable.</p>"}
+      content={
+        "<p>HTML content passed as a <em>string</em> is rendered as <strong>HTML</strong>, useful in cases where HTML content is stored in an environment variable.</p>"
+      }
       heading="String content with HTML"
       type="neutral"
     />

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -353,4 +353,15 @@ describe("Banner", () => {
 
     expect(container.querySelector("aside")).toBe(ref.current);
   });
+
+  it("renders string content as div with dangerouslySetInnerHTML", () => {
+    utils.rerender(
+      <Banner
+        id="bannerID"
+        content="<p data-testid='dangerous'>Dangerous HTML</p>"
+      />
+    );
+
+    expect(screen.getByTestId("dangerous")).toHaveTextContent("Dangerous HTML");
+  });
 });

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -241,9 +241,9 @@ export const Banner: ChakraComponent<
         {...rest}
       >
         {finalIcon}
-        <Box maxWidth="800px">
+        <Box maxWidth="800px" >
           {heading && finalHeading}
-          {content}
+          {typeof content === "string" ? (<Box dangerouslySetInnerHTML={{__html: content}} />) :(<>{content}</>)}
         </Box>
         {isDismissible && dismissibleButton}
       </Box>

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -243,6 +243,8 @@ export const Banner: ChakraComponent<
         {finalIcon}
         <Box maxWidth="800px">
           {heading && finalHeading}
+          {/* Render string content as div with dangerouslySetInnerHTML prop in case HTML is passed in as string
+            (e.g. notification HTML stored in an environment variable. */}
           {typeof content === "string" ? (
             <Box dangerouslySetInnerHTML={{ __html: content }} />
           ) : (

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -18,7 +18,7 @@ export const bannerTypesArray = [
   "recommendation",
   "warning",
 ] as const;
-export type BannerTypes = (typeof bannerTypesArray)[number];
+export type BannerTypes = typeof bannerTypesArray[number];
 export const bannerBgColorsArray = [
   "brand.primary-05",
   "section.blogs.primary-05",
@@ -43,7 +43,7 @@ export const bannerBgColorsArray = [
   "dark.section.research-library.schwarzman-05",
   "dark.section.whats-on.primary-05",
 ] as const;
-export type BannerBgColors = (typeof bannerBgColorsArray)[number];
+export type BannerBgColors = typeof bannerBgColorsArray[number];
 export const bannerHighlightColorsArray = [
   "brand.primary",
   "section.blogs.primary",
@@ -68,7 +68,7 @@ export const bannerHighlightColorsArray = [
   "dark.section.research-library-schwarzman.primary",
   "dark.section.whats-on.primary",
 ] as const;
-export type BannerHighlightColors = (typeof bannerHighlightColorsArray)[number];
+export type BannerHighlightColors = typeof bannerHighlightColorsArray[number];
 
 export interface BannerProps {
   /** Label used to describe the `Banner`'s aside HTML element. */

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -18,7 +18,7 @@ export const bannerTypesArray = [
   "recommendation",
   "warning",
 ] as const;
-export type BannerTypes = typeof bannerTypesArray[number];
+export type BannerTypes = (typeof bannerTypesArray)[number];
 export const bannerBgColorsArray = [
   "brand.primary-05",
   "section.blogs.primary-05",
@@ -43,7 +43,7 @@ export const bannerBgColorsArray = [
   "dark.section.research-library.schwarzman-05",
   "dark.section.whats-on.primary-05",
 ] as const;
-export type BannerBgColors = typeof bannerBgColorsArray[number];
+export type BannerBgColors = (typeof bannerBgColorsArray)[number];
 export const bannerHighlightColorsArray = [
   "brand.primary",
   "section.blogs.primary",
@@ -68,7 +68,7 @@ export const bannerHighlightColorsArray = [
   "dark.section.research-library-schwarzman.primary",
   "dark.section.whats-on.primary",
 ] as const;
-export type BannerHighlightColors = typeof bannerHighlightColorsArray[number];
+export type BannerHighlightColors = (typeof bannerHighlightColorsArray)[number];
 
 export interface BannerProps {
   /** Label used to describe the `Banner`'s aside HTML element. */
@@ -241,9 +241,13 @@ export const Banner: ChakraComponent<
         {...rest}
       >
         {finalIcon}
-        <Box maxWidth="800px" >
+        <Box maxWidth="800px">
           {heading && finalHeading}
-          {typeof content === "string" ? (<Box dangerouslySetInnerHTML={{__html: content}} />) :(<>{content}</>)}
+          {typeof content === "string" ? (
+            <Box dangerouslySetInnerHTML={{ __html: content }} />
+          ) : (
+            <>{content}</>
+          )}
         </Box>
         {isDismissible && dismissibleButton}
       </Box>

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -10,7 +10,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "2024-07-30",
+    date: "Prerelease",
     version: "Prerelease",
     type: "Update",
     affects: ["Functionality"],

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2024-07-30",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Render HTML content when passed as a string in the `content` prop."],
+  },
+  {
     date: "2024-07-25",
     version: "3.2.0",
     type: "Update",

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -10,13 +10,6 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
-    date: "2024-07-30",
-    version: "Prerelease",
-    type: "Update",
-    affects: ["Functionality"],
-    notes: ["Render HTML content when passed as a string in the `content` prop."],
-  },
-  {
     date: "2024-07-25",
     version: "3.2.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1782](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1782)

## This PR does the following:

- Passes string content passed to the Banner component via the `content` prop in a Div via the dangerouslySetInnerHTML prop.
- This is intended to allow HTML to be stored in environment variables and rendered correctly.

## How has this been tested?

- Visually tested manually and added a unit test.

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1782]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ