### PR TITLE
DSD-1803: Remove image alt warning from FeaturedContent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the `FilterBarInline` component to apply `closeOnBlur` to `MultiSelect` components when `layout="row"`.
 - Updates `Breadcrumbs` component props to include `customLinkComponent` and `linkProps`.
-- Updates Banner component to allow for HTML content in the `content` prop when passed as a string.
+- Updates `Banner` component to allow for HTML content in the `content` prop when passed as a string.
+- Updates `Image` component to default the `alt` attribute to an empty string if no value is passed.
+
+### Removes
+
+- Removes `imageProps.alt` missing warning message from `FeaturedContent` as the prop is not always required.
 
 ## 3.2.0 (July 25, 2024)
 

--- a/src/components/FeaturedContent/FeaturedContent.mdx
+++ b/src/components/FeaturedContent/FeaturedContent.mdx
@@ -8,10 +8,10 @@ import Link from "../Link/Link";
 
 # Featured Content
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `2.1.0`    |
-| Latest            | `3.2.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `2.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/FeaturedContent/FeaturedContent.stories.tsx
+++ b/src/components/FeaturedContent/FeaturedContent.stories.tsx
@@ -121,7 +121,7 @@ export const LayoutVariations: Story = {
           </div>
         }
         imageProps={{
-          alt: "",
+          alt: "Alt text",
           width: "default",
           position: "end",
           src: "https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg",

--- a/src/components/FeaturedContent/FeaturedContent.stories.tsx
+++ b/src/components/FeaturedContent/FeaturedContent.stories.tsx
@@ -121,7 +121,7 @@ export const LayoutVariations: Story = {
           </div>
         }
         imageProps={{
-          alt: "Alt text",
+          alt: "",
           width: "default",
           position: "end",
           src: "https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg",

--- a/src/components/FeaturedContent/FeaturedContent.test.tsx
+++ b/src/components/FeaturedContent/FeaturedContent.test.tsx
@@ -96,23 +96,6 @@ describe("FeaturedContent", () => {
       `NYPL Reservoir FeaturedContent: A value for 'imageProps.src' is required.`
     );
   });
-
-  it("logs a warning if `imageProps.alt` is empty", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      <FeaturedContent
-        isFullWidth={true}
-        imageProps={{
-          alt: "",
-          src: getPlaceholderImage("smaller", 0),
-        }}
-        textContent={textContent}
-      />
-    );
-    expect(warn).toHaveBeenCalledWith(
-      `NYPL Reservoir FeaturedContent: A value for 'imageProps.alt' is required.`
-    );
-  });
 });
 
 it("Renders the UI snapshot correctly", () => {

--- a/src/components/FeaturedContent/FeaturedContent.tsx
+++ b/src/components/FeaturedContent/FeaturedContent.tsx
@@ -82,11 +82,6 @@ export const FeaturedContent: ChakraComponent<
           `NYPL Reservoir FeaturedContent: A value for 'imageProps.src' is required.`
         );
       }
-      if (!imageProps.alt) {
-        console.warn(
-          `NYPL Reservoir FeaturedContent: A value for 'imageProps.alt' is required.`
-        );
-      }
       if (!textContent) {
         console.warn(
           `NYPL Reservoir FeaturedContent: The 'textContent' prop is required.`

--- a/src/components/FeaturedContent/featuredContentChangelogData.ts
+++ b/src/components/FeaturedContent/featuredContentChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Documentation"],
+    notes: [
+      "Removes `imageProps.alt` missing warning message as the prop is not always required.",
+    ],
+  },
+  {
     date: "2024-07-25",
     version: "3.2.0",
     type: "Update",

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./imageChangelogData";
 
 # Image
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.6`    |
-| Latest            | `3.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.6`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -43,9 +43,10 @@ If you want a simple HTML `img` element then don't pass in values for the
 
 ## Accessibility
 
-All images must have an `alt` attribute, even if it's empty. The `alt` prop should
-be used to concisely describe the image. If the image is decorative, then the
-`alt` prop should be an empty string `""`.
+The `alt` prop should be used to concisely describe the image. If the image is purely decorative,
+the `alt` attribute should still be present, but can be set to an empty string. In this scenario,
+an `alt` prop does not need to be passed. The component will set the attribute to an empty string
+`""` by default.
 
 Resources:
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -148,7 +148,7 @@ export const Image: ChakraComponent<
       additionalFigureStyles = {},
       additionalImageStyles = {},
       additionalWrapperStyles = {},
-      alt,
+      alt = "",
       aspectRatio = "original",
       caption,
       className = "",

--- a/src/components/Image/imageChangelogData.ts
+++ b/src/components/Image/imageChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Accessibility"],
+    notes: [
+      "Defaults the `alt` attribute to an empty string if no value is passed.",
+    ],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1803](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1803)

## This PR does the following:

- Updates `Image` component to default the `alt` attribute to an empty string if no value is passed.
- Removes `imageProps.alt` missing warning message from `FeaturedContent` as the prop is not always required.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally, in Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- None. Change approved by Clare.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1803]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ