### PR TITLE
[POC] DSD-1851: Updates `Template` to be more responsive using grid

### DIFF
--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -230,7 +230,7 @@ export const WithControls: Story = {
     },
   },
 };
-// The following are additional Template example Stories.
+// The following are additional Template example stories.
 export const ChildrenComponentProps: Story = {
   args: {
     sidebar: "left",
@@ -341,7 +341,7 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
         <TemplateContent sidebar="right">
           <TemplateContentTop>
             <Banner
-              content="This is an the top content area!"
+              content="This is the top content area!"
               heading="Content Top"
               type="informative"
             />
@@ -440,7 +440,7 @@ export const FullExampleWithTemplateChildrenComponents: Story = {
           </TemplateContentSidebar>
           <TemplateContentBottom>
             <Banner
-              content="This is an the bottom content area!"
+              content="This is the bottom content area!"
               heading="Content Bottom"
               type="informative"
             />

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -89,8 +89,7 @@ const Template: ChakraComponent<
 const TemplateAboveHeader: React.FC<any> = (
   props: React.PropsWithChildren<TemplateProps>
 ) => {
-  const styles = useStyleConfig("TemplateBreakout", {});
-  return <Box __css={styles}>{props.children}</Box>;
+  return <Box>{props.children}</Box>;
 };
 
 /**
@@ -104,8 +103,7 @@ const TemplateHeader: React.FC<any> = ({
   children,
   renderHeaderElement = true,
 }: React.PropsWithChildren<TemplateHeaderProps>) => {
-  const styles = useStyleConfig("TemplateBreakout", {});
-  let headerElement = <Box __css={styles}>{children}</Box>;
+  let headerElement = <Box>{children}</Box>;
 
   // The user wants to render the `header` HTML element.
   if (renderHeaderElement) {
@@ -120,11 +118,7 @@ const TemplateHeader: React.FC<any> = ({
         );
       }
     });
-    headerElement = (
-      <Box as="header" __css={styles}>
-        {children}
-      </Box>
-    );
+    headerElement = <Box as="header">{children}</Box>;
   }
   return headerElement;
 };
@@ -138,8 +132,7 @@ const TemplateHeader: React.FC<any> = ({
 const TemplateBreakout: React.FC<any> = (
   props: React.PropsWithChildren<TemplateProps>
 ) => {
-  const styles = useStyleConfig("TemplateBreakout", {});
-  return <Box __css={styles}>{props.children}</Box>;
+  return <Box>{props.children}</Box>;
 };
 
 /**
@@ -242,11 +235,7 @@ const TemplateContentPrimary: React.FC<any> = (
 const TemplateContentSidebar: React.FC<any> = (
   props: React.PropsWithChildren<TemplateContentProps>
 ) => {
-  const { sidebar } = props;
-  const styles = useStyleConfig("TemplateContentSidebar", {
-    variant: sidebar,
-  });
-  return <Box __css={styles}>{props.children}</Box>;
+  return <Box>{props.children}</Box>;
 };
 
 /**
@@ -259,8 +248,8 @@ const TemplateFooter: React.FC<any> = ({
   children,
   renderFooterElement = true,
 }: React.PropsWithChildren<TemplateFooterProps>) => {
-  const styles = useStyleConfig("TemplateBreakout", {});
-  let footerElement = <Box __css={styles}>{children}</Box>;
+  // const styles = useStyleConfig("TemplateBreakout", {});
+  let footerElement = <Box>{children}</Box>;
 
   // The user wants to render the `footer` HTML element.
   if (renderFooterElement) {
@@ -274,11 +263,7 @@ const TemplateFooter: React.FC<any> = ({
         );
       }
     });
-    footerElement = (
-      <Box as="footer" __css={styles}>
-        {children}
-      </Box>
-    );
+    footerElement = <Box as="footer">{children}</Box>;
   }
   return footerElement;
 };

--- a/src/components/Template/Template.tsx
+++ b/src/components/Template/Template.tsx
@@ -248,7 +248,6 @@ const TemplateFooter: React.FC<any> = ({
   children,
   renderFooterElement = true,
 }: React.PropsWithChildren<TemplateFooterProps>) => {
-  // const styles = useStyleConfig("TemplateBreakout", {});
   let footerElement = <Box>{children}</Box>;
 
   // The user wants to render the `footer` HTML element.

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -27,6 +27,9 @@ const TemplateContent = defineStyleConfig({
   }),
 
   variants: {
+    // If neither `left` nor `right` variants are used, we default to
+    // `none` and the grid will show 1 column only at any viewport
+    // width.
     left: {
       gridTemplateColumns: {
         md: "repeat(2, minmax(100px, 1fr))",

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -55,6 +55,14 @@ const TemplateContentTopBottom = defineStyleConfig({
 const TemplateContentPrimary = defineStyleConfig({
   baseStyle: defineStyle({
     overflow: "hidden",
+    // We need `overflow: hidden` to ensure larger elements passed to the template
+    // appear correctly, but it also cuts off the default focus ring. The following
+    // offset property ensures the focus ring is fully visible.
+    "*": {
+      _focus: {
+        outlineOffset: "-2px !important",
+      },
+    },
   }),
 });
 

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -1,19 +1,13 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { defineStyle } from "@chakra-ui/system";
-/**
- * Grid layout based on https://www.joshwcomeau.com/css/full-bleed/
- */
+
+export const responsiveGap = { base: "1rem", md: "1.5rem", xl: "1rem" };
+export const responsivePadding = { base: "1rem", md: "1.5rem", xl: "2rem" };
 
 const Template = defineStyleConfig({
   baseStyle: defineStyle({
     boxSizing: "border-box",
     color: "ui.typography.body",
-    display: "grid",
-    gridTemplateColumns: `
-      1fr
-      min(1280px, 100%)
-      1fr`,
-    rowGap: "grid.l",
     _dark: {
       color: "dark.ui.typography.body",
     },
@@ -21,83 +15,52 @@ const Template = defineStyleConfig({
   sizes: {},
   defaultProps: {},
 });
-// Elements that need to breakout will span outside
-// the center 1280px grid column.
-const TemplateBreakout = defineStyleConfig({
-  baseStyle: defineStyle({
-    width: "100%",
-    // This could be "1 / 4" and it would mean the same. This is
-    // "future-proof" the grid column assignment to the last column.
-    gridColumn: "1 / -1",
-  }),
-});
+
 const TemplateContent = defineStyleConfig({
   baseStyle: defineStyle({
-    // Set this element to start on the second 1280px grid column.
-    gridColumn: "2",
-    // This element also contains its own grid system within, but we use "flex"
-    // for mobile to deal with overflow issues related to the Table component.
-    display: { base: "flex", md: "grid" },
-    flexDirection: { base: "column", md: null },
-    gridTemplateColumns: "1fr",
-    paddingY: 0,
-    paddingX: "s",
-    gap: "grid.l",
+    display: "grid",
+    gridTemplateColumns: {
+      base: "repeat(1, minmax(100px, 1fr))",
+    },
+    gap: responsiveGap,
+    padding: responsivePadding,
   }),
-  // With left or right sidebars, we need to set two grid columns and
-  // the column for the sidebar is max 255px width.
+
   variants: {
     left: {
-      gridTemplateColumns: { md: "255px 1fr" },
+      gridTemplateColumns: {
+        md: "repeat(2, minmax(100px, 1fr))",
+        lg: "1fr 2fr",
+        xl: "1fr 3fr",
+      },
     },
     right: {
-      gridTemplateColumns: { md: "1fr 255px" },
+      gridTemplateColumns: {
+        md: "repeat(2, minmax(100px, 1fr))",
+        lg: "2fr 1fr",
+        xl: "3fr 1fr",
+      },
     },
   },
 });
 
 const TemplateContentTopBottom = defineStyleConfig({
   baseStyle: defineStyle({
-    gridColumn: { base: "1", md: "1 / span 2" },
-    height: "100%",
+    /** 1 / -1 ensures the item spans all columns,
+     * no matter how many there are. */
+    gridColumn: "1 / -1",
   }),
 });
 
-/** The overflow styles were added to deal with overflow issues related to the
- * Table component. */
 const TemplateContentPrimary = defineStyleConfig({
   baseStyle: defineStyle({
-    gridColumn: { base: "1", md: "1 / span 2" },
+    overflow: "hidden",
   }),
-  variants: {
-    left: {
-      gridColumn: { base: "1", md: "2" },
-      marginEnd: { md: 0 },
-      minWidth: { md: 0 },
-      overflow: { base: "unset", md: "hidden" },
-    },
-    right: {
-      gridColumn: { base: "1", md: "1" },
-      overflow: { base: "unset", md: "hidden" },
-    },
-  },
-});
-const TemplateContentSidebar = defineStyleConfig({
-  variants: {
-    left: {
-      gridColumn: "1",
-    },
-    right: {
-      gridColumn: { base: "1", md: "2" },
-    },
-  },
 });
 
 export default {
   Template,
-  TemplateBreakout,
   TemplateContent,
   TemplateContentTopBottom,
   TemplateContentPrimary,
-  TemplateContentSidebar,
 };

--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -27,9 +27,8 @@ const TemplateContent = defineStyleConfig({
   }),
 
   variants: {
-    // If neither `left` nor `right` variants are used, we default to
-    // `none` and the grid will show 1 column only at any viewport
-    // width.
+    /** If neither `left` nor `right` variants are used, we default to `none` and
+     * the grid will show 1 column only at any viewport width. */
     left: {
       gridTemplateColumns: {
         md: "repeat(2, minmax(100px, 1fr))",
@@ -49,8 +48,7 @@ const TemplateContent = defineStyleConfig({
 
 const TemplateContentTopBottom = defineStyleConfig({
   baseStyle: defineStyle({
-    /** 1 / -1 ensures the item spans all columns,
-     * no matter how many there are. */
+    /** 1 / -1 ensures the item spans all columns, no matter how many there are. */
     gridColumn: "1 / -1",
   }),
 });
@@ -58,9 +56,9 @@ const TemplateContentTopBottom = defineStyleConfig({
 const TemplateContentPrimary = defineStyleConfig({
   baseStyle: defineStyle({
     overflow: "hidden",
-    // We need `overflow: hidden` to ensure larger elements passed to the template
-    // appear correctly, but it also cuts off the default focus ring. The following
-    // offset property ensures the focus ring is fully visible.
+    /**  We need `overflow: hidden` to ensure larger elements passed to the template
+     * appear correctly, but it also cuts off the default focus ring. The following
+     * offset property ensures the focus ring is fully visible. */
     "*": {
       _focus: {
         outlineOffset: "-2px !important",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1851](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1851)

## This PR does the following:

- Uses one grid rather than two to make a fully responsive template, including responsive gaps, padding, and sidebar
- Uses the `outlineOffset` property to make the focus ring visible even with `overflow: hidden` turned on
- This is merely a POC to help support the work of the new `Template` TAD and is not expected to be merged

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- In Storybook
- Plans to create an RC to test in Turbine and other apps

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- None that I can think of.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1851]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ