### PR TITLE
DSD-1870: contentFilterList icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `"contentFilterRelease"` option to the `Icon` component.
+
 ### Updates
 
 - Updates Storybook and related dependencies to version 8.3.6.

--- a/icons/svg/content-filter-list.svg
+++ b/icons/svg/content-filter-list.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 6V8H21V6H3ZM10 18H14V16H10V18ZM18 13H6V11H18V13Z" />
+</svg>

--- a/src/components/Icons/Icon.mdx
+++ b/src/components/Icons/Icon.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Icon
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `3.4.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Icons/IconSvgs.tsx
+++ b/src/components/Icons/IconSvgs.tsx
@@ -26,6 +26,7 @@ import building from "../../../icons/svg/building.svg";
 import communicationCall from "../../../icons/svg/communication-call.svg";
 import communicationChatBubble from "../../../icons/svg/communication-chat-bubble.svg";
 import communicationEmail from "../../../icons/svg/communication-email.svg";
+import contentFilterList from "../../../icons/svg/content-filter-list.svg";
 import check from "../../../icons/svg/check.svg";
 import clock from "../../../icons/svg/clock.svg";
 import close from "../../../icons/svg/close.svg";
@@ -106,6 +107,7 @@ export default {
   communicationCall,
   communicationChatBubble,
   communicationEmail,
+  contentFilterList,
   decorativeBookBroken,
   decorativeEnvelope,
   decorativeLibraryCard,

--- a/src/components/Icons/iconChangelogData.ts
+++ b/src/components/Icons/iconChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Added the `contentFilterList` icon."],
+  },
+  {
     date: "2024-10-24",
     version: "3.4.1",
     type: "Update",

--- a/src/components/Icons/iconVariables.ts
+++ b/src/components/Icons/iconVariables.ts
@@ -138,6 +138,7 @@ export const iconNamesArray = [
   "communicationCall",
   "communicationChatBubble",
   "communicationEmail",
+  "contentFilterList",
   "decorativeBookBroken",
   "decorativeEnvelope",
   "decorativeLibraryCard",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1870](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1870)

## This PR does the following:

- Adds the `"contentFilterRelease"` option to the `Icon` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- n/a

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1870]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1870?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ