### PR TITLE
DSD-1905: suggestions for format number PR

### DIFF
--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import Text, { textSizesArray } from "./Text";
 import { argsBooleanType } from "../../helpers/storybookUtils";
+import formatNumber from "../../hooks/useFormatNumber";
 
 const meta: Meta<typeof Text> = {
   title: "Components/Typography & Styles/Text",
@@ -24,6 +25,12 @@ const meta: Meta<typeof Text> = {
     },
   },
 };
+
+const copiesSold = formatNumber(81450000);
+const suggestedPrice = formatNumber(100, 20000);
+// const getFormattedNumbers = () => {
+//   formatNumber(81450000);
+// };
 
 export default meta;
 type Story = StoryObj<typeof Text>;
@@ -72,6 +79,10 @@ export const WithControls: Story = {
         games have also been released: Animal Crossing: Happy Home Designer for
         Nintendo 3DS, Animal Crossing: Amiibo Festival for Wii U, and Animal
         Crossing: Pocket Camp for mobile devices.
+      </Text>
+      <Text {...args}>
+        As of June 2024, the Animal Crossing franchise has sold over $
+        {copiesSold} copies worldwide. Suggested retail price: ${suggestedPrice}
       </Text>
     </>
   ),

--- a/src/components/Text/Text.stories.tsx
+++ b/src/components/Text/Text.stories.tsx
@@ -27,10 +27,7 @@ const meta: Meta<typeof Text> = {
 };
 
 const copiesSold = formatNumber(81450000);
-const suggestedPrice = formatNumber(100, 20000);
-// const getFormattedNumbers = () => {
-//   formatNumber(81450000);
-// };
+const suggestedPrice = formatNumber(100, "20000");
 
 export default meta;
 type Story = StoryObj<typeof Text>;

--- a/src/hooks/__tests__/useFormatNumber.test.ts
+++ b/src/hooks/__tests__/useFormatNumber.test.ts
@@ -1,19 +1,20 @@
-import useFormatNumber from "../useFormatNumber";
+import formatNumber from "../../hooks/useFormatNumber";
+const enDash = "\u2013";
 
 describe("useFormatNumber hook", () => {
   it("returns a number with commas and handles a range of numbers", () => {
-    expect(useFormatNumber("4382")).toEqual("4,382");
-    expect(useFormatNumber("4382", "1234")).toEqual("1,234&ndash;4,382");
-    expect(useFormatNumber("4382", "XX1234")).toEqual(null);
-    expect(useFormatNumber("4382XXX", "1234")).toEqual(null);
-    expect(useFormatNumber("4382XXX", "1234XXX")).toEqual(null);
-    expect(useFormatNumber(4382)).toEqual("4,382");
-    expect(useFormatNumber(4382)).toEqual("4,382");
-    expect(useFormatNumber(4276835)).toEqual("4,276,835");
-    expect(useFormatNumber(4276835.879)).toEqual("4,276,835.879");
-    expect(useFormatNumber(1, 99)).toEqual("1&ndash;99");
-    expect(useFormatNumber(141, 58)).toEqual("58&ndash;141");
-    expect(useFormatNumber(100, 102)).toEqual("100&ndash;102");
-    expect(useFormatNumber(10, 100)).toEqual("10&ndash;100");
+    expect(formatNumber("4382")).toEqual("4,382");
+    expect(formatNumber("4382", "1234")).toEqual(`1,234${enDash}4,382`);
+    expect(formatNumber("4382", "XX1234")).toEqual(null);
+    expect(formatNumber("4382XXX", "1234")).toEqual(null);
+    expect(formatNumber("4382XXX", "1234XXX")).toEqual(null);
+    expect(formatNumber(4382)).toEqual("4,382");
+    expect(formatNumber(4382)).toEqual("4,382");
+    expect(formatNumber(4276835)).toEqual("4,276,835");
+    expect(formatNumber(4276835.879)).toEqual("4,276,835.879");
+    expect(formatNumber(1, 99)).toEqual(`1${enDash}99`);
+    expect(formatNumber(141, 58)).toEqual(`58${enDash}141`);
+    expect(formatNumber(100, 102)).toEqual(`100${enDash}102`);
+    expect(formatNumber(10, 100)).toEqual(`10${enDash}100`);
   });
 });

--- a/src/hooks/useFormatNumber.mdx
+++ b/src/hooks/useFormatNumber.mdx
@@ -10,6 +10,9 @@ import { Meta, Source } from "@storybook/blocks";
 | Latest       | `Prerelease` |
 
 `useFormatNumber` provides a number with commas and handles a range of numbers.
+The formatting is based on standards from the NYPL Writing Style Guide.
+
+## Usage
 
 This function formats a number with commas and handles a range of numbers.
 

--- a/src/hooks/useFormatNumber.mdx
+++ b/src/hooks/useFormatNumber.mdx
@@ -4,43 +4,40 @@ import { Meta, Source } from "@storybook/blocks";
 
 # useFormatNumber
 
-| Hook Version | DS Version |
-| ------------ | ---------- |
-| Added        | `Prerelease`    |
-| Latest       | `Prerelease`    |
+| Hook Version | DS Version   |
+| ------------ | ------------ |
+| Added        | `Prerelease` |
+| Latest       | `Prerelease` |
 
 `useFormatNumber` provides a number with commas and handles a range of numbers.
 
 This function formats a number with commas and handles a range of numbers.
- 
-  1. If one number is passed, it formats that number with commas.
-  2. If two numbers are passed, it creates a range:
-     - Numbers are formatted with commas.
-     - En dash (`–`) is used for the range.
-  3. Allows numbers passed as strings (e.g., "123456").
- 
-  Examples:
-   - (4382) -> "4,382"
-   - (4276835) -> "4,276,835"
-   - (1, 99) -> "1–99"
-   - (141, 58) -> "58–141"
-   - (100, 102) -> "100–102"
-   - (10, 100) -> "10–100"
-   - ("200", "100") -> "100–200"
-   - ("200XX", "100") -> null
-   - ("200XX", "100XX") -> null
 
+1. If one number is passed, it formats that number with commas.
+2. If two numbers are passed, it creates a range:
+   - Numbers are formatted with commas.
+   - En dash (`–`) is used for the range.
+3. Allows numbers passed as strings (e.g., "123456").
+
+Examples:
+
+- (4382) -> "4,382"
+- (4276835) -> "4,276,835"
+- (1, 99) -> "1–99"
+- (141, 58) -> "58–141"
+- (100, 102) -> "100–102"
+- (10, 100) -> "10–100"
+- ("200", "100") -> "100–200"
+- ("200XX", "100") -> null
+- ("200XX", "100XX") -> null
 
 <Source
   code={`
-// ...
-<Box>
-  <Text>
-    As of June 2024, the Animal Crossing franchise has sold over $ useFormatNumber(num1: 81450000) copies worldwide.
-    Suggested retail price: $ useFormatNumber(num1: 100, num2?: 20000)
-  </Text>
-</Box>
-`} 
-  language="jsx"
-/>
+const copiesSold = formatNumber(81450000);
+const suggestedPriceRange = formatNumber(100, 20000);
 
+<Text>
+  As of June 2024, the Animal Crossing franchise has sold over \${copiesSold}
+  copies worldwide. Suggested retail price: $\${suggestedPriceRange}.
+</Text>
+`} language="jsx" />

--- a/src/hooks/useFormatNumber.ts
+++ b/src/hooks/useFormatNumber.ts
@@ -17,7 +17,10 @@
  *  - (10, 100) -> "10–100"
  */
 
-export default function useFormatNumber(num1: any, num2?: any) {
+// export default function useFormatNumber(num1: any, num2?: any) {
+const useFormatNumber = (num1: any, num2?: any) => {
+  // const num1Pass = num1;
+  // const num2Pass = num2;
   // Helper function to format a number with commas
   const formatNumberWithCommas = (num: number): string => {
     return num.toLocaleString(); // Formats the number with commas (e.g., 4382 -> "4,382")
@@ -29,52 +32,59 @@ export default function useFormatNumber(num1: any, num2?: any) {
     return !isNaN(value) && !/[^0-9.-]/.test(value); // Ensures the value is purely numeric
   };
 
-  // Check if num1 is valid
-  if (!isValidNumber(num1)) {
-    console.warn(
-      "NYPL Reservoir useFormatNumber: An unsupported value was passed."
-    );
-    return null;
-  }
+  const formatNumber = (num1: any, num2?: any): string => {
+    // Check if num1 is valid
+    if (!isValidNumber(num1)) {
+      console.warn(
+        "NYPL Reservoir useFormatNumber: An unsupported value was passed."
+      );
+      return null;
+    }
 
-  // Convert num1 to a number if it is a valid numeric string
-  num1 = typeof num1 === "string" ? parseFloat(num1) : num1;
+    // Convert num1 to a number if it is a valid numeric string
+    num1 = typeof num1 === "string" ? parseFloat(num1) : num1;
 
-  // Check if num2 is provided and valid
-  if (num2 !== undefined && !isValidNumber(num2)) {
-    console.warn(
-      "NYPL Reservoir useFormatNumber: An unsupported value was passed."
-    );
-    return null;
-  }
+    // Check if num2 is provided and valid
+    if (num2 !== undefined && !isValidNumber(num2)) {
+      console.warn(
+        "NYPL Reservoir useFormatNumber: An unsupported value was passed."
+      );
+      return null;
+    }
 
-  // Convert num2 to a number if it is a valid numeric string
-  if (num2 !== undefined) {
-    num2 = typeof num2 === "string" ? parseFloat(num2) : num2;
-  }
+    // Convert num2 to a number if it is a valid numeric string
+    if (num2 !== undefined) {
+      num2 = typeof num2 === "string" ? parseFloat(num2) : num2;
+    }
 
-  // Case 1: Only one number is provided
-  if (num2 === undefined) {
-    return formatNumberWithCommas(num1); // Simply return the formatted number
-  }
+    // Case 1: Only one number is provided
+    if (num2 === undefined) {
+      return formatNumberWithCommas(num1); // Simply return the formatted number
+    }
 
-  // Case 2: Two numbers are provided, create a range
-  const [start, end] = num1 < num2 ? [num1, num2] : [num2, num1]; // Ensure start is smaller
+    // Case 2: Two numbers are provided, create a range
+    const [start, end] = num1 < num2 ? [num1, num2] : [num2, num1]; // Ensure start is smaller
 
-  // If the numbers are the same, return one formatted number
-  if (start === end) {
-    return formatNumberWithCommas(start);
-  }
+    // If the numbers are the same, return one formatted number
+    if (start === end) {
+      return formatNumberWithCommas(start);
+    }
 
-  // If the range is between two consecutive numbers, display both
-  if (end - start === 1) {
-    return `${formatNumberWithCommas(start)}&ndash;${formatNumberWithCommas(
+    // If the range is between two consecutive numbers, display both
+    if (end - start === 1) {
+      return `${formatNumberWithCommas(start)}&ndash;${formatNumberWithCommas(
+        end
+      )}`;
+    }
+
+    const enDash = "\u2013";
+    // For a larger range, simply return the full formatted range with commas
+    return `${formatNumberWithCommas(start)}${enDash}${formatNumberWithCommas(
       end
     )}`;
-  }
+  };
 
-  // For a larger range, simply return the full formatted range with commas
-  return `${formatNumberWithCommas(start)}&ndash;${formatNumberWithCommas(
-    end
-  )}`;
-}
+  return formatNumber(num1, num2);
+};
+
+export default useFormatNumber;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1905](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1905)

## This PR does the following:

- This includes some suggestion for the `useFormatNumber` hook that are intended for ease of use.
- While the code does work, I thought the implementation would be different from what I used.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1905]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1905?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ