### PR TITLE
DSD-1994: fontSize for StatusBadge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `labelFontSize` prop to the `StatusBadge` component.
+
 ### Updates
 
 - Updates the `Pagination` component to handle 4 digit page counts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
-### Adds
+### Updates
 
-- Adds the `labelFontSize` prop to the `StatusBadge` component.
+- Updates the `StatusBadge` component to support the `fontSize` style prop.
 
 ## 3.5.3 (January 30, 2025)
 

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -108,7 +108,7 @@ between the icon and the text. The use of the design tokens (ie, `xs`) is encour
   On-Site Access Only
 </StatusBadge>
 
-<StatusBadge labelFontSize="caption" type="warning">
+<StatusBadge font-size="caption" type="warning">
   <Icon
     color="ui.warning.secondary"
     mr="xs"
@@ -125,7 +125,7 @@ between the icon and the text. The use of the design tokens (ie, `xs`) is encour
   <Icon color="ui.black" ml="xs" name="actionIdentityFilled" size="medium" />
 </StatusBadge>
 
-<StatusBadge labelFontSize="body1" type="informative">
+<StatusBadge font-size="body1" type="informative">
   Includes audio
   <Icon color="ui.link.secondary" ml="xs" name="headset" size="medium" />
 </StatusBadge>

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -19,10 +19,10 @@ import { changelogData } from "./statusBadgeChangelogData";
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
-- {<Link href="#semantic-types" target="_self">Semantic Types</Link>}
-- {<Link href="#levels-deprecated" target="_self">Levels (deprecated)</Link>}
+- {<Link href="#visual-style" target="_self">Visual Style</Link>}
 - {<Link href="#font-size" target="_self">Font Size</Link>}
-- {<Link href="#labeling" target="_self">Labeling</Link>}
+- {<Link href="#label-capitalization" target="_self">Capitalization</Link>}
+- {<Link href="#icons" target="_self">Icons</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
@@ -49,53 +49,56 @@ with the general meaning associated with the semantic colors used in a specific
 variant. In this way, the user will be able to understand the priority of the
 `StatusBadge` and not rely just on the color.
 
-## Semantic Types
+## Visual Style
 
-The semantic `type` variants align with specific uses. Please refer to the
-purpose of each variant.
+The component offers two props for setting the visuall style:
 
-<Canvas of={StatusBadgeStories.SemanticTypes} />
+- `type`
+- `level` (deprecated)
 
-## Levels (deprecated)
+### Type
 
-The `level` variants have been deprecated in favor of the semantic `type`
-variants. However, for backward compatability, the `level` prop will override
-the `type` prop.
+- The semantic `type` variants align with specific uses.
+- Refer to the table below for the recommended purpose of each variant.
+
+<Canvas of={StatusBadgeStories.Types} />
+
+### Level (deprecated)
+
+- The `level` variants have been deprecated in favor of the semantic `type`
+  variants.
+- For backward compatability, the `level` prop will override the `type` prop.
 
 <Canvas of={StatusBadgeStories.Levels} />
 
 ## Font Size
 
-The label font size can be set using the font sizes from the `Text` component:
+Use the `fontSize` prop to set the font size with the following design tokens:
 
-- `body1`
-- `body2`
-- `caption`
+- `desktop.body.body1`
+- `desktop.body.body2`
+- `desktop.caption`
 
-The default label font size is `body2`.
+The default label font size is `desktop.body.body2`.
 
 <Canvas of={StatusBadgeStories.FontSize} />
 
-## Labeling
+## Capitalization
 
-The capitalization of a badge label will not be forced by the component and
-labels will render exactly as they are passed into the component. If an
-all-lowercase string is passed in, the label will render all lowercase. If an
-all-caps string is passed in, the label will render all caps. And so on.
-
-The text case should be dependent on the use case and the final decision should
-ultimately come from Product and UX.
+- Capitalization of a badge label will not be forced by the component.
+- Labels will render exactly as they are passed into the component.
+- Text capitalization is dependent on each use case and final decisions should
+  come from Product and UX.
 
 <Canvas of={StatusBadgeStories.Labeling} />
 
 ### Icons
 
-You may render an icon within the `StatusBadge` by passing it as a child to the component.
-If you are using an icon, you should still pass text to the badge so that the user can
-understand its meaning.
-
-You will have to pass a `margin-left` or `margin-right` to add space
-between the icon and the text. The use of the design tokens (ie, `xs`) is encouraged.
+- An icon can be rendered within the component by passing a DS `Icon` component
+  as a child.
+- When using an icon, text should also be included to ensure understanding.
+- For proper spacing, add a left or right marign to icons, as needed. Use design
+  tokens for spacing vlaues (ex. `marginRight="xs"`).
 
 <Canvas of={StatusBadgeStories.Icons} />
 

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -9,19 +9,20 @@ import { changelogData } from "./statusBadgeChangelogData";
 
 # StatusBadge
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.18.7`   |
-| Latest            | `3.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.18.7`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
-- {<Link href="#semantic-type-variants" target="_self">Semantic Type Variants</Link>}
-- {<Link href="#level-variants-deprecated" target="_self">Level Variants (deprecated)</Link>}
-- {<Link href="#labeling-variations" target="_self">Labeling Variations</Link>}
+- {<Link href="#semantic-types" target="_self">Semantic Types</Link>}
+- {<Link href="#levels-deprecated" target="_self">Levels (deprecated)</Link>}
+- {<Link href="#font-size" target="_self">Font Size</Link>}
+- {<Link href="#labeling" target="_self">Labeling</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
@@ -48,22 +49,34 @@ with the general meaning associated with the semantic colors used in a specific
 variant. In this way, the user will be able to understand the priority of the
 `StatusBadge` and not rely just on the color.
 
-## Semantic Type Variants
+## Semantic Types
 
 The semantic `type` variants align with specific uses. Please refer to the
 purpose of each variant.
 
-<Canvas of={StatusBadgeStories.TypeVariants} />
+<Canvas of={StatusBadgeStories.SemanticTypes} />
 
-## Level Variants (deprecated)
+## Levels (deprecated)
 
 The `level` variants have been deprecated in favor of the semantic `type`
 variants. However, for backward compatability, the `level` prop will override
 the `type` prop.
 
-<Canvas of={StatusBadgeStories.LevelVariants} />
+<Canvas of={StatusBadgeStories.Levels} />
 
-## Labeling Variations
+## Font Size
+
+The label font size can be set using the font sizes from the `Text` component:
+
+- `body1`
+- `body2`
+- `caption`
+
+The default label font size is `body2`.
+
+<Canvas of={StatusBadgeStories.FontSize} />
+
+## Labeling
 
 The capitalization of a badge label will not be forced by the component and
 labels will render exactly as they are passed into the component. If an
@@ -73,7 +86,7 @@ all-caps string is passed in, the label will render all caps. And so on.
 The text case should be dependent on the use case and the final decision should
 ultimately come from Product and UX.
 
-<Canvas of={StatusBadgeStories.LabelingVariations} />
+<Canvas of={StatusBadgeStories.Labeling} />
 
 ### Icons
 
@@ -95,11 +108,26 @@ between the icon and the text. The use of the design tokens (ie, `xs`) is encour
   On-Site Access Only
 </StatusBadge>
 
+<StatusBadge labelFontSize="caption" type="warning">
+  <Icon
+    color="ui.warning.secondary"
+    mr="xs"
+    name="actionHelpDefault"
+    size="medium"
+  />
+  Mising information
+</StatusBadge>
+
 // Icon second (add margin-left)
 
 <StatusBadge level="low">
   Registration Required
   <Icon color="ui.black" ml="xs" name="actionIdentityFilled" size="medium" />
+</StatusBadge>
+
+<StatusBadge labelFontSize="body1" type="informative">
+  Includes audio
+  <Icon color="ui.link.secondary" ml="xs" name="headset" size="medium" />
 </StatusBadge>
 `} language="jsx" />
 

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -67,7 +67,7 @@ The component offers two props for setting the visuall style:
 
 - The `level` variants have been deprecated in favor of the semantic `type`
   variants.
-- For backward compatability, the `level` prop will override the `type` prop.
+- For backward compatibility, the `level` prop will override the `type` prop.
 
 <Canvas of={StatusBadgeStories.Levels} />
 

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -51,7 +51,7 @@ variant. In this way, the user will be able to understand the priority of the
 
 ## Visual Style
 
-The component offers two props for setting the visuall style:
+The component offers two props for setting the visual style:
 
 - `type`
 - `level` (deprecated)
@@ -97,8 +97,8 @@ The default label font size is `desktop.body.body2`.
 - An icon can be rendered within the component by passing a DS `Icon` component
   as a child.
 - When using an icon, text should also be included to ensure understanding.
-- For proper spacing, add a left or right marign to icons, as needed. Use design
-  tokens for spacing vlaues (ex. `marginRight="xs"`).
+- For proper spacing, add a left or right margin to icons, as needed. Use design
+  tokens for spacing values (ex. `marginRight="xs"`).
 
 <Canvas of={StatusBadgeStories.Icons} />
 
@@ -118,7 +118,7 @@ The default label font size is `desktop.body.body2`.
     name="actionHelpDefault"
     size="medium"
   />
-  Mising information
+  Missing information
 </StatusBadge>
 
 // Icon second (add margin-left)

--- a/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -166,7 +166,7 @@ export const FontSize: Story = {
       tableData={[
         [
           <>
-            <StatusBadge labelFontSize="body1" type="neutral">
+            <StatusBadge font-size="body1" type="neutral">
               Neutral
             </StatusBadge>
           </>,
@@ -174,14 +174,14 @@ export const FontSize: Story = {
             <StatusBadge type="neutral">Neutral</StatusBadge>
           </>,
           <>
-            <StatusBadge labelFontSize="caption" type="neutral">
+            <StatusBadge font-size="caption" type="neutral">
               Neutral
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge labelFontSize="body1" type="informative">
+            <StatusBadge font-size="body1" type="informative">
               Informative
             </StatusBadge>
           </>,
@@ -189,14 +189,14 @@ export const FontSize: Story = {
             <StatusBadge type="informative">Informative</StatusBadge>
           </>,
           <>
-            <StatusBadge labelFontSize="caption" type="informative">
+            <StatusBadge font-size="caption" type="informative">
               Informative
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge labelFontSize="body1" type="positive">
+            <StatusBadge font-size="body1" type="positive">
               Positive
             </StatusBadge>
           </>,
@@ -204,14 +204,14 @@ export const FontSize: Story = {
             <StatusBadge type="positive">Positive</StatusBadge>
           </>,
           <>
-            <StatusBadge labelFontSize="caption" type="positive">
+            <StatusBadge font-size="caption" type="positive">
               Positive
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge labelFontSize="body1" type="negative">
+            <StatusBadge font-size="body1" type="negative">
               Negative
             </StatusBadge>
           </>,
@@ -219,14 +219,14 @@ export const FontSize: Story = {
             <StatusBadge type="negative">Negative</StatusBadge>
           </>,
           <>
-            <StatusBadge labelFontSize="caption" type="negative">
+            <StatusBadge font-size="caption" type="negative">
               Negative
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge labelFontSize="body1" type="warning">
+            <StatusBadge font-size="body1" type="warning">
               Warning
             </StatusBadge>
           </>,
@@ -234,14 +234,14 @@ export const FontSize: Story = {
             <StatusBadge type="warning">Warning</StatusBadge>
           </>,
           <>
-            <StatusBadge labelFontSize="caption" type="warning">
+            <StatusBadge font-size="caption" type="warning">
               Warning
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge labelFontSize="body1" type="recommendation">
+            <StatusBadge font-size="body1" type="recommendation">
               Recommendation
             </StatusBadge>
           </>,
@@ -249,7 +249,7 @@ export const FontSize: Story = {
             <StatusBadge type="recommendation">Recommendation</StatusBadge>
           </>,
           <>
-            <StatusBadge labelFontSize="caption" type="recommendation">
+            <StatusBadge font-size="caption" type="recommendation">
               Recommendation
             </StatusBadge>
           </>,
@@ -324,7 +324,7 @@ export const Icons: Story = {
         <Icon color="brand.primary" mr="xs" name="errorFilled" size="medium" />
         On-Site Access Only
       </StatusBadge>
-      <StatusBadge labelFontSize="caption" type="warning">
+      <StatusBadge font-size="caption" type="warning">
         <Icon
           color="ui.warning.secondary"
           mr="xs"
@@ -342,7 +342,7 @@ export const Icons: Story = {
           size="medium"
         />
       </StatusBadge>
-      <StatusBadge labelFontSize="body1" type="informative">
+      <StatusBadge font-size="body1" type="informative">
         Includes audio
         <Icon color="ui.link.secondary" ml="xs" name="headset" size="medium" />
       </StatusBadge>

--- a/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import Icon from "../Icons/Icon";
 import StatusBadge, {
+  statusBadgeFontSizeArray,
   statusBadgeLevelArray,
   statusBadgeTypeArray,
 } from "./StatusBadge";
@@ -13,6 +14,11 @@ const meta: Meta<typeof StatusBadge> = {
   component: StatusBadge,
   argTypes: {
     className: { control: false },
+    labelFontSize: {
+      table: { defaultValue: { summary: "body2" } },
+      control: { type: "radio" },
+      options: statusBadgeFontSizeArray,
+    },
     id: { control: false },
     level: {
       table: { defaultValue: { summary: "low" } },
@@ -36,6 +42,7 @@ type Story = StoryObj<typeof StatusBadge>;
 export const WithControls: Story = {
   args: {
     className: undefined,
+    labelFontSize: undefined,
     id: "statusBadge-id",
     level: undefined,
     type: undefined,
@@ -54,7 +61,7 @@ export const WithControls: Story = {
 
 // The following are additional StatusBadge example Stories.
 
-export const TypeVariants: Story = {
+export const SemanticTypes: Story = {
   render: () => (
     <Table
       columnHeaders={["", "Variant", "Purpose", "Examples"]}
@@ -110,11 +117,12 @@ export const TypeVariants: Story = {
           "Recommended for you, Related",
         ],
       ]}
+      tableTextSize="body2"
     />
   ),
 };
 
-export const LevelVariants: Story = {
+export const Levels: Story = {
   render: () => (
     <Table
       columnHeaders={["", "Variant", "Purpose", "Examples"]}
@@ -146,11 +154,112 @@ export const LevelVariants: Story = {
           "On-Site Access Only, Closed, Unavailable",
         ],
       ]}
+      tableTextSize="body2"
     />
   ),
 };
 
-export const LabelingVariations: Story = {
+export const FontSize: Story = {
+  render: () => (
+    <Table
+      columnHeaders={["Body1", "Body2", "Caption"]}
+      tableData={[
+        [
+          <>
+            <StatusBadge labelFontSize="body1" type="neutral">
+              Neutral
+            </StatusBadge>
+          </>,
+          <>
+            <StatusBadge type="neutral">Neutral</StatusBadge>
+          </>,
+          <>
+            <StatusBadge labelFontSize="caption" type="neutral">
+              Neutral
+            </StatusBadge>
+          </>,
+        ],
+        [
+          <>
+            <StatusBadge labelFontSize="body1" type="informative">
+              Informative
+            </StatusBadge>
+          </>,
+          <>
+            <StatusBadge type="informative">Informative</StatusBadge>
+          </>,
+          <>
+            <StatusBadge labelFontSize="caption" type="informative">
+              Informative
+            </StatusBadge>
+          </>,
+        ],
+        [
+          <>
+            <StatusBadge labelFontSize="body1" type="positive">
+              Positive
+            </StatusBadge>
+          </>,
+          <>
+            <StatusBadge type="positive">Positive</StatusBadge>
+          </>,
+          <>
+            <StatusBadge labelFontSize="caption" type="positive">
+              Positive
+            </StatusBadge>
+          </>,
+        ],
+        [
+          <>
+            <StatusBadge labelFontSize="body1" type="negative">
+              Negative
+            </StatusBadge>
+          </>,
+          <>
+            <StatusBadge type="negative">Negative</StatusBadge>
+          </>,
+          <>
+            <StatusBadge labelFontSize="caption" type="negative">
+              Negative
+            </StatusBadge>
+          </>,
+        ],
+        [
+          <>
+            <StatusBadge labelFontSize="body1" type="warning">
+              Warning
+            </StatusBadge>
+          </>,
+          <>
+            <StatusBadge type="warning">Warning</StatusBadge>
+          </>,
+          <>
+            <StatusBadge labelFontSize="caption" type="warning">
+              Warning
+            </StatusBadge>
+          </>,
+        ],
+        [
+          <>
+            <StatusBadge labelFontSize="body1" type="recommendation">
+              Recommendation
+            </StatusBadge>
+          </>,
+          <>
+            <StatusBadge type="recommendation">Recommendation</StatusBadge>
+          </>,
+          <>
+            <StatusBadge labelFontSize="caption" type="recommendation">
+              Recommendation
+            </StatusBadge>
+          </>,
+        ],
+      ]}
+    />
+  ),
+};
+
+export const Labeling: Story = {
   render: () => (
     <Table
       columnHeaders={["Standard", "All Caps"]}
@@ -215,6 +324,15 @@ export const Icons: Story = {
         <Icon color="brand.primary" mr="xs" name="errorFilled" size="medium" />
         On-Site Access Only
       </StatusBadge>
+      <StatusBadge labelFontSize="caption" type="warning">
+        <Icon
+          color="ui.warning.secondary"
+          mr="xs"
+          name="actionHelpDefault"
+          size="medium"
+        />
+        Mising information
+      </StatusBadge>
       <StatusBadge level="low">
         Registration Required
         <Icon
@@ -223,6 +341,10 @@ export const Icons: Story = {
           name="actionIdentityFilled"
           size="medium"
         />
+      </StatusBadge>
+      <StatusBadge labelFontSize="body1" type="informative">
+        Includes audio
+        <Icon color="ui.link.secondary" ml="xs" name="headset" size="medium" />
       </StatusBadge>
     </VStack>
   ),

--- a/src/components/StatusBadge/StatusBadge.stories.tsx
+++ b/src/components/StatusBadge/StatusBadge.stories.tsx
@@ -14,8 +14,10 @@ const meta: Meta<typeof StatusBadge> = {
   component: StatusBadge,
   argTypes: {
     className: { control: false },
-    labelFontSize: {
-      table: { defaultValue: { summary: "body2" } },
+    fontSize: {
+      description: "**Only used for Storybook** - Set the label font size.",
+      table: { defaultValue: { summary: "desktop.body.body2" } },
+      type: { name: "string" },
       control: { type: "radio" },
       options: statusBadgeFontSizeArray,
     },
@@ -42,7 +44,7 @@ type Story = StoryObj<typeof StatusBadge>;
 export const WithControls: Story = {
   args: {
     className: undefined,
-    labelFontSize: undefined,
+    fontSize: undefined,
     id: "statusBadge-id",
     level: undefined,
     type: undefined,
@@ -61,7 +63,7 @@ export const WithControls: Story = {
 
 // The following are additional StatusBadge example Stories.
 
-export const SemanticTypes: Story = {
+export const Types: Story = {
   render: () => (
     <Table
       columnHeaders={["", "Variant", "Purpose", "Examples"]}
@@ -162,11 +164,11 @@ export const Levels: Story = {
 export const FontSize: Story = {
   render: () => (
     <Table
-      columnHeaders={["Body1", "Body2", "Caption"]}
+      columnHeaders={["Body1", "Body2 (default)", "Caption"]}
       tableData={[
         [
           <>
-            <StatusBadge font-size="body1" type="neutral">
+            <StatusBadge fontSize="desktop.body.body1" type="neutral">
               Neutral
             </StatusBadge>
           </>,
@@ -174,14 +176,14 @@ export const FontSize: Story = {
             <StatusBadge type="neutral">Neutral</StatusBadge>
           </>,
           <>
-            <StatusBadge font-size="caption" type="neutral">
+            <StatusBadge fontSize="desktop.caption" type="neutral">
               Neutral
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge font-size="body1" type="informative">
+            <StatusBadge fontSize="desktop.body.body1" type="informative">
               Informative
             </StatusBadge>
           </>,
@@ -189,14 +191,14 @@ export const FontSize: Story = {
             <StatusBadge type="informative">Informative</StatusBadge>
           </>,
           <>
-            <StatusBadge font-size="caption" type="informative">
+            <StatusBadge fontSize="desktop.caption" type="informative">
               Informative
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge font-size="body1" type="positive">
+            <StatusBadge fontSize="desktop.body.body1" type="positive">
               Positive
             </StatusBadge>
           </>,
@@ -204,14 +206,14 @@ export const FontSize: Story = {
             <StatusBadge type="positive">Positive</StatusBadge>
           </>,
           <>
-            <StatusBadge font-size="caption" type="positive">
+            <StatusBadge fontSize="desktop.caption" type="positive">
               Positive
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge font-size="body1" type="negative">
+            <StatusBadge fontSize="desktop.body.body1" type="negative">
               Negative
             </StatusBadge>
           </>,
@@ -219,14 +221,14 @@ export const FontSize: Story = {
             <StatusBadge type="negative">Negative</StatusBadge>
           </>,
           <>
-            <StatusBadge font-size="caption" type="negative">
+            <StatusBadge fontSize="desktop.caption" type="negative">
               Negative
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge font-size="body1" type="warning">
+            <StatusBadge fontSize="desktop.body.body1" type="warning">
               Warning
             </StatusBadge>
           </>,
@@ -234,14 +236,14 @@ export const FontSize: Story = {
             <StatusBadge type="warning">Warning</StatusBadge>
           </>,
           <>
-            <StatusBadge font-size="caption" type="warning">
+            <StatusBadge fontSize="desktop.caption" type="warning">
               Warning
             </StatusBadge>
           </>,
         ],
         [
           <>
-            <StatusBadge font-size="body1" type="recommendation">
+            <StatusBadge fontSize="desktop.body.body1" type="recommendation">
               Recommendation
             </StatusBadge>
           </>,
@@ -249,7 +251,7 @@ export const FontSize: Story = {
             <StatusBadge type="recommendation">Recommendation</StatusBadge>
           </>,
           <>
-            <StatusBadge font-size="caption" type="recommendation">
+            <StatusBadge fontSize="desktop.caption" type="recommendation">
               Recommendation
             </StatusBadge>
           </>,
@@ -324,7 +326,7 @@ export const Icons: Story = {
         <Icon color="brand.primary" mr="xs" name="errorFilled" size="medium" />
         On-Site Access Only
       </StatusBadge>
-      <StatusBadge font-size="caption" type="warning">
+      <StatusBadge fontSize="desktop.caption" type="warning">
         <Icon
           color="ui.warning.secondary"
           mr="xs"
@@ -342,7 +344,7 @@ export const Icons: Story = {
           size="medium"
         />
       </StatusBadge>
-      <StatusBadge font-size="body1" type="informative">
+      <StatusBadge fontSize="desktop.body.body1" type="informative">
         Includes audio
         <Icon color="ui.link.secondary" ml="xs" name="headset" size="medium" />
       </StatusBadge>

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -88,6 +88,27 @@ describe("StatusBadge", () => {
         </StatusBadge>
       )
       .toJSON();
+    const body1 = renderer
+      .create(
+        <StatusBadge id="body1" type="neutral">
+          Font size body1
+        </StatusBadge>
+      )
+      .toJSON();
+    const body2 = renderer
+      .create(
+        <StatusBadge id="body2" type="neutral">
+          Font size body2
+        </StatusBadge>
+      )
+      .toJSON();
+    const caption = renderer
+      .create(
+        <StatusBadge id="caption" type="neutral">
+          Font size caption
+        </StatusBadge>
+      )
+      .toJSON();
     const withChakraProps = renderer
       .create(
         <StatusBadge id="chakra" p="20px" color="ui.error.primary">
@@ -112,6 +133,9 @@ describe("StatusBadge", () => {
     expect(negative).toMatchSnapshot();
     expect(warning).toMatchSnapshot();
     expect(recommendation).toMatchSnapshot();
+    expect(body1).toMatchSnapshot();
+    expect(body2).toMatchSnapshot();
+    expect(caption).toMatchSnapshot();
     expect(withChakraProps).toMatchSnapshot();
     expect(withOtherProps).toMatchSnapshot();
   });

--- a/src/components/StatusBadge/StatusBadge.test.tsx
+++ b/src/components/StatusBadge/StatusBadge.test.tsx
@@ -90,21 +90,21 @@ describe("StatusBadge", () => {
       .toJSON();
     const body1 = renderer
       .create(
-        <StatusBadge id="body1" type="neutral">
+        <StatusBadge fontSize="desktop.body.body1" id="body1" type="neutral">
           Font size body1
         </StatusBadge>
       )
       .toJSON();
     const body2 = renderer
       .create(
-        <StatusBadge id="body2" type="neutral">
+        <StatusBadge fontSize="desktop.body.body2" id="body2" type="neutral">
           Font size body2
         </StatusBadge>
       )
       .toJSON();
     const caption = renderer
       .create(
-        <StatusBadge id="caption" type="neutral">
+        <StatusBadge fontSize="desktop.caption" id="caption" type="neutral">
           Font size caption
         </StatusBadge>
       )

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -22,8 +22,6 @@ export type StatusBadgeTypes = typeof statusBadgeTypeArray[number];
 export interface StatusBadgeProps {
   /** Additional class for the component */
   className?: string;
-  /** Font size of the badge label. */
-  labelFontSize?: StatusBadgeFontSizes;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Level of the status badge. This prop has been deprecated in favor of the
@@ -40,23 +38,15 @@ export interface StatusBadgeProps {
  */
 export const StatusBadge: ChakraComponent<
   React.ForwardRefExoticComponent<
-    StatusBadgeProps & {
-      children?: React.ReactNode;
-    } & React.RefAttributes<HTMLDivElement>
+    React.PropsWithChildren<StatusBadgeProps> &
+      React.RefAttributes<HTMLDivElement>
   >,
-  StatusBadgeProps
+  React.PropsWithChildren<StatusBadgeProps>
 > = chakra(
   forwardRef<HTMLDivElement, React.PropsWithChildren<StatusBadgeProps>>(
     (props, ref?) => {
-      const {
-        children,
-        className,
-        labelFontSize = "body2",
-        id,
-        level,
-        type,
-        ...rest
-      } = props;
+      const { children, className, id, level, type, ...rest } = props;
+      const labelFontSize = rest["font-size"] || "body2";
       const finalVariant = level ? level : type ? type : "low";
       const styles = useStyleConfig("StatusBadge", {
         labelFontSize,

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -1,8 +1,12 @@
 import { Box, chakra, ChakraComponent, useStyleConfig } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
+export const statusBadgeFontSizeArray = ["body1", "body2", "caption"] as const;
+export type StatusBadgeFontSizes = typeof statusBadgeFontSizeArray[number];
+
 export const statusBadgeLevelArray = ["low", "medium", "high"] as const;
 export type StatusBadgeLevels = typeof statusBadgeLevelArray[number];
+
 export const statusBadgeTypeArray = [
   "informative",
   "negative",
@@ -18,6 +22,8 @@ export type StatusBadgeTypes = typeof statusBadgeTypeArray[number];
 export interface StatusBadgeProps {
   /** Additional class for the component */
   className?: string;
+  /** Font size of the badge label. */
+  labelFontSize?: StatusBadgeFontSizes;
   /** ID that other components can cross reference for accessibility purposes */
   id?: string;
   /** Level of the status badge. This prop has been deprecated in favor of the
@@ -42,9 +48,20 @@ export const StatusBadge: ChakraComponent<
 > = chakra(
   forwardRef<HTMLDivElement, React.PropsWithChildren<StatusBadgeProps>>(
     (props, ref?) => {
-      const { children, className, id, level, type, ...rest } = props;
+      const {
+        children,
+        className,
+        labelFontSize = "body2",
+        id,
+        level,
+        type,
+        ...rest
+      } = props;
       const finalVariant = level ? level : type ? type : "low";
-      const styles = useStyleConfig("StatusBadge", { variant: finalVariant });
+      const styles = useStyleConfig("StatusBadge", {
+        labelFontSize,
+        variant: finalVariant,
+      });
 
       if (!children) {
         console.warn("NYPL Reservoir StatusBadge: No children were passed.");

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -1,7 +1,11 @@
 import { Box, chakra, ChakraComponent, useStyleConfig } from "@chakra-ui/react";
 import React, { forwardRef } from "react";
 
-export const statusBadgeFontSizeArray = ["body1", "body2", "caption"] as const;
+export const statusBadgeFontSizeArray = [
+  "desktop.body.body1",
+  "desktop.body.body2",
+  "desktop.caption",
+] as const;
 export type StatusBadgeFontSizes = typeof statusBadgeFontSizeArray[number];
 
 export const statusBadgeLevelArray = ["low", "medium", "high"] as const;
@@ -46,7 +50,7 @@ export const StatusBadge: ChakraComponent<
   forwardRef<HTMLDivElement, React.PropsWithChildren<StatusBadgeProps>>(
     (props, ref?) => {
       const { children, className, id, level, type, ...rest } = props;
-      const labelFontSize = rest["font-size"] || "body2";
+      const labelFontSize = rest["fontSize"] || "desktop.body.body2";
       const finalVariant = level ? level : type ? type : "low";
       const styles = useStyleConfig("StatusBadge", {
         labelFontSize,

--- a/src/components/StatusBadge/StatusBadge.tsx
+++ b/src/components/StatusBadge/StatusBadge.tsx
@@ -6,7 +6,6 @@ export const statusBadgeFontSizeArray = [
   "desktop.body.body2",
   "desktop.caption",
 ] as const;
-export type StatusBadgeFontSizes = typeof statusBadgeFontSizeArray[number];
 
 export const statusBadgeLevelArray = ["low", "medium", "high"] as const;
 export type StatusBadgeLevels = typeof statusBadgeLevelArray[number];
@@ -50,10 +49,9 @@ export const StatusBadge: ChakraComponent<
   forwardRef<HTMLDivElement, React.PropsWithChildren<StatusBadgeProps>>(
     (props, ref?) => {
       const { children, className, id, level, type, ...rest } = props;
-      const labelFontSize = rest["fontSize"] || "desktop.body.body2";
       const finalVariant = level ? level : type ? type : "low";
       const styles = useStyleConfig("StatusBadge", {
-        labelFontSize,
+        labelFontSize: rest["fontSize"],
         variant: finalVariant,
       });
 

--- a/src/components/StatusBadge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/src/components/StatusBadge/__snapshots__/StatusBadge.test.tsx.snap
@@ -83,6 +83,33 @@ exports[`StatusBadge renders the UI snapshot correctly 9`] = `
 
 exports[`StatusBadge renders the UI snapshot correctly 10`] = `
 <div
+  className="css-1xdhyk6"
+  id="body1"
+>
+  Font size body1
+</div>
+`;
+
+exports[`StatusBadge renders the UI snapshot correctly 11`] = `
+<div
+  className="css-1xdhyk6"
+  id="body2"
+>
+  Font size body2
+</div>
+`;
+
+exports[`StatusBadge renders the UI snapshot correctly 12`] = `
+<div
+  className="css-1xdhyk6"
+  id="caption"
+>
+  Font size caption
+</div>
+`;
+
+exports[`StatusBadge renders the UI snapshot correctly 13`] = `
+<div
   className="css-kle7zy"
   id="chakra"
 >
@@ -90,7 +117,7 @@ exports[`StatusBadge renders the UI snapshot correctly 10`] = `
 </div>
 `;
 
-exports[`StatusBadge renders the UI snapshot correctly 11`] = `
+exports[`StatusBadge renders the UI snapshot correctly 14`] = `
 <div
   className="css-1xdhyk6"
   data-testid="props"

--- a/src/components/StatusBadge/__snapshots__/StatusBadge.test.tsx.snap
+++ b/src/components/StatusBadge/__snapshots__/StatusBadge.test.tsx.snap
@@ -83,7 +83,7 @@ exports[`StatusBadge renders the UI snapshot correctly 9`] = `
 
 exports[`StatusBadge renders the UI snapshot correctly 10`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-8tjen4"
   id="body1"
 >
   Font size body1
@@ -92,7 +92,7 @@ exports[`StatusBadge renders the UI snapshot correctly 10`] = `
 
 exports[`StatusBadge renders the UI snapshot correctly 11`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1lkzcz8"
   id="body2"
 >
   Font size body2
@@ -101,7 +101,7 @@ exports[`StatusBadge renders the UI snapshot correctly 11`] = `
 
 exports[`StatusBadge renders the UI snapshot correctly 12`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1jsj0zc"
   id="caption"
 >
   Font size caption

--- a/src/components/StatusBadge/statusBadgeChangelogData.ts
+++ b/src/components/StatusBadge/statusBadgeChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "New Feature",
+    affects: ["Styles", "Functionality"],
+    notes: ["Adds the `labelFontSize` prop."],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",

--- a/src/components/StatusBadge/statusBadgeChangelogData.ts
+++ b/src/components/StatusBadge/statusBadgeChangelogData.ts
@@ -14,7 +14,7 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "New Feature",
     affects: ["Styles", "Functionality"],
-    notes: ["Adds the `labelFontSize` prop."],
+    notes: ["Adds support for the `fontSize` style prop."],
   },
   {
     date: "2024-04-25",

--- a/src/theme/components/statusBadge.ts
+++ b/src/theme/components/statusBadge.ts
@@ -1,7 +1,12 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { defineStyle } from "@chakra-ui/system";
+import { statusBadgeFontSizeArray } from "../../components/StatusBadge/StatusBadge";
 
 const baseStyle = defineStyle(({ labelFontSize }) => {
+  const finalFontSize = statusBadgeFontSizeArray.includes(labelFontSize)
+    ? `desktop.body.${labelFontSize}`
+    : labelFontSize;
+
   return {
     alignItems: "center",
     bgColor: "ui.bg.default",
@@ -10,10 +15,7 @@ const baseStyle = defineStyle(({ labelFontSize }) => {
     borderRadius: "base",
     color: "ui.typography.heading",
     display: "flex",
-    fontSize:
-      labelFontSize === "caption"
-        ? "desktop.caption"
-        : `desktop.body.${labelFontSize}`,
+    fontSize: labelFontSize === "caption" ? "desktop.caption" : finalFontSize,
     fontWeight: "500",
     py: "inset.extranarrow",
     paddingInlineEnd: "inset.default",

--- a/src/theme/components/statusBadge.ts
+++ b/src/theme/components/statusBadge.ts
@@ -1,26 +1,31 @@
 import { defineStyleConfig } from "@chakra-ui/react";
 import { defineStyle } from "@chakra-ui/system";
 
-const baseStyle = defineStyle({
-  alignItems: "center",
-  bgColor: "ui.bg.default",
-  borderLeft: "4px solid",
-  borderColor: "ui.gray.semi-dark",
-  borderRadius: "base",
-  color: "ui.typography.heading",
-  display: "flex",
-  fontSize: "desktop.body.body2", // slightly smaller than the default size
-  fontWeight: "500",
-  py: "inset.extranarrow",
-  paddingInlineEnd: "inset.default",
-  paddingInlineStart: ".75rem",
-  whiteSpace: "nowrap",
-  width: "fit-content",
-  _dark: {
-    backgroundColor: "dark.ui.bg.default",
-    borderColor: "dark.ui.border.default",
-    color: "dark.ui.typography.heading",
-  },
+const baseStyle = defineStyle(({ labelFontSize }) => {
+  return {
+    alignItems: "center",
+    bgColor: "ui.bg.default",
+    borderLeft: "4px solid",
+    borderColor: "ui.gray.semi-dark",
+    borderRadius: "base",
+    color: "ui.typography.heading",
+    display: "flex",
+    fontSize:
+      labelFontSize === "caption"
+        ? "desktop.caption"
+        : `desktop.body.${labelFontSize}`,
+    fontWeight: "500",
+    py: "inset.extranarrow",
+    paddingInlineEnd: "inset.default",
+    paddingInlineStart: ".75rem",
+    whiteSpace: "nowrap",
+    width: "fit-content",
+    _dark: {
+      backgroundColor: "dark.ui.bg.default",
+      borderColor: "dark.ui.border.default",
+      color: "dark.ui.typography.heading",
+    },
+  };
 });
 
 // Level variants

--- a/src/theme/components/statusBadge.ts
+++ b/src/theme/components/statusBadge.ts
@@ -3,9 +3,10 @@ import { defineStyle } from "@chakra-ui/system";
 import { statusBadgeFontSizeArray } from "../../components/StatusBadge/StatusBadge";
 
 const baseStyle = defineStyle(({ labelFontSize }) => {
+  const defaultFontSize = "desktop.body.body2";
   const finalFontSize = statusBadgeFontSizeArray.includes(labelFontSize)
-    ? `desktop.body.${labelFontSize}`
-    : labelFontSize;
+    ? labelFontSize
+    : defaultFontSize;
 
   return {
     alignItems: "center",
@@ -15,7 +16,8 @@ const baseStyle = defineStyle(({ labelFontSize }) => {
     borderRadius: "base",
     color: "ui.typography.heading",
     display: "flex",
-    fontSize: labelFontSize === "caption" ? "desktop.caption" : finalFontSize,
+    fontSize:
+      labelFontSize === "desktop.caption" ? "desktop.caption" : finalFontSize,
     fontWeight: "500",
     py: "inset.extranarrow",
     paddingInlineEnd: "inset.default",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1994](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1994)

## This PR does the following:

- Adds support for the `fontSize` prop in the `StatusBadge` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1994]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1994?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ