### PR TITLE
DSD-1889: POC for <search> exploration

### DIFF
--- a/src/components/AccessibilityGuide/ARIALandmarks.mdx
+++ b/src/components/AccessibilityGuide/ARIALandmarks.mdx
@@ -1,0 +1,34 @@
+import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+
+import * as SearchBarStories from "../SearchBar/SearchBar.stories";
+import Link from "../Link/Link";
+
+<Meta title="Accessibility Guide/ARIA Landmarks" />
+
+# ARIA Landmarks
+
+## Overview
+
+ARIA landmarks denote important sections of a page that a user might want to navigate to directly. Adding landmark roles essentially creates "skip links"
+for assistive technologies to find content quickly.
+
+Each landmark role has a corresponding semantic element:
+
+| Landmark role | HTML element        |
+| ------------- | ------------------- |
+| banner        | document `<header>` |
+| complementary | `<aside>`           |
+| contentinfo   | document `<footer>` |
+| form          | `<form>`            |
+| main          | `<main>`            |
+| navigation    | `<nav>`             |
+| region        | `<section>`         |
+| search        | `<search>`          |
+
+### `<search>`
+
+The `<search>` HTML element is a container for the search/filter functionality, and defines a search landmark.
+
+Inspect the below Story to see `<search>` in the DOM– notice that it wraps the `Heading`, the `Searchbar`, and the `Checkbox`:
+
+<Canvas of={SearchBarStories.WithSearchElement} />

--- a/src/components/SearchBar/SearchBar.mdx
+++ b/src/components/SearchBar/SearchBar.mdx
@@ -54,8 +54,9 @@ aria-labels are used to make these children components accessible.
 The `SearchBar` component is implemented with Reservoir `Select`, `TextInput`,
 and `Button` accessible components. This a "complete" component that renders an
 HTML `<form>` element that is submitted with a `<button>` element of `type="submit"`.
-The `<form>` element also has a `role="search"` attribute that allows
-screenreaders to pick up this entire search form.
+
+The `Searchbar`, along with any other search/filter functionality, must be wrapped in `<search>` tags for a screenreader to recognize it correctly, or in a container with `role="search"`.
+See [search element in "ARIA Landmarks"](../?path=/docs/accessibility-guide-aria-landmarks--docs#search) for details.
 
 Resources:
 
@@ -63,6 +64,7 @@ Resources:
 - [Reservoir TextInput](../?path=/docs/components-form-elements-textinput--docs)
 - [a11ymatters Accessible Search Form](https://www.a11ymatters.com/pattern/accessible-search/)
 - [MDN ARIA: search role](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/search_role)
+- [MDN ARIA: search element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/search)
 
 ## With Custom Heading
 

--- a/src/components/SearchBar/SearchBar.mdx
+++ b/src/components/SearchBar/SearchBar.mdx
@@ -55,7 +55,7 @@ The `SearchBar` component is implemented with Reservoir `Select`, `TextInput`,
 and `Button` accessible components. This a "complete" component that renders an
 HTML `<form>` element that is submitted with a `<button>` element of `type="submit"`.
 
-The `Searchbar`, along with any other search/filter functionality, must be wrapped in `<search>` tags for a screenreader to recognize it correctly, or in a container with `role="search"`.
+The `Searchbar`, along with any other search/filter functionality, must be wrapped in `<search>` tags, or in a container with `role="search"`, for a screenreader to recognize it correctly.
 See [search element in "ARIA Landmarks"](../?path=/docs/accessibility-guide-aria-landmarks--docs#search) for details.
 
 Resources:

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -6,6 +6,8 @@ import SearchBar from "./SearchBar";
 import * as autoSuggestStories from "../Autosuggest/Autosuggest.stories-unresolved";
 import Heading from "../Heading/Heading";
 import { argsBooleanType } from "../../helpers/storybookUtils";
+import Checkbox from "../Checkbox/Checkbox";
+import { Box } from "@chakra-ui/react";
 
 const meta: Meta<typeof SearchBar> = {
   title: "Components/Form Elements/SearchBar",
@@ -317,6 +319,28 @@ function SearchBarValueExampleComponent() {
     />
   );
 }
+
+export const WithSearchElement: Story = {
+  render: () => (
+    <search>
+      <SearchBar
+        headingText={<Heading level="h4">Item search</Heading>}
+        id="with-search-element"
+        labelText="With search element example"
+        onSubmit={() => {}}
+        textInputProps={{
+          labelText: "Item Search",
+          name: "textInputName",
+          placeholder: "Item Search",
+        }}
+      />
+      <Box sx={{ marginTop: "s" }}>
+        <Checkbox id={"public-domain"} labelText={"Only public domain"} />
+      </Box>
+    </search>
+  ),
+  name: "Search Landmark Element Example",
+};
 
 export const SearchBarValueExample: Story = {
   render: () => <SearchBarValueExampleComponent />,

--- a/src/components/SearchBar/SearchBar.test.tsx
+++ b/src/components/SearchBar/SearchBar.test.tsx
@@ -101,8 +101,8 @@ describe("SearchBar", () => {
         textInputProps={textInputProps}
       />
     );
-    expect(screen.getByRole("search")).toBeInTheDocument();
-    expect(screen.getByRole("search")).toHaveAttribute(
+    expect(screen.getByRole("form")).toBeInTheDocument();
+    expect(screen.getByRole("form")).toHaveAttribute(
       "aria-label",
       `${labelText} - ${helperText}`
     );

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -238,7 +238,6 @@ export const SearchBar: ChakraComponent<
           as="form"
           id={`searchbar-form-${id}`}
           className={className}
-          role="search"
           aria-label={finalAriaLabel}
           onSubmit={onSubmit}
           method={method}

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -10,7 +10,6 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
     className="css-1xdhyk6"
     id="searchbar-form-basic"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -113,7 +112,6 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
     className="css-1xdhyk6"
     id="searchbar-form-withSelect"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1u8qly9"
@@ -335,7 +333,6 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
     className="css-1xdhyk6"
     id="searchbar-form-withoutHelperText"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -421,7 +418,6 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
     className="css-1xdhyk6"
     id="searchbar-form-withClearButton"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -524,7 +520,6 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
     className="css-1xdhyk6"
     id="searchbar-form-invalidState"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -619,7 +614,6 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
     className="css-1xdhyk6"
     id="searchbar-form-disabledState"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -706,7 +700,6 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
     className="css-1xdhyk6"
     id="searchbar-form-requiredState"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -794,7 +787,6 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
     className="css-1xdhyk6"
     id="searchbar-form-noBrandButtonType"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -888,7 +880,6 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
     className="css-1xdhyk6"
     id="searchbar-form-withHeading"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -955,7 +946,6 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
     className="css-1xdhyk6"
     id="searchbar-form-withDescription"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -1028,7 +1018,6 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
     className="css-1xdhyk6"
     id="searchbar-form-withHeadingAndDescription"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -1090,7 +1079,6 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
     className="css-kle7zy"
     id="searchbar-form-chakra"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"
@@ -1194,7 +1182,6 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
     className="css-1xdhyk6"
     id="searchbar-form-props"
     onSubmit={[MockFunction]}
-    role="search"
   >
     <div
       className="css-1ik4laa"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1889](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1889). See [this document](https://docs.google.com/document/d/1LdLsyDkl7vX_yz7JBlMInt8fpCOqNhwNy0CiRhijdG8/edit?usp=sharing) for explanation behind these proposed changes.

## This PR does the following:

- Most importantly: removes `role="search"` from form element within `Searchbar`
- Adds recommendation to use `<search>` in `Searchbar` documentation
- Creates new page in Reservoir accessibility guide for ARIA landmarks

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Updating use of search role in response to new HTML search element

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1889]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ