### PR TITLE
DSD-1892: Fix TextInput ref conflicting issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes `TextInput`'s conflicting internal and external ref values for the clearable button focus management.
+
 ## 3.5.0 (December 5, 2024)
 
 ### Adds

--- a/src/components/TextInput/TextInput.mdx
+++ b/src/components/TextInput/TextInput.mdx
@@ -165,6 +165,55 @@ export const App = () => {
 
 <Canvas of={TextInputStories.ControlledExample} />
 
+### Focus Ref Management
+
+Focus management is important for accessibility and can get complicated in pages
+that have multiple focusable elements and various user interactions. The
+following is an example found in the Research Catalog's
+[My Account](https://nypl.org/research/research-catalog/account) page (you have
+to sign in) where the page's accessibility requirement conflicted with the
+`TextInput` component's internal focus management. This was apparent through the
+use of the clearable "X" button and has now been resolved.
+
+The `TextInput` component keeps track of it's own ref for clearing the input
+field. If your app needs to manage focus separately, you should still pass a ref
+to the `TextInput` component as you normally would with a React component.
+
+In the following example, when the user clicks on the "Edit" button, focus needs
+to go to the input field. It is the consuming application's responsibility to
+send focus to the input field when the "Edit" button is clicked.
+
+<Source
+  code={`
+// Snippet shorten for brevity
+<Button
+  id="edit"
+  ref={editBtnRef}
+  onClick={() => {
+    setIsEdit(true);
+    setTimeout(() => inputRef.current?.focus(), 0);
+  }}
+>
+  Edit
+</Button>
+// In Edit mode
+<TextInput
+  ref={inputRef}
+  id="focus-management"
+  labelText="What is your favorite color?"
+  onFocus={() => setIsEdit(true)}
+  placeholder="i.e. blue, green, etc."
+  isClearable
+  isClearableCallback={() => setValue("")}
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+/>
+`}
+  language="jsx"
+/>
+
+<Canvas of={TextInputStories.FocusRefManagement} />
+
 ## Number Type
 
 The `TextInput` component can be configured to render a number input by setting

--- a/src/components/TextInput/TextInput.stories.tsx
+++ b/src/components/TextInput/TextInput.stories.tsx
@@ -1,13 +1,15 @@
-import { Box, VStack } from "@chakra-ui/react";
+import { Box, HStack, VStack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react";
 import { expect, userEvent, waitFor, within } from "@storybook/test";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
+import Button from "../Button/Button";
 import Heading from "../Heading/Heading";
 import TextInput, {
   autoCompleteValuesArray,
   textInputTypesArray,
 } from "./TextInput";
+import type { TextInputRefType } from "./TextInput";
 import { argsBooleanType } from "../../helpers/storybookUtils";
 
 const meta: Meta<typeof TextInput> = {
@@ -221,6 +223,54 @@ const ControlledExampleComponent = () => {
       value={value}
     />
   );
+};
+
+const FocusManagementComponent = () => {
+  const [isEdit, setIsEdit] = useState(false);
+  const [value, setValue] = useState("");
+  const inputRef = useRef<TextInputRefType | null>(null);
+  const editBtnRef = useRef<HTMLButtonElement>(null);
+
+  return !isEdit ? (
+    <Button
+      id="edit"
+      ref={editBtnRef}
+      onClick={() => {
+        setIsEdit(true);
+        setTimeout(() => inputRef.current?.focus(), 0);
+      }}
+    >
+      Edit
+    </Button>
+  ) : (
+    <HStack alignItems="end">
+      <TextInput
+        ref={inputRef}
+        id="focus-management"
+        labelText="What is your favorite color?"
+        onFocus={() => setIsEdit(true)}
+        placeholder="i.e. blue, green, etc."
+        isClearable
+        isClearableCallback={() => setValue("")}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+      />
+      <Button
+        id="cancel"
+        onClick={() => {
+          setIsEdit(false);
+          setTimeout(() => editBtnRef.current?.focus(), 0);
+        }}
+      >
+        Cancel
+      </Button>
+    </HStack>
+  );
+};
+
+export const FocusRefManagement: Story = {
+  render: () => <FocusManagementComponent />,
+  name: "Focus Ref Management",
 };
 
 export const ControlledExample: Story = {

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -291,7 +291,7 @@ export const TextInput: ChakraComponent<
         setFinalValue("");
         isClearableCallback && isClearableCallback();
         // Set focus back to the input element.
-        (finalRef as any).current.focus();
+        closedRef.current?.focus();
       };
       let finalIsInvalid = isInvalid;
       let fieldOutput;

--- a/src/components/TextInput/textInputChangelogData.ts
+++ b/src/components/TextInput/textInputChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Functionality", "Accessibility"],
+    notes: [
+      "Fixes conflicting internal and external ref props and values for the clearable button focus management.",
+    ],
+  },
+  {
     date: "2024-09-19",
     version: "3.3.2",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1892](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1892)

## This PR does the following:

- Uses the `TextInput`'s internal ref for the clearable "X" button. The external ref prop can still be used as intended.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally in Storybook. The example is a simplified version of the problem encountered in LSP's My Account project.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Helps make use of an app-wide focus management concern.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1892]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1892?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ