### PR TITLE
DSD-1849: new size options for Icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the `"decorativeBookBroken"` option (for error pages) to the `Icon` component.
+- Adds the `"xxxxlarge"` and `"xxxxxlarge"` size options for the `Icon` component.
+- Adds the `"2xlarge"`, `"3xlarge"`, `"4xlarge"`, and `"5xlarge"` sustainable size options for the `Icon` component.
 
 ### Updates
 

--- a/src/components/Icons/Icon.stories.tsx
+++ b/src/components/Icons/Icon.stories.tsx
@@ -163,8 +163,10 @@ const iconSizesValues = [
   { size: "medium", display: "medium (18px)" },
   { size: "large", display: "large (24px)" },
   { size: "xlarge", display: "xlarge (32px)" },
-  { size: "xxlarge", display: "xxlarge (48px)" },
-  { size: "xxxlarge", display: "xxxlarge (64px)" },
+  { size: "xxlarge", display: "2xlarge or xxlarge (48px)" },
+  { size: "xxxlarge", display: "3xlarge or xxxlarge (64px)" },
+  { size: "4xlarge", display: "4xlarge or xxxxlarge (80px)" },
+  { size: "5xlarge", display: "5xlarge or xxxxxlarge (96px)" },
 ];
 for (const icon in iconNamesValues) {
   icons.push(

--- a/src/components/Icons/iconChangelogData.ts
+++ b/src/components/Icons/iconChangelogData.ts
@@ -14,7 +14,11 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Functionality"],
-    notes: ["Added the decorativeBookBroken icon."],
+    notes: [
+      "Added the `decorativeBookBroken` icon.",
+      "Added the `xxxxlarge` and `xxxxxlarge` sizes.",
+      "Added the `2xlarge`, `3xlarge`, `4xlarge`, and `5xlarge` sustainable size options.",
+    ],
   },
   {
     date: "2024-04-11",

--- a/src/components/Icons/iconVariables.ts
+++ b/src/components/Icons/iconVariables.ts
@@ -199,5 +199,11 @@ export const iconSizesArray = [
   "xlarge",
   "xxlarge",
   "xxxlarge",
+  "xxxxlarge",
+  "xxxxxlarge",
+  "2xlarge",
+  "3xlarge",
+  "4xlarge",
+  "5xlarge",
 ] as const;
 export const iconTypesArray = ["default", "breadcrumbs"] as const;

--- a/src/theme/components/icon.ts
+++ b/src/theme/components/icon.ts
@@ -27,33 +27,67 @@ const iconRotation = {
   },
 };
 const size = {
+  // 96px
+  xxxxxlarge: {
+    height: "var(--nypl-space-xxxl)",
+    width: "var(--nypl-space-xxxl)",
+  },
+  "5xlarge": {
+    height: "var(--nypl-space-xxxl)",
+    width: "var(--nypl-space-xxxl)",
+  },
+  // 80px
+  xxxxlarge: {
+    height: "5rem",
+    width: "5rem",
+  },
+  "4xlarge": {
+    height: "5rem",
+    width: "5rem",
+  },
+  // 64px
   xxxlarge: {
     height: "var(--nypl-space-xxl)",
     width: "var(--nypl-space-xxl)",
   },
+  "3xlarge": {
+    height: "var(--nypl-space-xxl)",
+    width: "var(--nypl-space-xxl)",
+  },
+  // 48px
   xxlarge: {
     height: "var(--nypl-space-xl)",
     width: "var(--nypl-space-xl)",
   },
+  "2xlarge": {
+    height: "var(--nypl-space-xl)",
+    width: "var(--nypl-space-xl)",
+  },
+  // 32px
   xlarge: {
     height: "var(--nypl-space-l)",
     width: "var(--nypl-space-l)",
   },
+  // 24px
   large: {
     height: "var(--nypl-space-m)",
     width: "var(--nypl-space-m)",
   },
+  // 100%
   default: {
     width: "100%",
   },
+  // 18px
   medium: {
     height: "1.125rem",
     width: "1.125rem",
   },
+  // 14px
   small: {
     height: "0.875rem",
     width: "0.875rem",
   },
+  // 10px
   xsmall: {
     height: "0.65rem",
     width: "0.65rem",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1849](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1849)

## This PR does the following:

- Adds the `"xxxxlarge"` and `"xxxxxlarge"` size options for the `Icon` component.
- Adds the `"2xlarge"`, `"3xlarge"`, `"4xlarge"`, and `"5xlarge"` sustainable size options for the `Icon` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1849]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ