### PR TITLE
DSD-1929: `Image` new aspect ratio options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the spacing between heading and content in `Banner` component.
 - Updates the `Card`, `FeaturedContent`, and `SearchBar` components to use container queries.
+- Updates `Image` to include 'fourByOne' and 'twoByThree' aspect ratio options.
 
 ## 3.5.4 (February 13, 2025)
 

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -10,10 +10,10 @@ import { changelogData } from "./imageChangelogData";
 
 # Image
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.6`    |
-| Latest            | `3.5.2`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.6`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Image/Image.stories.tsx
+++ b/src/components/Image/Image.stories.tsx
@@ -209,6 +209,22 @@ export const AspectRatios: Story = {
         />
       </Box>
       <Box style={imageBlockStyles}>
+        <Heading id="fourbyone" level="h4" size="heading6" text="fourByOne" />
+        <Image
+          alt="Alt text"
+          aspectRatio="fourByOne"
+          src={getPlaceholderImage()}
+        />
+      </Box>
+      <Box style={imageBlockStyles}>
+        <Heading id="twobythree" level="h4" size="heading6" text="twoByThree" />
+        <Image
+          alt="Alt text"
+          aspectRatio="twoByThree"
+          src={getPlaceholderImage()}
+        />
+      </Box>
+      <Box style={imageBlockStyles}>
         <Heading id="onebytwo" level="h4" size="heading6" text="oneByTwo" />
         <Image
           alt="Alt text"

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -170,6 +170,12 @@ describe("Image", () => {
     const ratioThreeByFour = renderer
       .create(<Image src="test.png" alt="" aspectRatio="threeByFour" />)
       .toJSON();
+    const ratioFourByOne = renderer
+      .create(<Image src="test.png" alt="" aspectRatio="fourByOne" />)
+      .toJSON();
+    const ratioTwoByThree = renderer
+      .create(<Image src="test.png" alt="" aspectRatio="twoByThree" />)
+      .toJSON();
     const ratioThreeByTwo = renderer
       .create(<Image src="test.png" alt="" aspectRatio="threeByTwo" />)
       .toJSON();
@@ -206,6 +212,8 @@ describe("Image", () => {
     expect(sizeBasedOnHeight).toMatchSnapshot();
     expect(ratioFourByThree).toMatchSnapshot();
     expect(ratioOneByTwo).toMatchSnapshot();
+    expect(ratioFourByOne).toMatchSnapshot();
+    expect(ratioTwoByThree).toMatchSnapshot();
     expect(ratioOriginal).toMatchSnapshot();
     expect(ratioSixteenByNine).toMatchSnapshot();
     expect(ratioSquare).toMatchSnapshot();

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -13,6 +13,8 @@ import { DimensionTypes } from "../../helpers/types";
 
 export const imageRatiosArray = [
   "fourByThree",
+  "fourByOne",
+  "twoByThree",
   "oneByTwo",
   "original",
   "sixteenByNine",

--- a/src/components/Image/__snapshots__/Image.test.tsx.snap
+++ b/src/components/Image/__snapshots__/Image.test.tsx.snap
@@ -258,6 +258,50 @@ exports[`Image Renders the UI snapshot correctly 13`] = `
 <div
   className="css-0"
 >
+  <div
+    className="the-wrap css-xfxtr7"
+    id={null}
+  >
+    <div
+      className="the-crop css-0"
+    >
+      <img
+        alt=""
+        className="css-0"
+        id={null}
+        src="test.png"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Image Renders the UI snapshot correctly 14`] = `
+<div
+  className="css-0"
+>
+  <div
+    className="the-wrap css-2kayve"
+    id={null}
+  >
+    <div
+      className="the-crop css-0"
+    >
+      <img
+        alt=""
+        className="css-0"
+        id={null}
+        src="test.png"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Image Renders the UI snapshot correctly 15`] = `
+<div
+  className="css-0"
+>
   <img
     alt=""
     className="css-0"
@@ -267,7 +311,7 @@ exports[`Image Renders the UI snapshot correctly 13`] = `
 </div>
 `;
 
-exports[`Image Renders the UI snapshot correctly 14`] = `
+exports[`Image Renders the UI snapshot correctly 16`] = `
 <div
   className="css-0"
 >
@@ -289,56 +333,12 @@ exports[`Image Renders the UI snapshot correctly 14`] = `
 </div>
 `;
 
-exports[`Image Renders the UI snapshot correctly 15`] = `
-<div
-  className="css-0"
->
-  <div
-    className="the-wrap css-12nxalf"
-    id={null}
-  >
-    <div
-      className="the-crop css-0"
-    >
-      <img
-        alt=""
-        className="css-0"
-        id={null}
-        src="test.png"
-      />
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Image Renders the UI snapshot correctly 16`] = `
-<div
-  className="css-0"
->
-  <div
-    className="the-wrap css-1atfqya"
-    id={null}
-  >
-    <div
-      className="the-crop css-0"
-    >
-      <img
-        alt=""
-        className="css-0"
-        id={null}
-        src="test.png"
-      />
-    </div>
-  </div>
-</div>
-`;
-
 exports[`Image Renders the UI snapshot correctly 17`] = `
 <div
   className="css-0"
 >
   <div
-    className="the-wrap css-vy443d"
+    className="the-wrap css-12nxalf"
     id={null}
   >
     <div
@@ -360,7 +360,7 @@ exports[`Image Renders the UI snapshot correctly 18`] = `
   className="css-0"
 >
   <div
-    className="the-wrap css-3hzznc"
+    className="the-wrap css-1atfqya"
     id={null}
   >
     <div
@@ -382,7 +382,7 @@ exports[`Image Renders the UI snapshot correctly 19`] = `
   className="css-0"
 >
   <div
-    className="the-wrap css-12nxalf"
+    className="the-wrap css-vy443d"
     id={null}
   >
     <div
@@ -403,6 +403,50 @@ exports[`Image Renders the UI snapshot correctly 20`] = `
 <div
   className="css-0"
 >
+  <div
+    className="the-wrap css-3hzznc"
+    id={null}
+  >
+    <div
+      className="the-crop css-0"
+    >
+      <img
+        alt=""
+        className="css-0"
+        id={null}
+        src="test.png"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Image Renders the UI snapshot correctly 21`] = `
+<div
+  className="css-0"
+>
+  <div
+    className="the-wrap css-12nxalf"
+    id={null}
+  >
+    <div
+      className="the-crop css-0"
+    >
+      <img
+        alt=""
+        className="css-0"
+        id={null}
+        src="test.png"
+      />
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Image Renders the UI snapshot correctly 22`] = `
+<div
+  className="css-0"
+>
   <img
     alt=""
     className="css-qvgr6z"
@@ -412,7 +456,7 @@ exports[`Image Renders the UI snapshot correctly 20`] = `
 </div>
 `;
 
-exports[`Image Renders the UI snapshot correctly 21`] = `
+exports[`Image Renders the UI snapshot correctly 23`] = `
 <div
   className="css-0"
 >

--- a/src/components/Image/imageChangelogData.ts
+++ b/src/components/Image/imageChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles", "Functionality"],
+    notes: ["Adds 'fourByOne' and 'twoByThree' aspect ratios."],
+  },
+  {
     date: "2025-01-16",
     version: "3.5.2",
     type: "Bug Fix",

--- a/src/theme/components/image.ts
+++ b/src/theme/components/image.ts
@@ -96,6 +96,12 @@ const imageRatios = {
   fourByThree: {
     paddingBottom: "75%",
   },
+  fourByOne: {
+    paddingBottom: "400%",
+  },
+  twoByThree: {
+    paddingBottom: "150%",
+  },
   oneByTwo: {
     paddingBottom: "200%",
   },
@@ -123,6 +129,12 @@ const imageWidthsBasedOnHeight = (height: number) => {
     },
     oneByTwo: {
       maxWidth: `${height / 2}px`,
+    },
+    fourByOne: {
+      maxWidth: `${4 * height}px`,
+    },
+    twoByThree: {
+      maxWidth: `${(2 / 3) * height}px`,
     },
     original: {},
     sixteenByNine: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1929](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1929)

## This PR does the following:

- Adds `'fourByOne'` and `'twoByThree'` as aspect ratios to `Image`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1929]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ