### PR TITLE
DSD-1926/7: Update Hero styles to match VDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `primary` variant of the `Hero` component to have appropriate padding for desktop and mobile, and `max-width` of 860px
+- Updates the `campaign` variant of the `Hero component to have consistent padding.
+
 ## 3.5.3 (January 30, 2025)
 
 ### Adds

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `primary` variant of the `Hero` component to have appropriate padding for desktop and mobile, and `max-width` of 860px
-- Updates the `campaign` variant of the `Hero component to have consistent padding.
+- Updates the `campaign` variant of the `Hero` component to have consistent padding.
 
 ## 3.5.3 (January 30, 2025)
 

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -10,6 +10,16 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Updates the `primary` variant of the `Hero` component to have appropriate padding for desktop and mobile, and `max-width` of 860px",
+      "Updates the `campaign` variant of the `Hero component to have consistent padding.",
+    ],
+  },
+  {
     date: "2024-10-24",
     version: "3.4.1",
     type: "Update",

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -15,8 +15,8 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Styles"],
     notes: [
-      "Updates the `primary` variant of the `Hero` component to have appropriate padding for desktop and mobile, and `max-width` of 860px",
-      "Updates the `campaign` variant of the `Hero component to have consistent padding.",
+      "Updates the `primary` variant to have appropriate padding for desktop and mobile, and `max-width` of 860px",
+      "Updates the `campaign` variant to have consistent padding.",
     ],
   },
   {

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -171,11 +171,10 @@ const primary = definePartsStyle(({ foregroundColor, isDarkText }) => ({
       base: "0 0 100%",
       md: "0 0 60%",
     },
-    maxWidth: { md: "960px" },
-    paddingTop: "inset.extrawide",
-    paddingBottom: "inset.extrawide",
-    paddingEnd: "inset.wide",
-    paddingStart: "inset.wide",
+    maxWidth: { md: "860px" },
+    padding: { base: "inset.default", lg: "inset.wide" },
+    paddingEnd: { lg: "inset.wide" },
+    paddingStart: { lg: "inset.wide" },
     a: {
       color: "inherit",
       display: "inline-block",
@@ -350,10 +349,7 @@ const campaign = definePartsStyle(({ foregroundColor, isDarkText }) => ({
   interior: {
     alignSelf: "center",
     maxWidth: { md: "960px" },
-    padding: {
-      base: "inset.default",
-      md: "inset.wide",
-    },
+    padding: "inset.wide",
     width: {
       base: "100%",
       lg: "50%",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1926](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1926) [DSD-1927](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1927)

## This PR does the following:

- Updates `primary` variant desktop view to have padding of 32px (2rem) and mobile view to have padding of 16px (1rem) within text content, and max-width to 860px.
- Updates `campaign` variant to have padding of 32px (2rem) within text content.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Locally in Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1926]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSD-1927]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1927?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ