### PR TITLE
DSD-1733: Adds defaultValue prop to Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `FilterBarInline` component to apply `closeOnBlur` to `MultiSelect` components when `layout="row"`.
 - Updates `Breadcrumbs` component props to include `customLinkComponent` and `linkProps`.
 - Updates Banner component to allow for HTML content in the `content` prop when passed as a string.
+- Updates `Select` component to accept a `defaultValue` prop to set initial value of uncontrolled components.
 
 ## 3.2.0 (July 25, 2024)
 
@@ -31,8 +32,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates Storybook and related npm packages to version `8.1.11`. Does not affect any DS component.
 - Updates `Menu` component with new `showSelectionAsLabel` prop and `aria-label` behavior.
 - Updates the `Banner`, `Button`, `ButtonGroup`, `DatePicker`, `FeaturedContent`, `FeedbackBox`, `Fieldset`, `HelperErrorText`, `Label`, `SkipNavigation`, and `StyledList` components to export all types and prop interfaces.
-- Updates `Select` component to accept a `defaultValue` prop to set initial value of uncontrolled components.
-
 
 ## 3.1.7 (July 3, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates Storybook and related npm packages to version `8.1.11`. Does not affect any DS component.
 - Updates `Menu` component with new `showSelectionAsLabel` prop and `aria-label` behavior.
 - Updates the `Banner`, `Button`, `ButtonGroup`, `DatePicker`, `FeaturedContent`, `FeedbackBox`, `Fieldset`, `HelperErrorText`, `Label`, `SkipNavigation`, and `StyledList` components to export all types and prop interfaces.
+- Updates `Select` component to accept a `defaultValue` prop to set initial value of uncontrolled components.
+
 
 ## 3.1.7 (July 3, 2024)
 

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -8,10 +8,10 @@ import { changelogData } from "./selectChangelogData";
 
 # Select
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.7.0`    |
-| Latest            | `3.1.6`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.7.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -151,7 +151,8 @@ export function SelectControlledExample() {
 If your application uses uncontrolled components, you can pass a React `ref`
 prop to the DS Select component to get the selected value from the DOM. Note
 that this example uses a `Form` and a `Button` to submit the form, only then
-will the value be available.
+will the value be available. Additionally, you may pass a `defaultValue` prop
+to set the component's initial value.
 
 Try it out: open up the browser's console to see new values being logged on
 each change.
@@ -168,6 +169,7 @@ export function SelectUncontrolledExample() {
     <Form id="form">
       <FormField>
         <Select
+          defaultValue="white"
           helperText="This is the helper text."
           id="example-2"
           labelText="What is your favorite color?"

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -14,6 +14,7 @@ const meta: Meta<typeof Select> = {
   argTypes: {
     children: { table: { disable: true } },
     className: { control: false },
+    defaultValue: { control: false },
     helperText: { control: "text" },
     id: { control: false },
     invalidText: { control: "text" },
@@ -51,6 +52,7 @@ type Story = StoryObj<typeof Select>;
 export const WithControls: Story = {
   args: {
     className: undefined,
+    defaultValue: undefined,
     helperText: "This is the helper text.",
     id: "select-id",
     invalidText: "This is the error text :(",
@@ -61,6 +63,7 @@ export const WithControls: Story = {
     labelText: "What is your favorite color?",
     name: "color",
     onChange: undefined,
+    placeholder: undefined,
     showHelperInvalidText: undefined,
     showLabel: true,
     showRequiredLabel: true,

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -254,6 +254,7 @@ function SelectUncontrolledExample() {
     <Form id="form">
       <FormField>
         <Select
+          defaultValue="white"
           helperText="This is the helper text."
           id="example-2"
           labelText="What is your favorite color?"

--- a/src/components/Select/Select.test.tsx
+++ b/src/components/Select/Select.test.tsx
@@ -234,6 +234,22 @@ describe("Select", () => {
     );
   });
 
+  it("logs a warning when both `onChange` and `defaultValue` are passed", () => {
+    const warn = jest.spyOn(console, "warn");
+    let value = "defaultValue";
+    const changeCallback = (e: React.FormEvent) => {
+      value = (e.target as HTMLInputElement).value;
+    };
+    render(
+      <Select {...baseProps} onChange={changeCallback} defaultValue={value}>
+        {baseOptions}
+      </Select>
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Select: Both an `onChange` prop (used for controlled components) and a `defaultValue` prop (used for uncontrolled components) were passed. `defaultValue` will be ignored."
+    );
+  });
+
   it("Renders the UI snapshot correctly", () => {
     const siblings = ["Kendall", "Shiv", "Connor", "Roman", "Tom"];
     const options = siblings.map((sibling) => (

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -139,7 +139,7 @@ export const Select: ChakraComponent<
 
       if (onChange && defaultValue) {
         console.warn(
-          "NYPL Reservoir Select: Both an `onChange` prop (used for controlled components) and a `defaultValue` prop (used for controlled components) were passed. `defaultValue` will be ignored."
+          "NYPL Reservoir Select: Both an `onChange` prop (used for controlled components) and a `defaultValue` prop (used for uncontrolled components) were passed. `defaultValue` will be ignored."
         );
       }
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -22,6 +22,8 @@ export type LabelPositions = typeof labelPositionsArray[number];
 export interface SelectProps {
   /** A class name for the `div` parent element. */
   className?: string;
+  /** The initial value of an uncontrolled component */
+  defaultValue?: string;
   /** Optional string to populate the `HelperErrorText` for the standard state. */
   helperText?: HelperErrorTextType;
   /** ID that other components can cross reference for accessibility purposes */
@@ -81,6 +83,7 @@ export const Select: ChakraComponent<
       const {
         children,
         className,
+        defaultValue,
         helperText,
         id,
         invalidText,
@@ -118,7 +121,11 @@ export const Select: ChakraComponent<
       });
       // To control the `Select` component, both `onChange` and `value`
       // must be passed.
-      const controlledProps = onChange ? { onChange, value } : {};
+      const controlledOrUncontrolledProps = onChange
+        ? { onChange, value }
+        : defaultValue
+        ? { defaultValue }
+        : {};
 
       // The number of pixels between the label and select elements
       // when the labelPosition is inline (equivalent to --nypl-space-xs).
@@ -129,6 +136,12 @@ export const Select: ChakraComponent<
         isInvalid ? "ui.error.primary" : "ui.black",
         isInvalid ? "dark.ui.error.primary" : "dark.ui.typography.body"
       );
+
+      if (onChange && defaultValue) {
+        console.warn(
+          "NYPL Reservoir Select: Both an `onChange` prop (used for controlled components) and a `defaultValue` prop (used for controlled components) were passed. `defaultValue` will be ignored."
+        );
+      }
 
       if (!id) {
         console.warn(
@@ -183,7 +196,7 @@ export const Select: ChakraComponent<
               name={name}
               placeholder={placeholder}
               ref={ref}
-              {...controlledProps}
+              {...controlledOrUncontrolledProps}
               {...ariaAttributes}
               icon={
                 <Icon

--- a/src/components/Select/selectChangelogData.ts
+++ b/src/components/Select/selectChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: [
+      "Updates component to accept a `defaultValue` prop to set initial value of uncontrolled components.",
+    ],
+  },
+  {
     date: "2024-06-20",
     version: "3.1.6",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1733](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1733).

## This PR does the following:

-  Updates `Select` component to accept a `defaultValue` prop to set initial value of uncontrolled components.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally, in Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- None

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1733]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1733?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ