### PR TITLE
DSD-1840: Reverting Hero documentation about custom image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates `Select` in the `SearchBar` component to allow long option titles before truncation.
 - Updates the `ProgressIndicator` component to add the `labelPlacement` prop to allow for custom placement of a label for circular indicators.
 - Updates Vite from `5.2.8` to `5.2.14` to fix a security vulnerability.
-- Updates image props in the `Hero` component to allow custom image components.
 
 ### Removes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds the `"decorativeBookBroken"` option (for error pages) to the `Icon` component.
 - Adds the `"xxxxlarge"` and `"xxxxxlarge"` size options for the `Icon` component.
 - Adds the `"2xlarge"`, `"3xlarge"`, `"4xlarge"`, and `"5xlarge"` sustainable size options for the `Icon` component.
+- Updates image props in the `Hero` component to allow custom image components.
 
 ### Updates
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -485,47 +485,6 @@ should not be used at the same time.
   language="jsx"
 />
 
-## Custom Image Component
-
-Instead of passing a path for the `imageProps.src` prop, you can pass a custom image component using the `imageProps.component` prop.
-Note that this only impacts the "campaign" variant, and the custom component will only replace the foreground image, since the background image is set using `background-image`.
-
-<Source
-  code={`
-import Image as NextImage from "next/image";
-
-const CampaignCustomImageExample = () => {
-return (
-
-  <Hero
-    heroType="campaign"
-    heading={
-      <Heading
-        level="h1"
-        id="campaign-custom-image"
-        text="Hero Campaign with Custom Image"
-      />
-    }
-    imageProps={{
-      component: (
-        <NextImage
-          alt={"Alt text"}
-          fill
-          src={"/image.jpg""}
-          onError={(\_event) => {
-          handleError(\_event);
-          }}
-        />
-      ),
-    }}
-    />
-  )
-`}
-  language="jsx"
-/>
-
-<Canvas of={HeroStories.HeroWithCustomImage} />
-
 ## Fallback Campaign Image
 
 The `imageProps` prop can be used to set a fallback for the **main** image in

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -9,7 +9,6 @@ import Hero, { heroSecondaryTypes, heroTypesArray } from "./Hero";
 import Link from "../Link/Link";
 import Text from "../Text/Text";
 import { getPlaceholderImage } from "../../utils/utils";
-import Image from "../Image/Image";
 
 const secondarySubHeaderText = (
   <>
@@ -71,12 +70,6 @@ const otherSubHeaderTextLong = (
 const imageProps = {
   alt: "Image example",
   src: getPlaceholderImage(),
-};
-
-const componentImageProps = {
-  component: (
-    <Image alt={"Custom Image component example"} src={getPlaceholderImage()} />
-  ),
 };
 
 const meta: Meta<typeof Hero> = {
@@ -326,24 +319,6 @@ export const Campaign: Story = {
         />
       </div>
     </Stack>
-  ),
-};
-
-export const HeroWithCustomImage: Story = {
-  render: () => (
-    <Hero
-      backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
-      heroType="campaign"
-      heading={
-        <Heading
-          level="h1"
-          id="campaign-hero-long-text-heading"
-          text="Hero Campaign With DS Image Component"
-        />
-      }
-      imageProps={componentImageProps}
-      subHeaderText={otherSubHeaderTextLong}
-    />
   ),
 };
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -131,6 +131,12 @@ export const Hero: ChakraComponent<
         />
       );
 
+      // Using the custom Image component's props to check requirements.
+      if (imageProps.component) {
+        const { src, alt } = imageProps.component.props;
+        Object.assign(imageProps, { src, alt });
+      }
+
       if (imageProps.src && !imageProps.alt) {
         console.warn(
           `NYPL Reservoir Hero: The "imageProps.src" prop was passed but the "imageProps.alt"` +


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1840](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1840)

## This PR does the following:

- Reverts the documentation that says the custom image component can display as the foreground image in `Hero`
- Keeps the ability to pass `component` in the `HeroImageProps`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1840]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1840?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ