### PR TITLE
DSD 1829: Adding responsive tooltip example to Card docs

### DIFF
--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -254,8 +254,8 @@ You may need to keep track of the offset values through state, and update accord
 <Source
   code={`
   const [offset, setOffset] = useState<[number, number]>([0, 0]);
-  const cardRef = useRef<HTMLDivElement>(null);
-  const getOffset = () => {
+const cardRef = useRef<HTMLDivElement>(null);
+const getOffset = () => {
     if (cardRef.current) {
       const image = cardRef.current.children[0] as HTMLElement;
       const percentageHeightOffset = image.offsetHeight * 1.01;
@@ -263,13 +263,15 @@ You may need to keep track of the offset values through state, and update accord
       setOffset([-percentageWidthOffset, -percentageHeightOffset]);
     }
   };
-  useEffect(() => {
-    setTimeout(getOffset, 0);
-    window.addEventListener("resize", getOffset);
-    return () => {
-        window.removeEventListener("resize", getOffset);
-    };}, 
-  []);
+useEffect(() => {
+  setTimeout(getOffset, 0);
+  window.addEventListener("resize", getOffset);
+  return () => {
+      window.removeEventListener("resize", getOffset);
+  };}, 
+[]);
+
+return (
 
 <Tooltip offset={offset} content={"Tooltip text"}>
   <Card
@@ -277,9 +279,10 @@ You may need to keep track of the offset values through state, and update accord
     // ..
   />
 </Tooltip>
+)
 
 `}
-language="jsx"
+language="tsx"
 />
 
 <Canvas of={CardStories.FullClickWithTooltip} />

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -247,7 +247,8 @@ This example can be found in the [Turbine homepage](https://nypl-ds-test-app.ver
 When the `Card` is fully clickable, an internal component wraps everything in a link, which in turn overrides the pointer events that trigger a `Tooltip`.
 
 If you need a tooltip within a clickable `Card`, wrap the entire `Card` component inside the `Tooltip` and use the `placement` and `offset` props to move the `Tooltip` to display next to the intended reference.
-Keep in mind that `offset` is static pixel values, so check where the `Tooltip` displays on all breakpoints. You may need to keep track of the offset values through state, and update them conditionally with the `useNYPLBreakpoints` hook.
+Keep in mind that `offset` is static pixel values, so check where the `Tooltip` displays on all breakpoints.
+You may need to keep track of the offset values through state, and update accordingly. See the below story for an example.
 
 <Canvas of={CardStories.FullClickWithTooltip} />
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -246,8 +246,9 @@ This example can be found in the [Turbine homepage](https://nypl-ds-test-app.ver
 
 When the `Card` is fully clickable, an internal component wraps everything in a link, which in turn overrides the pointer events that trigger a `Tooltip`.
 
-If you need a tooltip within a clickable `Card`, wrap the entire `Card` component inside the `Tooltip` and use the `placement` and `offset` props to move the `Tooltip` to display next to the intended reference.
+If you need a tooltip within a clickable `Card`, wrap the entire `Card` component inside the `Tooltip` and use the `Tooltip`'s `placement` and `offset` props to move the `Tooltip` to display next to the intended reference.
 Keep in mind that `offset` is static pixel values, so check where the `Tooltip` displays on all breakpoints.
+
 You may need to keep track of the offset values through state, and update accordingly. See the below story for an example.
 
 <Canvas of={CardStories.FullClickWithTooltip} />

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -249,7 +249,38 @@ When the `Card` is fully clickable, an internal component wraps everything in a 
 If you need a tooltip within a clickable `Card`, wrap the entire `Card` component inside the `Tooltip` and use the `Tooltip`'s `placement` and `offset` props to move the `Tooltip` to display next to the intended reference.
 Keep in mind that `offset` is static pixel values, so check where the `Tooltip` displays on all breakpoints.
 
-You may need to keep track of the offset values through state, and update accordingly. See the below story for an example.
+You may need to keep track of the offset values through state, and update accordingly– see below example.
+
+<Source
+  code={`
+  const [offset, setOffset] = useState<[number, number]>([0, 0]);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const getOffset = () => {
+    if (cardRef.current) {
+      const image = cardRef.current.children[0] as HTMLElement;
+      const percentageHeightOffset = image.offsetHeight * 1.01;
+      const percentageWidthOffset = image.offsetWidth * 0.4;
+      setOffset([-percentageWidthOffset, -percentageHeightOffset]);
+    }
+  };
+  useEffect(() => {
+    setTimeout(getOffset, 0);
+    window.addEventListener("resize", getOffset);
+    return () => {
+        window.removeEventListener("resize", getOffset);
+    };}, 
+  []);
+
+<Tooltip offset={offset} content={"Tooltip text"}>
+  <Card
+    ref={cardRef}
+    // ..
+  />
+</Tooltip>
+
+`}
+language="jsx"
+/>
 
 <Canvas of={CardStories.FullClickWithTooltip} />
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -268,7 +268,7 @@ useEffect(() => {
   window.addEventListener("resize", getOffset);
   return () => {
       window.removeEventListener("resize", getOffset);
-  };}, 
+  }}
 []);
 
 return (

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -1,6 +1,6 @@
 import { action } from "@storybook/addon-actions";
 import type { Meta, StoryObj } from "@storybook/react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import Button from "../Button/Button";
 import Card, { CardHeading, CardContent, CardActions } from "./Card";
@@ -767,37 +767,29 @@ export const CardFullClickTurbineExample: Story = {
 };
 
 function FullClickWithTooltipExample() {
-  const [currentOffset, setCurrentOffset] = useState<[number, number]>([
-    -350, -450,
-  ]);
-  const [tooltipText, setTooltipText] = useState("Default offset");
-
+  const [offset, setOffset] = useState<[number, number]>([0, 0]);
+  const cardRef = useRef<HTMLDivElement>(null);
+  const getOffset = () => {
+    if (cardRef.current) {
+      const image = cardRef.current.children[0] as HTMLElement;
+      const percentageHeightOffset = image.offsetHeight * 1.01;
+      const percentageWidthOffset = image.offsetWidth * 0.4;
+      setOffset([-percentageWidthOffset, -percentageHeightOffset]);
+    }
+  };
   useEffect(() => {
-    const updateOffset = () => {
-      if (window.innerWidth < 600) {
-        setCurrentOffset([-200, -250]);
-        setTooltipText("Less than 600 offset");
-      } else if (window.innerWidth < 960) {
-        setCurrentOffset([-400, -375]);
-        setTooltipText("Less than 960 offset");
-      } else if (window.innerWidth < 1280) {
-        setCurrentOffset([-450, -450]);
-        setTooltipText("Less than 1280 offset");
-      } else {
-        setCurrentOffset([-850, -650]);
-        setTooltipText("Greater than 1280 offset");
-      }
-    };
-    updateOffset();
-    window.addEventListener("resize", updateOffset);
+    setTimeout(getOffset, 0);
+    window.addEventListener("resize", getOffset);
+
     return () => {
-      window.removeEventListener("resize", updateOffset);
+      window.removeEventListener("resize", getOffset);
     };
   }, []);
 
   return (
-    <Tooltip offset={currentOffset} content={tooltipText}>
+    <Tooltip offset={offset} content={"Tooltip text"}>
       <Card
+        ref={cardRef}
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -793,7 +793,7 @@ function FullClickWithTooltipExample() {
         imageProps={{
           alt: "Alt text",
           aspectRatio: "twoByOne",
-          src: getPlaceholderImage("smaller"),
+          src: "https://images.nypl.org/index.php?id=swope_243025&t=r",
         }}
         mainActionLink="http://nypl.org"
       >


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1829](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1829).

## This PR does the following:

- Adds code example of `Tooltip` workaround on a fully clickable `Card` with responsive offset values 
  - Don't think this requires a changelog update as it's really part of the work from #1652

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

Locally

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1829]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1829?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ