### PR TITLE
NO-REF: Update focus for FilterBarPopup on clear

### DIFF
--- a/src/components/FilterBarPopup/FilterBarPopup.tsx
+++ b/src/components/FilterBarPopup/FilterBarPopup.tsx
@@ -13,7 +13,7 @@ import {
   useDisclosure,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef } from "react";
+import React, { forwardRef, useRef } from "react";
 import Button from "../Button/Button";
 import ButtonGroup from "../ButtonGroup/ButtonGroup";
 import Heading, { HeadingSizes } from "../Heading/Heading";
@@ -109,6 +109,17 @@ export const FilterBarPopup: ChakraComponent<
         finalOnClose();
       };
 
+      const showResultsButtonRef: React.RefObject<HTMLButtonElement> =
+        useRef<HTMLButtonElement>();
+
+      const onClearAndFocus = () => {
+        onClear();
+
+        setTimeout(() => {
+          showResultsButtonRef.current?.focus();
+        }, 1);
+      };
+
       return (
         <Box id={`filter-bar-${id}`} ref={ref} {...rest}>
           <Button
@@ -147,6 +158,7 @@ export const FilterBarPopup: ChakraComponent<
                     buttonType="primary"
                     type="submit"
                     onClick={onSubmit ? onSubmitAndClose : finalOnClose}
+                    ref={showResultsButtonRef}
                   >
                     {`Show ${totalResults ?? ""} results`}
                   </Button>
@@ -155,7 +167,7 @@ export const FilterBarPopup: ChakraComponent<
                       id={`filter-bar-${id}-clear`}
                       buttonType="text"
                       type="reset"
-                      onClick={onClear}
+                      onClick={onClearAndFocus}
                       textAlign="center"
                     >
                       Clear all filters


### PR DESCRIPTION


## This PR does the following:

- Updates focus to the "Show results" button when the "Clear all filters" button is clicked.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

-

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
