### PR TITLE
DSD-1978: Fixing image onerror callback function so it doesn't infinite loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes the infinite loop in the `Image` component caused when there is no `fallbackSrc` prop value.
+
 ## 3.5.1 (December 19, 2024)
 
 ### Adds

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "3.5.1",
+  "version": "3.5.2-rc",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@nypl/design-system-react-components",
-      "version": "3.5.1",
+      "version": "3.5.2-rc",
       "license": "Apache-2.0",
       "dependencies": {
         "@chakra-ui/react": "2.8.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nypl/design-system-react-components",
-  "version": "3.5.1",
+  "version": "3.5.2-rc",
   "description": "NYPL Reservoir Design System React Components",
   "repository": {
     "type": "git",

--- a/src/components/Card/__snapshots__/Card.test.tsx.snap
+++ b/src/components/Card/__snapshots__/Card.test.tsx.snap
@@ -15,7 +15,6 @@ exports[`Card Renders the UI snapshot correctly 1`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-regularCard"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -66,7 +65,6 @@ exports[`Card Renders the UI snapshot correctly 2`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-cardWithExtendedStyles"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -144,7 +142,6 @@ exports[`Card Renders the UI snapshot correctly 3`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-cardWithNoCTAs"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -191,7 +188,6 @@ exports[`Card Renders the UI snapshot correctly 4`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-cardWithNoContent"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -327,7 +323,6 @@ exports[`Card Renders the UI snapshot correctly 6`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-fullclick"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -383,7 +378,6 @@ exports[`Card Renders the UI snapshot correctly 7`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-cardWithRightActions"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -446,7 +440,6 @@ exports[`Card Renders the UI snapshot correctly 8`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-chakraProps"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>
@@ -498,7 +491,6 @@ exports[`Card Renders the UI snapshot correctly 9`] = `
         alt="Alt text"
         className="css-0"
         id="img-id-otherProps"
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
     </div>

--- a/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
+++ b/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
@@ -19,7 +19,6 @@ exports[`Renders the UI snapshot correctly 1`] = `
           alt="Image example"
           className="css-0"
           id={null}
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -82,7 +81,6 @@ exports[`Renders the UI snapshot correctly 2`] = `
           alt="Image example"
           className="css-0"
           id={null}
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -145,7 +143,6 @@ exports[`Renders the UI snapshot correctly 3`] = `
           alt="Image example"
           className="css-0"
           id={null}
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -208,7 +205,6 @@ exports[`Renders the UI snapshot correctly 4`] = `
           alt="Image example"
           className="css-0"
           id={null}
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -271,7 +267,6 @@ exports[`Renders the UI snapshot correctly 5`] = `
           alt="Image example"
           className="css-0"
           id={null}
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -334,7 +329,6 @@ exports[`Renders the UI snapshot correctly 6`] = `
           alt="Image example"
           className="css-0"
           id={null}
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -56,7 +56,6 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -102,7 +101,6 @@ exports[`Hero Renders the UI snapshot correctly 3`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -148,7 +146,6 @@ exports[`Hero Renders the UI snapshot correctly 4`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -194,7 +191,6 @@ exports[`Hero Renders the UI snapshot correctly 5`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -240,7 +236,6 @@ exports[`Hero Renders the UI snapshot correctly 6`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -318,7 +313,6 @@ exports[`Hero Renders the UI snapshot correctly 8`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>
@@ -368,7 +362,6 @@ exports[`Hero Renders the UI snapshot correctly 9`] = `
           alt="Image example"
           className="css-0"
           id="image-example"
-          onError={[Function]}
           src="https://images.nypl.org/index.php?id=swope_243048&t=r"
         />
       </div>

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -1,5 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
+import Banner from "../Banner/Banner";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as ImageStories from "./Image.stories";
 import Link from "../Link/Link";
@@ -123,8 +124,15 @@ be logged to the console when the error occurs and the fallback image is loaded.
 If an _additional_ action needs to be performed when the fallback image is
 loaded, pass a callback function to the `onError` prop.
 
-NOTE: if no `fallbackSrc` prop is passed, the `Image` component will not call
-the `onerror` image attribute.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> if no `fallbackSrc` prop is passed, the
+      `Image` component will not call the `onerror` image attribute.
+    </>
+  }
+  type="warning"
+/>
 
 <Source
   code={`
@@ -138,10 +146,18 @@ the `onerror` image attribute.
   language="jsx"
 />
 
-**IMPORTANT**: If a custom image component, such as the Next.js `Image` component,
-is passed to the `component` prop, then the `fallbackSrc` and `onError` props
-won't work. It is expected that the custom image component that is passed in
-implements the `onError` attribute.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> If a custom image component, such as the
+      Next.js `Image` component, is passed to the `component` prop, then the
+      `fallbackSrc` and `onError` props won't work. It is expected that the
+      custom image component that is passed in implements the `onError`
+      attribute.
+    </>
+  }
+  type="warning"
+/>
 
 <Source
   code={`

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./imageChangelogData";
 
 # Image
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.6`    |
-| Latest            | `3.3.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.6`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -122,6 +122,9 @@ be logged to the console when the error occurs and the fallback image is loaded.
 
 If an _additional_ action needs to be performed when the fallback image is
 loaded, pass a callback function to the `onError` prop.
+
+NOTE: if no `fallbackSrc` prop is passed, the `Image` component will not call
+the `onerror` image attribute.
 
 <Source
   code={`

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -191,7 +191,7 @@ export const Image: ChakraComponent<
         "NYPL Reservoir Image: The initial image failed to load in the " +
           "browser. The fallback image source will now be used."
       );
-      (event.target as any).src = fallbackSrc || "";
+      (event.target as any).src = fallbackSrc;
       onError && onError(event);
     };
     let imageComponent: JSX.Element | null = null;
@@ -229,7 +229,7 @@ export const Image: ChakraComponent<
         alt={alt}
         id={id ? id : null}
         loading={isLazy ? "lazy" : undefined}
-        onError={onImageError}
+        onError={fallbackSrc && onImageError}
         {...srcProp}
         __css={{ ...styles.img, ...additionalImageStyles }}
         {...rest}

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -8,7 +8,6 @@ exports[`Image Renders the UI snapshot correctly 1`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -25,7 +24,6 @@ exports[`Image Renders the UI snapshot correctly 2`] = `
       alt=""
       className="css-0"
       id={null}
-      onError={[Function]}
       src="test.png"
     />
     <figcaption
@@ -61,7 +59,6 @@ exports[`Image Renders the UI snapshot correctly 3`] = `
       alt=""
       className="css-0"
       id={null}
-      onError={[Function]}
       src="test.png"
     />
     <figcaption
@@ -97,7 +94,6 @@ exports[`Image Renders the UI snapshot correctly 4`] = `
       alt=""
       className="css-0"
       id={null}
-      onError={[Function]}
       src="test.png"
     />
     <figcaption
@@ -144,7 +140,6 @@ exports[`Image Renders the UI snapshot correctly 5`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -158,7 +153,6 @@ exports[`Image Renders the UI snapshot correctly 6`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -172,7 +166,6 @@ exports[`Image Renders the UI snapshot correctly 7`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -186,7 +179,6 @@ exports[`Image Renders the UI snapshot correctly 8`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -200,7 +192,6 @@ exports[`Image Renders the UI snapshot correctly 9`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -214,7 +205,6 @@ exports[`Image Renders the UI snapshot correctly 10`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -235,7 +225,6 @@ exports[`Image Renders the UI snapshot correctly 11`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -258,7 +247,6 @@ exports[`Image Renders the UI snapshot correctly 12`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -274,7 +262,6 @@ exports[`Image Renders the UI snapshot correctly 13`] = `
     alt=""
     className="css-0"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -295,7 +282,6 @@ exports[`Image Renders the UI snapshot correctly 14`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -318,7 +304,6 @@ exports[`Image Renders the UI snapshot correctly 15`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -341,7 +326,6 @@ exports[`Image Renders the UI snapshot correctly 16`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -364,7 +348,6 @@ exports[`Image Renders the UI snapshot correctly 17`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -387,7 +370,6 @@ exports[`Image Renders the UI snapshot correctly 18`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -410,7 +392,6 @@ exports[`Image Renders the UI snapshot correctly 19`] = `
         alt=""
         className="css-0"
         id={null}
-        onError={[Function]}
         src="test.png"
       />
     </div>
@@ -426,7 +407,6 @@ exports[`Image Renders the UI snapshot correctly 20`] = `
     alt=""
     className="css-qvgr6z"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>
@@ -441,7 +421,6 @@ exports[`Image Renders the UI snapshot correctly 21`] = `
     className="css-0"
     data-testid="image"
     id={null}
-    onError={[Function]}
     src="test.png"
   />
 </div>

--- a/src/components/Image/imageChangelogData.ts
+++ b/src/components/Image/imageChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Functionality"],
+    notes: ["Fixes an infinite loop when no fallbackSrc value is provided."],
+  },
+  {
     date: "2024-09-05",
     version: "3.3.1",
     type: "Bug Fix",

--- a/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
+++ b/src/components/StructuredContent/__snapshots__/StructuredContent.test.tsx.snap
@@ -27,7 +27,6 @@ exports[`StructuredContent renders the UI snapshot 1`] = `
         alt="Image alt text"
         className="css-0"
         id={null}
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
       <figcaption
@@ -102,7 +101,6 @@ exports[`StructuredContent renders the UI snapshot 2`] = `
         alt="Image alt text"
         className="css-0"
         id={null}
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
       <figcaption
@@ -236,7 +234,6 @@ exports[`StructuredContent renders the UI snapshot 4`] = `
       alt="Image alt text"
       className="css-0"
       id={null}
-      onError={[Function]}
       src="https://images.nypl.org/index.php?id=swope_243048&t=r"
     />
   </div>
@@ -272,7 +269,6 @@ exports[`StructuredContent renders the UI snapshot 5`] = `
         alt="Image alt text"
         className="css-0"
         id={null}
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
       <figcaption
@@ -369,7 +365,6 @@ exports[`StructuredContent renders the UI snapshot 7`] = `
         alt="Image alt text"
         className="css-0"
         id={null}
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
       <figcaption
@@ -445,7 +440,6 @@ exports[`StructuredContent renders the UI snapshot 8`] = `
         alt="Image alt text"
         className="css-0"
         id={null}
-        onError={[Function]}
         src="https://images.nypl.org/index.php?id=swope_243048&t=r"
       />
       <figcaption

--- a/src/components/Table/__snapshots__/Table.test.tsx.snap
+++ b/src/components/Table/__snapshots__/Table.test.tsx.snap
@@ -3454,7 +3454,6 @@ exports[`Table renders the UI snapshot correctly 9`] = `
                 alt="Tom Nook"
                 className="css-0"
                 id={null}
-                onError={[Function]}
                 src="https://play.nintendo.com/images/AC_Tom_FRYtwIN.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
               />
             </div>
@@ -3502,7 +3501,6 @@ exports[`Table renders the UI snapshot correctly 9`] = `
                 alt="Isabelle"
                 className="css-0"
                 id={null}
-                onError={[Function]}
                 src="https://play.nintendo.com/images/AC_Isabelle_7XU6aGu.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
               />
             </div>
@@ -3550,7 +3548,6 @@ exports[`Table renders the UI snapshot correctly 9`] = `
                 alt="K.K Slider"
                 className="css-0"
                 id={null}
-                onError={[Function]}
                 src="https://play.nintendo.com/images/AC_KK_jh4yj5t.17345b1513ac044897cfc243542899dce541e8dc.9afde10b.png"
               />
             </div>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1978](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1978)

## This PR does the following:

- Only calls the image's `onerror` attribute function when a `fallbackSrc` value is passed. This will prevent the error function to call itself forever since an empty string is not a valid img value.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

**Turbine**

- Check the logs on this broken page: https://nypl-ds-test-app.vercel.app/components/featuredcontent
- Check the logs on this fixed page: https://nypl-ds-test-app-git-dsd-1978-infinite-image-fix-nypl.vercel.app/components/featuredcontent 

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1978]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1978?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ