### PR TITLE
DSD-1836: better overflow styles for Template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Table` component to add the `columnStyles` prop to allow for custom column styles (i.e. width, text alignment, etc.).
 - Updates the `Table` component to add the `tableTextSize` prop to set the size of the text within the table.
 - Updates the `Table` component to add the `titleText` and `showTitleText` props to control the `<caption>` element and `aria-label` attribute.
-- Updates the styles for the `Template` component to use `overflow: "auto"` for the primary content area.
+- Updates the styles for the `Template` component to use `display` and `overflow` for the primary content area to better accommodate the horizontal scrolling in the `Table` component.
 
 ## 3.3.2 (September 19, 2024)
 

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -5,6 +5,7 @@ import Banner from "../Banner/Banner";
 import Breadcrumbs from "../Breadcrumbs/Breadcrumbs";
 import Button from "../Button/Button";
 import Card, { CardHeading, CardContent, CardActions } from "../Card/Card";
+import FeaturedContent from "../FeaturedContent/FeaturedContent";
 import Form, { FormRow, FormField } from "../Form/Form";
 import Heading from "../Heading/Heading";
 import Hero from "../Hero/Hero";
@@ -194,7 +195,6 @@ export const WithControls: Story = {
         <Placeholder variant="short">More Content</Placeholder>
       </>
     ),
-    contentSidebar: <Placeholder>Left Sidebar</Placeholder>,
     contentTop: <Placeholder variant="short">Content Top</Placeholder>,
     footer: <Placeholder>Footer</Placeholder>,
     header: <Placeholder variant="short">Header</Placeholder>,
@@ -217,7 +217,12 @@ export const WithControls: Story = {
       table: { defaultValue: { summary: "none" } },
     },
   },
-  render: (args) => <TemplateAppContainer {...args} />,
+  render: (args) => (
+    <TemplateAppContainer
+      {...args}
+      contentSidebar={<Placeholder>Sidebar ({args.sidebar})</Placeholder>}
+    />
+  ),
   parameters: {
     design: {
       type: "figma",
@@ -382,12 +387,30 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
                 <Button id="submit">Submit</Button>
               </FormField>
             </Form>
+            <FeaturedContent
+              imageProps={{
+                alt: "",
+                src: getPlaceholderImage("smaller"),
+                position: "end",
+                width: "",
+              }}
+              isFullWidth
+              my="l"
+              textContent={
+                <>
+                  <Heading size="heading5">Sit Dapibus Elit</Heading>
+                  Donec id elit non mi porta gravida at eget metus. Nulla vitae
+                  elit libero, a pharetra augue. Cum sociis natoque penatibus et
+                  magnis dis parturient montes, nascetur ridiculus mus. Cras
+                  mattis consectetur purus sit amet fermentum.
+                </>
+              }
+            />
             <Table
               columnHeaders={columnHeadersAlt}
               columnStyles={columnStylesComplex}
               id="table-horizontal-scrolling-wo-row-headers"
               isScrollable
-              mt="l"
               showRowDividers
               showTitleText={false}
               tableData={tableDataAlt}

--- a/src/components/Template/templateChangelogData.ts
+++ b/src/components/Template/templateChangelogData.ts
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Styles"],
     notes: [
-      'Updates the styles for the primary content area to use `overflow: "auto"`.',
+      "Updates the `display` and `overflow` styles for the primary content area to better accommodate the horizontal scrolling in the `Table` component.",
     ],
   },
   {

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -61,19 +61,23 @@ const TemplateContentTopBottom = defineStyleConfig({
   }),
 });
 
+/** The display and overflow styles were added to deal with overflow issues
+ * related to the Table component. */
 const TemplateContentPrimary = defineStyleConfig({
   baseStyle: defineStyle({
-    gridColumn: { base: "1", md: "1 / span 2" },
-    overflow: "auto",
+    gridColumn: { base: "1 / 1", md: "1 / span 2" },
+    display: { base: "contents", md: "unset" },
   }),
   variants: {
     left: {
       gridColumn: { base: "1", md: "2" },
       marginEnd: { md: 0 },
       minWidth: { md: 0 },
+      overflow: { base: "unset", md: "hidden" },
     },
     right: {
       gridColumn: { base: "1", md: "1" },
+      overflow: { base: "unset", md: "hidden" },
     },
   },
 });


### PR DESCRIPTION
Fixes JIRA ticket DSD-1836

## This PR does the following:

- Updates the styles for the `Template` component to use `display` and `overflow` for the primary content area to better accommodate the horizontal scrolling in the `Table` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- locally

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
