### PR TITLE
DSD-1888: Pagination style updates

### DIFF
--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Pagination
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.10`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Pagination/Pagination.stories.tsx
+++ b/src/components/Pagination/Pagination.stories.tsx
@@ -55,7 +55,7 @@ export const UnchangingURL: Story = {
     onPageChange: (selectedPage) => {
       console.log(`Current page: ${selectedPage}`);
     },
-    pageCount: 100,
+    pageCount: 10,
   },
   name: "Pagination with Unchanging URL",
   render: (args) => <Pagination {...args} getPageHref={undefined} />,

--- a/src/components/Pagination/Pagination.test.tsx
+++ b/src/components/Pagination/Pagination.test.tsx
@@ -52,30 +52,38 @@ describe("Pagination", () => {
       expect(screen.getAllByRole("link")).toHaveLength(7);
     });
 
-    it("does not render the Previous link on the first page", () => {
+    it("renders the disabled Previous link on the first page", () => {
       render(
         <Pagination pageCount={5} initialPage={1} getPageHref={getPageHref} />
       );
       // Pagination should show:
-      // 1 2 3 4 5 Next
+      // Previous 1 2 3 4 5 Next
       const links = screen.getAllByRole("link");
 
-      expect(links).toHaveLength(6);
-      expect(screen.queryByText("Previous")).not.toBeInTheDocument();
+      expect(links).toHaveLength(7);
+      expect(screen.queryByText("Previous")).toBeInTheDocument();
+      expect(screen.getByText("Previous").parentElement).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      );
       expect(screen.getByText("Next")).toBeInTheDocument();
     });
 
-    it("does not render the Next link on the last page", () => {
+    it("renders the disabled Next link on the last page", () => {
       render(
         <Pagination pageCount={5} initialPage={5} getPageHref={getPageHref} />
       );
       // Pagination should show:
-      // Previous 1 2 3 4 5
+      // Previous 1 2 3 4 5 Next
       const links = screen.getAllByRole("link");
 
-      expect(links).toHaveLength(6);
+      expect(links).toHaveLength(7);
       expect(screen.getByText("Previous")).toBeInTheDocument();
-      expect(screen.queryByText("Next")).not.toBeInTheDocument();
+      expect(screen.queryByText("Next")).toBeInTheDocument();
+      expect(screen.getByText("Next").parentElement).toHaveAttribute(
+        "aria-disabled",
+        "true"
+      );
     });
 
     it("renders an ellipsis at the end of the list", () => {
@@ -83,15 +91,15 @@ describe("Pagination", () => {
         <Pagination pageCount={10} initialPage={1} getPageHref={getPageHref} />
       );
       // Pagination should show:
-      // 1 2 3 4 5 ... 10 Next
+      // Previous 1 2 3 4 5 ... 10 Next
       const listitem = screen.getAllByRole("listitem");
 
-      expect(listitem).toHaveLength(8);
+      expect(listitem).toHaveLength(9);
       // The ellipsis is not a link
-      expect(screen.getAllByRole("link")).toHaveLength(7);
-      expect(listitem[4].textContent).toEqual("5");
-      expect(listitem[5].textContent).toEqual("...");
-      expect(listitem[6].textContent).toEqual("10");
+      expect(screen.getAllByRole("link")).toHaveLength(8);
+      expect(listitem[5].textContent).toEqual("5");
+      expect(listitem[6].textContent).toEqual("...");
+      expect(listitem[7].textContent).toEqual("10");
       expect(screen.getByText("...")).toBeInTheDocument();
     });
 
@@ -100,12 +108,12 @@ describe("Pagination", () => {
         <Pagination pageCount={10} initialPage={10} getPageHref={getPageHref} />
       );
       // Pagination should show:
-      // Previous 1 ... 6 7 8 9 10
+      // Previous 1 ... 6 7 8 9 10 Next
       const listitem = screen.getAllByRole("listitem");
 
-      expect(listitem).toHaveLength(8);
+      expect(listitem).toHaveLength(9);
       // The ellipsis is not a link
-      expect(screen.getAllByRole("link")).toHaveLength(7);
+      expect(screen.getAllByRole("link")).toHaveLength(8);
       expect(listitem[1].textContent).toEqual("1");
       expect(listitem[2].textContent).toEqual("...");
       expect(listitem[3].textContent).toEqual("6");
@@ -361,7 +369,7 @@ describe("Pagination", () => {
         />
       );
       // Pagination should show:
-      // Previous 1 ... 6 7 8 9 10
+      // Previous 1 ... 6 7 8 9 10 Next
       links = screen.getAllByRole("link");
 
       // Page 6
@@ -376,9 +384,10 @@ describe("Pagination", () => {
       );
 
       let links = screen.getAllByRole("link");
-      let page1 = links[0].getAttribute("aria-current");
-      let page2 = links[1].getAttribute("aria-current");
-      let page3 = links[2].getAttribute("aria-current");
+      // links[0] is "Previous"
+      let page1 = links[1].getAttribute("aria-current");
+      let page2 = links[2].getAttribute("aria-current");
+      let page3 = links[3].getAttribute("aria-current");
 
       // Only the current page has `aria-current="page"` for accessibility.
       expect(page1).toEqual("page");
@@ -390,7 +399,7 @@ describe("Pagination", () => {
       );
 
       links = screen.getAllByRole("link");
-      // links[0] is now "Previous"
+      // links[0] is "Previous"
       page1 = links[1].getAttribute("aria-current");
       page2 = links[2].getAttribute("aria-current");
       page3 = links[3].getAttribute("aria-current");

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -180,7 +180,14 @@ export const Pagination: ChakraComponent<
           }}
         >
           {!isPrevious && (
-            <Text sx={{ display: { base: "none", md: "inline" } }}>{text}</Text>
+            <Text
+              size="body2"
+              sx={{
+                display: { base: "none", md: "inline" },
+              }}
+            >
+              {text}
+            </Text>
           )}
           <Icon
             name="arrow"
@@ -188,8 +195,7 @@ export const Pagination: ChakraComponent<
             size="xsmall"
             sx={{
               display: { base: "none", md: "inline" },
-              marginRight: "xxs",
-              marginLeft: "xxs",
+              marginRight: isPrevious ? "xs" : 0,
             }}
           />
           <Icon
@@ -198,14 +204,13 @@ export const Pagination: ChakraComponent<
             size="small"
             sx={{
               display: { base: "inline", md: "none" },
-              marginRight: "xxs",
-              marginLeft: "xxs",
+              marginRight: isPrevious ? "xs" : 0,
             }}
           />
           {isPrevious && (
             <Text
+              size="body2"
               sx={{
-                "> p": { marginBottom: 0 },
                 display: { base: "none", md: "inline" },
               }}
             >

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -161,6 +161,7 @@ export const Pagination: ChakraComponent<
               sx={{
                 fontSize: "14px",
                 display: { base: "none", md: "inline" },
+                marginInlineStart: "8px",
               }}
             >
               {text}
@@ -216,9 +217,11 @@ export const Pagination: ChakraComponent<
       // Styles for the current page link.
       const currentStyles = isSelectedPage
         ? {
+            display: "flex",
+            justifyContent: "center",
+            alignItems: "center",
             pointerEvents: "none",
             border: "1px solid",
-            padding: "4px 8px",
             borderRadius: "4px",
             borderColor: "ui.link.primary",
             bg: "ui.link.primary-05",
@@ -256,6 +259,11 @@ export const Pagination: ChakraComponent<
           __css={{
             ...styles.link,
             ...currentStyles,
+            ...{
+              minWidth: { base: "44px", md: "32px" },
+              height: { base: "44px", md: "32px" },
+              padding: { base: "2px 8px", md: "4px 8px" },
+            },
           }}
         >
           {item}

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -127,7 +127,7 @@ export const Pagination: ChakraComponent<
     };
 
     // Returns the "Previous" or "Next" link element, disabled according to current page number.
-    const previousNextElement = ({
+    const getPreviousNextElement = ({
       pageNumber,
       text,
       isDisabled,
@@ -137,43 +137,17 @@ export const Pagination: ChakraComponent<
       isDisabled: boolean;
     }) => {
       const isPrevious = text === "Previous";
-      const baseStyles = {
-        justifyItems: "center",
-        textDecoration: "none !important",
-        color: "ui.link.primary",
-        _hover: {
-          svg: { fill: "ui.link.secondary" },
-          color: "ui.link.secondary",
-        },
-        svg: {
-          fill: "ui.link.primary",
-          marginLeft: "xxs",
-        },
-        _dark: {
-          color: "dark.ui.link.primary",
-          svg: { fill: "dark.ui.link.primary" },
-        },
-      };
-
-      const disabledStyles = isDisabled
-        ? {
-            color: "ui.disabled.primary",
-            pointerEvents: "none",
-            svg: { fill: "ui.disabled.primary" },
-            _dark: {
-              color: "ui.disabled.secondary",
-              svg: { fill: "ui.disabled.secondary" },
-            },
-          }
-        : {};
-
-      const combinedStyles = { ...baseStyles, ...disabledStyles };
+      const disabledStyles = isDisabled ? styles.disabledElement : {};
 
       return (
         <Link
           href={changeUrls ? getPageHref(pageNumber) : "#"}
           id={`${id}-${text}`}
-          sx={combinedStyles}
+          __css={{
+            ...styles.link,
+            ...styles.previousNextElement,
+            ...disabledStyles,
+          }}
           type="action"
           aria-label={`${isPrevious ? "Previous" : "Next"} page`}
           aria-disabled={isDisabled}
@@ -209,6 +183,7 @@ export const Pagination: ChakraComponent<
             sx={{
               display: { base: "inline", md: "none" },
               marginRight: isPrevious ? "xs" : 0,
+              marginLeft: isPrevious ? 0 : "xs",
             }}
           />
           {isPrevious && (
@@ -362,7 +337,7 @@ export const Pagination: ChakraComponent<
     // Disable the previous link when you're on the first page.
     const previousLiLink = (
       <li key="previous">
-        {previousNextElement({
+        {getPreviousNextElement({
           pageNumber: previousPageNumber,
           text: "Previous",
           isDisabled: selectedPage === 1,
@@ -372,7 +347,7 @@ export const Pagination: ChakraComponent<
     // Disable the next link when you're on the last page.
     const nextLiLink = (
       <li key="next">
-        {previousNextElement({
+        {getPreviousNextElement({
           pageNumber: nextPageNumber,
           text: "Next",
           isDisabled: selectedPage === pageCount,

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -158,8 +158,8 @@ export const Pagination: ChakraComponent<
           {!isPrevious && (
             <Text
               as="span"
-              size="body2"
               sx={{
+                fontSize: "14px",
                 display: { base: "none", md: "inline" },
               }}
             >
@@ -189,8 +189,8 @@ export const Pagination: ChakraComponent<
           {isPrevious && (
             <Text
               as="span"
-              size="body2"
               sx={{
+                fontSize: "14px",
                 display: { base: "none", md: "inline" },
               }}
             >

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -262,7 +262,11 @@ export const Pagination: ChakraComponent<
             ...{
               minWidth: { base: "44px", md: "32px" },
               height: { base: "44px", md: "32px" },
-              padding: { base: "2px 8px", md: "4px 8px" },
+              // Remove padding at 360px so all page numbers (up to 4 digits) can still fit.
+              padding: ["0", "inherit"],
+              "@media (min-width: 360px)": {
+                padding: { base: "2px 8px", md: "4px 8px" },
+              },
             },
           }}
         >
@@ -296,7 +300,8 @@ export const Pagination: ChakraComponent<
           // one number before the current page.
           selected - 1,
           // If the current page is near the end, show the last five items.
-          pageCount - 4
+          // If the page number has 4 digits, show only the last four items.
+          pageCount > 999 ? pageCount - 3 : pageCount - 4
         )
       );
       // Where should the middle range of numbers end at?
@@ -312,6 +317,8 @@ export const Pagination: ChakraComponent<
           5
         )
       );
+      //}
+
       const itemList =
         pageCount < 4
           ? // Get a short array with 2 or 3 items: [1, 2] or [1, 2, 3]
@@ -331,6 +338,7 @@ export const Pagination: ChakraComponent<
               // Always display the last page.
               pageCount,
             ];
+
       // If it's a number, render an `li` element with a link page item,
       // otherwise return the `li` with the ellipse for a break.
       const pageLiItems = itemList.map((item) => {

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -127,11 +127,15 @@ export const Pagination: ChakraComponent<
     };
 
     // Returns the "Previous" or "Next" link element, disabled according to current page number.
-    const previousNextElement = (
-      pageNumber: number,
-      text: string,
-      isDisabled: boolean
-    ) => {
+    const previousNextElement = ({
+      pageNumber,
+      text,
+      isDisabled,
+    }: {
+      pageNumber: number;
+      text: "Previous" | "Next";
+      isDisabled: boolean;
+    }) => {
       const isPrevious = text === "Previous";
       const baseStyles = {
         justifyItems: "center",
@@ -171,16 +175,15 @@ export const Pagination: ChakraComponent<
           id={`${id}-${text}`}
           sx={combinedStyles}
           type="action"
+          aria-label={`${isPrevious ? "Previous" : "Next"} page`}
+          aria-disabled={isDisabled}
           onClick={
             changeUrls ? undefined : isPrevious ? previousPage : nextPage
           }
-          {...{
-            "aria-label": `${isPrevious ? "Previous" : "Next"} page`,
-            "aria-disabled": isDisabled,
-          }}
         >
           {!isPrevious && (
             <Text
+              as="span"
               size="body2"
               sx={{
                 display: { base: "none", md: "inline" },
@@ -195,7 +198,8 @@ export const Pagination: ChakraComponent<
             size="xsmall"
             sx={{
               display: { base: "none", md: "inline" },
-              marginRight: isPrevious ? "xs" : 0,
+              marginRight: isPrevious ? "xxs" : 0,
+              marginLeft: isPrevious ? 0 : "xxs",
             }}
           />
           <Icon
@@ -209,6 +213,7 @@ export const Pagination: ChakraComponent<
           />
           {isPrevious && (
             <Text
+              as="span"
               size="body2"
               sx={{
                 display: { base: "none", md: "inline" },
@@ -357,21 +362,21 @@ export const Pagination: ChakraComponent<
     // Disable the previous link when you're on the first page.
     const previousLiLink = (
       <li key="previous">
-        {previousNextElement(
-          previousPageNumber,
-          "Previous",
-          selectedPage === 1
-        )}
+        {previousNextElement({
+          pageNumber: previousPageNumber,
+          text: "Previous",
+          isDisabled: selectedPage === 1,
+        })}
       </li>
     );
     // Disable the next link when you're on the last page.
     const nextLiLink = (
       <li key="next">
-        {previousNextElement(
-          nextPageNumber,
-          "Next",
-          selectedPage === pageCount
-        )}
+        {previousNextElement({
+          pageNumber: nextPageNumber,
+          text: "Next",
+          isDisabled: selectedPage === pageCount,
+        })}
       </li>
     );
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -144,7 +144,6 @@ export const Pagination: ChakraComponent<
         svg: {
           fill: "ui.link.primary",
           marginLeft: "xxs",
-          strokeWidth: "1.5px",
         },
         _dark: {
           color: "dark.ui.link.primary",

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -13,9 +13,42 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
   >
     <li>
       <a
+        aria-disabled={true}
+        aria-label="Previous page"
+        className="chakra-link css-gkrqvu"
+        href="page=0"
+        id="firstPage-Previous"
+        rel={null}
+        target={null}
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <p
+          className="chakra-text css-4b8jmh"
+        >
+          Previous
+        </p>
+      </a>
+    </li>
+    <li>
+      <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-17tw9ye"
+        className="chakra-link css-ocqjav"
         href="page=1"
         id="firstPage-1"
         rel={null}
@@ -26,7 +59,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 2"
         className="chakra-link css-1xdhyk6"
         href="page=2"
@@ -39,7 +71,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 3"
         className="chakra-link css-1xdhyk6"
         href="page=3"
@@ -52,7 +83,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 4"
         className="chakra-link css-1xdhyk6"
         href="page=4"
@@ -65,7 +95,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 5"
         className="chakra-link css-1xdhyk6"
         href="page=5"
@@ -81,7 +110,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 10"
         className="chakra-link css-1xdhyk6"
         href="page=10"
@@ -94,14 +122,35 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     </li>
     <li>
       <a
+        aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-1q8jgcr"
         href="page=2"
         id="firstPage-Next"
         rel={null}
         target={null}
       >
-        Next
+        <p
+          className="chakra-text css-gd6c27"
+        >
+          Next
+        </p>
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
       </a>
     </li>
   </ul>
@@ -121,19 +170,39 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
   >
     <li>
       <a
+        aria-disabled={false}
         aria-label="Previous page"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-1q8jgcr"
         href="page=9"
         id="lastPage-Previous"
         rel={null}
         target={null}
       >
-        Previous
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <p
+          className="chakra-text css-4b8jmh"
+        >
+          Previous
+        </p>
       </a>
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 1"
         className="chakra-link css-1xdhyk6"
         href="page=1"
@@ -149,7 +218,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 6"
         className="chakra-link css-1xdhyk6"
         href="page=6"
@@ -162,7 +230,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 7"
         className="chakra-link css-1xdhyk6"
         href="page=7"
@@ -175,7 +242,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 8"
         className="chakra-link css-1xdhyk6"
         href="page=8"
@@ -188,7 +254,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 9"
         className="chakra-link css-1xdhyk6"
         href="page=9"
@@ -203,13 +268,46 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-current="page"
         aria-label="Page 10"
-        className="chakra-link css-17tw9ye"
+        className="chakra-link css-ocqjav"
         href="page=10"
         id="lastPage-10"
         rel={null}
         target={null}
       >
         10
+      </a>
+    </li>
+    <li>
+      <a
+        aria-disabled={true}
+        aria-label="Next page"
+        className="chakra-link css-gkrqvu"
+        href="page=11"
+        id="lastPage-Next"
+        rel={null}
+        target={null}
+      >
+        <p
+          className="chakra-text css-gd6c27"
+        >
+          Next
+        </p>
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
       </a>
     </li>
   </ul>
@@ -229,19 +327,39 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
   >
     <li>
       <a
+        aria-disabled={false}
         aria-label="Previous page"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-1q8jgcr"
         href="page=4"
         id="middlePage-Previous"
         rel={null}
         target={null}
       >
-        Previous
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <p
+          className="chakra-text css-4b8jmh"
+        >
+          Previous
+        </p>
       </a>
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 1"
         className="chakra-link css-1xdhyk6"
         href="page=1"
@@ -257,7 +375,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 4"
         className="chakra-link css-1xdhyk6"
         href="page=4"
@@ -272,7 +389,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-current="page"
         aria-label="Page 5"
-        className="chakra-link css-17tw9ye"
+        className="chakra-link css-ocqjav"
         href="page=5"
         id="middlePage-5"
         rel={null}
@@ -283,7 +400,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 6"
         className="chakra-link css-1xdhyk6"
         href="page=6"
@@ -299,7 +415,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 10"
         className="chakra-link css-1xdhyk6"
         href="page=10"
@@ -312,14 +427,35 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     </li>
     <li>
       <a
+        aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-1q8jgcr"
         href="page=6"
         id="middlePage-Next"
         rel={null}
         target={null}
       >
-        Next
+        <p
+          className="chakra-text css-gd6c27"
+        >
+          Next
+        </p>
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
       </a>
     </li>
   </ul>
@@ -339,9 +475,42 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
   >
     <li>
       <a
+        aria-disabled={true}
+        aria-label="Previous page"
+        className="chakra-link css-gkrqvu"
+        href="page=0"
+        id="chakra-Previous"
+        rel={null}
+        target={null}
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <p
+          className="chakra-text css-4b8jmh"
+        >
+          Previous
+        </p>
+      </a>
+    </li>
+    <li>
+      <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-17tw9ye"
+        className="chakra-link css-ocqjav"
         href="page=1"
         id="chakra-1"
         rel={null}
@@ -352,7 +521,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 2"
         className="chakra-link css-1xdhyk6"
         href="page=2"
@@ -365,7 +533,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 3"
         className="chakra-link css-1xdhyk6"
         href="page=3"
@@ -378,7 +545,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 4"
         className="chakra-link css-1xdhyk6"
         href="page=4"
@@ -391,7 +557,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 5"
         className="chakra-link css-1xdhyk6"
         href="page=5"
@@ -407,7 +572,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 10"
         className="chakra-link css-1xdhyk6"
         href="page=10"
@@ -420,14 +584,35 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     </li>
     <li>
       <a
+        aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-1q8jgcr"
         href="page=2"
         id="chakra-Next"
         rel={null}
         target={null}
       >
-        Next
+        <p
+          className="chakra-text css-gd6c27"
+        >
+          Next
+        </p>
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
       </a>
     </li>
   </ul>
@@ -448,9 +633,42 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
   >
     <li>
       <a
+        aria-disabled={true}
+        aria-label="Previous page"
+        className="chakra-link css-gkrqvu"
+        href="page=0"
+        id="props-Previous"
+        rel={null}
+        target={null}
+      >
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <p
+          className="chakra-text css-4b8jmh"
+        >
+          Previous
+        </p>
+      </a>
+    </li>
+    <li>
+      <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-17tw9ye"
+        className="chakra-link css-ocqjav"
         href="page=1"
         id="props-1"
         rel={null}
@@ -461,7 +679,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 2"
         className="chakra-link css-1xdhyk6"
         href="page=2"
@@ -474,7 +691,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 3"
         className="chakra-link css-1xdhyk6"
         href="page=3"
@@ -487,7 +703,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 4"
         className="chakra-link css-1xdhyk6"
         href="page=4"
@@ -500,7 +715,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 5"
         className="chakra-link css-1xdhyk6"
         href="page=5"
@@ -516,7 +730,6 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     </li>
     <li>
       <a
-        aria-current={null}
         aria-label="Page 10"
         className="chakra-link css-1xdhyk6"
         href="page=10"
@@ -529,14 +742,35 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     </li>
     <li>
       <a
+        aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-1q8jgcr"
         href="page=2"
         id="props-Next"
         rel={null}
         target={null}
       >
-        Next
+        <p
+          className="chakra-text css-gd6c27"
+        >
+          Next
+        </p>
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-1799zku"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
+        <svg
+          aria-hidden={true}
+          className="chakra-icon css-15pfpp5"
+          data-file-name="SvgArrow"
+          focusable={false}
+          role="img"
+          title="arrow icon"
+        />
       </a>
     </li>
   </ul>

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -38,8 +38,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
           title="arrow icon"
         />
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Previous
         </span>
@@ -132,8 +131,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         target={null}
       >
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Next
         </span>
@@ -197,8 +195,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
           title="arrow icon"
         />
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Previous
         </span>
@@ -291,8 +288,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         target={null}
       >
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Next
         </span>
@@ -356,8 +352,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
           title="arrow icon"
         />
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Previous
         </span>
@@ -441,8 +436,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         target={null}
       >
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Next
         </span>
@@ -506,8 +500,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
           title="arrow icon"
         />
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Previous
         </span>
@@ -600,8 +593,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         target={null}
       >
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Next
         </span>
@@ -666,8 +658,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
           title="arrow icon"
         />
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Previous
         </span>
@@ -760,8 +751,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         target={null}
       >
         <span
-          className="css-13b35wz"
-          size="body2"
+          className="css-rb3ek3"
         >
           Next
         </span>

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-disabled={true}
         aria-label="Previous page"
-        className="chakra-link css-15jccru"
+        className="chakra-link css-1xdhyk6"
         href="page=0"
         id="firstPage-Previous"
         rel={null}
@@ -23,7 +23,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-3i73uu"
+          className="chakra-icon css-1hiwo6q"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -31,17 +31,18 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1xdq4c0"
+          className="chakra-icon css-s2ejzr"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Previous
-        </p>
+        </span>
       </a>
     </li>
     <li>
@@ -124,20 +125,21 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-90tav9"
+        className="chakra-link css-1xdhyk6"
         href="page=2"
         id="firstPage-Next"
         rel={null}
         target={null}
       >
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Next
-        </p>
+        </span>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-tngas5"
+          className="chakra-icon css-16chr5f"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -145,7 +147,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-kgmpbo"
+          className="chakra-icon css-1lhtxwf"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -172,7 +174,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-disabled={false}
         aria-label="Previous page"
-        className="chakra-link css-90tav9"
+        className="chakra-link css-1xdhyk6"
         href="page=9"
         id="lastPage-Previous"
         rel={null}
@@ -180,7 +182,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-3i73uu"
+          className="chakra-icon css-1hiwo6q"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -188,17 +190,18 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1xdq4c0"
+          className="chakra-icon css-s2ejzr"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Previous
-        </p>
+        </span>
       </a>
     </li>
     <li>
@@ -281,20 +284,21 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-disabled={true}
         aria-label="Next page"
-        className="chakra-link css-15jccru"
+        className="chakra-link css-1xdhyk6"
         href="page=11"
         id="lastPage-Next"
         rel={null}
         target={null}
       >
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Next
-        </p>
+        </span>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-tngas5"
+          className="chakra-icon css-16chr5f"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -302,7 +306,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-kgmpbo"
+          className="chakra-icon css-1lhtxwf"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -329,7 +333,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-disabled={false}
         aria-label="Previous page"
-        className="chakra-link css-90tav9"
+        className="chakra-link css-1xdhyk6"
         href="page=4"
         id="middlePage-Previous"
         rel={null}
@@ -337,7 +341,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-3i73uu"
+          className="chakra-icon css-1hiwo6q"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -345,17 +349,18 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1xdq4c0"
+          className="chakra-icon css-s2ejzr"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Previous
-        </p>
+        </span>
       </a>
     </li>
     <li>
@@ -429,20 +434,21 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-90tav9"
+        className="chakra-link css-1xdhyk6"
         href="page=6"
         id="middlePage-Next"
         rel={null}
         target={null}
       >
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Next
-        </p>
+        </span>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-tngas5"
+          className="chakra-icon css-16chr5f"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -450,7 +456,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-kgmpbo"
+          className="chakra-icon css-1lhtxwf"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -477,7 +483,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-disabled={true}
         aria-label="Previous page"
-        className="chakra-link css-15jccru"
+        className="chakra-link css-1xdhyk6"
         href="page=0"
         id="chakra-Previous"
         rel={null}
@@ -485,7 +491,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-3i73uu"
+          className="chakra-icon css-1hiwo6q"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -493,17 +499,18 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1xdq4c0"
+          className="chakra-icon css-s2ejzr"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Previous
-        </p>
+        </span>
       </a>
     </li>
     <li>
@@ -586,20 +593,21 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-90tav9"
+        className="chakra-link css-1xdhyk6"
         href="page=2"
         id="chakra-Next"
         rel={null}
         target={null}
       >
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Next
-        </p>
+        </span>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-tngas5"
+          className="chakra-icon css-16chr5f"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -607,7 +615,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-kgmpbo"
+          className="chakra-icon css-1lhtxwf"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -635,7 +643,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-disabled={true}
         aria-label="Previous page"
-        className="chakra-link css-15jccru"
+        className="chakra-link css-1xdhyk6"
         href="page=0"
         id="props-Previous"
         rel={null}
@@ -643,7 +651,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-3i73uu"
+          className="chakra-icon css-1hiwo6q"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -651,17 +659,18 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1xdq4c0"
+          className="chakra-icon css-s2ejzr"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Previous
-        </p>
+        </span>
       </a>
     </li>
     <li>
@@ -744,20 +753,21 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-90tav9"
+        className="chakra-link css-1xdhyk6"
         href="page=2"
         id="props-Next"
         rel={null}
         target={null}
       >
-        <p
-          className="chakra-text css-gd6c27"
+        <span
+          className="css-13b35wz"
+          size="body2"
         >
           Next
-        </p>
+        </span>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-tngas5"
+          className="chakra-icon css-16chr5f"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -765,7 +775,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-kgmpbo"
+          className="chakra-icon css-1lhtxwf"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-disabled={true}
         aria-label="Previous page"
-        className="chakra-link css-gkrqvu"
+        className="chakra-link css-15jccru"
         href="page=0"
         id="firstPage-Previous"
         rel={null}
@@ -23,7 +23,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-3i73uu"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -31,14 +31,14 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-1xdq4c0"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
         <p
-          className="chakra-text css-4b8jmh"
+          className="chakra-text css-gd6c27"
         >
           Previous
         </p>
@@ -48,7 +48,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-ocqjav"
+        className="chakra-link css-1ye7m05"
         href="page=1"
         id="firstPage-1"
         rel={null}
@@ -124,7 +124,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1q8jgcr"
+        className="chakra-link css-90tav9"
         href="page=2"
         id="firstPage-Next"
         rel={null}
@@ -137,7 +137,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         </p>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-tngas5"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -145,7 +145,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-kgmpbo"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -172,7 +172,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-disabled={false}
         aria-label="Previous page"
-        className="chakra-link css-1q8jgcr"
+        className="chakra-link css-90tav9"
         href="page=9"
         id="lastPage-Previous"
         rel={null}
@@ -180,7 +180,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-3i73uu"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -188,14 +188,14 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-1xdq4c0"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
         <p
-          className="chakra-text css-4b8jmh"
+          className="chakra-text css-gd6c27"
         >
           Previous
         </p>
@@ -268,7 +268,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-current="page"
         aria-label="Page 10"
-        className="chakra-link css-ocqjav"
+        className="chakra-link css-1ye7m05"
         href="page=10"
         id="lastPage-10"
         rel={null}
@@ -281,7 +281,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-disabled={true}
         aria-label="Next page"
-        className="chakra-link css-gkrqvu"
+        className="chakra-link css-15jccru"
         href="page=11"
         id="lastPage-Next"
         rel={null}
@@ -294,7 +294,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         </p>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-tngas5"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -302,7 +302,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-kgmpbo"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -329,7 +329,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-disabled={false}
         aria-label="Previous page"
-        className="chakra-link css-1q8jgcr"
+        className="chakra-link css-90tav9"
         href="page=4"
         id="middlePage-Previous"
         rel={null}
@@ -337,7 +337,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-3i73uu"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -345,14 +345,14 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-1xdq4c0"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
         <p
-          className="chakra-text css-4b8jmh"
+          className="chakra-text css-gd6c27"
         >
           Previous
         </p>
@@ -389,7 +389,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-current="page"
         aria-label="Page 5"
-        className="chakra-link css-ocqjav"
+        className="chakra-link css-1ye7m05"
         href="page=5"
         id="middlePage-5"
         rel={null}
@@ -429,7 +429,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1q8jgcr"
+        className="chakra-link css-90tav9"
         href="page=6"
         id="middlePage-Next"
         rel={null}
@@ -442,7 +442,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         </p>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-tngas5"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -450,7 +450,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-kgmpbo"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -477,7 +477,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-disabled={true}
         aria-label="Previous page"
-        className="chakra-link css-gkrqvu"
+        className="chakra-link css-15jccru"
         href="page=0"
         id="chakra-Previous"
         rel={null}
@@ -485,7 +485,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-3i73uu"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -493,14 +493,14 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-1xdq4c0"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
         <p
-          className="chakra-text css-4b8jmh"
+          className="chakra-text css-gd6c27"
         >
           Previous
         </p>
@@ -510,7 +510,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-ocqjav"
+        className="chakra-link css-1ye7m05"
         href="page=1"
         id="chakra-1"
         rel={null}
@@ -586,7 +586,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1q8jgcr"
+        className="chakra-link css-90tav9"
         href="page=2"
         id="chakra-Next"
         rel={null}
@@ -599,7 +599,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         </p>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-tngas5"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -607,7 +607,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-kgmpbo"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -635,7 +635,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-disabled={true}
         aria-label="Previous page"
-        className="chakra-link css-gkrqvu"
+        className="chakra-link css-15jccru"
         href="page=0"
         id="props-Previous"
         rel={null}
@@ -643,7 +643,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       >
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-3i73uu"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -651,14 +651,14 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-1xdq4c0"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
           title="arrow icon"
         />
         <p
-          className="chakra-text css-4b8jmh"
+          className="chakra-text css-gd6c27"
         >
           Previous
         </p>
@@ -668,7 +668,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-ocqjav"
+        className="chakra-link css-1ye7m05"
         href="page=1"
         id="props-1"
         rel={null}
@@ -744,7 +744,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-disabled={false}
         aria-label="Next page"
-        className="chakra-link css-1q8jgcr"
+        className="chakra-link css-90tav9"
         href="page=2"
         id="props-Next"
         rel={null}
@@ -757,7 +757,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         </p>
         <svg
           aria-hidden={true}
-          className="chakra-icon css-1799zku"
+          className="chakra-icon css-tngas5"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"
@@ -765,7 +765,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         />
         <svg
           aria-hidden={true}
-          className="chakra-icon css-15pfpp5"
+          className="chakra-icon css-kgmpbo"
           data-file-name="SvgArrow"
           focusable={false}
           role="img"

--- a/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -48,7 +48,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-1ye7m05"
+        className="chakra-link css-1oyhq6a"
         href="page=1"
         id="firstPage-1"
         rel={null}
@@ -60,7 +60,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     <li>
       <a
         aria-label="Page 2"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=2"
         id="firstPage-2"
         rel={null}
@@ -72,7 +72,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     <li>
       <a
         aria-label="Page 3"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=3"
         id="firstPage-3"
         rel={null}
@@ -84,7 +84,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     <li>
       <a
         aria-label="Page 4"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=4"
         id="firstPage-4"
         rel={null}
@@ -96,7 +96,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     <li>
       <a
         aria-label="Page 5"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=5"
         id="firstPage-5"
         rel={null}
@@ -111,7 +111,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
     <li>
       <a
         aria-label="Page 10"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=10"
         id="firstPage-10"
         rel={null}
@@ -131,7 +131,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 1`] = `
         target={null}
       >
         <span
-          className="css-rb3ek3"
+          className="css-70cl0f"
         >
           Next
         </span>
@@ -204,7 +204,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     <li>
       <a
         aria-label="Page 1"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=1"
         id="lastPage-1"
         rel={null}
@@ -219,7 +219,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     <li>
       <a
         aria-label="Page 6"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=6"
         id="lastPage-6"
         rel={null}
@@ -231,7 +231,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     <li>
       <a
         aria-label="Page 7"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=7"
         id="lastPage-7"
         rel={null}
@@ -243,7 +243,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     <li>
       <a
         aria-label="Page 8"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=8"
         id="lastPage-8"
         rel={null}
@@ -255,7 +255,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
     <li>
       <a
         aria-label="Page 9"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=9"
         id="lastPage-9"
         rel={null}
@@ -268,7 +268,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
       <a
         aria-current="page"
         aria-label="Page 10"
-        className="chakra-link css-1ye7m05"
+        className="chakra-link css-1oyhq6a"
         href="page=10"
         id="lastPage-10"
         rel={null}
@@ -288,7 +288,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 2`] = `
         target={null}
       >
         <span
-          className="css-rb3ek3"
+          className="css-70cl0f"
         >
           Next
         </span>
@@ -361,7 +361,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     <li>
       <a
         aria-label="Page 1"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=1"
         id="middlePage-1"
         rel={null}
@@ -376,7 +376,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     <li>
       <a
         aria-label="Page 4"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=4"
         id="middlePage-4"
         rel={null}
@@ -389,7 +389,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
       <a
         aria-current="page"
         aria-label="Page 5"
-        className="chakra-link css-1ye7m05"
+        className="chakra-link css-1oyhq6a"
         href="page=5"
         id="middlePage-5"
         rel={null}
@@ -401,7 +401,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     <li>
       <a
         aria-label="Page 6"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=6"
         id="middlePage-6"
         rel={null}
@@ -416,7 +416,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
     <li>
       <a
         aria-label="Page 10"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=10"
         id="middlePage-10"
         rel={null}
@@ -436,7 +436,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 3`] = `
         target={null}
       >
         <span
-          className="css-rb3ek3"
+          className="css-70cl0f"
         >
           Next
         </span>
@@ -510,7 +510,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-1ye7m05"
+        className="chakra-link css-1oyhq6a"
         href="page=1"
         id="chakra-1"
         rel={null}
@@ -522,7 +522,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     <li>
       <a
         aria-label="Page 2"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=2"
         id="chakra-2"
         rel={null}
@@ -534,7 +534,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     <li>
       <a
         aria-label="Page 3"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=3"
         id="chakra-3"
         rel={null}
@@ -546,7 +546,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     <li>
       <a
         aria-label="Page 4"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=4"
         id="chakra-4"
         rel={null}
@@ -558,7 +558,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     <li>
       <a
         aria-label="Page 5"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=5"
         id="chakra-5"
         rel={null}
@@ -573,7 +573,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
     <li>
       <a
         aria-label="Page 10"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=10"
         id="chakra-10"
         rel={null}
@@ -593,7 +593,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 4`] = `
         target={null}
       >
         <span
-          className="css-rb3ek3"
+          className="css-70cl0f"
         >
           Next
         </span>
@@ -668,7 +668,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
       <a
         aria-current="page"
         aria-label="Page 1"
-        className="chakra-link css-1ye7m05"
+        className="chakra-link css-1oyhq6a"
         href="page=1"
         id="props-1"
         rel={null}
@@ -680,7 +680,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     <li>
       <a
         aria-label="Page 2"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=2"
         id="props-2"
         rel={null}
@@ -692,7 +692,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     <li>
       <a
         aria-label="Page 3"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=3"
         id="props-3"
         rel={null}
@@ -704,7 +704,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     <li>
       <a
         aria-label="Page 4"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=4"
         id="props-4"
         rel={null}
@@ -716,7 +716,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     <li>
       <a
         aria-label="Page 5"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=5"
         id="props-5"
         rel={null}
@@ -731,7 +731,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
     <li>
       <a
         aria-label="Page 10"
-        className="chakra-link css-1xdhyk6"
+        className="chakra-link css-10hitgp"
         href="page=10"
         id="props-10"
         rel={null}
@@ -751,7 +751,7 @@ exports[`Pagination Rendering renders the UI snapshot correctly 5`] = `
         target={null}
       >
         <span
-          className="css-rb3ek3"
+          className="css-70cl0f"
         >
           Next
         </span>

--- a/src/components/Pagination/paginationChangelogData.ts
+++ b/src/components/Pagination/paginationChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Component styling."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -65,8 +65,8 @@ const Pagination = defineMultiStyleConfig({
       pointerEvents: "none",
       svg: { fill: "ui.disabled.primary" },
       _dark: {
-        color: "ui.disabled.secondary",
-        svg: { fill: "ui.disabled.secondary" },
+        color: "dark.ui.disabled.secondary",
+        svg: { fill: "dark.ui.disabled.secondary" },
       },
     },
   }),

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -9,9 +9,7 @@ const { defineMultiStyleConfig, definePartsStyle } =
 
 const Pagination = defineMultiStyleConfig({
   baseStyle: definePartsStyle({
-    alignItems: "stretch",
     display: "flex",
-    maxWidth: { base: "480px", md: "unset" },
     minWidth: { base: "320px", md: "unset" },
     width: "100%",
     link: {
@@ -30,8 +28,10 @@ const Pagination = defineMultiStyleConfig({
       },
     },
     ul: {
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
       marginBottom: "0",
-      gap: "10px",
       justifyItems: "center",
     },
     previousNextElement: {

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -38,6 +38,7 @@ const Pagination = defineMultiStyleConfig({
       alignItems: "center",
       color: "ui.link.primary",
       _hover: {
+        textDecoration: "none",
         svg: { fill: "ui.link.secondary" },
         color: "ui.link.secondary",
       },

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -7,6 +7,8 @@ const Pagination = defineMultiStyleConfig({
   baseStyle: definePartsStyle({
     alignItems: "stretch",
     display: "flex",
+    maxWidth: { base: "480px", md: "unset" },
+    minWidth: { base: "320px", md: "unset" },
     width: "100%",
     link: {
       lineHeight: "1.15",
@@ -14,9 +16,18 @@ const Pagination = defineMultiStyleConfig({
       _hover: {
         textDecoration: "none",
       },
+      _visited: {
+        color: "ui.link.primary",
+      },
+      _dark: {
+        _visited: {
+          color: "dark.ui.link.primary",
+        },
+      },
     },
     ul: {
       marginBottom: "0",
+      gap: "10px",
     },
   }),
 });

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -28,6 +28,7 @@ const Pagination = defineMultiStyleConfig({
     ul: {
       marginBottom: "0",
       gap: "10px",
+      justifyItems: "center",
     },
   }),
 });

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -1,7 +1,11 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 
 const { defineMultiStyleConfig, definePartsStyle } =
-  createMultiStyleConfigHelpers(["link"]);
+  createMultiStyleConfigHelpers([
+    "link",
+    "previousNextElement",
+    "disabledElement",
+  ]);
 
 const Pagination = defineMultiStyleConfig({
   baseStyle: definePartsStyle({
@@ -29,6 +33,40 @@ const Pagination = defineMultiStyleConfig({
       marginBottom: "0",
       gap: "10px",
       justifyItems: "center",
+    },
+    previousNextElement: {
+      alignItems: "center",
+      color: "ui.link.primary",
+      _hover: {
+        svg: { fill: "ui.link.secondary" },
+        color: "ui.link.secondary",
+      },
+      _visited: {
+        color: "ui.link.primary",
+        svg: {
+          fill: "ui.link.primary",
+        },
+      },
+      svg: {
+        fill: "ui.link.primary",
+      },
+      _dark: {
+        color: "dark.ui.link.primary",
+        svg: { fill: "dark.ui.link.primary" },
+        _visited: {
+          color: "dark.ui.link.primary",
+          svg: { fill: "dark.ui.link.primary" },
+        },
+      },
+    },
+    disabledElement: {
+      color: "ui.disabled.primary",
+      pointerEvents: "none",
+      svg: { fill: "ui.disabled.primary" },
+      _dark: {
+        color: "ui.disabled.secondary",
+        svg: { fill: "ui.disabled.secondary" },
+      },
     },
   }),
 });


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1888](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1888)

## This PR does the following:

- Updates the style of the `Pagination` component, particularly the Previous and Next links

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1888]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1888?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ