### PR TITLE
DSD-1791: Fix SearchBar select cutoff issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates `Select` in the `SearchBar` component to allow long option titles before truncation.
+
 ## 3.4.0 (October 2, 2024)
 
 ### Updates
@@ -20,10 +24,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Table` component to add the `tableTextSize` prop to set the size of the text within the table.
 - Updates the `Table` component to add the `titleText` and `showTitleText` props to control the `<caption>` element and `aria-label` attribute.
 - Updates the styles for the `Template` component to better accommodate the horizontal scrolling in the `Table` component.
-
-### Fixes
-
-- Fixes issue with cut off `Select` options in the `SearchBar` component.
 
 ## 3.3.2 (September 19, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Table` component to add the `titleText` and `showTitleText` props to control the `<caption>` element and `aria-label` attribute.
 - Updates the styles for the `Template` component to use `display` and `overflow` for the primary content area to better accommodate the horizontal scrolling in the `Table` component.
 
+### Fixes
+
+- Fixes issue with cut off `Select` options in the `SearchBar` component.
+
 ## 3.3.2 (September 19, 2024)
 
 ### Updates

--- a/src/components/SearchBar/SearchBar.mdx
+++ b/src/components/SearchBar/SearchBar.mdx
@@ -100,6 +100,9 @@ page for a full demonstration.
 The `optionsData` prop is an array of objects that contain the `text` and
 `value` properties.
 
+**Note:** when `Select` options have a length greater than ~30 characters then
+the text will be truncated.
+
 <Source
   code={`
 const optionsGroup = [

--- a/src/components/SearchBar/SearchBar.mdx
+++ b/src/components/SearchBar/SearchBar.mdx
@@ -100,8 +100,8 @@ page for a full demonstration.
 The `optionsData` prop is an array of objects that contain the `text` and
 `value` properties.
 
-**Note:** when `Select` options have a length greater than ~30 characters then
-the text will be truncated.
+**Note:** when `Select` options have a length greater than approximately 30
+characters then the text will be truncated.
 
 <Source
   code={`

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -41,7 +41,7 @@ const SearchBar = defineMultiStyleConfig({
       marginBottom: { base: "-1px", md: "0" },
       maxWidth: { base: undefined, md: "255px" },
       textOverflow: "ellipsis",
-      marginRight: { base: undefined, md: "-1px" },
+      overflow: "hidden",
       _hover: {
         zIndex: "10",
         "+ .chakra-select__icon-wrapper": {

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -24,7 +24,7 @@ const select = (labelPosition: string) => ({
   fontSize: "desktop.body.body2",
   minHeight: { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
   paddingTop: "inset.narrow",
-  paddingEnd: "inset.extrawide",
+  paddingEnd: "2.5rem",
   paddingBottom: "inset.narrow",
   paddingStart: "inset.default",
   flex: labelPosition === "inline" ? { md: "1" } : null,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1791](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1791)

The `Select` component is sized to fit the largest option size; if the option exceeds the maxWidth of 255px (~30 characters) then the text is truncated.

## This PR does the following:

- Removes the right margin on the Select component of the SearchBar which caused the longest option text to be truncated even if the Select component is not at the maxWidth.
- Fixes issue on Safari where overflowed text was not being truncated due to not having `overflow: hidden`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally on Storybook (Chrome, Firefox, Safari)

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1791]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ