### PR TITLE
DSD-1914: Banner spacing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the spacing between heading and content in `Banner` component.
+
 ## 3.5.4 (February 13, 2025)
 
 ### Adds

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./bannerChangelogData";
 
 # Banner
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `3.1.0`    |
-| Latest            | `3.3.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `3.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -172,6 +172,7 @@ export const Banner: ChakraComponent<
       _dark: {
         color: type === "negative" ? "dark.ui.error.primary" : null,
       },
+      paddingBottom: "xs",
     };
     // If `heading is a string, then we want the default heading,
     // otherwise, use whatever the user passed in.

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Banner renders the UI snapshot correctly 1`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>
@@ -46,7 +46,7 @@ exports[`Banner renders the UI snapshot correctly 2`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-1nof84k"
+      className="chakra-heading css-15kduf4"
     >
       Banner Heading
     </h2>
@@ -74,7 +74,7 @@ exports[`Banner renders the UI snapshot correctly 3`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>
@@ -102,7 +102,7 @@ exports[`Banner renders the UI snapshot correctly 4`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>
@@ -130,7 +130,7 @@ exports[`Banner renders the UI snapshot correctly 5`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>
@@ -158,7 +158,7 @@ exports[`Banner renders the UI snapshot correctly 6`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>
@@ -249,7 +249,7 @@ exports[`Banner renders the UI snapshot correctly 9`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>
@@ -278,7 +278,7 @@ exports[`Banner renders the UI snapshot correctly 10`] = `
     className="css-1bxarir"
   >
     <h2
-      className="chakra-heading css-hagw4o"
+      className="chakra-heading css-u0977i"
     >
       Banner Heading
     </h2>

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Update space between heading and content."],
+  },
+  {
     date: "2024-08-29",
     version: "3.3.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1914](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1914)

## This PR does the following:

- Adds 8px of space between heading and content

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1914]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1914?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ