### PR TITLE
DSD-413: Correct `AlphabetFilter` font weight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Updates
 
+- Updates the `AlphabetFilter` component to correct the font weight.
 - Updates the `StatusBadge` component to support the `fontSize` style prop.
 - Updates the `Checkbox` component to set the correct background color for all states.
 - Updates the `Menu` component to set the line height to 1.5 for menu options.

--- a/src/components/AlphabetFilter/AlphabetFilter.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./alphabetFilterChangelogData";
 
 # AlphabetFilter
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/AlphabetFilter/alphabetFilterChangelogData.ts
+++ b/src/components/AlphabetFilter/alphabetFilterChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Removed bold font weight."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/theme/components/alphabetFilter.ts
+++ b/src/theme/components/alphabetFilter.ts
@@ -11,7 +11,6 @@ const AlphabetFilter = defineMultiStyleConfig({
       height: { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
       padding: "1px 4px",
       margin: "2px 1px",
-      fontWeight: "bold",
       fontSize: {
         base: "mobile.subtitle.subtitle1",
         md: "desktop.subtitle.subtitle1",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1913](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1913)

## This PR does the following:

- Removes `fontWeight: bold` from the component

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1913]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ