### PR TITLE
DSD-2012: `TagSetFilter` button wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the spacing between heading and content in `Banner` component.
 - Updates the `Card`, `FeaturedContent`, and `SearchBar` components to use container queries.
-- Updated `TagSetFilter` to remove tag button wrapper when `isDismissible` and `onClick` are false.
+- Updated the `"filter"` variant of `TagSet` to remove tag button wrapper when `isDismissible` and `onClick` are false.
 
 ## 3.5.4 (February 13, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the spacing between heading and content in `Banner` component.
 - Updates the `Card`, `FeaturedContent`, and `SearchBar` components to use container queries.
-- Updated `TagSetFilter` to remove tag button wrapper when `isDismissible` is false.
+- Updated `TagSetFilter` to remove tag button wrapper when `isDismissible` and `onClick` are false.
 
 ## 3.5.4 (February 13, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the spacing between heading and content in `Banner` component.
 - Updates the `Card`, `FeaturedContent`, and `SearchBar` components to use container queries.
+- Updated `TagSetFilter` to remove tag button wrapper when `isDismissible` is false.
 
 ## 3.5.4 (February 13, 2025)
 

--- a/src/components/TagSet/TagSet.mdx
+++ b/src/components/TagSet/TagSet.mdx
@@ -112,8 +112,7 @@ Notes:
   function will return the following object as an argument:
   `{ label: "Clear Filters", id: "clear-filters" }`
 - When `isDismissible` is false, the tags will not render as buttons, since they
-  have no `onClick`. In this case, they should be used similarly to `StatusBadge`,
-  as a label.
+  have no `onClick`. In this case, they should be used as a static list of keywords.
 
 <Canvas of={TagSetStories.FilterVariant} />
 

--- a/src/components/TagSet/TagSet.mdx
+++ b/src/components/TagSet/TagSet.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./tagSetChangelogData";
 
 # TagSet
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `3.1.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -111,6 +111,9 @@ Notes:
   Clicking this button will also trigger the `onClick` prop. The `onClick`
   function will return the following object as an argument:
   `{ label: "Clear Filters", id: "clear-filters" }`
+- When `isDismissible` is false, the tags will not render as buttons, since they
+  have no `onClick`. In this case, they should be used similarly to `StatusBadge`,
+  as a label.
 
 <Canvas of={TagSetStories.FilterVariant} />
 

--- a/src/components/TagSet/TagSet.stories.tsx
+++ b/src/components/TagSet/TagSet.stories.tsx
@@ -219,9 +219,6 @@ export const FormattingExamples: Story = {
         type="explore"
       />
       <TagSet
-        onClick={(tagLabel) =>
-          console.log(`Clicked from the onClick props: ${tagLabel}`)
-        }
         tagSetData={[
           { id: "red", label: "Red" },
           { id: "orange", label: "Orange" },

--- a/src/components/TagSet/TagSet.test.tsx
+++ b/src/components/TagSet/TagSet.test.tsx
@@ -329,6 +329,14 @@ describe("TagSet Filter", () => {
     expect(screen.getByText("Clear filters")).toBeInTheDocument();
   });
 
+  it("it does not render tags as buttons when isDismissible is false", () => {
+    const tagSetData = [{ id: "red", label: "Red" }];
+    render(
+      <TagSet isDismissible={false} tagSetData={tagSetData} type="filter" />
+    );
+    expect(screen.queryByRole("button")).not.toBeInTheDocument;
+  });
+
   it("returns correct meta data when the 'Clear filters' button is clicked", () => {
     let currentTag = {};
     const onClick = (tagSet) => {

--- a/src/components/TagSet/TagSetFilter.tsx
+++ b/src/components/TagSet/TagSetFilter.tsx
@@ -73,7 +73,7 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
 
           return (
             <TooltipWrapper key={key} label={tagSet.label}>
-              {isDismissible ? (
+              {isDismissible || onClick ? (
                 <Button
                   aria-label={`${tagSet.label}, click to remove filter`}
                   data-testid="filter-tags"
@@ -81,6 +81,15 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
                   onClick={() => finalOnClick(tagSet)}
                   sx={styles.base}
                 >
+                  {!isDismissible && tagSet.iconName ? (
+                    <Icon
+                      align="left"
+                      color={iconColor}
+                      data-testid="ts-icon"
+                      name={tagSet.iconName}
+                      size="small"
+                    />
+                  ) : null}
                   <span>{tagSet.label}</span>
                   <Icon
                     data-testid="filter-close-icon"

--- a/src/components/TagSet/TagSetFilter.tsx
+++ b/src/components/TagSet/TagSetFilter.tsx
@@ -1,9 +1,9 @@
 import {
+  Box,
   chakra,
   useColorModeValue,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-
 import Button from "../Button/Button";
 import Icon from "../Icons/Icon";
 import { IconNames } from "../Icons/Icon";
@@ -73,28 +73,15 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
 
           return (
             <TooltipWrapper key={key} label={tagSet.label}>
-              <Button
-                aria-label={
-                  isDismissible
-                    ? `${tagSet.label}, click to remove filter`
-                    : undefined
-                }
-                data-testid="filter-tags"
-                id={`ts-filter-${tagSet.id}-${key}`}
-                onClick={isDismissible ? () => finalOnClick(tagSet) : undefined}
-                sx={styles.base}
-              >
-                {!isDismissible && tagSet.iconName ? (
-                  <Icon
-                    align="left"
-                    color={iconColor}
-                    data-testid="ts-icon"
-                    name={tagSet.iconName}
-                    size="small"
-                  />
-                ) : null}
-                <span>{tagSet.label}</span>
-                {isDismissible ? (
+              {isDismissible ? (
+                <Button
+                  aria-label={`${tagSet.label}, click to remove filter`}
+                  data-testid="filter-tags"
+                  id={`ts-filter-${tagSet.id}-${key}`}
+                  onClick={() => finalOnClick(tagSet)}
+                  sx={styles.base}
+                >
+                  <span>{tagSet.label}</span>
                   <Icon
                     data-testid="filter-close-icon"
                     align="right"
@@ -103,8 +90,31 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
                     color={dismissButtonColor}
                     width="12px"
                   />
-                ) : null}
-              </Button>
+                </Button>
+              ) : (
+                <Box
+                  data-testid="filter-tags"
+                  id={`ts-filter-${tagSet.id}-${key}`}
+                  sx={styles.base}
+                >
+                  {tagSet.iconName ? (
+                    <Icon
+                      align="left"
+                      color={iconColor}
+                      data-testid="ts-icon"
+                      name={tagSet.iconName}
+                      size="small"
+                    />
+                  ) : null}
+                  <span
+                    style={{
+                      fontWeight: "var(--nypl-fontWeights-button-default)",
+                    }}
+                  >
+                    {tagSet.label}
+                  </span>
+                </Box>
+              )}
             </TooltipWrapper>
           );
         })}

--- a/src/components/TagSet/TagSetFilter.tsx
+++ b/src/components/TagSet/TagSetFilter.tsx
@@ -104,7 +104,10 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
                 <Box
                   data-testid="filter-tags"
                   id={`ts-filter-${tagSet.id}-${key}`}
-                  sx={styles.base}
+                  sx={{
+                    ...styles.base,
+                    fontWeight: "regular",
+                  }}
                 >
                   {tagSet.iconName ? (
                     <Icon
@@ -115,13 +118,8 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
                       size="small"
                     />
                   ) : null}
-                  <span
-                    style={{
-                      fontWeight: "var(--nypl-fontWeights-button-default)",
-                    }}
-                  >
-                    {tagSet.label}
-                  </span>
+
+                  {tagSet.label}
                 </Box>
               )}
             </TooltipWrapper>

--- a/src/components/TagSet/__snapshots__/TagSet.test.tsx.snap
+++ b/src/components/TagSet/__snapshots__/TagSet.test.tsx.snap
@@ -461,74 +461,151 @@ exports[`TagSet Filter renders the UI snapshot correctly 1`] = `
   className="css-1xdhyk6"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Red, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-red-0"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Red
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Orange, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-orange-1"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Orange
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Yellow, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-yellow-2"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Yellow
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Green, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-green-3"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Green
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Blue, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-blue-4"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Blue
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Indigo, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-indigo-5"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Indigo
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Violet, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-violet-6"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Violet
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
 </div>
 `;
@@ -538,9 +615,11 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
   className="css-1xdhyk6"
 >
   <button
+    aria-label="Red, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-red-0"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -555,11 +634,22 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Red
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
+    aria-label="Orange, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-orange-1"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -574,11 +664,22 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Orange
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
+    aria-label="Yellow, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-yellow-2"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -593,11 +694,22 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Yellow
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
+    aria-label="Green, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-green-3"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -612,11 +724,22 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Green
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
+    aria-label="Blue, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-blue-4"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -631,11 +754,22 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Blue
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
+    aria-label="Indigo, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-indigo-5"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -650,11 +784,22 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Indigo
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
+    aria-label="Violet, click to remove filter"
     className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-violet-6"
+    onClick={[Function]}
     type="button"
   >
     <svg
@@ -669,6 +814,15 @@ exports[`TagSet Filter renders the UI snapshot correctly 2`] = `
     <span>
       Violet
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
 </div>
 `;
@@ -841,74 +995,151 @@ exports[`TagSet Filter renders the UI snapshot correctly 4`] = `
   className="css-1t0bvx9"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Red, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-red-0"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Red
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Orange, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-orange-1"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Orange
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Yellow, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-yellow-2"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Yellow
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Green, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-green-3"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Green
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Blue, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-blue-4"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Blue
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Indigo, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-indigo-5"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Indigo
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Violet, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-violet-6"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Violet
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
 </div>
 `;
@@ -919,74 +1150,151 @@ exports[`TagSet Filter renders the UI snapshot correctly 5`] = `
   data-testid="testid"
 >
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Red, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-red-0"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Red
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Orange, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-orange-1"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Orange
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Yellow, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-yellow-2"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Yellow
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Green, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-green-3"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Green
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Blue, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-blue-4"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Blue
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Indigo, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-indigo-5"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Indigo
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
   <button
-    className="chakra-button css-1xdhyk6"
+    aria-label="Violet, click to remove filter"
+    className="chakra-button css-8bx9xp"
     data-testid="filter-tags"
     id="ts-filter-violet-6"
+    onClick={[Function]}
     type="button"
   >
     <span>
       Violet
     </span>
+    <svg
+      aria-hidden={true}
+      className="chakra-icon css-14pq4bw"
+      data-file-name="SvgClose"
+      data-testid="filter-close-icon"
+      focusable={false}
+      role="img"
+      title="close icon"
+    />
   </button>
 </div>
 `;

--- a/src/components/TagSet/tagSetChangelogData.ts
+++ b/src/components/TagSet/tagSetChangelogData.ts
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Documentation", "Accessibility"],
     notes: [
-      "Updated `TagSetFilter` to remove button wrapper on each tag when `isDismissible` is false and no `onClick` is passed.",
+      "Updated the `'filter'` variant to remove button wrapper on each tag when `isDismissible` is false and no `onClick` is passed.",
     ],
   },
   {

--- a/src/components/TagSet/tagSetChangelogData.ts
+++ b/src/components/TagSet/tagSetChangelogData.ts
@@ -15,7 +15,7 @@ export const changelogData: ChangelogData[] = [
     type: "Update",
     affects: ["Documentation", "Accessibility"],
     notes: [
-      "Updated `TagSetFilter` to remove button wrapper on each tag when `isDismissible` is false.",
+      "Updated `TagSetFilter` to remove button wrapper on each tag when `isDismissible` is false and no `onClick` is passed.",
     ],
   },
   {

--- a/src/components/TagSet/tagSetChangelogData.ts
+++ b/src/components/TagSet/tagSetChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Documentation", "Accessibility"],
+    notes: [
+      "Updated `TagSetFilter` to remove button wrapper on each tag when `isDismissible` is false.",
+    ],
+  },
+  {
     date: "2024-04-25",
     version: "3.1.1",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2012](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2012)

## This PR does the following:

- Removes the `button` wrapping each tag in the `TagSetFilter` if `isDismissible` is false and no `onClick` has been passed
- Adds/updates `TagSet` tests

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- This should correct the existing issue of tags that are essentially labels being identified as buttons, and being tabbable/clickable as if they are buttons

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-2012]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ