### PR TITLE
NO-REF: Fix issues in FilterBarPopup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `FilterBarPopup` compoonent and `useFilterBarPopup` hook.
+
 ### Updates
 
 - Updates the `FilterBarInline` component to apply `closeOnBlur` to `MultiSelect` components when `layout="row"`.
@@ -19,7 +23,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the `FilterBarInline` component.
-- Adds the `FilterBarPopup` compoonent and `useFilterBarPopup` hook.
 - Adds refined `NewsletterSignup` component with updated props.
 - Adds refined `SocialMediaLinks` component with updated props
 

--- a/src/components/FilterBarPopup/FilterBarPopup.mdx
+++ b/src/components/FilterBarPopup/FilterBarPopup.mdx
@@ -273,7 +273,6 @@ return (
   <FilterBarPopup
     id={args.id}
     heading={args.heading}
-    layout={args.layout}
     onClear={onClearFilterBar}
     onSubmit={() => console.log(selectedFilterItems)}
     selectedItems={selectedFilterItems}

--- a/src/components/FilterBarPopup/FilterBarPopup.tsx
+++ b/src/components/FilterBarPopup/FilterBarPopup.tsx
@@ -115,6 +115,7 @@ export const FilterBarPopup: ChakraComponent<
             id={`filter-bar-${id}-show-filters`}
             buttonType="secondary"
             onClick={finalOnOpen}
+            width={{ base: "100%", md: "fit-content" }}
           >
             {`Show filters`}
           </Button>

--- a/src/components/FilterBarPopup/__snapshots__/FilterBarPopup.test.tsx.snap
+++ b/src/components/FilterBarPopup/__snapshots__/FilterBarPopup.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`FilterBarPopup renders the UI snapshots correctly 1`] = `
   id="filter-bar-defaultFilterBarNoButtons"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    className="chakra-button css-1llumfr"
     id="filter-bar-defaultFilterBarNoButtons-show-filters"
     onClick={[Function]}
     type="button"
@@ -22,7 +22,7 @@ exports[`FilterBarPopup renders the UI snapshots correctly 2`] = `
   id="filter-bar-filterBarWithClearAllButton"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    className="chakra-button css-1llumfr"
     id="filter-bar-filterBarWithClearAllButton-show-filters"
     onClick={[Function]}
     type="button"
@@ -38,7 +38,7 @@ exports[`FilterBarPopup renders the UI snapshots correctly 3`] = `
   id="filter-bar-filterBarWithSubmitAllButton"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    className="chakra-button css-1llumfr"
     id="filter-bar-filterBarWithSubmitAllButton-show-filters"
     onClick={[Function]}
     type="button"
@@ -54,7 +54,7 @@ exports[`FilterBarPopup renders the UI snapshots correctly 4`] = `
   id="filter-bar-filterBarWithButtons"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    className="chakra-button css-1llumfr"
     id="filter-bar-filterBarWithButtons-show-filters"
     onClick={[Function]}
     type="button"


### PR DESCRIPTION

## This PR does the following:

- Makes the width of FIlterBarPopup's trigger button be full width when the viewport is mobile width
- Minor update to docs

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

-

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
