### PR TITLE
DSD-2003: Add the container query guide doc page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `Container Query Guide` page to the `Development Guide` section of Storybook.
+
 ## 3.5.4 (February 13, 2025)
 
 ### Adds

--- a/src/components/StyleGuide/ContainerQuery.mdx
+++ b/src/components/StyleGuide/ContainerQuery.mdx
@@ -11,7 +11,7 @@ import Link from "../Link/Link";
 
 - {<Link href="#general-information" target="_self">General Information</Link>}
 - {<Link href="#updating-a-component-to-use-container-queries" target="_self">Updating a component to use container queries</Link>}
-- {<Link href="#full-componentexample" target="_self">Full component example</Link>}
+- {<Link href="#full-component-example" target="_self">Full component example</Link>}
 
 ## General Information
 
@@ -25,6 +25,11 @@ responsive designs that adapt to the size of individual components.
 The `setContainerStyles` function helps you generate container query styles based
 on the provided breakpoint and styles. This function is useful for applying
 responsive styles within a container.
+
+### Resources
+
+- [MDN container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries)
+- [CSS Tricks container queries](https://css-tricks.com/css-container-queries/)
 
 ## Updating a component to use container queries
 
@@ -47,7 +52,7 @@ sx={{ containerType: "inline-size" }}
     <>
       <strong>NOTE:</strong> A container cannot change its own styles, so if the
       top-most element has responsive styles applied, you will need to wrap it
-      with a `Box` to define the container.
+      with a <code>Box</code> to define the container.
     </>
   }
   type="warning"
@@ -55,7 +60,7 @@ sx={{ containerType: "inline-size" }}
 
 ### Defining child elements
 
-To minimize css selectors, we recommend to specify child elements with data-\*
+To minimize CSS selectors, we recommend to specify child elements with data-\*
 attributes to style them.
 
 ### Convert media query styles to container query styles

--- a/src/components/StyleGuide/ContainerQuery.mdx
+++ b/src/components/StyleGuide/ContainerQuery.mdx
@@ -1,0 +1,250 @@
+import { Meta, Source } from "@storybook/blocks";
+
+import Link from "../Link/Link";
+
+<Meta title="Development Guide/Container Query Guide" />
+
+# Container Query Guide
+
+## Table of Contents
+
+- {<Link href="#general-information" target="_self">General Information</Link>}
+- {<Link href="#updating-a-component-to-use-container-queries" target="_self">Updating a component to use container queries</Link>}
+- {<Link href="#full-componentexample" target="_self">Full component example</Link>}
+
+The `setContainerStyles` function helps you generate container query styles based
+on the provided breakpoint and styles. This function is useful for applying
+responsive styles within a container.
+
+## General Information
+
+This guide will walk you through updating a component in Reservoir to replace
+media queries with container queries.
+
+Container queries allow you to apply styles to an element based on the size of
+its container, rather than the size of the viewport. This is useful for creating
+responsive designs that adapt to the size of individual components.
+
+## Updating a component to use container queries
+
+### Defining the container
+
+To define an element as the container add the style prop `container-type: inline-size`
+to the top-most parent.
+
+If the component is using `ComponentWrapper`, add the following prop to the
+definition:
+
+<Source
+  code={`
+sx={{ containerType: "inline-size" }}
+`}
+/>
+
+**Note**: A container cannot change its own styles, so if the top most element has responsive
+styles applied, you will need to wrap it with a `Box` to define the container.
+
+### Defining child elements
+
+To minimize css selectors, we recommend to specify child elements with data-\*
+attributes to style them.
+
+### Convert media query styles to container query styles
+
+Here is a snippet of a component's styles which includes use of Chakra's object syntax
+which applies media queries based on breakpoints:
+
+<Source
+  code={`
+{
+  wrapper: {
+    flexDirection: imageAtEnd
+      ? { base: "column-reverse", md: "row-reverse" }
+      : { base: "column", md: "row" },
+    paddingLeft: full ? { base: null, md: "s" } : null,
+    paddingRight: full ? { base: null, md: "s" } : null,
+  },
+  imgWrapper: {
+    height: { base: "320px", md: "auto" },
+    width: { base: "100%", md: wrapperWidth },
+  },
+};
+`}
+/>
+
+To update the above to use container queries each object property would need to be
+broken out into individual container queries:
+
+<Source
+  code={`
+{
+  "@container (min-width: 0px)": {
+    "[data-wrapper]": {
+      flexDirection: imageAtEnd ? "column-reverse" : "column",
+    },
+    "[data-imageWrapper]": {
+      height: "320px",
+      width: "100%",
+    },
+  },
+  "@container (min-width: 600px)": {
+    "[data-wrapper]": {
+      flexDirection: imageAtEnd ? "row-reverse" : "row",
+      paddingLeft: full ? "s" : null,
+      paddingRight: full ? "s" : null,
+    },
+    "[data-imageWrapper]": {
+      height: "auto",
+      width: wrapperWidth,
+    },
+  },
+}
+`}
+/>
+
+Instead of using hard-coded breakpoint values, the `setContainerStyles` function can
+be used to generate the container query code with existing breakpoints in the system:
+
+<Source
+  code={`
+...setContainerStyles({
+  breakpoint: "base",
+  styles: {
+    "[data-wrapper]": {
+      flexDirection: imageAtEnd ? "column-reverse" : "column",
+    },
+    "[data-imageWrapper]": {
+      height: "320px",
+      width: "100%",
+    },
+  },
+}),
+`}
+/>
+
+### setContainerStyles function
+
+The `setContainerStyles` function provides a way to generate container
+query styles based on breakpoints and styles. Use this function in the component's
+theme file to apply the appropriate container query styles.
+
+#### Function Signature
+
+<Source
+  code={`
+setContainerStyles(props: {
+  breakpoint: "base" | keyof typeof breakpoints;
+  styles: { [selector: string]: { [property: string]: string | number | null } };
+}): { [key: string]: { [selector: string]: { [property: string]: string | number | null } } }
+`}
+/>
+
+#### Parameters
+
+`props.breakpoint`: The breakpoint at which the container query should apply. It
+can be "base" or a key from the breakpoints object.
+
+`props.styles`: An object containing the styles to apply within the container query.
+The keys are CSS selectors, and the values are objects representing CSS properties
+and their values.
+
+#### Returns
+
+An object containing the container query styles.
+
+#### Example
+
+<Source
+  code={`
+import { setContainerStyles } from "../utils/setContainerStyles";
+const styles = setContainerStyles({
+    breakpoint: "md",
+    styles: {
+        "[data-body]": {
+        flexBasis: "100%",
+        },
+    },
+});
+// Result:
+// {
+//   "@container (min-width: 37.5em)": {
+//     "[data-body]": {
+//       flexBasis: "100%",
+//     },
+//   },
+// }
+`}
+/>
+
+## Full component example
+
+This is an example of an updated component with data attributes added to
+be targeted in the container query styles:
+
+<Source
+  code={`
+<Box
+    __css={styles.base}
+    ref={ref}
+    {...rest}
+>
+    <Box __css={styles.wrapper} data-wrapper>
+        <Box
+            __css={{
+            ...styles.imgWrapper,
+            }}
+            data-imageWrapper
+        >
+            <Image
+            alt={imageProps.alt}
+            src={imageProps.src ? imageProps.src : undefined}
+            />
+        </Box>
+        <Box __css={styles.text} data-text>
+            {textContent}
+        </Box>
+    </Box>
+</Box>
+`}
+/>
+
+The `setContainerStyles` function is used to generate container query styles for
+the `sm` and `md` breakpoints. The resulting styles are then spread into the
+`componentStyles` object.
+
+<Source
+  code={`
+const componentStyles = {
+  base: {
+    bgColor: "ui.bg.default",
+    ...setContainerStyles({
+      breakpoint: "sm",
+      styles: {
+        "[data-body]": {
+          flexBasis: "100%",
+        },
+      },
+    }),
+    ...setContainerStyles({
+      breakpoint: "md",
+      styles: {
+        "[data-imageWrapper]": {
+          flexFlow: "row",
+        },
+        "[data-actions]": {
+          flexShrink: "0",
+          marginStart: "m",
+          marginTop: "0",
+          maxWidth: "180px",
+        },
+        "[data-body]": {
+          display: "block",
+          flexFlow: "row nowrap",
+          width: "auto",
+        },
+      },
+    }),
+  },
+};
+`}
+/>

--- a/src/components/StyleGuide/ContainerQuery.mdx
+++ b/src/components/StyleGuide/ContainerQuery.mdx
@@ -1,5 +1,6 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import Banner from "../Banner/Banner";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Container Query Guide" />
@@ -12,10 +13,6 @@ import Link from "../Link/Link";
 - {<Link href="#updating-a-component-to-use-container-queries" target="_self">Updating a component to use container queries</Link>}
 - {<Link href="#full-componentexample" target="_self">Full component example</Link>}
 
-The `setContainerStyles` function helps you generate container query styles based
-on the provided breakpoint and styles. This function is useful for applying
-responsive styles within a container.
-
 ## General Information
 
 This guide will walk you through updating a component in Reservoir to replace
@@ -24,6 +21,10 @@ media queries with container queries.
 Container queries allow you to apply styles to an element based on the size of
 its container, rather than the size of the viewport. This is useful for creating
 responsive designs that adapt to the size of individual components.
+
+The `setContainerStyles` function helps you generate container query styles based
+on the provided breakpoint and styles. This function is useful for applying
+responsive styles within a container.
 
 ## Updating a component to use container queries
 
@@ -41,8 +42,16 @@ sx={{ containerType: "inline-size" }}
 `}
 />
 
-**Note**: A container cannot change its own styles, so if the top most element has responsive
-styles applied, you will need to wrap it with a `Box` to define the container.
+<Banner
+  content={
+    <>
+      <strong>NOTE:</strong> A container cannot change its own styles, so if the
+      top-most element has responsive styles applied, you will need to wrap it
+      with a `Box` to define the container.
+    </>
+  }
+  type="warning"
+/>
 
 ### Defining child elements
 
@@ -196,8 +205,8 @@ be targeted in the container query styles:
             data-imageWrapper
         >
             <Image
-            alt={imageProps.alt}
-            src={imageProps.src ? imageProps.src : undefined}
+              alt={imageProps.alt}
+              src={imageProps.src ? imageProps.src : undefined}
             />
         </Box>
         <Box __css={styles.text} data-text>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2003](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2003)

## This PR does the following:

- Adds the container query guide page to Storybook

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

-

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2003]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2003?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ