### PR TITLE
DSD-1868: better spacing and dark mode styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates Storybook and related dependencies to version 8.3.6.
 
+## Fixes
+
+- Fixes spacing issues and dark mode color styles in the `Table` component.
+
 ## 3.4.1 (October 24, 2024)
 
 ### Adds

--- a/src/components/Table/Table.mdx
+++ b/src/components/Table/Table.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./tableChangelogData";
 
 # Table
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.9`   |
-| Latest            | `3.4.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.9`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Table/tableChangelogData.ts
+++ b/src/components/Table/tableChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Styles"],
+    notes: ["Fixes spacing issues and dark mode color styles."],
+  },
+  {
     date: "2024-10-02",
     version: "3.4.0",
     type: "Update",

--- a/src/theme/components/customTable.ts
+++ b/src/theme/components/customTable.ts
@@ -16,10 +16,11 @@ interface BaseStyleProps extends StyleFunctionProps {
 }
 
 const CellBorderColorStyles = () => {
-  const colorValues = useColorModeValue("ui.gray.semi-medium", {
-    base: "ui.gray.xx-dark",
-    md: "dark.ui.border.default",
-  });
+  // Using CSS vars here because of how the values are used in the styles
+  const colorValues = useColorModeValue(
+    "var(--nypl-colors-ui-gray-semi-medium)",
+    "var(--nypl-colors-ui-gray-x-dark)"
+  );
   return colorValues;
 };
 export const fixedColumnStyles = (
@@ -43,9 +44,14 @@ export const fixedColumnStyles = (
   position: useRowHeaders ? "sticky" : undefined,
   zIndex: "5",
   _dark: {
-    backgroundColor: useRowHeaders ? "dark.ui.bg.default" : undefined,
+    backgroundColor: useRowHeaders ? "dark.ui.bg.hover" : undefined,
     borderRight: useRowHeaders
-      ? "2px solid var(--nypl-colors-dark-ui-border-default)"
+      ? isScrollable
+        ? "1px solid var(--nypl-colors-ui-gray-x-dark)"
+        : {
+            base: undefined,
+            md: "1px solid var(--nypl-colors-ui-gray-x-dark)",
+          }
       : undefined,
   },
 });
@@ -105,7 +111,13 @@ export const baseCellStyles = (
   lineHeight: 1.5,
   paddingBottom: isScrollable ? "s" : { base: "0", md: "s" },
   paddingEnd: "s",
-  paddingStart: columnHeadersBackgroundColor ? { base: "0", md: "s" } : "s",
+  paddingStart: columnHeadersBackgroundColor
+    ? isScrollable
+      ? "s"
+      : { base: "0", md: "s" }
+    : isScrollable
+    ? "s"
+    : { base: "0", md: "s" },
   paddingTop: isScrollable ? "s" : { base: "0", md: "s" },
   _first: {
     borderBottom: showRowDividers
@@ -116,6 +128,16 @@ export const baseCellStyles = (
             md: "1px solid var(--nypl-colors-ui-gray-semi-medium)",
           }
       : "none",
+    _dark: {
+      borderBottom: showRowDividers
+        ? isScrollable
+          ? "1px solid var(--nypl-colors-ui-gray-x-dark)"
+          : {
+              base: "1px solid var(--nypl-colors-ui-gray-x-dark)",
+              md: "1px solid var(--nypl-colors-ui-gray-x-dark)",
+            }
+        : "none",
+    },
   },
   _last: {
     borderBottom: showRowDividers ? "1px solid" : "none",
@@ -191,9 +213,9 @@ export const baseTDStyles = (
     borderBottom: showRowDividers
       ? isScrollable
         ? "1px solid"
-        : { base: 0, md: "1px solid" }
-      : { base: 0, md: undefined },
-    borderColor: `${CellBorderColorStyles()} !important`,
+        : { base: 0, md: `1px solid ${CellBorderColorStyles()}` }
+      : { base: 0, md: "1px solid" },
+    borderColor: CellBorderColorStyles(),
   },
 });
 export const baseStyle = definePartsStyle(
@@ -212,13 +234,25 @@ export const baseStyle = definePartsStyle(
       whiteSpace: "wrap",
 
       /** Show shadow to scroll */
-      background:
-        "linear-gradient(to right, white 30%, rgba(255,255,255,0)), linear-gradient(to right, rgba(255,255,255,0), white 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0,0,0,.2), rgba(0,0,0,0)), radial-gradient(farthest-side at 100% 50%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%",
+      background: isScrollable
+        ? "linear-gradient(to right, white 30%, rgba(255,255,255,0)), linear-gradient(to right, rgba(255,255,255,0), white 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0,0,0,.2), rgba(0,0,0,0)), radial-gradient(farthest-side at 100% 50%, rgba(0,0,0,.2), rgba(0,0,0,0)) 0 100%"
+        : null,
       backgroundRepeat: "no-repeat",
-      backgroundColor: "white",
+      backgroundColor: "ui.white",
       backgroundSize: "40px 100%, 40px 100%, 14px 100%, 14px 100%",
       backgroundPosition: "0 0, 100%, 0 0, 100%",
       backgroundAttachment: "local, local, scroll, scroll",
+      _dark: {
+        /** Show shadow to scroll */
+        background: isScrollable
+          ? "linear-gradient(to right, var(--nypl-colors-dark-ui-bg-default) 30%, rgba(255,255,255,0)), linear-gradient(to right, rgba(255,255,255,0), var(--nypl-colors-dark-ui-bg-default) 70%) 0 100%, radial-gradient(farthest-side at 0% 50%, rgba(0,0,0,.4), rgba(0,0,0,0)), radial-gradient(farthest-side at 100% 50%, rgba(0,0,0,.4), rgba(0,0,0,0)) 0 100%"
+          : null,
+        backgroundRepeat: "no-repeat",
+        backgroundColor: "dark.ui.bg.default",
+        backgroundSize: "40px 100%, 40px 100%, 14px 100%, 14px 100%",
+        backgroundPosition: "0 0, 100%, 0 0, 100%",
+        backgroundAttachment: "local, local, scroll, scroll",
+      },
     },
     /* The actual table element */
     innerTable: {
@@ -247,9 +281,6 @@ export const baseStyle = definePartsStyle(
           textTransform: "capitalize",
           verticalAlign: "top",
           _dark: {
-            backgroundColor: useRowHeaders
-              ? { base: "dark.ui.bg.default", md: "unset" }
-              : undefined,
             color: "dark.ui.typography.heading",
           },
         },
@@ -268,6 +299,13 @@ export const baseStyle = definePartsStyle(
               : useRowHeaders
               ? "ui.gray.x-light-cool"
               : "ui.white",
+            _dark: {
+              backgroundColor: columnHeadersBackgroundColor
+                ? columnHeadersBackgroundColor
+                : useRowHeaders
+                ? "dark.ui.bg.hover"
+                : "transparent",
+            },
           },
         },
       },

--- a/src/theme/components/customTable.ts
+++ b/src/theme/components/customTable.ts
@@ -111,31 +111,15 @@ export const baseCellStyles = (
   lineHeight: 1.5,
   paddingBottom: isScrollable ? "s" : { base: "0", md: "s" },
   paddingEnd: "s",
-  paddingStart: columnHeadersBackgroundColor
-    ? isScrollable
-      ? "s"
-      : { base: "0", md: "s" }
-    : isScrollable
-    ? "s"
-    : { base: "0", md: "s" },
+  paddingStart: isScrollable ? "s" : { base: "0", md: "s" },
   paddingTop: isScrollable ? "s" : { base: "0", md: "s" },
   _first: {
     borderBottom: showRowDividers
-      ? isScrollable
-        ? "1px solid var(--nypl-colors-ui-gray-semi-medium)"
-        : {
-            base: "1px solid var(--nypl-colors-ui-gray-semi-medium)",
-            md: "1px solid var(--nypl-colors-ui-gray-semi-medium)",
-          }
+      ? "1px solid var(--nypl-colors-ui-gray-semi-medium)"
       : "none",
     _dark: {
       borderBottom: showRowDividers
-        ? isScrollable
-          ? "1px solid var(--nypl-colors-ui-gray-x-dark)"
-          : {
-              base: "1px solid var(--nypl-colors-ui-gray-x-dark)",
-              md: "1px solid var(--nypl-colors-ui-gray-x-dark)",
-            }
+        ? "1px solid var(--nypl-colors-ui-gray-x-dark)"
         : "none",
     },
   },
@@ -212,10 +196,9 @@ export const baseTDStyles = (
   _last: {
     borderBottom: showRowDividers
       ? isScrollable
-        ? "1px solid"
+        ? `1px solid ${CellBorderColorStyles()}`
         : { base: 0, md: `1px solid ${CellBorderColorStyles()}` }
-      : { base: 0, md: "1px solid" },
-    borderColor: CellBorderColorStyles(),
+      : undefined,
   },
 });
 export const baseStyle = definePartsStyle(


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1868](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1868)

## This PR does the following:

- Fixes spacing issues and dark mode color styles in the `Table` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- locall Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Implemented proper dark mode colors.

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- n/a

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1868]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1868?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ