### PR TITLE
DSD-1896: replacing the fieldset/legend in RadioGroup with a simpler div/span

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Replaces the `fieldset` and `legend` wrappers in the `RadioGroup` with a div and span for the title. The main div wrapper around the `Radio` components already has a `role="radiogroup"` values which makes the `fieldset` redundant.
+
 ## 3.5.1 (December 19, 2024)
 
 ### Adds

--- a/src/components/Header/components/__snapshots__/HeaderSearchForm.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/HeaderSearchForm.test.tsx.snap
@@ -102,10 +102,12 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 1`] = `
           >
             <span
               className="css-0"
+              id="rg-span-title-search-type"
             >
               Type of search
             </span>
             <div
+              aria-labelledby="rg-span-title-search-type"
               className="chakra-radio-group css-0"
               role="radiogroup"
             >
@@ -403,10 +405,12 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 2`] = `
           >
             <span
               className="css-0"
+              id="rg-span-title-search-type"
             >
               Type of search
             </span>
             <div
+              aria-labelledby="rg-span-title-search-type"
               className="chakra-radio-group css-0"
               role="radiogroup"
             >

--- a/src/components/Header/components/__snapshots__/HeaderSearchForm.test.tsx.snap
+++ b/src/components/Header/components/__snapshots__/HeaderSearchForm.test.tsx.snap
@@ -96,13 +96,15 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 1`] = `
           className="css-7ajbp2"
           id="search-header-child1-grandchild0"
         >
-          <fieldset
-            className="css-anp9yh"
+          <div
+            className="css-1piljje"
             id="radio-group-search-type"
           >
-            <legend>
+            <span
+              className="css-0"
+            >
               Type of search
-            </legend>
+            </span>
             <div
               className="chakra-radio-group css-0"
               role="radiogroup"
@@ -291,7 +293,7 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 1`] = `
                 className="css-0"
               />
             </div>
-          </fieldset>
+          </div>
         </div>
       </div>
     </div>
@@ -395,13 +397,15 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 2`] = `
           className="css-7ajbp2"
           id="search-header-child1-grandchild0"
         >
-          <fieldset
-            className="css-anp9yh"
+          <div
+            className="css-1piljje"
             id="radio-group-search-type"
           >
-            <legend>
+            <span
+              className="css-0"
+            >
               Type of search
-            </legend>
+            </span>
             <div
               className="chakra-radio-group css-0"
               role="radiogroup"
@@ -590,7 +594,7 @@ exports[`HeaderSearchForm renders the UI snapshot correctly 2`] = `
                 className="css-0"
               />
             </div>
-          </fieldset>
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/RadioGroup/RadioGroup.mdx
+++ b/src/components/RadioGroup/RadioGroup.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./radioGroupChangelogData";
 
 # RadioGroup
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.0`   |
-| Latest            | `3.3.2`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -37,8 +37,7 @@ import { changelogData } from "./radioGroupChangelogData";
 
 ## Accessibility
 
-The `RadioGroup` renders a group of `Radio` components that are wrapped in a
-`<fieldset>` element. The `<fieldset>` element renders a `<legend>` element that
+The `RadioGroup` renders a group of `Radio` components along with a title that
 can be visually hidden through the `showLabel` prop.
 
 Resources:

--- a/src/components/RadioGroup/RadioGroup.test.tsx
+++ b/src/components/RadioGroup/RadioGroup.test.tsx
@@ -59,7 +59,7 @@ describe("Radio Accessibility", () => {
     );
     expect(await axe(container)).toHaveNoViolations();
   });
-  it("passes axe accessibility with the legend hidden", async () => {
+  it("passes axe accessibility with the title hidden", async () => {
     const { container } = render(
       <RadioGroup
         id="radioGroup"
@@ -93,7 +93,7 @@ describe("Radio Button", () => {
     expect(screen.getByText("Radio 4")).toBeInTheDocument();
   });
 
-  it("<legend> element is available in the DOM when 'showLabel' prop is set to true or false", () => {
+  it("span element is available in the DOM when 'showLabel' prop is set to true or false", () => {
     const { container, rerender } = render(
       <RadioGroup
         id="radioGroup"
@@ -106,8 +106,10 @@ describe("Radio Button", () => {
         <Radio id="radio4" value="4" labelText="Radio 4" />
       </RadioGroup>
     );
-    expect(container.querySelector("legend")).toBeVisible();
-    expect(container.querySelector("legend")).toHaveTextContent("Test Label");
+    expect(container.querySelectorAll("span")[0]).toBeVisible();
+    expect(container.querySelectorAll("span")[0]).toHaveTextContent(
+      "Test Label"
+    );
 
     rerender(
       <RadioGroup
@@ -121,8 +123,10 @@ describe("Radio Button", () => {
         <Radio id="radio4" value="4" labelText="Radio 4" />
       </RadioGroup>
     );
-    expect(container.querySelector("legend")).toBeVisible();
-    expect(container.querySelector("legend")).toHaveTextContent("Test Label");
+    expect(container.querySelectorAll("span")[0]).toBeVisible();
+    expect(container.querySelectorAll("span")[0]).toHaveTextContent(
+      "Test Label"
+    );
   });
 
   it("renders visible helper or error text", () => {
@@ -164,20 +168,6 @@ describe("Radio Button", () => {
     expect(
       screen.queryByText("This is the helper text for the full group.")
     ).not.toBeInTheDocument();
-  });
-
-  it("sets the RadioGroup's ID", () => {
-    render(
-      <RadioGroup labelText="Test Label" name="test5" id="some-id">
-        <Radio id="radio2" value="2" labelText="Radio 2" />
-      </RadioGroup>
-    );
-
-    // The "group" role here is for the `fieldset` element.
-    expect(screen.getByRole("group")).toHaveAttribute(
-      "id",
-      "radio-group-some-id"
-    );
   });
 
   it("sets the next value through the onChange function", () => {
@@ -290,6 +280,45 @@ describe("Radio Button", () => {
       </RadioGroup>
     );
     expect(screen.queryByText("There is an error :(")).not.toBeInTheDocument();
+  });
+
+  it("should throw warning when a non-Radio component is used as a child", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      <RadioGroup labelText="wrong child!" name="wrong" id="wrong-child">
+        <p>This is wrong!</p>
+      </RadioGroup>
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside " +
+        "the `RadioGroup` component."
+    );
+  });
+
+  it("logs a warning when there is no `id` passed", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      // @ts-ignore: Typescript complains when a required prop is not passed, but
+      // here we don't want to pass the required prop to make sure the warning appears.
+      <RadioGroup labelText="RadioGroup example" name="a11y-test">
+        <Radio id="radio1" value="1" labelText="Radio 1" />
+      </RadioGroup>
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir RadioGroup: This component's required `id` prop was not passed."
+    );
+  });
+
+  it("passes a ref to the input element", () => {
+    const ref = React.createRef<HTMLDivElement>();
+    render(
+      <RadioGroup id="column" labelText="column" name="column" ref={ref}>
+        <Radio value="2" labelText="Radio 2" id="radio-2" />
+        <Radio value="3" labelText="Radio 3" id="radio-3" />
+      </RadioGroup>
+    );
+
+    expect(screen.getByRole("radiogroup")).toBe(ref.current);
   });
 
   it("renders the UI snapshot correctly", () => {
@@ -469,44 +498,5 @@ describe("Radio Button", () => {
     expect(withJSXRadioLabels).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
-  });
-
-  it("should throw warning when a non-Radio component is used as a child", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      <RadioGroup labelText="wrong child!" name="wrong" id="wrong-child">
-        <p>This is wrong!</p>
-      </RadioGroup>
-    );
-    expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir RadioGroup: Only `Radio` components are allowed inside " +
-        "the `RadioGroup` component."
-    );
-  });
-
-  it("logs a warning when there is no `id` passed", () => {
-    const warn = jest.spyOn(console, "warn");
-    render(
-      // @ts-ignore: Typescript complains when a required prop is not passed, but
-      // here we don't want to pass the required prop to make sure the warning appears.
-      <RadioGroup labelText="RadioGroup example" name="a11y-test">
-        <Radio id="radio1" value="1" labelText="Radio 1" />
-      </RadioGroup>
-    );
-    expect(warn).toHaveBeenCalledWith(
-      "NYPL Reservoir RadioGroup: This component's required `id` prop was not passed."
-    );
-  });
-
-  it("passes a ref to the input element", () => {
-    const ref = React.createRef<HTMLDivElement>();
-    const { container } = render(
-      <RadioGroup id="column" labelText="column" name="column" ref={ref}>
-        <Radio value="2" labelText="Radio 2" id="radio-2" />
-        <Radio value="3" labelText="Radio 3" id="radio-3" />
-      </RadioGroup>
-    );
-
-    expect(container.querySelector("fieldset > div")).toBe(ref.current);
   });
 });

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   chakra,
   ChakraComponent,
   RadioGroup as ChakraRadioGroup,
@@ -7,7 +8,6 @@ import {
 } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
-import Fieldset from "../Fieldset/Fieldset";
 import HelperErrorText, {
   HelperErrorTextType,
 } from "../HelperErrorText/HelperErrorText";
@@ -57,9 +57,9 @@ export interface RadioGroupProps {
 const noop = () => {};
 
 /**
- * RadioGroup is a wrapper for DS `Radio` components that renders as a fieldset
- * HTML element along with optional helper text. The `name` prop is essential
- * for this form group element and is not needed for individual DS `Radio`
+ * `RadioGroup` is a wrapper for DS `Radio` components that render together
+ * along with an optional helper text. The `name` prop is essential for this
+ * form group element and is not needed for individual DS `Radio`
  * components when `RadioGroup` is used.
  */
 export const RadioGroup: ChakraComponent<
@@ -98,7 +98,10 @@ export const RadioGroup: ChakraComponent<
       const spacingProp = layout === "column" ? spacing.s : spacing.l;
       const newChildren: JSX.Element[] = [];
       // Get the Chakra-based styles for the custom elements in this component.
-      const styles = useMultiStyleConfig("RadioGroup", { isFullWidth });
+      const styles = useMultiStyleConfig("RadioGroup", {
+        isFullWidth,
+        isLegendHidden: !showLabel,
+      });
       // Props for the `ChakraRadioGroup` component.
       const radioGroupProps = {
         name,
@@ -145,16 +148,16 @@ export const RadioGroup: ChakraComponent<
       );
 
       return (
-        <Fieldset
+        <Box
           className={className}
           id={`radio-group-${id}`}
-          isLegendHidden={!showLabel}
-          isRequired={isRequired}
-          legendText={labelText}
-          showRequiredLabel={showRequiredLabel}
           {...rest}
           __css={styles}
         >
+          <Box as="span" __css={styles.spanLegend}>
+            {labelText}
+            {showRequiredLabel && isRequired && <span> (required)</span>}
+          </Box>
           <ChakraRadioGroup {...radioGroupProps}>
             <Stack direction={[layout]} spacing={spacingProp}>
               {newChildren}
@@ -167,7 +170,7 @@ export const RadioGroup: ChakraComponent<
             text={footnote}
             __css={styles.helperErrorText}
           />
-        </Fieldset>
+        </Box>
       );
     }
   )

--- a/src/components/RadioGroup/RadioGroup.tsx
+++ b/src/components/RadioGroup/RadioGroup.tsx
@@ -104,6 +104,7 @@ export const RadioGroup: ChakraComponent<
       });
       // Props for the `ChakraRadioGroup` component.
       const radioGroupProps = {
+        ["aria-labelledby"]: `rg-span-title-${id}`,
         name,
         onChange: (selected: string) => {
           setValue(selected);
@@ -154,7 +155,7 @@ export const RadioGroup: ChakraComponent<
           {...rest}
           __css={styles}
         >
-          <Box as="span" __css={styles.spanLegend}>
+          <Box as="span" id={`rg-span-title-${id}`} __css={styles.spanLegend}>
             {labelText}
             {showRequiredLabel && isRequired && <span> (required)</span>}
           </Box>

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -1,13 +1,15 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Radio Button renders the UI snapshot correctly 1`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-column"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     column
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -138,17 +140,19 @@ exports[`Radio Button renders the UI snapshot correctly 1`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 2`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-row"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     row
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -279,17 +283,19 @@ exports[`Radio Button renders the UI snapshot correctly 2`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 3`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-noLabel"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     no label
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -420,17 +426,19 @@ exports[`Radio Button renders the UI snapshot correctly 3`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 4`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-helperText"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     helperText
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -566,17 +574,19 @@ exports[`Radio Button renders the UI snapshot correctly 4`] = `
       }
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 5`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-invalidText"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     invalidText
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -707,17 +717,19 @@ exports[`Radio Button renders the UI snapshot correctly 5`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 6`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-noRequiredLabel"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     no optional or required label
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -850,20 +862,22 @@ exports[`Radio Button renders the UI snapshot correctly 6`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 7`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-required"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     required
     <span>
        (required)
     </span>
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -996,17 +1010,19 @@ exports[`Radio Button renders the UI snapshot correctly 7`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 8`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-invalid"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     invalid
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -1145,17 +1161,19 @@ exports[`Radio Button renders the UI snapshot correctly 8`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 9`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-disabled"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     disabled
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -1294,17 +1312,19 @@ exports[`Radio Button renders the UI snapshot correctly 9`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 10`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   id="radio-group-jsxLabels"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     RadioGroup example
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -1459,17 +1479,19 @@ exports[`Radio Button renders the UI snapshot correctly 10`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 11`] = `
-<fieldset
-  className="css-1y4kn3e"
+<div
+  className="css-kle7zy"
   id="radio-group-chakra"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     chakra
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -1600,18 +1622,20 @@ exports[`Radio Button renders the UI snapshot correctly 11`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;
 
 exports[`Radio Button renders the UI snapshot correctly 12`] = `
-<fieldset
-  className="css-1u8qly9"
+<div
+  className="css-1xdhyk6"
   data-testid="props"
   id="radio-group-props"
 >
-  <legend>
+  <span
+    className="css-0"
+  >
     props
-  </legend>
+  </span>
   <div
     className="chakra-radio-group css-0"
     role="radiogroup"
@@ -1742,5 +1766,5 @@ exports[`Radio Button renders the UI snapshot correctly 12`] = `
       className="css-0"
     />
   </div>
-</fieldset>
+</div>
 `;

--- a/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
+++ b/src/components/RadioGroup/__snapshots__/RadioGroup.test.tsx.snap
@@ -7,10 +7,12 @@ exports[`Radio Button renders the UI snapshot correctly 1`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-column"
   >
     column
   </span>
   <div
+    aria-labelledby="rg-span-title-column"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -150,10 +152,12 @@ exports[`Radio Button renders the UI snapshot correctly 2`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-row"
   >
     row
   </span>
   <div
+    aria-labelledby="rg-span-title-row"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -293,10 +297,12 @@ exports[`Radio Button renders the UI snapshot correctly 3`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-noLabel"
   >
     no label
   </span>
   <div
+    aria-labelledby="rg-span-title-noLabel"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -436,10 +442,12 @@ exports[`Radio Button renders the UI snapshot correctly 4`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-helperText"
   >
     helperText
   </span>
   <div
+    aria-labelledby="rg-span-title-helperText"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -584,10 +592,12 @@ exports[`Radio Button renders the UI snapshot correctly 5`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-invalidText"
   >
     invalidText
   </span>
   <div
+    aria-labelledby="rg-span-title-invalidText"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -727,10 +737,12 @@ exports[`Radio Button renders the UI snapshot correctly 6`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-noRequiredLabel"
   >
     no optional or required label
   </span>
   <div
+    aria-labelledby="rg-span-title-noRequiredLabel"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -872,6 +884,7 @@ exports[`Radio Button renders the UI snapshot correctly 7`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-required"
   >
     required
     <span>
@@ -879,6 +892,7 @@ exports[`Radio Button renders the UI snapshot correctly 7`] = `
     </span>
   </span>
   <div
+    aria-labelledby="rg-span-title-required"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -1020,10 +1034,12 @@ exports[`Radio Button renders the UI snapshot correctly 8`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-invalid"
   >
     invalid
   </span>
   <div
+    aria-labelledby="rg-span-title-invalid"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -1171,10 +1187,12 @@ exports[`Radio Button renders the UI snapshot correctly 9`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-disabled"
   >
     disabled
   </span>
   <div
+    aria-labelledby="rg-span-title-disabled"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -1322,10 +1340,12 @@ exports[`Radio Button renders the UI snapshot correctly 10`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-jsxLabels"
   >
     RadioGroup example
   </span>
   <div
+    aria-labelledby="rg-span-title-jsxLabels"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -1489,10 +1509,12 @@ exports[`Radio Button renders the UI snapshot correctly 11`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-chakra"
   >
     chakra
   </span>
   <div
+    aria-labelledby="rg-span-title-chakra"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >
@@ -1633,10 +1655,12 @@ exports[`Radio Button renders the UI snapshot correctly 12`] = `
 >
   <span
     className="css-0"
+    id="rg-span-title-props"
   >
     props
   </span>
   <div
+    aria-labelledby="rg-span-title-props"
     className="chakra-radio-group css-0"
     role="radiogroup"
   >

--- a/src/components/RadioGroup/radioGroupChangelogData.tsx
+++ b/src/components/RadioGroup/radioGroupChangelogData.tsx
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Accessibility"],
     notes: [
-      "Removes the fieldset wrapper and replaces it wiht a div and simple span for the title. The main wrapper around the `Radio` componnents are already in an accessible 'radiogroup' role element.",
+      "Removes the fieldset wrapper and replaces it with a div and simple span for the title. The main wrapper around the `Radio` componnents are already in an accessible 'radiogroup' role element.",
     ],
   },
   {

--- a/src/components/RadioGroup/radioGroupChangelogData.tsx
+++ b/src/components/RadioGroup/radioGroupChangelogData.tsx
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Accessibility"],
+    notes: [
+      "Removes the fieldset wrapper and replaces it wiht a div and simple span for the title. The main wrapper around the `Radio` componnents are already in an accessible 'radiogroup' role element.",
+    ],
+  },
+  {
     date: "2024-09-19",
     version: "3.3.2",
     type: "Update",

--- a/src/theme/components/radioGroup.ts
+++ b/src/theme/components/radioGroup.ts
@@ -10,6 +10,7 @@ const RadioGroup = defineMultiStyleConfig({
     ({ isFullWidth = false, isLegendHidden = false }) => ({
       spanLegend: {
         ...labelLegendText,
+        display: "block",
         ...(isLegendHidden ? screenreaderOnly() : {}),
       },
       ...checkboxRadioGroupStyles(isFullWidth),

--- a/src/theme/components/radioGroup.ts
+++ b/src/theme/components/radioGroup.ts
@@ -1,13 +1,20 @@
-import { checkboxRadioGroupStyles } from "./global";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
+import { checkboxRadioGroupStyles, labelLegendText } from "./global";
+import { screenreaderOnly } from "./globalMixins";
 
 const { defineMultiStyleConfig, definePartsStyle } =
-  createMultiStyleConfigHelpers(["helperErrorText", "stack"]);
+  createMultiStyleConfigHelpers(["helperErrorText", "label", "legend"]);
 
 const RadioGroup = defineMultiStyleConfig({
-  baseStyle: definePartsStyle(({ isFullWidth = false }) => ({
-    ...checkboxRadioGroupStyles(isFullWidth),
-  })),
+  baseStyle: definePartsStyle(
+    ({ isFullWidth = false, isLegendHidden = false }) => ({
+      spanLegend: {
+        ...labelLegendText,
+        ...(isLegendHidden ? screenreaderOnly() : {}),
+      },
+      ...checkboxRadioGroupStyles(isFullWidth),
+    })
+  ),
 });
 
 export default RadioGroup;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1896](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1896)

## This PR does the following:

- The `fieldset` and `legend` wrapper elements in the `RadioGroup` component are redundant since the main wrapper already contains `role="radiogroup"`. This replaces the `fieldset`/`legend` with a div and a span but still keeps the same styles. 
- Chakra's `RadioGroup` component hard codes the role attribute and it cannot be removed.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->
 
- Storybook in the `RadioGroup` component page.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Flagged in the Research Catalog Hold project.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1896]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ