### PR TITLE
DSD-1991: Pagination numbering fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `Pagination` component to handle 4 digit page counts.
+
 ## 3.5.2 (January 16, 2025)
 
 ### Adds

--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Pagination
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.10`   |
-| Latest            | `3.5.2`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.10`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -305,6 +305,7 @@ export const Pagination: ChakraComponent<
             : selected - 1,
           // If the current page is near the end, show the last five items.
           // If the page number has 4 digits, show only the last four items.
+          // Ex. 1 ... 1998, 1999, 2000, 2001
           pageCount > 999 ? pageCount - 3 : pageCount - 4
         )
       );

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -298,7 +298,11 @@ export const Pagination: ChakraComponent<
         Math.min(
           // If the current page is in the middle, start the range
           // one number before the current page.
-          selected - 1,
+          // But if page number has 4 digits and is fourth from the end,
+          // start the range at that number.
+          pageCount > 999 && selected === pageCount - 3
+            ? selected
+            : selected - 1,
           // If the current page is near the end, show the last five items.
           // If the page number has 4 digits, show only the last four items.
           pageCount > 999 ? pageCount - 3 : pageCount - 4

--- a/src/components/Pagination/Pagination.tsx
+++ b/src/components/Pagination/Pagination.tsx
@@ -300,12 +300,12 @@ export const Pagination: ChakraComponent<
           // one number before the current page.
           // But if page number has 4 digits and is fourth from the end,
           // start the range at that number.
+          // Ex. 1 ... 1998, 1999, 2000, 2001
           pageCount > 999 && selected === pageCount - 3
             ? selected
             : selected - 1,
           // If the current page is near the end, show the last five items.
           // If the page number has 4 digits, show only the last four items.
-          // Ex. 1 ... 1998, 1999, 2000, 2001
           pageCount > 999 ? pageCount - 3 : pageCount - 4
         )
       );

--- a/src/components/Pagination/paginationChangelogData.ts
+++ b/src/components/Pagination/paginationChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Handling for 4 digit page counts"],
+  },
+  {
     date: "2025-01-16",
     version: "3.5.2",
     type: "Update",

--- a/src/theme/components/pagination.ts
+++ b/src/theme/components/pagination.ts
@@ -13,7 +13,7 @@ const Pagination = defineMultiStyleConfig({
     minWidth: { base: "320px", md: "unset" },
     width: "100%",
     link: {
-      lineHeight: "1.15",
+      lineHeight: "1",
       textDecoration: "none",
       _hover: {
         textDecoration: "none",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1991](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1991)

## This PR does the following:

- Adds a condition for page numbers > 999 at the end of the page count: only 4 numbers display instead of 5
- Updates link line height to 1

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1991]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1991?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ