### PR TITLE
Dsd 1695/search bar better error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Lowercases the 'r' of '(required)' in labels and placeholders where necessary in order to align with sentence case guidelines.
-- Adds 'There was a problem. ' prefix on invalid text in the SearchBar component.
+- Updates invalid text in the SearchBar component to include "There was a problem. " prefix.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Lowercases the 'r' of '(required)' in labels and placeholders where necessary in order to align with sentence case guidelines.
-- Added 'There was a problem. ' prefix on invalid text in the SearchBar component.
+- Adds 'There was a problem. ' prefix on invalid text in the SearchBar component.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Lowercases the 'r' of '(required)' in labels and placeholders where necessary in order to align with sentence case guidelines.
+- Added 'There was a problem. ' prefix on invalid text in the SearchBar component.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Lowercases the 'r' of '(required)' in labels and placeholders where necessary in order to align with sentence case guidelines.
-- Updates invalid text in the SearchBar component to include "There was a problem. " prefix.
+- Updates invalid text in the `SearchBar` component to include "There was a problem. " prefix.
 
 ### Fixes
 

--- a/src/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/SearchBar/SearchBar.test.tsx
@@ -150,7 +150,9 @@ describe("SearchBar", () => {
         textInputProps={textInputProps}
       />
     );
-    expect(screen.getByText(invalidText)).toBeInTheDocument();
+    expect(
+      screen.getByText(`There was a problem. ${invalidText}`)
+    ).toBeInTheDocument();
     expect(screen.queryByText(helperText)).not.toBeInTheDocument();
   });
 

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -227,7 +227,9 @@ export const SearchBar: ChakraComponent<
         headingText={headingText}
         helperText={helperText}
         id={id}
-        invalidText={`There was a problem. ${invalidText}`}
+        invalidText={
+          invalidText ? `There was a problem. ${invalidText}` : undefined
+        }
         isInvalid={isInvalid}
         ref={ref}
         {...rest}

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -227,7 +227,7 @@ export const SearchBar: ChakraComponent<
         headingText={headingText}
         helperText={helperText}
         id={id}
-        invalidText={invalidText}
+        invalidText={`There was a problem. ${invalidText}`}
         isInvalid={isInvalid}
         ref={ref}
         {...rest}

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -16,7 +16,7 @@ export const changelogData: ChangelogData[] = [
     affects: ["Styles", "Functionality"],
     notes: [
       "Changes 'r' in '(required)' placeholder from upper- to lowercase",
-      "Adds 'There was a problem. ' prefix on invalid text in the SearchBar component",
+      "Updates invalid text in the SearchBar component to include 'There was a problem. ' prefix",
     ],
   },
   {

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -13,6 +13,15 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
+    affects: ["Functionality"],
+    notes: [
+      "Adds 'There was a problem. ' prefix on invalid text in the SearchBar component",
+    ],
+  },
+  {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
     affects: ["Styles"],
     notes: ["Changes 'r' in '(required)' placeholder from upper- to lowercase"],
   },

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -13,17 +13,11 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Functionality"],
+    affects: ["Styles", "Functionality"],
     notes: [
+      "Changes 'r' in '(required)' placeholder from upper- to lowercase",
       "Adds 'There was a problem. ' prefix on invalid text in the SearchBar component",
     ],
-  },
-  {
-    date: "Prerelease",
-    version: "Prerelease",
-    type: "Update",
-    affects: ["Styles"],
-    notes: ["Changes 'r' in '(required)' placeholder from upper- to lowercase"],
   },
   {
     date: "2024-08-29",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1695](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1695)

## This PR does the following:

- Adds 'There was a problem. ' prefix on invalid text in the SearchBar component

## How has this been tested?

-Updated unit tests

## Accessibility concerns or updates

NA

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1695]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1695?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ