### PR TITLE
DSD-1811: Searchbar responsive styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates Banner component to allow for HTML content in the `content` prop when passed as a string.
+- Updates `Searchbar` component styles on mobile breakpoints
 
 ## 3.2.0 (July 25, 2024)
 

--- a/src/components/SearchBar/SearchBar.mdx
+++ b/src/components/SearchBar/SearchBar.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # SearchBar
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `3.1.6`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -206,7 +206,6 @@ export const SearchBar: ChakraComponent<
         isDisabled={isDisabled}
         onClick={buttonOnClick}
         type="submit"
-        sx={styles.button}
         aria-label={isLargerThanMobile ? "" : "Search"}
       >
         <Icon

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -14,6 +14,7 @@ import Select, { SelectProps as InitialSelectProps } from "../Select/Select";
 import TextInput, {
   InputProps as InitialInputProps,
 } from "../TextInput/TextInput";
+import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 interface SelectOptionsProps {
   text: string;
@@ -141,13 +142,8 @@ export const SearchBar: ChakraComponent<
       isRequired ? "(Required)" : ""
     }`;
     const buttonType = noBrandButtonType ? "noBrand" : "primary";
-    const searchBarButtonStyles = {
-      borderLeftRadius: "none",
-      borderRightRadius: { base: "none", md: "sm" },
-      lineHeight: "1.70",
-      marginBottom: "auto",
-      maxWidth: { base: "unset", md: "80px" },
-    };
+    const { isLargerThanMobile } = useNYPLBreakpoints();
+    const iconSize = isLargerThanMobile ? "small" : "medium";
 
     if (!id) {
       console.warn(
@@ -204,15 +200,15 @@ export const SearchBar: ChakraComponent<
         isDisabled={isDisabled}
         onClick={buttonOnClick}
         type="submit"
-        sx={searchBarButtonStyles}
+        sx={styles.button}
       >
         <Icon
           align="left"
           id={`searchbar-icon-${id}`}
           name="search"
-          size="small"
+          size={iconSize}
         />
-        Search
+        <span>Search</span>
       </Button>
     );
     // If a custom input element was passed, use that element
@@ -242,8 +238,10 @@ export const SearchBar: ChakraComponent<
           __css={styles}
         >
           {selectElem}
-          {textInputElem}
-          {buttonElem}
+          <Box sx={{ id: "hello", display: "flex", flexDirection: "row" }}>
+            {textInputElem}
+            {buttonElem}
+          </Box>
         </Box>
       </ComponentWrapper>
     );

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -238,7 +238,7 @@ export const SearchBar: ChakraComponent<
           __css={styles}
         >
           {selectElem}
-          <Box sx={{ id: "hello", display: "flex", flexDirection: "row" }}>
+          <Box sx={{ display: "flex", flexDirection: "row", width: "100%" }}>
             {textInputElem}
             {buttonElem}
           </Box>

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -206,6 +206,7 @@ export const SearchBar: ChakraComponent<
         onClick={buttonOnClick}
         type="submit"
         sx={styles.button}
+        aria-label={isLargerThanMobile ? "" : "Search"}
       >
         <Icon
           align="left"

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -200,6 +200,7 @@ export const SearchBar: ChakraComponent<
     // Render the `Button` component.
     const buttonElem = (
       <Button
+        className="searchButton"
         buttonType={buttonType}
         id={`searchbar-button-${id}`}
         isDisabled={isDisabled}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -189,6 +189,11 @@ export const SearchBar: ChakraComponent<
         textInputType={selectElem ? "searchBarSelect" : "searchBar"}
         type="text"
         value={textInputProps?.value}
+        sx={{
+          "div > input": {
+            borderLeftRadius: isLargerThanMobile && selectElem ? 0 : "sm",
+          },
+        }}
         {...stateProps}
       />
     );

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-basic-wrapper"
       >
         <div
@@ -237,7 +237,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-z1r9u7"
         id="searchbar-textinput-withSelect-wrapper"
       >
         <div
@@ -339,7 +339,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-withoutHelperText-wrapper"
       >
         <div
@@ -424,7 +424,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-withClearButton-wrapper"
       >
         <div
@@ -526,7 +526,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-invalidState-wrapper"
       >
         <div
@@ -620,7 +620,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-disabledState-wrapper"
       >
         <div
@@ -706,7 +706,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-requiredState-wrapper"
       >
         <div
@@ -793,7 +793,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-noBrandButtonType-wrapper"
       >
         <div
@@ -1085,7 +1085,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-chakra-wrapper"
       >
         <div
@@ -1188,7 +1188,7 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
       className="css-1ik4laa"
     >
       <div
-        className="textInput css-1u8qly9"
+        className="textInput css-g1fpd3"
         id="searchbar-textinput-props-wrapper"
       >
         <div

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
       </div>
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-basic"
         type="submit"
       >
@@ -264,7 +264,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
       </div>
       <button
         aria-label=""
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-withSelect"
         type="submit"
       >
@@ -366,7 +366,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
       </div>
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-withoutHelperText"
         type="submit"
       >
@@ -453,7 +453,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
       </div>
       <button
         aria-label=""
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-withClearButton"
         type="submit"
       >
@@ -564,7 +564,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
       </div>
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-invalidState"
         type="submit"
       >
@@ -650,7 +650,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
       </div>
       <button
         aria-label=""
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         disabled={true}
         id="searchbar-button-disabledState"
         type="submit"
@@ -738,7 +738,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
       </div>
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         disabled={true}
         id="searchbar-button-requiredState"
         type="submit"
@@ -826,7 +826,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
       </div>
       <button
         aria-label=""
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         disabled={true}
         id="searchbar-button-noBrandButtonType"
         type="submit"
@@ -895,7 +895,7 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
     >
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-withHeading"
         type="submit"
       >
@@ -962,7 +962,7 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
     >
       <button
         aria-label=""
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-withDescription"
         type="submit"
       >
@@ -1035,7 +1035,7 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
     >
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-withHeadingAndDescription"
         type="submit"
       >
@@ -1122,7 +1122,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
       </div>
       <button
         aria-label=""
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-chakra"
         type="submit"
       >
@@ -1226,7 +1226,7 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
       </div>
       <button
         aria-label="Search"
-        className="chakra-button css-8bx9xp"
+        className="chakra-button searchButton css-8bx9xp"
         id="searchbar-button-props"
         type="submit"
       >

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -13,69 +13,75 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-basic-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-basic-wrapper"
       >
-        <input
-          aria-describedby="basic-helperText"
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-basic"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-basic"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-basic"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-describedby="basic-helperText"
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-basic"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-basic"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-basic"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
   <div
     aria-atomic={true}
@@ -228,69 +234,75 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
       </div>
     </div>
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-withSelect-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-withSelect-wrapper"
       >
-        <input
-          aria-describedby="withSelect-helperText"
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-withSelect"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-withSelect"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-withSelect"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-describedby="withSelect-helperText"
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-withSelect"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-withSelect"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-withSelect"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
   <div
     aria-atomic={true}
@@ -324,68 +336,74 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-withoutHelperText-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-withoutHelperText-wrapper"
       >
-        <input
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-withoutHelperText"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-withoutHelperText"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-withoutHelperText"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-withoutHelperText"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-withoutHelperText"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-withoutHelperText"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -403,69 +421,75 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-withClearButton-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-withClearButton-wrapper"
       >
-        <input
-          aria-describedby="withClearButton-helperText"
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-withClearButton"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-withClearButton"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-withClearButton"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-describedby="withClearButton-helperText"
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-withClearButton"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-withClearButton"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-withClearButton"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
   <div
     aria-atomic={true}
@@ -499,77 +523,83 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-invalidState-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-invalidState-wrapper"
       >
-        <input
-          aria-describedby="searchbar-textinput-invalidState-helperText"
-          aria-invalid={true}
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-invalidState"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
+        <div
+          className="css-79elbk"
+        >
+          <input
+            aria-describedby="searchbar-textinput-invalidState-helperText"
+            aria-invalid={true}
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-invalidState"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
+          />
+        </div>
+        <div
+          aria-atomic={true}
+          aria-live="polite"
+          className="css-1xdhyk6"
+          data-isinvalid={true}
+          id="searchbar-textinput-invalidState-helperText"
         />
       </div>
-      <div
-        aria-atomic={true}
-        aria-live="polite"
-        className="css-1xdhyk6"
-        data-isinvalid={true}
-        id="searchbar-textinput-invalidState-helperText"
-      />
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-invalidState"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-invalidState"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-invalidState"
+        type="submit"
       >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-invalidState"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -587,69 +617,75 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-disabledState-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-disabledState-wrapper"
       >
-        <input
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={true}
-          id="searchbar-textinput-disabledState"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      disabled={true}
-      id="searchbar-button-disabledState"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-disabledState"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={true}
+            id="searchbar-textinput-disabledState"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        disabled={true}
+        id="searchbar-button-disabledState"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-disabledState"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -667,70 +703,76 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-requiredState-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-requiredState-wrapper"
       >
-        <input
-          aria-label="Item Search"
-          aria-required={true}
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={true}
-          id="searchbar-textinput-requiredState"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search (Required)"
-          required={true}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      disabled={true}
-      id="searchbar-button-requiredState"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-requiredState"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-label="Item Search"
+            aria-required={true}
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={true}
+            id="searchbar-textinput-requiredState"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search (Required)"
+            required={true}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        disabled={true}
+        id="searchbar-button-requiredState"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-requiredState"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -748,70 +790,76 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-noBrandButtonType-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-noBrandButtonType-wrapper"
       >
-        <input
-          aria-label="Item Search"
-          aria-required={true}
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={true}
-          id="searchbar-textinput-noBrandButtonType"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search (Required)"
-          required={true}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      disabled={true}
-      id="searchbar-button-noBrandButtonType"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-noBrandButtonType"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-label="Item Search"
+            aria-required={true}
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={true}
+            id="searchbar-textinput-noBrandButtonType"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search (Required)"
+            required={true}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        disabled={true}
+        id="searchbar-button-noBrandButtonType"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-noBrandButtonType"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -834,45 +882,51 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
     onSubmit={[MockFunction]}
     role="search"
   >
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-withHeading"
-      type="submit"
+    <div
+      className="css-1ik4laa"
     >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-withHeading"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-withHeading"
+        type="submit"
       >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-withHeading"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -894,45 +948,51 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
     onSubmit={[MockFunction]}
     role="search"
   >
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-withDescription"
-      type="submit"
+    <div
+      className="css-1ik4laa"
     >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-withDescription"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-withDescription"
+        type="submit"
       >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-withDescription"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -960,45 +1020,51 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
     onSubmit={[MockFunction]}
     role="search"
   >
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-withHeadingAndDescription"
-      type="submit"
+    <div
+      className="css-1ik4laa"
     >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-withHeadingAndDescription"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-withHeadingAndDescription"
+        type="submit"
       >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-withHeadingAndDescription"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
-          />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
 </div>
 `;
@@ -1016,69 +1082,75 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-chakra-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-chakra-wrapper"
       >
-        <input
-          aria-describedby="chakra-helperText"
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-chakra"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-chakra"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-chakra"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-describedby="chakra-helperText"
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-chakra"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-chakra"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-chakra"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
   <div
     aria-atomic={true}
@@ -1113,69 +1185,75 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
     role="search"
   >
     <div
-      className="textInput css-1u8qly9"
-      id="searchbar-textinput-props-wrapper"
+      className="css-1ik4laa"
     >
       <div
-        className="css-79elbk"
+        className="textInput css-1u8qly9"
+        id="searchbar-textinput-props-wrapper"
       >
-        <input
-          aria-describedby="props-helperText"
-          aria-label="Item Search"
-          autoComplete={null}
-          className="chakra-input css-0"
-          disabled={false}
-          id="searchbar-textinput-props"
-          name="textInputName"
-          onBlur={[Function]}
-          onChange={[Function]}
-          onFocus={[Function]}
-          placeholder="Item Search "
-          required={false}
-          step={null}
-          type="text"
-        />
-      </div>
-    </div>
-    <button
-      className="chakra-button css-7l30z"
-      id="searchbar-button-props"
-      type="submit"
-    >
-      <svg
-        aria-hidden={true}
-        className="chakra-icon css-1grhd2q"
-        focusable={false}
-        id="searchbar-icon-props"
-        role="img"
-        title="search icon"
-        viewBox="0 0 24 24"
-      >
-        <g
-          stroke="currentColor"
-          strokeWidth="1.5"
+        <div
+          className="css-79elbk"
         >
-          <path
-            d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
-            fill="none"
-            strokeLinecap="round"
+          <input
+            aria-describedby="props-helperText"
+            aria-label="Item Search"
+            autoComplete={null}
+            className="chakra-input css-0"
+            disabled={false}
+            id="searchbar-textinput-props"
+            name="textInputName"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            placeholder="Item Search "
+            required={false}
+            step={null}
+            type="text"
           />
-          <path
-            d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
-            fill="currentColor"
-            strokeLinecap="round"
-          />
-          <circle
-            cx="12"
-            cy="12"
-            fill="none"
-            r="11.25"
-            strokeMiterlimit="10"
-          />
-        </g>
-      </svg>
-      Search
-    </button>
+        </div>
+      </div>
+      <button
+        className="chakra-button css-8bx9xp"
+        id="searchbar-button-props"
+        type="submit"
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1grhd2q"
+          focusable={false}
+          id="searchbar-icon-props"
+          role="img"
+          title="search icon"
+          viewBox="0 0 24 24"
+        >
+          <g
+            stroke="currentColor"
+            strokeWidth="1.5"
+          >
+            <path
+              d="M9,9a3,3,0,1,1,4,2.829,1.5,1.5,0,0,0-1,1.415V14.25"
+              fill="none"
+              strokeLinecap="round"
+            />
+            <path
+              d="M12,17.25a.375.375,0,1,0,.375.375A.375.375,0,0,0,12,17.25h0"
+              fill="currentColor"
+              strokeLinecap="round"
+            />
+            <circle
+              cx="12"
+              cy="12"
+              fill="none"
+              r="11.25"
+              strokeMiterlimit="10"
+            />
+          </g>
+        </svg>
+        <span>
+          Search
+        </span>
+      </button>
+    </div>
   </form>
   <div
     aria-atomic={true}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
         </div>
       </div>
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         id="searchbar-button-basic"
         type="submit"
@@ -262,6 +263,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
         </div>
       </div>
       <button
+        aria-label=""
         className="chakra-button css-8bx9xp"
         id="searchbar-button-withSelect"
         type="submit"
@@ -363,6 +365,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
         </div>
       </div>
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         id="searchbar-button-withoutHelperText"
         type="submit"
@@ -449,6 +452,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
         </div>
       </div>
       <button
+        aria-label=""
         className="chakra-button css-8bx9xp"
         id="searchbar-button-withClearButton"
         type="submit"
@@ -559,6 +563,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
         />
       </div>
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         id="searchbar-button-invalidState"
         type="submit"
@@ -644,6 +649,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
         </div>
       </div>
       <button
+        aria-label=""
         className="chakra-button css-8bx9xp"
         disabled={true}
         id="searchbar-button-disabledState"
@@ -731,6 +737,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
         </div>
       </div>
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         disabled={true}
         id="searchbar-button-requiredState"
@@ -818,6 +825,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
         </div>
       </div>
       <button
+        aria-label=""
         className="chakra-button css-8bx9xp"
         disabled={true}
         id="searchbar-button-noBrandButtonType"
@@ -886,6 +894,7 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
       className="css-1ik4laa"
     >
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         id="searchbar-button-withHeading"
         type="submit"
@@ -952,6 +961,7 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
       className="css-1ik4laa"
     >
       <button
+        aria-label=""
         className="chakra-button css-8bx9xp"
         id="searchbar-button-withDescription"
         type="submit"
@@ -1024,6 +1034,7 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
       className="css-1ik4laa"
     >
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         id="searchbar-button-withHeadingAndDescription"
         type="submit"
@@ -1110,6 +1121,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
         </div>
       </div>
       <button
+        aria-label=""
         className="chakra-button css-8bx9xp"
         id="searchbar-button-chakra"
         type="submit"
@@ -1213,6 +1225,7 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
         </div>
       </div>
       <button
+        aria-label="Search"
         className="chakra-button css-8bx9xp"
         id="searchbar-button-props"
         type="submit"

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Updates Searchbar style to remove stacking on mobile breakpoints."],
+  },
+  {
     date: "2024-06-20",
     version: "3.1.6",
     type: "Update",

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Styles"],
     notes: [
-      "Updates Searchbar style to remove stacking on mobile breakpoints.",
+      "Updates Searchbar style to remove stacking on mobile breakpoints, adds span element to text for CSS targeting.",
     ],
   },
   {

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Styles"],
     notes: [
-      "Updates Searchbar style to remove stacking on mobile breakpoints, adds span element to text for CSS targeting.",
+      "Updates styles on mobile breakpoints, adds span element to text for CSS targeting.",
     ],
   },
   {

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -14,7 +14,9 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Styles"],
-    notes: ["Updates Searchbar style to remove stacking on mobile breakpoints."],
+    notes: [
+      "Updates Searchbar style to remove stacking on mobile breakpoints.",
+    ],
   },
   {
     date: "2024-06-20",

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -10,7 +10,7 @@ const SearchBar = defineMultiStyleConfig({
       base: "xs",
       md: "auto",
     },
-    ".textInput" :{
+    ".textInput": {
       flexGrow: 1,
     },
     flexFlow: { base: "column nowrap", md: "row" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -17,14 +17,17 @@ const SearchBar = defineMultiStyleConfig({
       },
     },
     flexFlow: { base: "column nowrap", md: "row" },
-    button: {
+    ".searchButton": {
       minWidth: "44px",
       maxWidth: "80px",
       borderLeftRadius: "none",
       lineHeight: "1.70",
       marginBottom: "auto",
-      padding: { base: "xs", md: "s" },
-      gap: "xs",
+      paddingTop: { base: "xs", md: "xs" },
+      paddingLeft:{ base: "xs", md: "s" },
+      paddingBottom: { base: "xs", md: "xs" },
+      paddingRight: { base: "xs", md: "s" },
+      gap: "xxs",
       borderRightRadius: "sm",
       " > span": {
         display: { base: "none", md: "block" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -28,7 +28,7 @@ const SearchBar = defineMultiStyleConfig({
       },
     },
     select: {
-      paddingBottom: { base: "s", md: "unset" },
+      paddingBottom: { base: "xs", md: "unset" },
       flexShrink: "0",
       marginBottom: { base: "-1px", md: "0" },
       maxWidth: { base: undefined, md: "255px" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -19,7 +19,7 @@ const SearchBar = defineMultiStyleConfig({
     flexFlow: { base: "column nowrap", md: "row" },
     ".searchButton": {
       minWidth: "44px",
-      maxWidth: "80px",
+      maxWidth: {base: "unset", md: "80px"},
       borderLeftRadius: "none",
       lineHeight: "1.70",
       marginBottom: "auto",
@@ -27,7 +27,7 @@ const SearchBar = defineMultiStyleConfig({
       paddingLeft: { base: "xs", md: "s" },
       paddingBottom: { base: "xs", md: "xs" },
       paddingRight: { base: "xs", md: "s" },
-      gap: "xs",
+      gap: "xxs",
       borderRightRadius: "sm",
       " > span": {
         display: { base: "none", md: "block" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -23,7 +23,7 @@ const SearchBar = defineMultiStyleConfig({
       borderLeftRadius: "none",
       lineHeight: "1.70",
       marginBottom: "auto",
-      padding: {base: "xs", md: "s"},
+      padding: { base: "xs", md: "s" },
       gap: "xs",
       borderRightRadius: "sm",
       " > span": {

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -10,14 +10,23 @@ const SearchBar = defineMultiStyleConfig({
       base: "xs",
       md: "auto",
     },
-    flexFlow: {
-      base: "column nowrap",
-      md: "row nowrap",
-    },
-    ".textInput": {
-      flexGrow: "1",
+    flexGrow: 1,
+    flexFlow: { base: "column nowrap", md: "row"},
+    button: {
+      borderLeftRadius: "none",
+      lineHeight: "1.70",
+      marginBottom: "auto",
+      padding: "xs",
+      borderRightRadius: "sm",
+      " > span": {
+        display: { base: "none", md: "block"}
+      },
+      " > svg": {
+        margin: 0
+      }
     },
     select: {
+      paddingBottom: { base: "s",md: "unset"},
       flexShrink: "0",
       marginBottom: { base: "-1px", md: "0" },
       maxWidth: { base: undefined, md: "255px" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -13,9 +13,9 @@ const SearchBar = defineMultiStyleConfig({
     ".textInput": {
       flexGrow: 1,
       " div > input": {
-      borderRightRadius: 0,
-      borderLeftRadius: "sm"
-      }
+        borderRightRadius: 0,
+        borderLeftRadius: "sm",
+      },
     },
     flexFlow: { base: "column nowrap", md: "row" },
     button: {

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -12,17 +12,19 @@ const SearchBar = defineMultiStyleConfig({
     },
     ".textInput": {
       flexGrow: 1,
-      " div > input": {
+      "div > input": {
         borderRightRadius: 0,
-        borderLeftRadius: "sm",
       },
     },
     flexFlow: { base: "column nowrap", md: "row" },
     button: {
+      minWidth: "44px",
+      maxWidth: "80px",
       borderLeftRadius: "none",
       lineHeight: "1.70",
       marginBottom: "auto",
-      padding: "xs",
+      padding: {base: "xs", md: "s"},
+      gap: "xs",
       borderRightRadius: "sm",
       " > span": {
         display: { base: "none", md: "block" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -27,7 +27,7 @@ const SearchBar = defineMultiStyleConfig({
       paddingLeft: { base: "xs", md: "s" },
       paddingBottom: { base: "xs", md: "xs" },
       paddingRight: { base: "xs", md: "s" },
-      gap: "xxs",
+      gap: "xs",
       borderRightRadius: "sm",
       " > span": {
         display: { base: "none", md: "block" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -11,7 +11,7 @@ const SearchBar = defineMultiStyleConfig({
       md: "auto",
     },
     flexGrow: 1,
-    flexFlow: { base: "column nowrap", md: "row"},
+    flexFlow: { base: "column nowrap", md: "row" },
     button: {
       borderLeftRadius: "none",
       lineHeight: "1.70",
@@ -19,14 +19,14 @@ const SearchBar = defineMultiStyleConfig({
       padding: "xs",
       borderRightRadius: "sm",
       " > span": {
-        display: { base: "none", md: "block"}
+        display: { base: "none", md: "block" },
       },
       " > svg": {
-        margin: 0
-      }
+        margin: 0,
+      },
     },
     select: {
-      paddingBottom: { base: "s",md: "unset"},
+      paddingBottom: { base: "s", md: "unset" },
       flexShrink: "0",
       marginBottom: { base: "-1px", md: "0" },
       maxWidth: { base: undefined, md: "255px" },

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -19,7 +19,6 @@ const SearchBar = defineMultiStyleConfig({
     flexFlow: { base: "column nowrap", md: "row" },
     ".searchButton": {
       minWidth: "44px",
-      maxWidth: { base: "unset", md: "80px" },
       borderLeftRadius: "none",
       lineHeight: "1.70",
       marginBottom: "auto",

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -24,7 +24,7 @@ const SearchBar = defineMultiStyleConfig({
       lineHeight: "1.70",
       marginBottom: "auto",
       paddingTop: { base: "xs", md: "xs" },
-      paddingLeft:{ base: "xs", md: "s" },
+      paddingLeft: { base: "xs", md: "s" },
       paddingBottom: { base: "xs", md: "xs" },
       paddingRight: { base: "xs", md: "s" },
       gap: "xxs",

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -12,6 +12,10 @@ const SearchBar = defineMultiStyleConfig({
     },
     ".textInput": {
       flexGrow: 1,
+      " div > input": {
+      borderRightRadius: 0,
+      borderLeftRadius: "sm"
+      }
     },
     flexFlow: { base: "column nowrap", md: "row" },
     button: {

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -19,7 +19,7 @@ const SearchBar = defineMultiStyleConfig({
     flexFlow: { base: "column nowrap", md: "row" },
     ".searchButton": {
       minWidth: "44px",
-      maxWidth: {base: "unset", md: "80px"},
+      maxWidth: { base: "unset", md: "80px" },
       borderLeftRadius: "none",
       lineHeight: "1.70",
       marginBottom: "auto",

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -10,7 +10,9 @@ const SearchBar = defineMultiStyleConfig({
       base: "xs",
       md: "auto",
     },
-    flexGrow: 1,
+    ".textInput" :{
+      flexGrow: 1,
+    },
     flexFlow: { base: "column nowrap", md: "row" },
     button: {
       borderLeftRadius: "none",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1811](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1811).

## This PR does the following:

- Updates the responsive styles on `Searchbar` (no stacking on mobile)
- Adds `<span>` to "Search" text so DCF can use new breakpoints

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1811]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ