### PR TITLE
DSD-1993: styles for search input field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the `Pagination` component to handle 4 digit page counts.
 - Updates the `Heading` component to add `line-height` styles for mobile.
+- Updates the `MultiSelect` component to adjust the text and size styles for the search input field.
 
 ## 3.5.2 (January 16, 2025)
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./multiSelectChangelogData";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `3.5.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.4.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -14,7 +14,7 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Styles"],
-    notes: ["updates the text and size styles for the search input field."],
+    notes: ["Updates the text and size styles for the search input field."],
   },
   {
     date: "2024-12-05",

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["updates the text and size styles for the search input field."],
+  },
+  {
     date: "2024-12-05",
     version: "3.5.0",
     type: "Update",

--- a/src/theme/components/multiSelect.ts
+++ b/src/theme/components/multiSelect.ts
@@ -1,3 +1,4 @@
+import { defaultElementSizes } from "./global";
 import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 
 // This function creates a set of function that helps us
@@ -63,9 +64,19 @@ const MultiSelect = defineMultiStyleConfig({
       marginLeft: "56px",
     },
     menuSearchInputBox: {
+      button: {
+        height: "100%",
+        minWidth: "auto",
+        right: "0",
+        top: "0",
+        width: { base: defaultElementSizes.mobileFieldHeight, md: "30px" },
+      },
       input: {
         backgroundColor: "ui.bg.default",
         border: "none",
+        fontSize: "desktop.caption",
+        height: "auto",
+        minHeight: { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
       },
     },
     accordionStyles: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1993](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1993)

## This PR does the following:

- Updates the `MultiSelect` component to adjust the text and size styles for the search input field.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- The search input field has a min height of `"44px"` for mobile viewports. Otherwise, the height is smaller, based on the `font-size` value for the input field.

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1993]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1993?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ