### PR TITLE
DSD-1823: using buttonText in MultiSelect for CheckboxGroup legend value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `FilterBarInline` component to apply `closeOnBlur` to `MultiSelect` components when `layout="row"`.
 - Updates `Breadcrumbs` component props to include `customLinkComponent` and `linkProps`.
 - Updates Banner component to allow for HTML content in the `content` prop when passed as a string.
+- Updates the legend in the `MultiSelect`'s `CheckboxGroup` to use the `buttonText` prop value for better accessibility context.
 
 ## 3.2.0 (July 25, 2024)
 

--- a/src/components/FilterBarInline/__snapshots__/FilterBarInline.test.tsx.snap
+++ b/src/components/FilterBarInline/__snapshots__/FilterBarInline.test.tsx.snap
@@ -53,12 +53,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -118,7 +118,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                       id="multi-select-checkbox-group-colors-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -327,12 +327,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -392,7 +392,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                       id="multi-select-checkbox-group-pets-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -760,12 +760,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -825,7 +825,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                       id="multi-select-checkbox-group-tools-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -1224,12 +1224,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -1289,7 +1289,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                       id="multi-select-checkbox-group-colors-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -1498,12 +1498,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -1563,7 +1563,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                       id="multi-select-checkbox-group-pets-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -1931,12 +1931,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -1996,7 +1996,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                       id="multi-select-checkbox-group-tools-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -2407,12 +2407,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -2472,7 +2472,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                       id="multi-select-checkbox-group-colors-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -2681,12 +2681,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -2746,7 +2746,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                       id="multi-select-checkbox-group-pets-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -3114,12 +3114,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -3179,7 +3179,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                       id="multi-select-checkbox-group-tools-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -3590,12 +3590,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -3655,7 +3655,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                       id="multi-select-checkbox-group-colors-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -3864,12 +3864,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -3929,7 +3929,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                       id="multi-select-checkbox-group-pets-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"
@@ -4297,12 +4297,12 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                 <span
                   className="css-1kmgev1"
                 >
-                  <div
+                  <span
                     className="css-0"
                     title="MultiSelect"
                   >
                     MultiSelect
-                  </div>
+                  </span>
                 </span>
                 <svg
                   aria-hidden={true}
@@ -4362,7 +4362,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                       id="multi-select-checkbox-group-tools-checkbox-group"
                     >
                       <legend>
-                        Multi select checkbox group label
+                        MultiSelect
                       </legend>
                       <div
                         className="chakra-stack css-19s3t1h"

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./multiSelectChangelogData";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `3.1.7`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.4.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -78,7 +78,7 @@ const MultiSelectTestComponent = ({
   );
 };
 
-describe.skip("MultiSelect Accessibility", () => {
+describe("MultiSelect Accessibility", () => {
   let selectedTestItems;
   beforeEach(() => (selectedTestItems = {}));
 
@@ -101,7 +101,7 @@ describe.skip("MultiSelect Accessibility", () => {
   });
 });
 
-describe.skip("MultiSelect", () => {
+describe("MultiSelect", () => {
   beforeAll(() => {
     window.resizeTo = function resizeTo(width, height) {
       Object.assign(this, {
@@ -134,7 +134,7 @@ describe.skip("MultiSelect", () => {
     expect(container.querySelector("#multiselect-test-id")).toBeInTheDocument();
   });
 
-  it("should initially render with a given button text ", () => {
+  it("should initially render with a given button text", () => {
     render(
       <MultiSelect
         id="multiselect-test-id"
@@ -149,8 +149,29 @@ describe.skip("MultiSelect", () => {
         onClear={() => null}
       />
     );
-    expect(screen.getByText("Multiselect button text").textContent);
-    expect(screen.getByRole("button")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: /Multiselect button text/ })
+    ).toBeInTheDocument();
+  });
+
+  it("the CheckboxGroup legend should have the same button text", () => {
+    const { container } = render(
+      <MultiSelect
+        id="multiselect-test-id"
+        buttonText="Multiselect button text"
+        isDefaultOpen={false}
+        isSearchable={false}
+        isBlockElement={false}
+        defaultItemsVisible={defaultItemsVisible}
+        items={items}
+        selectedItems={selectedTestItems}
+        onChange={() => null}
+        onClear={() => null}
+      />
+    );
+    expect(container.querySelector("legend")).toHaveTextContent(
+      "Multiselect button text"
+    );
   });
 
   it("should initially render with a closed menu when the isDefaultOpen is omitted or set to false", () => {

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -359,6 +359,7 @@ export const MultiSelect: ChakraComponent<
       /** Components for accordionData */
       const accordionLabel = (
         <Box
+          as="span"
           title={buttonText}
           __css={selectedItemsCount > 0 ? styles.buttonTextLabel : null}
         >
@@ -392,7 +393,7 @@ export const MultiSelect: ChakraComponent<
                 layout="column"
                 isFullWidth
                 isRequired={false}
-                labelText="Multi select checkbox group label"
+                labelText={buttonText}
                 showLabel={false}
                 name="multi-select-checkbox-group"
               >

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -4,6 +4,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
 <div
   className="css-1xdhyk6"
   id="multiselect-test-id"
+  onClick={[Function]}
 >
   <div
     className="chakra-accordion css-1xdhyk6"
@@ -28,12 +29,12 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
         <span
           className="css-1kmgev1"
         >
-          <div
+          <span
             className="css-0"
             title="multiselect-button-text"
           >
             multiselect-button-text
-          </div>
+          </span>
         </span>
         <svg
           aria-hidden={true}
@@ -93,7 +94,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
               id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
-                Multi select checkbox group label
+                multiselect-button-text
               </legend>
               <div
                 className="chakra-stack css-19s3t1h"
@@ -548,6 +549,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
 <div
   className="css-1xdhyk6"
   id="multiselect-test-id"
+  onClick={[Function]}
 >
   <div
     className="chakra-accordion css-1xdhyk6"
@@ -572,12 +574,12 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
         <span
           className="css-1kmgev1"
         >
-          <div
+          <span
             className="css-0"
             title="multiselect-button-text"
           >
             multiselect-button-text
-          </div>
+          </span>
         </span>
         <svg
           aria-hidden={true}
@@ -637,7 +639,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
               id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
-                Multi select checkbox group label
+                multiselect-button-text
               </legend>
               <div
                 className="chakra-stack css-19s3t1h"
@@ -1092,6 +1094,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
 <div
   className="css-1xdhyk6"
   id="multiselect-test-id"
+  onClick={[Function]}
 >
   <div
     className="chakra-accordion css-1xdhyk6"
@@ -1116,12 +1119,12 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
         <span
           className="css-1kmgev1"
         >
-          <div
+          <span
             className="css-0"
             title="multiselect-button-text"
           >
             multiselect-button-text
-          </div>
+          </span>
         </span>
         <svg
           aria-hidden={true}
@@ -1181,7 +1184,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
               id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
-                Multi select checkbox group label
+                multiselect-button-text
               </legend>
               <div
                 className="chakra-stack css-19s3t1h"
@@ -1723,6 +1726,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
 <div
   className="css-1xdhyk6"
   id="multiselect-test-id"
+  onClick={[Function]}
 >
   <div
     className="chakra-accordion css-1xdhyk6"
@@ -1747,12 +1751,12 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
         <span
           className="css-1kmgev1"
         >
-          <div
+          <span
             className="css-0"
             title="multiselect-button-text"
           >
             multiselect-button-text
-          </div>
+          </span>
         </span>
         <svg
           aria-hidden={true}
@@ -1812,7 +1816,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
               id="multi-select-checkbox-group-multiselect-test-id-checkbox-group"
             >
               <legend>
-                Multi select checkbox group label
+                multiselect-button-text
               </legend>
               <div
                 className="chakra-stack css-19s3t1h"

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "New Feature",
+    affects: ["Accessibility"],
+    notes: [
+      "Renders the `buttonText` prop as the `CheckboxGroup`'s legend for more meaningful context.",
+    ],
+  },
+  {
     date: "2024-07-03",
     version: "3.1.7",
     type: "New Feature",

--- a/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
+++ b/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
@@ -41,12 +41,12 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
             <span
               className="css-1kmgev1"
             >
-              <div
+              <span
                 className="css-0"
                 title="MultiSelect"
               >
                 MultiSelect
-              </div>
+              </span>
             </span>
             <svg
               aria-hidden={true}
@@ -106,7 +106,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                   id="multi-select-checkbox-group-colors-checkbox-group"
                 >
                   <legend>
-                    Multi select checkbox group label
+                    MultiSelect
                   </legend>
                   <div
                     className="chakra-stack css-19s3t1h"
@@ -315,12 +315,12 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
             <span
               className="css-1kmgev1"
             >
-              <div
+              <span
                 className="css-0"
                 title="MultiSelect"
               >
                 MultiSelect
-              </div>
+              </span>
             </span>
             <svg
               aria-hidden={true}
@@ -380,7 +380,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                   id="multi-select-checkbox-group-pets-checkbox-group"
                 >
                   <legend>
-                    Multi select checkbox group label
+                    MultiSelect
                   </legend>
                   <div
                     className="chakra-stack css-19s3t1h"
@@ -748,12 +748,12 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
             <span
               className="css-1kmgev1"
             >
-              <div
+              <span
                 className="css-0"
                 title="MultiSelect"
               >
                 MultiSelect
-              </div>
+              </span>
             </span>
             <svg
               aria-hidden={true}
@@ -813,7 +813,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
                   id="multi-select-checkbox-group-tools-checkbox-group"
                 >
                   <legend>
-                    Multi select checkbox group label
+                    MultiSelect
                   </legend>
                   <div
                     className="chakra-stack css-19s3t1h"
@@ -1198,12 +1198,12 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
             <span
               className="css-1kmgev1"
             >
-              <div
+              <span
                 className="css-0"
                 title="MultiSelect"
               >
                 MultiSelect
-              </div>
+              </span>
             </span>
             <svg
               aria-hidden={true}
@@ -1263,7 +1263,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                   id="multi-select-checkbox-group-colors-checkbox-group"
                 >
                   <legend>
-                    Multi select checkbox group label
+                    MultiSelect
                   </legend>
                   <div
                     className="chakra-stack css-19s3t1h"
@@ -1472,12 +1472,12 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
             <span
               className="css-1kmgev1"
             >
-              <div
+              <span
                 className="css-0"
                 title="MultiSelect"
               >
                 MultiSelect
-              </div>
+              </span>
             </span>
             <svg
               aria-hidden={true}
@@ -1537,7 +1537,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                   id="multi-select-checkbox-group-pets-checkbox-group"
                 >
                   <legend>
-                    Multi select checkbox group label
+                    MultiSelect
                   </legend>
                   <div
                     className="chakra-stack css-19s3t1h"
@@ -1905,12 +1905,12 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
             <span
               className="css-1kmgev1"
             >
-              <div
+              <span
                 className="css-0"
                 title="MultiSelect"
               >
                 MultiSelect
-              </div>
+              </span>
             </span>
             <svg
               aria-hidden={true}
@@ -1970,7 +1970,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
                   id="multi-select-checkbox-group-tools-checkbox-group"
                 >
                   <legend>
-                    Multi select checkbox group label
+                    MultiSelect
                   </legend>
                   <div
                     className="chakra-stack css-19s3t1h"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1823](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1823)

## This PR does the following:

- Uses the `MultiSelect`'s `buttonText` prop value as the internal `CheckboxGroup`'s label text value. The previous hardcoded value had no meaning, was repetitive, and was confusing. This updates gives it more context for screen readers.
- Also replace the internal `div` inside the accordion button to a `span` for better HTML DOM.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally in Storybook.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Fixes an issue found in Research Catalog.

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1823]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1823?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ