### PR TITLE
DSD-1830: updating zindex in the FeedbackBox component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Lowercases the 'r' of '(required)' in labels and placeholders where necessary in order to align with sentence case guidelines.
+- Increases the z-index of the `FeedbackBox`'s `Drawer` component so it displays above all other elements on a page.
 
 ### Fixes
 

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -14,7 +14,10 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Styles"],
-    notes: ["Changes 'r' in '(required)' label from upper- to lowercase"],
+    notes: [
+      "Changes 'r' in '(required)' label from upper- to lowercase",
+      "Increases the z-index of the `Drawer` component so it displays above all other elements on a page.",
+    ],
   },
   {
     date: "2024-07-25",

--- a/src/theme/components/feedbackBox.ts
+++ b/src/theme/components/feedbackBox.ts
@@ -72,8 +72,11 @@ const FeedbackBox = defineMultiStyleConfig({
       borderRadius: "0",
       bottom: "0",
       right: "0",
-      zIndex: "5",
-      _focus: { boxShadow: "0 0 0 6px var(--nypl-colors-ui-white) !important" },
+      zIndex: "10000",
+      _focus: {
+        boxShadow: "0 0 0 6px var(--nypl-colors-ui-white) !important",
+        zIndex: "10000 !important",
+      },
     },
   }),
 });

--- a/src/theme/foundations/global.ts
+++ b/src/theme/foundations/global.ts
@@ -51,6 +51,9 @@ const global = {
   ".chakra-modal__content-container": {
     zIndex: "999999 !important",
   },
+  ".chakra-modal__overlay": {
+    zIndex: "999999 !important",
+  },
 };
 
 export default global;

--- a/src/theme/foundations/global.ts
+++ b/src/theme/foundations/global.ts
@@ -48,6 +48,9 @@ const global = {
   "*, *::before, &::after": {
     boxSizing: "inherit",
   },
+  ".chakra-modal__content-container": {
+    zIndex: "999999 !important",
+  },
 };
 
 export default global;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1830](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1830)

## This PR does the following:

This issue was found in a Research Catalog page. In mobile, the `MultiSelect` components displayed above the `FeedbackBox` button and drawer components.

- This updates the z-index of the button but also Chakra's `Drawer` component. Their component, unfortunately, does not accept a class name or style props so the z-index rule is added as a global rule. This still has the same effect.
- This is difficult to test in Storybook because we don't have examples where we can easily add a `FeedbackBox` button on `MultiSelects` that makes sense. So perhaps a Turbine example is better.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally and in Research Catalog.

Issues fixed:
Button
![Screenshot 2024-09-10 at 11 10 45 AM](https://github.com/user-attachments/assets/dac94a32-bf1b-499c-819a-fc095b7d7d77)

Drawer
<img width="355" alt="Screenshot 2024-09-13 at 1 57 06 PM" src="https://github.com/user-attachments/assets/8f37b9c6-7d44-4efc-ae07-9558394c8460">



## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1830]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ