### PR TITLE
DSD-1826: Fixing an issue where an id was being duplicated in the Image component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes a duplicate `id` issue in the `Image` component. This happened when an aspect ratio value rendered a wrapper div with the same `id` as the `img` element. This was not picked up by internal accessibility tests but in a consuming application.
+
 ## 3.3.0 (August 29, 2024)
 
 ### Adds

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -98,6 +98,7 @@ export const WithControls: Story = {
         alt: args["imageProps.alt"],
         aspectRatio: args["imageProps.aspectRatio"],
         component: args["imageProps.component"],
+        id: "card-image-id",
         isAtEnd: args["imageProps.isAtEnd"],
         isLazy: args["imageProps.isLazy"],
         size: args["imageProps.size"],

--- a/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
+++ b/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
@@ -18,6 +18,7 @@ exports[`Renders the UI snapshot correctly 1`] = `
         <img
           alt="Image example"
           className="css-0"
+          id={null}
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -80,6 +81,7 @@ exports[`Renders the UI snapshot correctly 2`] = `
         <img
           alt="Image example"
           className="css-0"
+          id={null}
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -142,6 +144,7 @@ exports[`Renders the UI snapshot correctly 3`] = `
         <img
           alt="Image example"
           className="css-0"
+          id={null}
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -204,6 +207,7 @@ exports[`Renders the UI snapshot correctly 4`] = `
         <img
           alt="Image example"
           className="css-0"
+          id={null}
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -266,6 +270,7 @@ exports[`Renders the UI snapshot correctly 5`] = `
         <img
           alt="Image example"
           className="css-0"
+          id={null}
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
@@ -328,6 +333,7 @@ exports[`Renders the UI snapshot correctly 6`] = `
         <img
           alt="Image example"
           className="css-0"
+          id={null}
           onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./imageChangelogData";
 
 # Image
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.6`    |
-| Latest            | `3.3.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.6`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -146,7 +146,7 @@ export const WithControls: Story = {
     sizeBasedOn: "width",
     src: getPlaceholderImage(),
   },
-  render: (args) => <Image {...args} />,
+  render: (args) => <Image {...args} id="image-id" />,
   parameters: {
     design: {
       type: "figma",

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -13,6 +13,13 @@ describe("Image Accessibility", () => {
     expect(await axe(container)).toHaveNoViolations();
   });
 
+  it("passes axe accessibility with an aspect ratio and id", async () => {
+    const { container } = render(
+      <Image alt="" src="test.png" aspectRatio="oneByTwo" id="test-id" />
+    );
+    expect(await axe(container)).toHaveNoViolations();
+  });
+
   it("passes axe accessibility for regular lazy loading img element", async () => {
     const { container } = render(<Image alt="" isLazy src="test.png" />);
 

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -31,9 +31,9 @@ export const imageSizesArray = [
   "large",
 ] as const;
 export const imageTypesArray = ["default", "circle"] as const;
-export type ImageRatios = typeof imageRatiosArray[number];
-export type ImageSizes = typeof imageSizesArray[number];
-export type ImageTypes = typeof imageTypesArray[number];
+export type ImageRatios = (typeof imageRatiosArray)[number];
+export type ImageSizes = (typeof imageSizesArray)[number];
+export type ImageTypes = (typeof imageTypesArray)[number];
 
 // Used for components that have an `imageProps` prop.
 export interface ComponentImageProps extends Partial<HTMLImageElement> {

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -51,6 +51,8 @@ export interface ComponentImageProps extends Partial<HTMLImageElement> {
   credit?: string;
   /** Fallback image path or URL. */
   fallbackSrc?: string;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
   /** Flag to set the internal `Image` component to `isLazy` mode. */
   isLazy?: boolean;
   /** Additional action to perform in the `img`'s `onerror` attribute function. */
@@ -68,6 +70,8 @@ interface ImageWrapperProps {
   additionalWrapperStyles?: { [key: string]: any };
   /** ClassName you can add in addition to 'image' */
   className?: string;
+  /** ID that other components can cross reference for accessibility purposes. */
+  id?: string;
   /** Optional value to control the aspect ratio of the card image; default
    * value is `"original"` */
   ratio?: ImageRatios;
@@ -113,6 +117,7 @@ const ImageWrapper = chakra(
       additionalWrapperStyles = {},
       className = "",
       children,
+      id,
       ratio = "original",
       size = "default",
       sizeBasedOn = "width",
@@ -126,6 +131,7 @@ const ImageWrapper = chakra(
     return (
       <Box
         className={`the-wrap ${className}`}
+        id={id}
         __css={{ ...styles.base, ...additionalWrapperStyles }}
         {...rest}
       >
@@ -155,6 +161,7 @@ export const Image: ChakraComponent<
       component,
       credit,
       fallbackSrc,
+      id,
       imageType = "default",
       isLazy = false,
       onError,
@@ -220,6 +227,7 @@ export const Image: ChakraComponent<
       <Box
         as="img"
         alt={alt}
+        id={id ? id : null}
         loading={isLazy ? "lazy" : undefined}
         onError={onImageError}
         {...srcProp}
@@ -230,8 +238,9 @@ export const Image: ChakraComponent<
     const finalImage = useImageWrapper ? (
       <ImageWrapper
         additionalWrapperStyles={additionalWrapperStyles}
-        ratio={aspectRatio}
         className={className}
+        id={id ? `${id}-wrapper` : null}
+        ratio={aspectRatio}
         size={size}
         sizeBasedOn={sizeBasedOn}
         {...(caption || credit ? {} : rest)}

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Image Renders the UI snapshot correctly 1`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -23,6 +24,7 @@ exports[`Image Renders the UI snapshot correctly 2`] = `
     <img
       alt=""
       className="css-0"
+      id={null}
       onError={[Function]}
       src="test.png"
     />
@@ -58,6 +60,7 @@ exports[`Image Renders the UI snapshot correctly 3`] = `
     <img
       alt=""
       className="css-0"
+      id={null}
       onError={[Function]}
       src="test.png"
     />
@@ -93,6 +96,7 @@ exports[`Image Renders the UI snapshot correctly 4`] = `
     <img
       alt=""
       className="css-0"
+      id={null}
       onError={[Function]}
       src="test.png"
     />
@@ -139,6 +143,7 @@ exports[`Image Renders the UI snapshot correctly 5`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -152,6 +157,7 @@ exports[`Image Renders the UI snapshot correctly 6`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -165,6 +171,7 @@ exports[`Image Renders the UI snapshot correctly 7`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -178,6 +185,7 @@ exports[`Image Renders the UI snapshot correctly 8`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -191,6 +199,7 @@ exports[`Image Renders the UI snapshot correctly 9`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -204,6 +213,7 @@ exports[`Image Renders the UI snapshot correctly 10`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -216,6 +226,7 @@ exports[`Image Renders the UI snapshot correctly 11`] = `
 >
   <div
     className="the-wrap css-6n2uy8"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -223,6 +234,7 @@ exports[`Image Renders the UI snapshot correctly 11`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -237,6 +249,7 @@ exports[`Image Renders the UI snapshot correctly 12`] = `
 >
   <div
     className="the-wrap css-fp4s7x"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -244,6 +257,7 @@ exports[`Image Renders the UI snapshot correctly 12`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -259,6 +273,7 @@ exports[`Image Renders the UI snapshot correctly 13`] = `
   <img
     alt=""
     className="css-0"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -271,6 +286,7 @@ exports[`Image Renders the UI snapshot correctly 14`] = `
 >
   <div
     className="the-wrap css-5r8zvy"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -278,6 +294,7 @@ exports[`Image Renders the UI snapshot correctly 14`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -292,6 +309,7 @@ exports[`Image Renders the UI snapshot correctly 15`] = `
 >
   <div
     className="the-wrap css-12nxalf"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -299,6 +317,7 @@ exports[`Image Renders the UI snapshot correctly 15`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -313,6 +332,7 @@ exports[`Image Renders the UI snapshot correctly 16`] = `
 >
   <div
     className="the-wrap css-1atfqya"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -320,6 +340,7 @@ exports[`Image Renders the UI snapshot correctly 16`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -334,6 +355,7 @@ exports[`Image Renders the UI snapshot correctly 17`] = `
 >
   <div
     className="the-wrap css-vy443d"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -341,6 +363,7 @@ exports[`Image Renders the UI snapshot correctly 17`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -355,6 +378,7 @@ exports[`Image Renders the UI snapshot correctly 18`] = `
 >
   <div
     className="the-wrap css-3hzznc"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -362,6 +386,7 @@ exports[`Image Renders the UI snapshot correctly 18`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -376,6 +401,7 @@ exports[`Image Renders the UI snapshot correctly 19`] = `
 >
   <div
     className="the-wrap css-12nxalf"
+    id={null}
   >
     <div
       className="the-crop css-0"
@@ -383,6 +409,7 @@ exports[`Image Renders the UI snapshot correctly 19`] = `
       <img
         alt=""
         className="css-0"
+        id={null}
         onError={[Function]}
         src="test.png"
       />
@@ -398,6 +425,7 @@ exports[`Image Renders the UI snapshot correctly 20`] = `
   <img
     alt=""
     className="css-qvgr6z"
+    id={null}
     onError={[Function]}
     src="test.png"
   />
@@ -412,6 +440,7 @@ exports[`Image Renders the UI snapshot correctly 21`] = `
     alt=""
     className="css-0"
     data-testid="image"
+    id={null}
     onError={[Function]}
     src="test.png"
   />

--- a/src/components/Image/imageChangelogData.ts
+++ b/src/components/Image/imageChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Accessibility"],
+    notes: [
+      "Fixes an issue where the `id` prop was being duplicated in the aspect ratio's wrapper div.",
+    ],
+  },
+  {
     date: "2024-08-29",
     version: "3.3.0",
     type: "Update",

--- a/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
+++ b/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
@@ -26,6 +26,7 @@ exports[`StructuredContent renders the UI snapshot 1`] = `
       <img
         alt="Image alt text"
         className="css-0"
+        id={null}
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -100,6 +101,7 @@ exports[`StructuredContent renders the UI snapshot 2`] = `
       <img
         alt="Image alt text"
         className="css-0"
+        id={null}
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -233,6 +235,7 @@ exports[`StructuredContent renders the UI snapshot 4`] = `
     <img
       alt="Image alt text"
       className="css-0"
+      id={null}
       onError={[Function]}
       src="https://images.nypl.org/index.php?id=swope_243048&t=r"
     />
@@ -268,6 +271,7 @@ exports[`StructuredContent renders the UI snapshot 5`] = `
       <img
         alt="Image alt text"
         className="css-0"
+        id={null}
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -364,6 +368,7 @@ exports[`StructuredContent renders the UI snapshot 7`] = `
       <img
         alt="Image alt text"
         className="css-0"
+        id={null}
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
@@ -439,6 +444,7 @@ exports[`StructuredContent renders the UI snapshot 8`] = `
       <img
         alt="Image alt text"
         className="css-0"
+        id={null}
         onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -3003,6 +3003,7 @@ exports[`Table renders the UI snapshot correctly 8`] = `
             <img
               alt="Tom Nook"
               className="css-0"
+              id={null}
               onError={[Function]}
               src="https://play.nintendo.com/images/AC_Tom_FRYtwIN.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
             />
@@ -3050,6 +3051,7 @@ exports[`Table renders the UI snapshot correctly 8`] = `
             <img
               alt="Isabelle"
               className="css-0"
+              id={null}
               onError={[Function]}
               src="https://play.nintendo.com/images/AC_Isabelle_7XU6aGu.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
             />
@@ -3097,6 +3099,7 @@ exports[`Table renders the UI snapshot correctly 8`] = `
             <img
               alt="K.K Slider"
               className="css-0"
+              id={null}
               onError={[Function]}
               src="https://play.nintendo.com/images/AC_KK_jh4yj5t.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
             />


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1826](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1826)

## This PR does the following:

- Fixes an issue where the `Image`'s id value was being duplicated in the `img` HTML element and in a wrapper div element that is used by the `aspectRatio` prop.
- This issue only happens when there's an id and aspect ratio value but not a caption or credit value.
- The `...rest` was the culprit.
- The jest-axe unit tests did not pick up this issue and neither does Storybook's accessibility tool. This was flagged in an accessibility test in DCF that @avertrees was working on.
- The issue is clearly in the DOM in jest-axe unit tests but the test still passes:
<img width="266" alt="Screenshot 2024-08-30 at 3 37 25 PM" src="https://github.com/user-attachments/assets/3b502169-7434-4e26-98b2-3a9c328c9808">

- This is now fixed
<img width="716" alt="Screenshot 2024-08-30 at 3 50 04 PM" src="https://github.com/user-attachments/assets/dceef390-df0b-452b-acc7-0d1a232819f3">


## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Fixes a non-flagged internal issue. It should've been flagged and maybe we need to upgrade our axe tools.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1826]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ