### PR TITLE
DSD-1931: font weight for RadioGroup

### DIFF
--- a/src/theme/components/global.ts
+++ b/src/theme/components/global.ts
@@ -119,7 +119,7 @@ const labelLegendText = {
   marginBottom: "xs",
   width: "100%",
   span: {
-    fontWeight: "regular",
+    fontWeight: "light",
   },
   _dark: {
     color: "dark.ui.typography.heading",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1931](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1931)

## This PR does the following:

- Fixing the font weight on `RadioGroup`, which was missed the first time around.

**NOTE:** This instance of the `(required)` label was missed in the first round and it was flagged by Alkim during QA. The fix was simple, but I am not sure if there are other places where this font weight change will be visible. If you can think of any when you are reviewing, please let me know so I can check myself to verify that everything looks ok. Ultimately, all "extra" text in a form label should be `light` and this change will ensure that, but I still want to see it in action.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1931]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1931?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ