### PR TITLE
DSD-2011: primitive and highlighter colors

### DIFF
--- a/.storybook/preview-body.html
+++ b/.storybook/preview-body.html
@@ -91,41 +91,38 @@
     border: 1px solid var(--nypl-colors-ui-gray-medium);
   }
 
-  .sb-show-main
-    :where(table.storybook-colors-example:not(.sb-anchor, .sb-unstyled, .sb-unstyled
-        table.storybook-colors-example)) {
-    border: none;
+  /* Styles for the contrast data table within the ColorCard component. */
+  .chakra-table__container:has(table.storybook-colors-example) {
+    background-color: transparent;
+    overflow: visible;
   }
-  /* .sb-show-main
-    :where(table.storybook-colors-example:not(.sb-anchor, .sb-unstyled, .sb-unstyled
-        table.storybook-colors-example))
-    tr
-    td,
-  .sb-show-main table.storybook-colors-example td > span:first-of-type {
-    color: unset;
-  } */
-  .sb-show-main
-    :where(table.storybook-colors-example:not(.sb-anchor, .sb-unstyled, .sb-unstyled
-        table.storybook-colors-example))
-    tr
-    span {
-    font-size: 12px;
+  table.storybook-colors-example th:first-of-type,
+  table.storybook-colors-example tr:nth-of-type(2n) {
+    background-color: transparent;
   }
-  .sb-show-main
-    :where(table.storybook-colors-example:not(.sb-anchor, .sb-unstyled, .sb-unstyled
-        table.storybook-colors-example))
-    tr:nth-of-type(2n) {
-    background-color: unset;
+  table.storybook-colors-example thead th {
+    font-size: 10px;
+    font-weight: bold;
   }
-  .sb-show-main table.storybook-colors-example thead tr,
-  .sb-show-main table.storybook-colors-example thead th,
-  .sb-show-main table.storybook-colors-example thead th:last-of-type,
-  .sb-show-main table.storybook-colors-example thead td:last-of-type,
-  .sb-show-main table.storybook-colors-example tbody tr,
-  .sb-show-main table.storybook-colors-example tbody th,
-  .sb-show-main table.storybook-colors-example tbody td,
-  .sb-show-main table.storybook-colors-example tbody th:last-of-type,
-  .sb-show-main table.storybook-colors-example tbody td:last-of-type {
+  table.storybook-colors-example thead th,
+  table.storybook-colors-example tbody th,
+  table.storybook-colors-example td {
+    min-width: 100px;
+    white-space: nowrap;
+  }
+  table.storybook-colors-example thead tr,
+  table.storybook-colors-example thead th,
+  table.storybook-colors-example thead th:first-of-type,
+  table.storybook-colors-example thead th:last-of-type,
+  table.storybook-colors-example thead td:first-of-type,
+  table.storybook-colors-example thead td:last-of-type,
+  table.storybook-colors-example tbody tr,
+  table.storybook-colors-example tbody th,
+  table.storybook-colors-example tbody td,
+  table.storybook-colors-example tbody th:first-of-type,
+  table.storybook-colors-example tbody th:last-of-type,
+  table.storybook-colors-example tbody td:first-of-type,
+  table.storybook-colors-example tbody td:last-of-type {
     border: unset;
   }
 </style>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the `Container Query Guide` page to the `Development Guide` section of Storybook.
+- Adds the `primitives` color object.
+- Adds the `highlighter` colors to the `colors` theme object.
 
 ### Updates
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -161,12 +161,12 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.9.tgz",
-      "integrity": "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.26.10.tgz",
+      "integrity": "sha512-rRHT8siFIXQrAYOYqZQVsAr8vJ+cBNqcVAY6m5V8/4QqzaPl+zDBe6cLEPRDuNOUf3ww8RfJVlOyQMoSI+5Ang==",
       "dependencies": {
-        "@babel/parser": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/parser": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.25",
         "jsesc": "^3.0.2"
@@ -255,13 +255,13 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.9.tgz",
-      "integrity": "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.10.tgz",
+      "integrity": "sha512-UPYc3SauzZ3JGgj87GgZ89JVdC5dj0AoetR5Bw6wj4niittNyFh6+eOGonYvJ1ao6B8lEa3Q3klS7ADZ53bc5g==",
       "dev": true,
       "dependencies": {
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -354,11 +354,11 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.9.tgz",
-      "integrity": "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.26.10.tgz",
+      "integrity": "sha512-6aQR2zGE/QFi8JpDLjUZEPYOs7+mhKXm86VaKFiLP35JQwQb6bwUE+XbvkH0EptsYhbNBSUGaUBLKqxH1xSgsA==",
       "dependencies": {
-        "@babel/types": "^7.26.9"
+        "@babel/types": "^7.26.10"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -620,9 +620,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.9.tgz",
-      "integrity": "sha512-aA63XwOkcl4xxQa3HjPMqOP6LiK0ZDv3mUPYEFXkpHbaFjtGggE1A61FjFzJnB+p7/oy2gA8E+rcBNl/zC1tMg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.26.10.tgz",
+      "integrity": "sha512-2WJMeRQPHKSPemqk/awGrAiuFfzBmOIPXKizAsVhWH9YJqLZ0H+HS4c8loHGgW6utJ3E/ejXQUsiGaQy2NZ9Fw==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -631,9 +631,9 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.9.tgz",
-      "integrity": "sha512-5EVjbTegqN7RSJle6hMWYxO4voo4rI+9krITk+DWR+diJgGrjZjrIBnJhjrHYYQsFgI7j1w1QnrvV7YSKBfYGg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.26.10.tgz",
+      "integrity": "sha512-uITFQYO68pMEYR46AHgQoyBg7KPPJDAbGn4jUTIRgCFJIp88MIBUianVOplhZDEec07bp9zIyr4Kp0FCyQzmWg==",
       "dev": true,
       "dependencies": {
         "core-js-pure": "^3.30.2",
@@ -657,15 +657,15 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.9.tgz",
-      "integrity": "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.26.10.tgz",
+      "integrity": "sha512-k8NuDrxr0WrPH5Aupqb2LCVURP/S0vBEn5mK6iH+GIYob66U5EtoZvcdudR2jQ4cmTwhEwW1DLB+Yyas9zjF6A==",
       "dependencies": {
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/generator": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/types": "^7.26.10",
         "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
@@ -674,9 +674,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.9.tgz",
-      "integrity": "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.26.10.tgz",
+      "integrity": "sha512-emqcG3vHrpxUKTrxcblR36dcrcoRDvKmnL/dCL6ZsHaShW80qxCAcNhzQZrpeM765VzEos+xOi4s+r4IXzTwdQ==",
       "dependencies": {
         "@babel/helper-string-parser": "^7.25.9",
         "@babel/helper-validator-identifier": "^7.25.9"
@@ -2390,9 +2390,9 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-      "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.5.1.tgz",
+      "integrity": "sha512-soEIOALTfTK6EjmKMMoLugwaP0rzkad90iIWd1hMO9ARkSAyjfMfkRRhLvD5qH7vvM0Cg72pieUfR6yh6XxC4w==",
       "dev": true,
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -2482,16 +2482,16 @@
       }
     },
     "node_modules/@figspec/react": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.3.tgz",
-      "integrity": "sha512-r683qOko+5CbT48Ox280fMx2MNAtaFPgCNJvldOqN3YtmAzlcTT+YSxd3OahA+kjXGGrnzDbUgeTOX1cPLII+g==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@figspec/react/-/react-1.0.4.tgz",
+      "integrity": "sha512-jaPvkIef4d6NjsRiw91OZabrfdPH9FtoPGYcY5mpXjYEcdUqIq1aHtLq3SkMVyVysEapTEJ6yS8amy93MyXBEQ==",
       "dev": true,
       "dependencies": {
         "@figspec/components": "^1.0.1",
         "@lit-labs/react": "^1.0.2"
       },
       "peerDependencies": {
-        "react": "^16.14.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.14.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -2980,44 +2980,44 @@
       }
     },
     "node_modules/@microsoft/api-extractor": {
-      "version": "7.50.1",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.50.1.tgz",
-      "integrity": "sha512-L18vz0ARLNaBLKwWe0DdEf7eijDsb7ERZspgZK7PxclLoQrc+9hJZo8y4OVfCHxNVyxlwVywY2WdE/3pOFViLQ==",
+      "version": "7.52.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor/-/api-extractor-7.52.1.tgz",
+      "integrity": "sha512-m3I5uAwE05orsu3D1AGyisX5KxsgVXB+U4bWOOaX/Z7Ftp/2Cy41qsNhO6LPvSxHBaapyser5dVorF1t5M6tig==",
       "dev": true,
       "dependencies": {
-        "@microsoft/api-extractor-model": "7.30.3",
+        "@microsoft/api-extractor-model": "7.30.4",
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.11.0",
+        "@rushstack/node-core-library": "5.12.0",
         "@rushstack/rig-package": "0.5.3",
-        "@rushstack/terminal": "0.15.0",
-        "@rushstack/ts-command-line": "4.23.5",
+        "@rushstack/terminal": "0.15.1",
+        "@rushstack/ts-command-line": "4.23.6",
         "lodash": "~4.17.15",
         "minimatch": "~3.0.3",
         "resolve": "~1.22.1",
         "semver": "~7.5.4",
         "source-map": "~0.6.1",
-        "typescript": "5.7.3"
+        "typescript": "5.8.2"
       },
       "bin": {
         "api-extractor": "bin/api-extractor"
       }
     },
     "node_modules/@microsoft/api-extractor-model": {
-      "version": "7.30.3",
-      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.3.tgz",
-      "integrity": "sha512-yEAvq0F78MmStXdqz9TTT4PZ05Xu5R8nqgwI5xmUmQjWBQ9E6R2n8HB/iZMRciG4rf9iwI2mtuQwIzDXBvHn1w==",
+      "version": "7.30.4",
+      "resolved": "https://registry.npmjs.org/@microsoft/api-extractor-model/-/api-extractor-model-7.30.4.tgz",
+      "integrity": "sha512-RobC0gyVYsd2Fao9MTKOfTdBm41P/bCMUmzS5mQ7/MoAKEqy0FOBph3JOYdq4X4BsEnMEiSHc+0NUNmdzxCpjA==",
       "dev": true,
       "dependencies": {
         "@microsoft/tsdoc": "~0.15.1",
         "@microsoft/tsdoc-config": "~0.17.1",
-        "@rushstack/node-core-library": "5.11.0"
+        "@rushstack/node-core-library": "5.12.0"
       }
     },
     "node_modules/@microsoft/api-extractor-model/node_modules/@rushstack/node-core-library": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.11.0.tgz",
-      "integrity": "sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.12.0.tgz",
+      "integrity": "sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==",
       "dev": true,
       "dependencies": {
         "ajv": "~8.13.0",
@@ -3108,9 +3108,9 @@
       "dev": true
     },
     "node_modules/@microsoft/api-extractor/node_modules/@rushstack/node-core-library": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.11.0.tgz",
-      "integrity": "sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.12.0.tgz",
+      "integrity": "sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==",
       "dev": true,
       "dependencies": {
         "ajv": "~8.13.0",
@@ -3216,9 +3216,9 @@
       }
     },
     "node_modules/@microsoft/api-extractor/node_modules/typescript": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
-      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "version": "5.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
+      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -3433,9 +3433,9 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.8.tgz",
-      "integrity": "sha512-q217OSE8DTp8AFHuNHXo0Y86e1wtlfVrXiAlwkIvGRQv9zbc6mE3sjIVfwI8sYUyNxwOg0j/Vm1RKM04JcWLJw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.35.0.tgz",
+      "integrity": "sha512-uYQ2WfPaqz5QtVgMxfN6NpLD+no0MYHDBywl7itPYd3K5TjjSghNKmX8ic9S8NU8w81NVhJv/XojcHptRly7qQ==",
       "cpu": [
         "arm"
       ],
@@ -3446,9 +3446,9 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.8.tgz",
-      "integrity": "sha512-Gigjz7mNWaOL9wCggvoK3jEIUUbGul656opstjaUSGC3eT0BM7PofdAJaBfPFWWkXNVAXbaQtC99OCg4sJv70Q==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.35.0.tgz",
+      "integrity": "sha512-FtKddj9XZudurLhdJnBl9fl6BwCJ3ky8riCXjEw3/UIbjmIY58ppWwPEvU3fNu+W7FUsAsB1CdH+7EQE6CXAPA==",
       "cpu": [
         "arm64"
       ],
@@ -3459,9 +3459,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.8.tgz",
-      "integrity": "sha512-02rVdZ5tgdUNRxIUrFdcMBZQoaPMrxtwSb+/hOfBdqkatYHR3lZ2A2EGyHq2sGOd0Owk80oV3snlDASC24He3Q==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.35.0.tgz",
+      "integrity": "sha512-Uk+GjOJR6CY844/q6r5DR/6lkPFOw0hjfOIzVx22THJXMxktXG6CbejseJFznU8vHcEBLpiXKY3/6xc+cBm65Q==",
       "cpu": [
         "arm64"
       ],
@@ -3472,9 +3472,9 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.8.tgz",
-      "integrity": "sha512-qIP/elwR/tq/dYRx3lgwK31jkZvMiD6qUtOycLhTzCvrjbZ3LjQnEM9rNhSGpbLXVJYQ3rq39A6Re0h9tU2ynw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.35.0.tgz",
+      "integrity": "sha512-3IrHjfAS6Vkp+5bISNQnPogRAW5GAV1n+bNCrDwXmfMHbPl5EhTmWtfmwlJxFRUCBZ+tZ/OxDyU08aF6NI/N5Q==",
       "cpu": [
         "x64"
       ],
@@ -3485,9 +3485,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.8.tgz",
-      "integrity": "sha512-IQNVXL9iY6NniYbTaOKdrlVP3XIqazBgJOVkddzJlqnCpRi/yAeSOa8PLcECFSQochzqApIOE1GHNu3pCz+BDA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.35.0.tgz",
+      "integrity": "sha512-sxjoD/6F9cDLSELuLNnY0fOrM9WA0KrM0vWm57XhrIMf5FGiN8D0l7fn+bpUeBSU7dCgPV2oX4zHAsAXyHFGcQ==",
       "cpu": [
         "arm64"
       ],
@@ -3498,9 +3498,9 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.8.tgz",
-      "integrity": "sha512-TYXcHghgnCqYFiE3FT5QwXtOZqDj5GmaFNTNt3jNC+vh22dc/ukG2cG+pi75QO4kACohZzidsq7yKTKwq/Jq7Q==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.35.0.tgz",
+      "integrity": "sha512-2mpHCeRuD1u/2kruUiHSsnjWtHjqVbzhBkNVQ1aVD63CcexKVcQGwJ2g5VphOd84GvxfSvnnlEyBtQCE5hxVVw==",
       "cpu": [
         "x64"
       ],
@@ -3511,9 +3511,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.8.tgz",
-      "integrity": "sha512-A4iphFGNkWRd+5m3VIGuqHnG3MVnqKe7Al57u9mwgbyZ2/xF9Jio72MaY7xxh+Y87VAHmGQr73qoKL9HPbXj1g==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.35.0.tgz",
+      "integrity": "sha512-mrA0v3QMy6ZSvEuLs0dMxcO2LnaCONs1Z73GUDBHWbY8tFFocM6yl7YyMu7rz4zS81NDSqhrUuolyZXGi8TEqg==",
       "cpu": [
         "arm"
       ],
@@ -3524,9 +3524,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.8.tgz",
-      "integrity": "sha512-S0lqKLfTm5u+QTxlFiAnb2J/2dgQqRy/XvziPtDd1rKZFXHTyYLoVL58M/XFwDI01AQCDIevGLbQrMAtdyanpA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.35.0.tgz",
+      "integrity": "sha512-DnYhhzcvTAKNexIql8pFajr0PiDGrIsBYPRvCKlA5ixSS3uwo/CWNZxB09jhIapEIg945KOzcYEAGGSmTSpk7A==",
       "cpu": [
         "arm"
       ],
@@ -3537,9 +3537,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.8.tgz",
-      "integrity": "sha512-jpz9YOuPiSkL4G4pqKrus0pn9aYwpImGkosRKwNi+sJSkz+WU3anZe6hi73StLOQdfXYXC7hUfsQlTnjMd3s1A==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.35.0.tgz",
+      "integrity": "sha512-uagpnH2M2g2b5iLsCTZ35CL1FgyuzzJQ8L9VtlJ+FckBXroTwNOaD0z0/UF+k5K3aNQjbm8LIVpxykUOQt1m/A==",
       "cpu": [
         "arm64"
       ],
@@ -3550,9 +3550,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.8.tgz",
-      "integrity": "sha512-KdSfaROOUJXgTVxJNAZ3KwkRc5nggDk+06P6lgi1HLv1hskgvxHUKZ4xtwHkVYJ1Rep4GNo+uEfycCRRxht7+Q==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.35.0.tgz",
+      "integrity": "sha512-XQxVOCd6VJeHQA/7YcqyV0/88N6ysSVzRjJ9I9UA/xXpEsjvAgDTgH3wQYz5bmr7SPtVK2TsP2fQ2N9L4ukoUg==",
       "cpu": [
         "arm64"
       ],
@@ -3563,9 +3563,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.8.tgz",
-      "integrity": "sha512-NyF4gcxwkMFRjgXBM6g2lkT58OWztZvw5KkV2K0qqSnUEqCVcqdh2jN4gQrTn/YUpAcNKyFHfoOZEer9nwo6uQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.35.0.tgz",
+      "integrity": "sha512-5pMT5PzfgwcXEwOaSrqVsz/LvjDZt+vQ8RT/70yhPU06PTuq8WaHhfT1LW+cdD7mW6i/J5/XIkX/1tCAkh1W6g==",
       "cpu": [
         "loong64"
       ],
@@ -3576,9 +3576,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.8.tgz",
-      "integrity": "sha512-LMJc999GkhGvktHU85zNTDImZVUCJ1z/MbAJTnviiWmmjyckP5aQsHtcujMjpNdMZPT2rQEDBlJfubhs3jsMfw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.35.0.tgz",
+      "integrity": "sha512-c+zkcvbhbXF98f4CtEIP1EBA/lCic5xB0lToneZYvMeKu5Kamq3O8gqrxiYYLzlZH6E3Aq+TSW86E4ay8iD8EA==",
       "cpu": [
         "ppc64"
       ],
@@ -3589,9 +3589,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.8.tgz",
-      "integrity": "sha512-xAQCAHPj8nJq1PI3z8CIZzXuXCstquz7cIOL73HHdXiRcKk8Ywwqtx2wrIy23EcTn4aZ2fLJNBB8d0tQENPCmw==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.35.0.tgz",
+      "integrity": "sha512-s91fuAHdOwH/Tad2tzTtPX7UZyytHIRR6V4+2IGlV0Cej5rkG0R61SX4l4y9sh0JBibMiploZx3oHKPnQBKe4g==",
       "cpu": [
         "riscv64"
       ],
@@ -3602,9 +3602,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.8.tgz",
-      "integrity": "sha512-DdePVk1NDEuc3fOe3dPPTb+rjMtuFw89gw6gVWxQFAuEqqSdDKnrwzZHrUYdac7A7dXl9Q2Vflxpme15gUWQFA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.35.0.tgz",
+      "integrity": "sha512-hQRkPQPLYJZYGP+Hj4fR9dDBMIM7zrzJDWFEMPdTnTy95Ljnv0/4w/ixFw3pTBMEuuEuoqtBINYND4M7ujcuQw==",
       "cpu": [
         "s390x"
       ],
@@ -3615,9 +3615,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.8.tgz",
-      "integrity": "sha512-8y7ED8gjxITUltTUEJLQdgpbPh1sUQ0kMTmufRF/Ns5tI9TNMNlhWtmPKKHCU0SilX+3MJkZ0zERYYGIVBYHIA==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.35.0.tgz",
+      "integrity": "sha512-Pim1T8rXOri+0HmV4CdKSGrqcBWX0d1HoPnQ0uw0bdp1aP5SdQVNBy8LjYncvnLgu3fnnCt17xjWGd4cqh8/hA==",
       "cpu": [
         "x64"
       ],
@@ -3628,9 +3628,9 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.8.tgz",
-      "integrity": "sha512-SCXcP0ZpGFIe7Ge+McxY5zKxiEI5ra+GT3QRxL0pMMtxPfpyLAKleZODi1zdRHkz5/BhueUrYtYVgubqe9JBNQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.35.0.tgz",
+      "integrity": "sha512-QysqXzYiDvQWfUiTm8XmJNO2zm9yC9P/2Gkrwg2dH9cxotQzunBHYr6jk4SujCTqnfGxduOmQcI7c2ryuW8XVg==",
       "cpu": [
         "x64"
       ],
@@ -3641,9 +3641,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.8.tgz",
-      "integrity": "sha512-YHYsgzZgFJzTRbth4h7Or0m5O74Yda+hLin0irAIobkLQFRQd1qWmnoVfwmKm9TXIZVAD0nZ+GEb2ICicLyCnQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.35.0.tgz",
+      "integrity": "sha512-OUOlGqPkVJCdJETKOCEf1mw848ZyJ5w50/rZ/3IBQVdLfR5jk/6Sr5m3iO2tdPgwo0x7VcncYuOvMhBWZq8ayg==",
       "cpu": [
         "arm64"
       ],
@@ -3654,9 +3654,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.8.tgz",
-      "integrity": "sha512-r3NRQrXkHr4uWy5TOjTpTYojR9XmF0j/RYgKCef+Ag46FWUTltm5ziticv8LdNsDMehjJ543x/+TJAek/xBA2w==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.35.0.tgz",
+      "integrity": "sha512-2/lsgejMrtwQe44glq7AFFHLfJBPafpsTa6JvP2NGef/ifOa4KBoglVf7AKN7EV9o32evBPRqfg96fEHzWo5kw==",
       "cpu": [
         "ia32"
       ],
@@ -3667,9 +3667,9 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.8.tgz",
-      "integrity": "sha512-U0FaE5O1BCpZSeE6gBl3c5ObhePQSfk9vDRToMmTkbhCOgW4jqvtS5LGyQ76L1fH8sM0keRp4uDTsbjiUyjk0g==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.35.0.tgz",
+      "integrity": "sha512-PIQeY5XDkrOysbQblSW7v3l1MDZzkTEzAfTPkj5VAu3FW8fS4ynyLg2sINp0fp3SjZ8xkRYpLqoKcYqAkhU1dw==",
       "cpu": [
         "x64"
       ],
@@ -3778,12 +3778,12 @@
       }
     },
     "node_modules/@rushstack/terminal": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.0.tgz",
-      "integrity": "sha512-vXQPRQ+vJJn4GVqxkwRe+UGgzNxdV8xuJZY2zem46Y0p3tlahucH9/hPmLGj2i9dQnUBFiRnoM9/KW7PYw8F4Q==",
+      "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/@rushstack/terminal/-/terminal-0.15.1.tgz",
+      "integrity": "sha512-3vgJYwumcjoDOXU3IxZfd616lqOdmr8Ezj4OWgJZfhmiBK4Nh7eWcv8sU8N/HdzXcuHDXCRGn/6O2Q75QvaZMA==",
       "dev": true,
       "dependencies": {
-        "@rushstack/node-core-library": "5.11.0",
+        "@rushstack/node-core-library": "5.12.0",
         "supports-color": "~8.1.1"
       },
       "peerDependencies": {
@@ -3796,9 +3796,9 @@
       }
     },
     "node_modules/@rushstack/terminal/node_modules/@rushstack/node-core-library": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.11.0.tgz",
-      "integrity": "sha512-I8+VzG9A0F3nH2rLpPd7hF8F7l5Xb7D+ldrWVZYegXM6CsKkvWc670RlgK3WX8/AseZfXA/vVrh0bpXe2Y2UDQ==",
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/@rushstack/node-core-library/-/node-core-library-5.12.0.tgz",
+      "integrity": "sha512-QSwwzgzWoil1SCQse+yCHwlhRxNv2dX9siPnAb9zR/UmMhac4mjMrlMZpk64BlCeOFi1kJKgXRkihSwRMbboAQ==",
       "dev": true,
       "dependencies": {
         "ajv": "~8.13.0",
@@ -3904,12 +3904,12 @@
       "dev": true
     },
     "node_modules/@rushstack/ts-command-line": {
-      "version": "4.23.5",
-      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.5.tgz",
-      "integrity": "sha512-jg70HfoK44KfSP3MTiL5rxsZH7X1ktX3cZs9Sl8eDu1/LxJSbPsh0MOFRC710lIuYYSgxWjI5AjbCBAl7u3RxA==",
+      "version": "4.23.6",
+      "resolved": "https://registry.npmjs.org/@rushstack/ts-command-line/-/ts-command-line-4.23.6.tgz",
+      "integrity": "sha512-7WepygaF3YPEoToh4MAL/mmHkiIImQq3/uAkQX46kVoKTNOOlCtFGyNnze6OYuWw2o9rxsyrHVfIBKxq/am2RA==",
       "dev": true,
       "dependencies": {
-        "@rushstack/terminal": "0.15.0",
+        "@rushstack/terminal": "0.15.1",
         "@types/argparse": "1.0.38",
         "argparse": "~1.0.9",
         "string-argv": "~0.3.1"
@@ -4324,9 +4324,9 @@
       }
     },
     "node_modules/@storybook/components": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.0.tgz",
-      "integrity": "sha512-k5MQAuLPt5KOaa5J4QvX/WKucaiFTMJiEX5lsSaY6qON6Sx8PtnLQxVwWF7BIMW/jLpd94BUxrVjVrQKlwoLKQ==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/components/-/components-8.6.4.tgz",
+      "integrity": "sha512-91VEVFWOgHkEFoNFMk6gs1AuOE9Yp7N283BXQOW+AgP+atpzED6t/fIBPGqJ2ewAuzLJ+cFOrasSzoNwVfg3Jg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4405,9 +4405,9 @@
       "dev": true
     },
     "node_modules/@storybook/icons": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.3.2.tgz",
-      "integrity": "sha512-t3xcbCKkPvqyef8urBM0j/nP6sKtnlRkVgC+8JTbTAZQjaTmOjes3byEgzs89p4B/K6cJsg9wLW2k3SknLtYJw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@storybook/icons/-/icons-1.4.0.tgz",
+      "integrity": "sha512-Td73IeJxOyalzvjQL+JXx72jlIYHgs+REaHiREOqfpo3A2AYYG71AUbcv+lg7mEDIweKVCxsMQ0UKo634c8XeA==",
       "dev": true,
       "engines": {
         "node": ">=14.0.0"
@@ -4436,9 +4436,9 @@
       }
     },
     "node_modules/@storybook/manager-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.0.tgz",
-      "integrity": "sha512-ddBibYrO3yQCdtZBqQYqfABjR9eS+llvt2NFDajfyQw+zmuNIZfw4BDGKH1WHE4wm/kXmlFFhPHXaHgAPTRPfQ==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/manager-api/-/manager-api-8.6.4.tgz",
+      "integrity": "sha512-w/Nn/VznfbIg2oezDfzZNwSTDY5kBZbzxVBHLCnIcyu2AKt2Yto3pfGi60SikFcTrsClaAKT7D92kMQ9qdQNQQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4449,9 +4449,9 @@
       }
     },
     "node_modules/@storybook/preview-api": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.0.tgz",
-      "integrity": "sha512-c/sZj4Tb+DtdCndcjoFUneUwl2XUdQckqN4nf1SuIJ/BXRbAexlD04fvPJ4wzmwUNg8EQF7BhTWVNDa1RvJz2w==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.4.tgz",
+      "integrity": "sha512-5HBfxggzxGz0dg2c61NpPiQJav7UAmzsQlzmI5SzWOS6lkaylcDG8giwKzASVCXVWBxNji9qIDFM++UH090aDg==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4572,9 +4572,9 @@
       "dev": true
     },
     "node_modules/@storybook/react/node_modules/@types/node": {
-      "version": "22.13.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.5.tgz",
-      "integrity": "sha512-+lTU0PxZXn0Dr1NBtC7Y8cR21AJr87dLLU953CWA6pMxxv/UDc7jYAY90upcrie1nRcD6XNG5HOYEDtgW5TxAg==",
+      "version": "22.13.10",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.13.10.tgz",
+      "integrity": "sha512-I6LPUvlRH+O6VRUqYOcMudhaIdUVWfsjnZavnsraHvpBwaEyMN29ry+0UVJhImYL16xsscu0aske3yA+uPOWfw==",
       "dev": true,
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -4729,9 +4729,9 @@
       "dev": true
     },
     "node_modules/@storybook/theming": {
-      "version": "8.6.0",
-      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.0.tgz",
-      "integrity": "sha512-te7dl0ZXnEyKS4LW+QHc3MP7nurWhWhmClY7G2WKNW9eHenb9zvXkcAQt6c4OWhrJi01CAYoXmZNJP0jEzxRRQ==",
+      "version": "8.6.4",
+      "resolved": "https://registry.npmjs.org/@storybook/theming/-/theming-8.6.4.tgz",
+      "integrity": "sha512-g9Ns4uenC9oAWETaJ/tEKEIPMdS+CqjNWZz5Wbw1bLNhXwADZgKrVqawzZi64+bYYtQ+i8VCTjPoFa6s2eHiDQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -4916,21 +4916,21 @@
       }
     },
     "node_modules/@svgr/core/node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -5047,21 +5047,21 @@
       }
     },
     "node_modules/@svgr/plugin-jsx/node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -5609,9 +5609,9 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-w/P33JFeySuhN6JLkysYUK2gEmy9kHHFN7E8ro0tkfmlDOgxBDzWEZ/J8cWA+fHqFevpswDTFZnDx+R9lbL6xw=="
+      "version": "4.17.16",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.16.tgz",
+      "integrity": "sha512-HX7Em5NYQAXKW+1T+FiuG27NGwzJfCX3s1GjOa7ujxZa52kjJLOr4FUxT+giF6Tgxv1e+/czV/iTtBw27WTU9g=="
     },
     "node_modules/@types/lodash.mergewith": {
       "version": "4.6.7",
@@ -6046,21 +6046,21 @@
       }
     },
     "node_modules/@vitejs/plugin-react/node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -6231,9 +6231,9 @@
       }
     },
     "node_modules/acorn-globals/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -6669,9 +6669,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.10.2",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.2.tgz",
-      "integrity": "sha512-RE3mdQ7P3FRSe7eqCWoeQ/Z9QXrtniSjp1wUjt5nRC3WIpz5rSCve6o3fsZ2aCpJtrZjSZgjwXAoTO5k4tEI0w==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.10.3.tgz",
+      "integrity": "sha512-Xm7bpRXnDSX2YE2YFfBk2FnF0ep6tmG7xPh8iHee8MIcrgq762Nkce856dYtJYLkuIoYZvGfTs/PbZhideTcEg==",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -7015,13 +7015,13 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7048,9 +7048,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001700",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001700.tgz",
-      "integrity": "sha512-2S6XIXwaE7K7erT8dY+kLQcpa5ms63XlRkMkReXjle+kf6c5g38vyMl+Z5y8dSxOFDhcFe+nxnn261PLxBSQsQ==",
+      "version": "1.0.30001704",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001704.tgz",
+      "integrity": "sha512-+L2IgBbV6gXB4ETf0keSvLr7JUrRVbIaB/lrQ1+z8mRcQiisG5k+lG6O4n6Y5q6f5EuNfaYXKgymucphlEXQew==",
       "dev": true,
       "funding": [
         {
@@ -7385,9 +7385,9 @@
       }
     },
     "node_modules/core-js-pure": {
-      "version": "3.40.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.40.0.tgz",
-      "integrity": "sha512-AtDzVIgRrmRKQai62yuSIN5vNiQjcJakJb4fbhVw3ehxx7Lohphvw9SGNWKhLFqSxC4ilD0g/L1huAYFQU3Q6A==",
+      "version": "3.41.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.41.0.tgz",
+      "integrity": "sha512-71Gzp96T9YPk63aUvE5Q5qP+DryB4ZloUZPSOebGM88VNw8VNfvdA7z6kGA8iGOTEzAomsRidp4jXSmUIJsL+Q==",
       "dev": true,
       "hasInstallScript": true,
       "funding": {
@@ -7643,9 +7643,9 @@
       "dev": true
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.0.2.tgz",
-      "integrity": "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.1.0.tgz",
+      "integrity": "sha512-Wy+JTSbFThEOXQIR2L6mxJvEs+veIzpmqD7ynWxMXGpnk3smkHQOp6forLdHsKpAMW9iJpaBBIxz285t1n1C3w==",
       "dev": true,
       "dependencies": {
         "character-entities": "^2.0.0"
@@ -7924,9 +7924,9 @@
       "dev": true
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.104",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.104.tgz",
-      "integrity": "sha512-Us9M2L4cO/zMBqVkJtnj353nQhMju9slHm62NprKTmdF3HH8wYOtNvDFq/JB2+ZRoGLzdvYDiATlMHs98XBM1g==",
+      "version": "1.5.117",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.117.tgz",
+      "integrity": "sha512-G4+CYIJBiQ72N0gi868tmG4WsD8bwLE9XytBdfgXO5zdlTlvOP2ABzWYILYxCIHmsbm2HjBSgm/E/H/QfcnIyQ==",
       "dev": true
     },
     "node_modules/emittery": {
@@ -8857,9 +8857,9 @@
       ]
     },
     "node_modules/fastq": {
-      "version": "1.19.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.0.tgz",
-      "integrity": "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA==",
+      "version": "1.19.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -10343,21 +10343,21 @@
       }
     },
     "node_modules/istanbul-lib-instrument/node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -11219,9 +11219,9 @@
       }
     },
     "node_modules/jsdom/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -12018,9 +12018,9 @@
       }
     },
     "node_modules/micromark": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.1.tgz",
-      "integrity": "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
       "dev": true,
       "funding": [
         {
@@ -12053,9 +12053,9 @@
       }
     },
     "node_modules/micromark-core-commonmark": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.2.tgz",
-      "integrity": "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
       "dev": true,
       "funding": [
         {
@@ -12527,9 +12527,9 @@
       }
     },
     "node_modules/micromark-util-subtokenize": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.0.4.tgz",
-      "integrity": "sha512-N6hXjrin2GTJDe3MVjf5FuXpm12PGm80BrUAeub9XFXca8JZbP+oIwY4LJSVwFUCL1IPm/WwSVUN7goFHmSGGQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
       "dev": true,
       "funding": [
         {
@@ -12565,9 +12565,9 @@
       ]
     },
     "node_modules/micromark-util-types": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.1.tgz",
-      "integrity": "sha512-534m2WhVTddrcKVepwmVEVnUAmtrx9bfIjNoQHRqfnvdaHQiFytEhJoTgpWJvDEXCO5gLTQh3wYC1PgOJA4NSQ==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
       "dev": true,
       "funding": [
         {
@@ -12692,9 +12692,9 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.8.tgz",
-      "integrity": "sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==",
+      "version": "3.3.9",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.9.tgz",
+      "integrity": "sha512-SppoicMGpZvbF1l3z4x7No3OlIjP7QJvC9XR7AhZr1kL133KHnKPztkKDc+Ir4aJ/1VhTySrtKhrsycmrMQfvg==",
       "dev": true,
       "funding": [
         {
@@ -12780,9 +12780,9 @@
       }
     },
     "node_modules/nwsapi": {
-      "version": "2.2.16",
-      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.16.tgz",
-      "integrity": "sha512-F1I/bimDpj3ncaNDhfyMWuFqmQDBwDB0Fogc2qpL3BWvkQteFD/8BzWuIRl83rq0DXfm8SGt/HFhLXZyljTXcQ==",
+      "version": "2.2.18",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.18.tgz",
+      "integrity": "sha512-p1TRH/edngVEHVbwqWnxUViEmq5znDvyB+Sik5cmuLpGOIfDf/39zLiq3swPF8Vakqn+gvNiOQAZu8djYlQILA==",
       "dev": true
     },
     "node_modules/object-assign": {
@@ -13656,21 +13656,21 @@
       }
     },
     "node_modules/react-docgen/node_modules/@babel/core": {
-      "version": "7.26.9",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.9.tgz",
-      "integrity": "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw==",
+      "version": "7.26.10",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
+      "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
       "dev": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.26.2",
-        "@babel/generator": "^7.26.9",
+        "@babel/generator": "^7.26.10",
         "@babel/helper-compilation-targets": "^7.26.5",
         "@babel/helper-module-transforms": "^7.26.0",
-        "@babel/helpers": "^7.26.9",
-        "@babel/parser": "^7.26.9",
+        "@babel/helpers": "^7.26.10",
+        "@babel/parser": "^7.26.10",
         "@babel/template": "^7.26.9",
-        "@babel/traverse": "^7.26.9",
-        "@babel/types": "^7.26.9",
+        "@babel/traverse": "^7.26.10",
+        "@babel/types": "^7.26.10",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.2",
@@ -13958,9 +13958,9 @@
       }
     },
     "node_modules/recast": {
-      "version": "0.23.9",
-      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.9.tgz",
-      "integrity": "sha512-Hx/BGIbwj+Des3+xy5uAtAbdCyqK9y9wbBcDFDYanLS9JnMqf7OeF87HQwUimE87OEc72mr6tkKUKMBBL+hF9Q==",
+      "version": "0.23.11",
+      "resolved": "https://registry.npmjs.org/recast/-/recast-0.23.11.tgz",
+      "integrity": "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==",
       "dev": true,
       "dependencies": {
         "ast-types": "^0.16.1",
@@ -14237,9 +14237,9 @@
       }
     },
     "node_modules/reusify": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
       "dev": true,
       "engines": {
         "iojs": ">=1.0.0",
@@ -15666,9 +15666,9 @@
       }
     },
     "node_modules/unplugin/node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "version": "8.14.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
+      "integrity": "sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -15688,9 +15688,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
-      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
       "dev": true,
       "funding": [
         {
@@ -16416,9 +16416,9 @@
       }
     },
     "node_modules/vite/node_modules/rollup": {
-      "version": "4.34.8",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.8.tgz",
-      "integrity": "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ==",
+      "version": "4.35.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.35.0.tgz",
+      "integrity": "sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==",
       "dev": true,
       "dependencies": {
         "@types/estree": "1.0.6"
@@ -16431,25 +16431,25 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.8",
-        "@rollup/rollup-android-arm64": "4.34.8",
-        "@rollup/rollup-darwin-arm64": "4.34.8",
-        "@rollup/rollup-darwin-x64": "4.34.8",
-        "@rollup/rollup-freebsd-arm64": "4.34.8",
-        "@rollup/rollup-freebsd-x64": "4.34.8",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.8",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.8",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.8",
-        "@rollup/rollup-linux-arm64-musl": "4.34.8",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.8",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.8",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.8",
-        "@rollup/rollup-linux-x64-gnu": "4.34.8",
-        "@rollup/rollup-linux-x64-musl": "4.34.8",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.8",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.8",
-        "@rollup/rollup-win32-x64-msvc": "4.34.8",
+        "@rollup/rollup-android-arm-eabi": "4.35.0",
+        "@rollup/rollup-android-arm64": "4.35.0",
+        "@rollup/rollup-darwin-arm64": "4.35.0",
+        "@rollup/rollup-darwin-x64": "4.35.0",
+        "@rollup/rollup-freebsd-arm64": "4.35.0",
+        "@rollup/rollup-freebsd-x64": "4.35.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.35.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.35.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.35.0",
+        "@rollup/rollup-linux-arm64-musl": "4.35.0",
+        "@rollup/rollup-linux-loongarch64-gnu": "4.35.0",
+        "@rollup/rollup-linux-powerpc64le-gnu": "4.35.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.35.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.35.0",
+        "@rollup/rollup-linux-x64-gnu": "4.35.0",
+        "@rollup/rollup-linux-x64-musl": "4.35.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.35.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.35.0",
+        "@rollup/rollup-win32-x64-msvc": "4.35.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -16623,15 +16623,16 @@
       }
     },
     "node_modules/which-typed-array": {
-      "version": "1.1.18",
-      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.18.tgz",
-      "integrity": "sha512-qEcY+KJYlWyLH9vNbsr6/5j59AXk5ni5aakf8ldzBvGde6Iz4sxZGkJyWSAueTG7QhOvNRYb1lDdFmL5Td0QKA==",
+      "version": "1.1.19",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.19.tgz",
+      "integrity": "sha512-rEvr90Bck4WZt9HHFC4DJMsjvu7x+r6bImz0/BrbWb7A2djJ8hnZMrWnHo9F8ssv0OMErasDhftrfROTyqSDrw==",
       "dev": true,
       "dependencies": {
         "available-typed-arrays": "^1.0.7",
         "call-bind": "^1.0.8",
-        "call-bound": "^1.0.3",
-        "for-each": "^0.3.3",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-tostringtag": "^1.0.2"
       },

--- a/src/components/AccessibilityGuide/HighlightingText.mdx
+++ b/src/components/AccessibilityGuide/HighlightingText.mdx
@@ -24,10 +24,6 @@ implement highlighted text for semantic coding purposes, but it should not be
 used to fulfill WCAG 2.1 criteria as is not announced by most screen reading
 technology in its default configuration.
 
-Resources:
-
-- [The Mark Text element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)
-
 ## NYPL Recommendations
 
 The NYPL Reservoir Design System (DS) provides semantic design tokens for a
@@ -124,3 +120,4 @@ Add a 1px border using a contrast compliant color.
 
 - [WCAG Success Criterion 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)
 - [NYPL Reservoir Design System Color Palette: Highlighter Colors](http://localhost:6006/?path=/docs/style-guide-colors--docs#highlighter-colors)
+- [The Mark Text element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)

--- a/src/components/AccessibilityGuide/HighlightingText.mdx
+++ b/src/components/AccessibilityGuide/HighlightingText.mdx
@@ -18,6 +18,16 @@ Highlighting text in the UI requires more than a color indicator, as WCAG 2.1 AA
 standards stipulate that color should not be used as the only visual means of
 distinguishing a visual element.
 
+The `<mark>` HTML element is intended to represent text which is marked or
+highlighted for reference or notation purposes. The element may be used to
+implement highlighted text for semantic coding purposes, but it should not be
+used to fulfill WCAG 2.1 criteria as is not announced by most screen reading
+technology in its default configuration.
+
+Resources:
+
+- [The Mark Text element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/mark)
+
 ## NYPL Recommendations
 
 The NYPL Reservoir Design System (DS) provides semantic design tokens for a

--- a/src/components/AccessibilityGuide/HighlightingText.mdx
+++ b/src/components/AccessibilityGuide/HighlightingText.mdx
@@ -20,10 +20,13 @@ distinguishing a visual element.
 
 ## NYPL Recommendations
 
-The NYPL Reservoir Design System (DS) provides semantic design tokens for colors
-that can be used for highlighting text, but the full implementation of the
-`highlight` requires the addition of at least one of the following styles to
-meet WCAG 2.1 AA requirements.
+The NYPL Reservoir Design System (DS) provides semantic design tokens for a
+range of colors that can be used for highlighting text. It is recommended to
+use `yellow` to highlight text, but other colors may be used based on the use
+case.
+
+To meet WCAG 2.1 AA requirements, the full implementation of the `highlight`
+requires the addition of at least one of the following styles.
 
 ### Heavier Font Weight
 

--- a/src/components/AccessibilityGuide/HighlightingText.mdx
+++ b/src/components/AccessibilityGuide/HighlightingText.mdx
@@ -1,0 +1,113 @@
+import { Meta, Source } from "@storybook/blocks";
+import { Box } from "@chakra-ui/react";
+import Link from "../Link/Link";
+
+<Meta title="Accessibility Guide/Highlighting Text" />
+
+# Highlighting Text
+
+## Table of Contents
+
+- {<Link href="#general-information" target="_self">General Information</Link>}
+- {<Link href="#nypl-recommendations" target="_self">NYPL Recommendations</Link>}
+- {<Link href="#resources" target="_self">Resources</Link>}
+
+## General Information
+
+Highlighting text in the UI requires more than a color indicator, as WCAG 2.1 AA
+standards stipulate that color should not be used as the only visual means of
+distinguishing a visual element.
+
+## NYPL Recommendations
+
+The NYPL Reservoir Design System (DS) provides semantic design tokens for colors
+that can be used for highlighting text, but the full implementation of the
+`highlight` requires the addition of at least one of the following styles to
+meet WCAG 2.1 AA requirements.
+
+### Heavier Font Weight
+
+Set the font weight to `medium` (500).
+
+#### Examples
+
+{
+
+<p>
+  This{" "}
+  <Box
+    as="mark"
+    __css={{
+      bgColor: "ui.highlighter.yellow",
+      fontWeight: "medium",
+      px: "xxxs",
+    }}
+  >
+    word
+  </Box>{" "}
+  is highlighted with yellow.
+</p>
+}
+{
+
+<p>
+  This{" "}
+  <Box
+    as="mark"
+    __css={{
+      bgColor: "ui.highlighter.blue",
+      fontWeight: "medium",
+      px: "xxxs",
+    }}
+  >
+    word
+  </Box>{" "}
+  is highlighted with blue.
+</p>
+}
+
+### Border
+
+Add a 1px border using a contrast compliant color.
+
+#### Examples
+
+{
+
+<p>
+  This <Box
+    as="mark"
+    __css={{
+      bgColor: "ui.highlighter.yellow",
+      border: "1px solid",
+      borderColor: "ui.gray.semi-dark",
+      px: "xxxs",
+    }}
+  >
+    word
+  </Box> is highlighted with yellow.
+</p>
+}
+{
+
+<p>
+  This{" "}
+  <Box
+    as="mark"
+    __css={{
+      bgColor: "ui.highlighter.blue",
+      border: "1px solid",
+      borderColor: "ui.gray.semi-dark",
+      px: "xxxs",
+    }}
+  >
+    word
+  </Box>{" "}
+  is highlighted with blue.
+</p>
+}
+
+## Resources
+
+- [WCAG Success Criterion 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG21/Understanding/use-of-color.html)
+- [NYPL Reservoir Design System Color Palette: Highlighter Colors](http://localhost:6006/?path=/docs/style-guide-colors--docs#highlighter-colors)

--- a/src/components/AccessibilityGuide/HighlightingText.mdx
+++ b/src/components/AccessibilityGuide/HighlightingText.mdx
@@ -14,15 +14,17 @@ import Link from "../Link/Link";
 
 ## General Information
 
-Highlighting text in the UI requires more than a color indicator, as WCAG 2.1 AA
-standards stipulate that color should not be used as the only visual means of
+The `<mark>` HTML element is intended to represent text which is marked or
+highlighted for reference or notation purposes. The element can be used to
+implement highlighted text for semantic coding purposes.
+
+From a visual perspective, highlighting text in the UI requires more than a just
+a color indicator, as color should not be used as the only visual means of
 distinguishing a visual element.
 
-The `<mark>` HTML element is intended to represent text which is marked or
-highlighted for reference or notation purposes. The element may be used to
-implement highlighted text for semantic coding purposes, but it should not be
-used to fulfill WCAG 2.1 criteria as is not announced by most screen reading
-technology in its default configuration.
+By combining the semantic meaning of the `<mark>` element and layering on an
+additional visual indicator beside color, the highlight will fulfill the
+requirements of both the relevant WCAG 2.1 AA success criteria.
 
 ## NYPL Recommendations
 

--- a/src/components/DevelopmentGuide/DesignTokens.mdx
+++ b/src/components/DevelopmentGuide/DesignTokens.mdx
@@ -264,45 +264,48 @@ For more information about NYPL colors and to view the actual hue, see the
 
 ##### Light Mode
 
-|             | JS Token                            | CSS Token                                         | Value                   |
-| ----------- | :---------------------------------- | :------------------------------------------------ | :---------------------- |
-| **Action**  | ui.disabled.primary                 | --nypl-colors-ui-disabled-primary                 | ui.gray.light-cool      |
-|             | ui.disabled.secondary               | --nypl-colors-ui-disabled-secondary               | ui.gray.xx-light-cool   |
-|             | ui.error.primary                    | --nypl-colors-ui-error-primary                    | #97272C                 |
-|             | ui.error.secondary                  | --nypl-colors-ui-error-secondary                  | #6F0106                 |
-|             | ui.focus                            | --nypl-colors-ui-focus                            | #4181F1                 |
-|             | ui.link.primary                     | --nypl-colors-ui-link-primary                     | #0576D3                 |
-|             | ui.link.primary-05                  | --nypl-colors-ui-link-primary-05                  | rgba(5, 118, 211, 0.05) |
-|             | ui.link.secondary                   | --nypl-colors-ui-link-secondary                   | #004B98                 |
-|             | ui.status.primary                   | --nypl-colors-ui-status-primary                   | #F9E08E                 |
-|             | ui.status.secondary                 | --nypl-colors-ui-status-secondary                 | #FBE7E1                 |
-|             | ui.success.primary                  | --nypl-colors-ui-success-primary                  | #077719                 |
-|             | ui.success.secondary                | --nypl-colors-ui-success-secondary                | #095212                 |
-|             | ui.test                             | --nypl-colors-ui-test                             | #FF6347                 |
-|             | ui.warning.primary                  | --nypl-colors-ui-warning-primary                  | #F88820                 |
-|             | ui.warning.secondary                | --nypl-colors-ui-warning-secondary                | #E36D17                 |
-|             | ui.warning.tertiary                 | --nypl-colors-ui-warning-tertiary                 | #CD4D05                 |
-|             |                                     |                                                   |                         |
-| **Brand**   | brand.primary                       | --nypl-colors-brand-primary                       | #C60917                 |
-|             | brand.secondary                     | --nypl-colors-brand-secondary                     | #760000                 |
-|             |                                     |                                                   |                         |
-| **Section** | section.blogs.primary               | --nypl-colors-section-blogs-primary               | ui.gray.light-cool      |
-|             | section.blogs.secondary             | --nypl-colors-section-blogs-secondary             | ui.gray.medium          |
-|             | section.books-and-more.primary      | --nypl-colors-section-books-and-more-primary      | brand.primary           |
-|             | section.books-and-more.secondary    | --nypl-colors-section-books-and-more-secondary    | brand.secondary         |
-|             | section.books-and-more.secondary    | --nypl-colors-section-connect-primary             | #737373                 |
-|             | section.books-and-more.secondary    | --nypl-colors-section-connect-secondary           | #565656                 |
-|             | section.education.primary           | --nypl-colors-section-education-primary           | #1D62E6                 |
-|             | section.education.secondary         | --nypl-colors-section-education-secondary         | #2540A4                 |
-|             | section.locations.primary           | --nypl-colors-section-locations-primary           | brand.primary           |
-|             | section.locations.secondary         | --nypl-colors-section-locations-secondary         | brand.secondary         |
-|             | section.research.primary            | --nypl-colors-section-research-primary            | #00838A                 |
-|             | section.research.secondary          | --nypl-colors-section-research-secondary          | #006166                 |
-|             | section.research-library-lpa        | --nypl-colors-section-research-library-lpa        | #005D53                 |
-|             | section.research-library-schomburg  | --nypl-colors-section-research-library-schomburh  | #A03E31                 |
-|             | section.research-library-schwarzman | --nypl-colors-section-research-library-schwarzman | brand.secondary         |
-|             | section.whats-on.primary            | --nypl-colors-section-whats-on-primary            | #242424                 |
-|             | section.whats-on.secondary          | --nypl-colors-section-whats-on-secondary          | ui.black                |
+|             | JS Token                            | CSS Token                                         | Value                               |
+| ----------- | :---------------------------------- | :------------------------------------------------ | :---------------------------------- |
+| **Action**  | ui.disabled.primary                 | --nypl-colors-ui-disabled-primary                 | ui.gray.light-cool                  |
+|             | ui.disabled.secondary               | --nypl-colors-ui-disabled-secondary               | ui.gray.xx-light-cool               |
+|             | ui.error.primary                    | --nypl-colors-ui-error-primary                    | primitives.vividBurgundy.DEFAULT \* |
+|             | ui.error.secondary                  | --nypl-colors-ui-error-secondary                  | #6F0106                             |
+|             | ui.focus                            | --nypl-colors-ui-focus                            | primitives.blueberry.DEFAULT        |
+|             | ui.link.primary                     | --nypl-colors-ui-link-primary                     | primitives.scienceBlue.DEFAULT      |
+|             | ui.link.primary-05                  | --nypl-colors-ui-link-primary-05                  | rgba(5, 118, 211, 0.05)             |
+|             | ui.link.secondary                   | --nypl-colors-ui-link-secondary                   | #004B98                             |
+|             | ui.link.tertiary                    | --nypl-colors-ui-link-tertiary                    | primitives.irisPurple.DEFAULT       |
+|             | ui.status.primary                   | --nypl-colors-ui-status-primary                   | primitives.flavescent.DEFAULT       |
+|             | ui.status.secondary                 | --nypl-colors-ui-status-secondary                 | #FBE7E1                             |
+|             | ui.success.primary                  | --nypl-colors-ui-success-primary                  | primitives.treeGreen.DEFAULT        |
+|             | ui.success.secondary                | --nypl-colors-ui-success-secondary                | #095212                             |
+|             | ui.test                             | --nypl-colors-ui-test                             | #FF6347                             |
+|             | ui.warning.primary                  | --nypl-colors-ui-warning-primary                  | primitives.carrotOrange.DEFAULT     |
+|             | ui.warning.secondary                | --nypl-colors-ui-warning-secondary                | #E36D17                             |
+|             | ui.warning.tertiary                 | --nypl-colors-ui-warning-tertiary                 | #CD4D05                             |
+|             |                                     |                                                   |                                     |
+| **Brand**   | brand.primary                       | --nypl-colors-brand-primary                       | primitives.nyplRed.DEFAULT          |
+|             | brand.secondary                     | --nypl-colors-brand-secondary                     | #760000                             |
+|             |                                     |                                                   |                                     |
+| **Section** | section.blogs.primary               | --nypl-colors-section-blogs-primary               | ui.gray.light-cool                  |
+|             | section.blogs.secondary             | --nypl-colors-section-blogs-secondary             | ui.gray.medium                      |
+|             | section.books-and-more.primary      | --nypl-colors-section-books-and-more-primary      | brand.primary                       |
+|             | section.books-and-more.secondary    | --nypl-colors-section-books-and-more-secondary    | brand.secondary                     |
+|             | section.books-and-more.secondary    | --nypl-colors-section-connect-primary             | #737373                             |
+|             | section.books-and-more.secondary    | --nypl-colors-section-connect-secondary           | #565656                             |
+|             | section.education.primary           | --nypl-colors-section-education-primary           | #1D62E6                             |
+|             | section.education.secondary         | --nypl-colors-section-education-secondary         | #2540A4                             |
+|             | section.locations.primary           | --nypl-colors-section-locations-primary           | brand.primary                       |
+|             | section.locations.secondary         | --nypl-colors-section-locations-secondary         | brand.secondary                     |
+|             | section.research.primary            | --nypl-colors-section-research-primary            | #00838A                             |
+|             | section.research.secondary          | --nypl-colors-section-research-secondary          | #006166                             |
+|             | section.research-library-lpa        | --nypl-colors-section-research-library-lpa        | #005D53                             |
+|             | section.research-library-schomburg  | --nypl-colors-section-research-library-schomburh  | #A03E31                             |
+|             | section.research-library-schwarzman | --nypl-colors-section-research-library-schwarzman | brand.secondary                     |
+|             | section.whats-on.primary            | --nypl-colors-section-whats-on-primary            | #242424                             |
+|             | section.whats-on.secondary          | --nypl-colors-section-whats-on-secondary          | ui.black                            |
+
+\* Primitive values are not available as design tokens
 
 ##### Dark Mode
 

--- a/src/components/DevelopmentGuide/DesignTokens.mdx
+++ b/src/components/DevelopmentGuide/DesignTokens.mdx
@@ -352,37 +352,59 @@ The semantic `color` tokens have both light and dark mode values.
 
 ##### Light Mode
 
-|                | JS Token                      | CSS Token                                   | Value                |
-| -------------- | :---------------------------- | :------------------------------------------ | :------------------- |
-| **Background** | ui.bg.page                    | --nypl-colors-ui-bg-page                    | ui.white             |
-|                | ui.bg.default                 | --nypl-colors-ui-bg-default                 | ui.gray.x-light-cool |
-|                | ui.bg.hover                   | --nypl-colors-ui-bg-hover                   | ui.gray.light-cool   |
-|                | ui.bg.active                  | --nypl-colors-ui-bg-active                  | ui.gray.medium       |
-|                |                               |                                             |                      |
-| **Border**     | ui.border.default             | --nypl-colors-ui-border-default             | ui.gray.medium       |
-|                | ui.border.hover               | --nypl-colors-ui-order-hover                | ui.gray.dark         |
-|                |                               |                                             |                      |
-| **Typography** | ui.typography.heading         | --nypl-colors-ui-typography-heading         | ui.black             |
-|                | ui.typography.body            | --nypl-colors-ui-typography-body            | ui.black             |
-|                | ui.inverse.typography.heading | --nypl-colors-ui-inverse-typography-heading | ui.white             |
-|                | ui.inverse.typography.body    | --nypl-colors-ui-inverse-typography-body    | ui.white             |
+|                 | JS Token                      | CSS Token                                   | Value                            |
+| --------------- | :---------------------------- | :------------------------------------------ | :------------------------------- |
+| **Background**  | ui.bg.page                    | --nypl-colors-ui-bg-page                    | ui.white                         |
+|                 | ui.bg.default                 | --nypl-colors-ui-bg-default                 | ui.gray.x-light-cool             |
+|                 | ui.bg.hover                   | --nypl-colors-ui-bg-hover                   | ui.gray.light-cool               |
+|                 | ui.bg.active                  | --nypl-colors-ui-bg-active                  | ui.gray.medium                   |
+|                 |                               |                                             |                                  |
+| **Border**      | ui.border.default             | --nypl-colors-ui-border-default             | ui.gray.medium                   |
+|                 | ui.border.hover               | --nypl-colors-ui-order-hover                | ui.gray.dark                     |
+|                 |                               |                                             |                                  |
+| **Typography**  | ui.typography.heading         | --nypl-colors-ui-typography-heading         | ui.black                         |
+|                 | ui.typography.body            | --nypl-colors-ui-typography-body            | ui.black                         |
+|                 | ui.inverse.typography.heading | --nypl-colors-ui-inverse-typography-heading | ui.white                         |
+|                 | ui.inverse.typography.body    | --nypl-colors-ui-inverse-typography-body    | ui.white                         |
+|                 |                               |                                             |                                  |
+| **Highlighter** | ui.highlighter.red            | --nypl-colors-ui-highlighter-red            | primatives.nyplBrand[100] \*     |
+|                 | ui.highlighter.pink           | --nypl-colors-ui-highlighter-pink           | primatives.fluorescenctPink[100] |
+|                 | ui.highlighter.burgundy       | --nypl-colors-ui-highlighter-burgundy       | primatives.vividBurgundy[100]    |
+|                 | ui.highlighter.orange         | --nypl-colors-ui-highlighter-orange         | primatives.carrotOrange[100]     |
+|                 | ui.highlighter.yellow         | --nypl-colors-ui-highlighter-yellow         | primatives.flavescent[100]       |
+|                 | ui.highlighter.green          | --nypl-colors-ui-highlighter-green          | primatives.treeGreen[100]        |
+|                 | ui.highlighter.blue           | --nypl-colors-ui-highlighter-blue           | primatives.scienceBlue[100]      |
+|                 | ui.highlighter.purple         | --nypl-colors-ui-highlighter-purple         | primatives.irisPurple[100]       |
+
+\* Primitive values are not available as design tokens
 
 ##### Dark Mode
 
-|                | JS Token                           | CSS Token                                        | Value               |
-| -------------- | :--------------------------------- | :----------------------------------------------- | :------------------ |
-| **Background** | dark.ui.bg.page                    | --nypl-colors-dark-ui-bg-page                    | ui.gray.xxxx-dark   |
-|                | dark.ui.bg.default                 | --nypl-colors-dark-ui-bg-default                 | ui.gray.xxx-dark    |
-|                | dark.ui.bg.hover                   | --nypl-colors-dark-ui-bg-hover                   | ui.gray.xx-dark     |
-|                | dark.ui.bg.active                  | --nypl-colors-dark-ui-bg-active                  | ui.gray.x-dark      |
-|                |                                    |                                                  |                     |
-| **Border**     | dark.ui.border.default             | --nypl-colors-dark-ui-border-default             | ui.gray.semi-dark   |
-|                | dark.ui.border.hover               | --nypl-colors-dark-ui-order-hover                | ui.gray.semi-medium |
-|                |                                    |                                                  |                     |
-| **Typography** | dark.ui.typography.heading         | --nypl-colors-dark-ui-typography-heading         | ui.gray.light-cool  |
-|                | dark.ui.typography.body            | --nypl-colors-dark-ui-typography-body            | ui.gray.medium      |
-|                | dark.ui.inverse.typography.heading | --nypl-colors-dark-ui-inverse-typography-heading | ui.gray.xxx-dark    |
-|                | dark.ui.inverse.typography.body    | --nypl-colors-dark-ui-inverse-typography-body    | ui.gray.xxx-dark    |
+|                 | JS Token                           | CSS Token                                        | Value                            |
+| --------------- | :--------------------------------- | :----------------------------------------------- | :------------------------------- |
+| **Background**  | dark.ui.bg.page                    | --nypl-colors-dark-ui-bg-page                    | ui.gray.xxxx-dark                |
+|                 | dark.ui.bg.default                 | --nypl-colors-dark-ui-bg-default                 | ui.gray.xxx-dark                 |
+|                 | dark.ui.bg.hover                   | --nypl-colors-dark-ui-bg-hover                   | ui.gray.xx-dark                  |
+|                 | dark.ui.bg.active                  | --nypl-colors-dark-ui-bg-active                  | ui.gray.x-dark                   |
+|                 |                                    |                                                  |                                  |
+| **Border**      | dark.ui.border.default             | --nypl-colors-dark-ui-border-default             | ui.gray.semi-dark                |
+|                 | dark.ui.border.hover               | --nypl-colors-dark-ui-order-hover                | ui.gray.semi-medium              |
+|                 |                                    |                                                  |                                  |
+| **Typography**  | dark.ui.typography.heading         | --nypl-colors-dark-ui-typography-heading         | ui.gray.light-cool               |
+|                 | dark.ui.typography.body            | --nypl-colors-dark-ui-typography-body            | ui.gray.medium                   |
+|                 | dark.ui.inverse.typography.heading | --nypl-colors-dark-ui-inverse-typography-heading | ui.gray.xxx-dark                 |
+|                 | dark.ui.inverse.typography.body    | --nypl-colors-dark-ui-inverse-typography-body    | ui.gray.xxx-dark                 |
+|                 |                                    |                                                  |                                  |
+| **Highlighter** | dark.ui.highlighter.red            | --nypl-colors-dark-ui-highlighter-red            | primatives.nyplBrand[800] \*     |
+|                 | dark.ui.highlighter.pink           | --nypl-colors-dark-ui-highlighter-pink           | primatives.fluorescenctPink[800] |
+|                 | dark.ui.highlighter.burgundy       | --nypl-colors-dark-ui-highlighter-burgundy       | primatives.vividBurgundy[800]    |
+|                 | dark.ui.highlighter.orange         | --nypl-colors-dark-ui-highlighter-orange         | primatives.carrotOrange[800]     |
+|                 | dark.ui.highlighter.yellow         | --nypl-colors-dark-ui-highlighter-yellow         | primatives.flavescent[800]       |
+|                 | dark.ui.highlighter.green          | --nypl-colors-dark-ui-highlighter-green          | primatives.treeGreen[800]        |
+|                 | dark.ui.highlighter.blue           | --nypl-colors-dark-ui-highlighter-blue           | primatives.scienceBlue[800]      |
+|                 | dark.ui.highlighter.purple         | --nypl-colors-dark-ui-highlighter-purple         | primatives.irisPurple[800]       |
+
+\* Primitive values are not available as design tokens
 
 ### Radii
 

--- a/src/components/StyleGuide/ColorCard.tsx
+++ b/src/components/StyleGuide/ColorCard.tsx
@@ -13,45 +13,37 @@ export const colorContrastData = {
     primary: {
       dataBlackColor: ["3.45", "Fail", "AA"],
       dataWhiteColor: ["6.08", "AA", "AAA"],
-      textColor: "ui.white",
     },
     secondary: {
       dataBlackColor: ["1.77", "Fail", "Fail"],
       dataWhiteColor: ["11.86", "AAA", "AAA"],
-      textColor: "ui.white",
     },
   },
   ui: {
     black: {
       dataBlackColor: ["1.00", "Fail", "Fail"],
       dataWhiteColor: ["21.00", "AAA", "AAA"],
-      textColor: "ui.white",
     },
     gray: {
       xxxxDark: {
         dataBlackColor: checkContrast("1.19"),
         dataWhiteColor: checkContrast("17.58"),
-        textColor: "ui.white",
       },
       xxxDark: {
         dataBlackColor: checkContrast("1.37"),
         dataWhiteColor: checkContrast("15.33"),
-        textColor: "ui.white",
       },
       xxDark: {
         dataBlackColor: checkContrast("1.55"),
         dataWhiteColor: checkContrast("13.58"),
-        textColor: "ui.white",
       },
       xDark: {
         dataBlackColor: checkContrast("2.09"),
         dataWhiteColor: checkContrast("10.05"),
-        textColor: "ui.white",
       },
       dark: {
         dataBlackColor: checkContrast("3.39"),
         dataWhiteColor: checkContrast("6.19"),
-        textColor: "ui.white",
       },
       semiDark: {
         dataBlackColor: checkContrast("6.33"),
@@ -121,13 +113,11 @@ export const colorCardsData = {
       name: "brand.primary",
       dataBlackColor: colorContrastData.brand.primary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.primary.dataWhiteColor,
-      textColor: colorContrastData.brand.primary.textColor,
     },
     {
       name: "brand.secondary",
       dataBlackColor: colorContrastData.brand.secondary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.secondary.dataWhiteColor,
-      textColor: colorContrastData.brand.secondary.textColor,
     },
   ],
   blogs: [
@@ -152,14 +142,12 @@ export const colorCardsData = {
       name: "section.books-and-more.primary",
       dataBlackColor: colorContrastData.brand.primary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.primary.dataWhiteColor,
-      textColor: colorContrastData.brand.primary.textColor,
     },
     {
       colorSource: "brand.secondary",
       name: "section.books-and-more.secondary",
       dataBlackColor: colorContrastData.brand.secondary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.secondary.dataWhiteColor,
-      textColor: colorContrastData.brand.secondary.textColor,
     },
   ],
   connect: [
@@ -167,13 +155,11 @@ export const colorCardsData = {
       name: "section.connect.primary",
       dataBlackColor: checkContrast(4.43),
       dataWhiteColor: checkContrast(4.74),
-      textColor: "ui.white",
     },
     {
       name: "section.connect.secondary",
       dataBlackColor: checkContrast(2.86),
       dataWhiteColor: checkContrast(7.34),
-      textColor: "ui.white",
     },
   ],
   education: [
@@ -181,13 +167,11 @@ export const colorCardsData = {
       name: "section.education.primary",
       dataBlackColor: ["3.94", "Fail", "AA"],
       dataWhiteColor: ["5.33", "AA", "AAA"],
-      textColor: "ui.white",
     },
     {
       name: "section.education.secondary",
       dataBlackColor: ["2.35", "Fail", "Fail"],
       dataWhiteColor: ["8.94", "AAA", "AAA"],
-      textColor: "ui.white",
     },
   ],
   locations: [
@@ -196,14 +180,12 @@ export const colorCardsData = {
       name: "section.locations.primary",
       dataBlackColor: colorContrastData.brand.primary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.primary.dataWhiteColor,
-      textColor: colorContrastData.brand.primary.textColor,
     },
     {
       colorSource: "brand.secondary",
       name: "section.locations.secondary",
       dataBlackColor: colorContrastData.brand.secondary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.secondary.dataWhiteColor,
-      textColor: colorContrastData.brand.secondary.textColor,
     },
   ],
   research: [
@@ -211,13 +193,11 @@ export const colorCardsData = {
       name: "section.research.primary",
       dataBlackColor: ["4.16", "AA", "AAA"],
       dataWhiteColor: ["4.44", "AA", "AAA"],
-      textColor: "ui.white",
     },
     {
       name: "section.research.secondary",
       dataBlackColor: ["2.90", "Fail", "Fail"],
       dataWhiteColor: ["7.24", "AAA", "AAA"],
-      textColor: "ui.white",
     },
   ],
   researchLibraries: [
@@ -225,20 +205,17 @@ export const colorCardsData = {
       name: "section.research-library.lpa",
       dataBlackColor: ["2.69", "Fail", "Fail"],
       dataWhiteColor: ["7.80", "AAA", "AAA"],
-      textColor: "ui.white",
     },
     {
       name: "section.research-library.schomburg",
       dataBlackColor: ["3.23", "Fail", "AA"],
       dataWhiteColor: ["6.51", "AA", "AAA"],
-      textColor: "ui.white",
     },
     {
       colorSource: "brand.secondary",
       name: "section.research-library.schwarzman",
       dataBlackColor: colorContrastData.brand.secondary.dataBlackColor,
       dataWhiteColor: colorContrastData.brand.secondary.dataWhiteColor,
-      textColor: colorContrastData.brand.secondary.textColor,
     },
   ],
   whatsOn: [
@@ -246,14 +223,12 @@ export const colorCardsData = {
       name: "section.whats-on.primary",
       dataBlackColor: ["1.35", "Fail", "Fail"],
       dataWhiteColor: ["15.52", "AAA", "AAA"],
-      textColor: "ui.white",
     },
     {
       colorSource: "ui.black",
       name: "section.whats-on.secondary",
       dataBlackColor: colorContrastData.ui.black.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.black.dataWhiteColor,
-      textColor: colorContrastData.ui.black.textColor,
     },
   ],
   ui: [
@@ -294,7 +269,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.dark.dataWhiteColor,
       dataBgPageColor: ["6.19", "AA", "AAA"],
       dataBgDefaultColor: ["5.68", "AA", "AAA"],
-      textColor: colorContrastData.ui.gray.dark.textColor,
     },
     {
       colorSource: "ui.gray.light-cool",
@@ -320,7 +294,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(7.95),
       dataBgPageColor: checkContrast(7.95),
       dataBgDefaultColor: checkContrast(7.29),
-      textColor: "ui.white",
     },
     {
       name: "ui.error.secondary",
@@ -328,7 +301,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(12.48),
       dataBgPageColor: checkContrast(12.48),
       dataBgDefaultColor: checkContrast(11.45),
-      textColor: "ui.white",
     },
     {
       name: "ui.focus",
@@ -344,7 +316,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(4.63),
       dataBgPageColor: checkContrast(4.63),
       dataBgDefaultColor: checkContrast(4.24),
-      textColor: "ui.white",
     },
     {
       name: "ui.link.secondary",
@@ -352,7 +323,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(8.54),
       dataBgPageColor: checkContrast(8.54),
       dataBgDefaultColor: checkContrast(7.83),
-      textColor: "ui.white",
     },
     {
       name: "ui.link.tertiary",
@@ -360,7 +330,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(11.01),
       dataBgPageColor: checkContrast(11.01),
       dataBgDefaultColor: checkContrast(10.1),
-      textColor: "ui.white",
     },
     // Colors that use transparency are tough to talk about when it comes to
     // color combinations and color contrast. For now, we will just use question
@@ -406,7 +375,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(5.73),
       dataBgPageColor: checkContrast(5.73),
       dataBgDefaultColor: checkContrast(5.26),
-      textColor: "ui.white",
     },
     {
       name: "ui.success.secondary",
@@ -414,7 +382,6 @@ export const colorCardsData = {
       dataWhiteColor: checkContrast(9.43),
       dataBgPageColor: checkContrast(9.43),
       dataBgDefaultColor: checkContrast(8.65),
-      textColor: "ui.white",
     },
     {
       name: "ui.test",
@@ -433,7 +400,6 @@ export const colorCardsData = {
       dataBrandSecondaryColor: checkContrast(1.77),
       dataBgPageColor: colorContrastData.ui.black.dataWhiteColor,
       dataBgDefaultColor: checkContrast(19.26),
-      textColor: colorContrastData.ui.black.textColor,
     },
     {
       colorSource: "ui.gray.xx-dark",
@@ -444,7 +410,6 @@ export const colorCardsData = {
       dataBrandSecondaryColor: checkContrast(1.77),
       dataBgPageColor: colorContrastData.ui.black.dataWhiteColor,
       dataBgDefaultColor: checkContrast(19.26),
-      textColor: colorContrastData.ui.black.textColor,
     },
     {
       colorSource: "ui.white",
@@ -500,7 +465,6 @@ export const colorCardsData = {
       name: "ui.black",
       dataBlackColor: colorContrastData.ui.black.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.black.dataWhiteColor,
-      textColor: colorContrastData.ui.black.textColor,
     },
     {
       name: "ui.white",
@@ -514,31 +478,26 @@ export const colorCardsData = {
       name: "ui.gray.xxxx-dark",
       dataBlackColor: colorContrastData.ui.gray.xxxxDark.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.gray.xxxxDark.dataWhiteColor,
-      textColor: colorContrastData.ui.gray.xxxxDark.textColor,
     },
     {
       name: "ui.gray.xxx-dark",
       dataBlackColor: colorContrastData.ui.gray.xxxDark.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.gray.xxxDark.dataWhiteColor,
-      textColor: colorContrastData.ui.gray.xxxDark.textColor,
     },
     {
       name: "ui.gray.xx-dark",
       dataBlackColor: colorContrastData.ui.gray.xxDark.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.gray.xxDark.dataWhiteColor,
-      textColor: colorContrastData.ui.gray.xxDark.textColor,
     },
     {
       name: "ui.gray.x-dark",
       dataBlackColor: colorContrastData.ui.gray.xDark.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.gray.xDark.dataWhiteColor,
-      textColor: colorContrastData.ui.gray.xDark.textColor,
     },
     {
       name: "ui.gray.dark",
       dataBlackColor: colorContrastData.ui.gray.dark.dataBlackColor,
       dataWhiteColor: colorContrastData.ui.gray.dark.dataWhiteColor,
-      textColor: colorContrastData.ui.gray.dark.textColor,
     },
     {
       name: "ui.gray.semi-dark",
@@ -648,7 +607,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.xxxxDark.dataWhiteColor,
       dataHeadingColor: ["15.43", "AAA", "AAA"],
       dataBodyColor: ["9.97", "AAA", "AAA"],
-      textColor: colorContrastData.ui.gray.xxxxDark.textColor,
     },
     {
       colorSource: "ui.gray.xxx-dark",
@@ -657,7 +615,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.xxxDark.dataWhiteColor,
       dataHeadingColor: ["14.48", "AAA", "AAA"],
       dataBodyColor: ["9.36", "AAA", "AAA"],
-      textColor: colorContrastData.ui.gray.xxxDark.textColor,
     },
     {
       colorSource: "ui.gray.xx-dark",
@@ -666,7 +623,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.xxDark.dataWhiteColor,
       dataHeadingColor: colorContrastData.dark.ui.gray.xxDark.dataHeadingColor,
       dataBodyColor: colorContrastData.dark.ui.gray.xxDark.dataBodyColor,
-      textColor: colorContrastData.ui.gray.xxDark.textColor,
     },
     {
       colorSource: "ui.gray.x-dark",
@@ -675,7 +631,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.xDark.dataWhiteColor,
       dataHeadingColor: colorContrastData.dark.ui.gray.xDark.dataHeadingColor,
       dataBodyColor: colorContrastData.dark.ui.gray.xDark.dataBodyColor,
-      textColor: colorContrastData.ui.gray.xDark.textColor,
     },
     {
       colorSource: "ui.gray.semi-dark",
@@ -702,7 +657,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.dark.dataWhiteColor,
       dataDarkBgPageColor: checkContrast("1.86"),
       dataDarkBgDefaultColor: checkContrast("1.75"),
-      textColor: colorContrastData.ui.gray.dark.textColor,
     },
     {
       colorSource: "ui.gray.x-dark",
@@ -711,7 +665,6 @@ export const colorCardsData = {
       dataWhiteColor: colorContrastData.ui.gray.xDark.dataWhiteColor,
       dataDarkBgPageColor: checkContrast("1.16"),
       dataDarkBgDefaultColor: checkContrast("1.09"),
-      textColor: colorContrastData.ui.gray.xDark.textColor,
     },
     {
       name: "dark.ui.error.primary",
@@ -770,7 +723,6 @@ export const colorCardsData = {
       dataWhiteColor: ["?", "?", "?"],
       dataDarkBgPageColor: ["?", "?", "?"],
       dataDarkBgDefaultColor: ["?", "?", "?"],
-      textColor: "ui.white",
     },
     // Colors that use transparency are tough to talk about when it comes to
     // color combinations and color contrast. For now, we will just use question
@@ -781,7 +733,6 @@ export const colorCardsData = {
       dataWhiteColor: ["?", "?", "?"],
       dataDarkBgPageColor: ["?", "?", "?"],
       dataDarkBgDefaultColor: ["?", "?", "?"],
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.status.primary",
@@ -823,7 +774,6 @@ export const colorCardsData = {
       dataWhiteColor: ["11.71", "AAA", "AAA"],
       dataHeadingColor: ["9.64", "AAA", "AAA"],
       dataBodyColor: ["6.23", "AA", "AAA"],
-      textColor: "ui.white",
     },
     {
       colorSource: "ui.gray.light-cool",
@@ -856,7 +806,6 @@ export const colorCardsData = {
       dataBrandSecondaryColor: checkContrast(1.36),
       dataDarkBgPageColor: checkContrast(1.16),
       dataDarkBgDefaultColor: checkContrast(1.09),
-      textColor: "ui.white",
     },
     {
       colorSource: "ui.gray.xxDark",
@@ -867,7 +816,6 @@ export const colorCardsData = {
       dataBrandSecondaryColor: checkContrast(1.36),
       dataDarkBgPageColor: checkContrast(1.16),
       dataDarkBgDefaultColor: checkContrast(1.09),
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.warning.primary",
@@ -890,37 +838,30 @@ export const colorCardsData = {
     {
       name: "dark.ui.highlighter.red",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.highlighter.burgundy",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.highlighter.orange",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.highlighter.yellow",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.highlighter.green",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.highlighter.blue",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
     {
       name: "dark.ui.highlighter.purple",
       showColorDataTable: false,
-      textColor: "ui.white",
     },
   ],
 };
@@ -967,13 +908,9 @@ export const makeColorCard = function (data) {
   return card;
 };
 export const getColorCards = (category: string) => {
-  const cards = [];
   const catArr = colorCardsData[category];
-  catArr.map((color: any) => {
-    const colorData = color;
-    const card = makeColorCard(colorData);
-    cards.push(card);
-  });
+  const cards =
+    catArr?.length < 0 ? [] : catArr.map((color: any) => makeColorCard(color));
   return cards;
 };
 

--- a/src/components/StyleGuide/ColorCard.tsx
+++ b/src/components/StyleGuide/ColorCard.tsx
@@ -6,6 +6,7 @@ import Icon, { IconColors } from "../Icons/Icon";
 import Table from "../Table/Table";
 import Text from "../Text/Text";
 import { checkContrast } from "../../utils/colorUtils";
+import { primitives } from "../../theme/foundations/colors";
 
 export const colorContrastData = {
   brand: {
@@ -593,8 +594,6 @@ export const colorCardsData = {
   highlighter: [
     {
       name: "ui.highlighter.red",
-      // dataBlackColor: colorContrastData.ui.gray.lightWarm.dataBlackColor,
-      // dataWhiteColor: colorContrastData.ui.gray.lightWarm.dataWhiteColor,
       showColorDataTable: false,
       textColor: "ui.black",
     },
@@ -967,17 +966,14 @@ export const makeColorCard = function (data) {
   );
   return card;
 };
-export const getColorCards = (category) => {
+export const getColorCards = (category: string) => {
   const cards = [];
   const catArr = colorCardsData[category];
-  if (category === "researchLibraries") {
-    console.log(catArr);
-  }
-  for (let i = 0; i < catArr.length; i++) {
-    const colorData = catArr[i];
+  catArr.map((color: any) => {
+    const colorData = color;
     const card = makeColorCard(colorData);
     cards.push(card);
-  }
+  });
   return cards;
 };
 
@@ -1059,6 +1055,35 @@ export interface ColorCardProps extends DataTableProps {
   showColorDataTable: boolean;
   /** Details on how a color should be used. */
   notes?: string;
+}
+
+export const colorNamesArray = [
+  "nyplRed",
+  "fluorescentPink",
+  "vividBurgundy",
+  "carrotOrange",
+  "flavescent",
+  "treeGreen",
+  "scienceBlue",
+  "blueberry",
+  "irisPurple",
+] as const;
+export type ColorNames = typeof colorNamesArray[number];
+
+export interface ColorBoxProps {
+  /** The backgroundColor of the color card. */
+  backgroundColor: string;
+  /** The name of a color's javascript theme object. */
+  colorName: ColorNames;
+  /** The name of a color's javascript theme object. */
+  colorOption: string;
+  /** The color to use for text in the color card. */
+  textColor?: IconColors;
+}
+
+export interface ColorScaleProps {
+  /** The name of a color's javascript theme object. */
+  colorName: ColorNames;
 }
 
 export const DataTable = (props: PropsWithChildren<DataTableProps>) => {
@@ -1360,6 +1385,78 @@ export const DataTable = (props: PropsWithChildren<DataTableProps>) => {
       tableData={tableData}
       useRowHeaders
     />
+  );
+};
+
+export const ColorBox = (props: ColorBoxProps) => {
+  const { backgroundColor, colorOption, textColor = "ui.black" } = props;
+  return (
+    <Box
+      alignItems="top"
+      bg={backgroundColor}
+      color={textColor}
+      display="flex"
+      flexDirection="column"
+      fontSize="10px !important"
+      fontWeight="bold"
+      h="100px"
+      justifyContent="space-between"
+    >
+      <Box
+        bg="dark.ui.bg.default"
+        borderBottom="1px solid white"
+        display="flex"
+        h="fit-content"
+        justifyContent="center"
+        px="xxs"
+        width="100%"
+      >
+        {colorOption}
+      </Box>
+      <Box
+        bg="dark.ui.bg.default"
+        borderTop="1px solid white"
+        display="flex"
+        h="fit-content"
+        justifyContent="center"
+        px="xxs"
+        width="100%"
+      >
+        {backgroundColor}
+      </Box>
+    </Box>
+  );
+};
+export const ColorScale = (props: ColorScaleProps) => {
+  const { colorName } = props;
+  const colorOptionsArray = [
+    "DEFAULT",
+    "25",
+    "50",
+    "100",
+    "200",
+    "300",
+    "400",
+    "500",
+    "600",
+    "700",
+    "800",
+    "900",
+    "950",
+  ];
+  const boxes = colorOptionsArray.map((colorOption) => (
+    <ColorBox
+      backgroundColor={primitives[colorName][colorOption]}
+      colorName={colorName}
+      colorOption={colorOption}
+      key={`${colorName}-${colorOption}`}
+      textColor="ui.white"
+    />
+  ));
+  return (
+    <Box display="grid" gap="1px" gridTemplateColumns="repeat(13, 1fr)">
+      {boxes}
+    </Box>
   );
 };
 

--- a/src/components/StyleGuide/ColorCard.tsx
+++ b/src/components/StyleGuide/ColorCard.tsx
@@ -114,7 +114,7 @@ export const colorContrastData = {
     },
   },
 };
-export const cssVars = {
+export const colorCardsData = {
   brand: [
     {
       name: "brand.primary",
@@ -590,6 +590,57 @@ export const cssVars = {
       textColor: colorContrastData.ui.gray.xLightWarm.textColor,
     },
   ],
+  highlighter: [
+    {
+      name: "ui.highlighter.red",
+      // dataBlackColor: colorContrastData.ui.gray.lightWarm.dataBlackColor,
+      // dataWhiteColor: colorContrastData.ui.gray.lightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+    {
+      name: "ui.highlighter.burgundy",
+      dataBlackColor: colorContrastData.ui.gray.xLightWarm.dataBlackColor,
+      dataWhiteColor: colorContrastData.ui.gray.xLightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+    {
+      name: "ui.highlighter.orange",
+      dataBlackColor: colorContrastData.ui.gray.xLightWarm.dataBlackColor,
+      dataWhiteColor: colorContrastData.ui.gray.xLightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+    {
+      name: "ui.highlighter.yellow",
+      dataBlackColor: colorContrastData.ui.gray.xLightWarm.dataBlackColor,
+      dataWhiteColor: colorContrastData.ui.gray.xLightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+    {
+      name: "ui.highlighter.green",
+      dataBlackColor: colorContrastData.ui.gray.xLightWarm.dataBlackColor,
+      dataWhiteColor: colorContrastData.ui.gray.xLightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+    {
+      name: "ui.highlighter.blue",
+      dataBlackColor: colorContrastData.ui.gray.xLightWarm.dataBlackColor,
+      dataWhiteColor: colorContrastData.ui.gray.xLightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+    {
+      name: "ui.highlighter.purple",
+      dataBlackColor: colorContrastData.ui.gray.xLightWarm.dataBlackColor,
+      dataWhiteColor: colorContrastData.ui.gray.xLightWarm.dataWhiteColor,
+      showColorDataTable: false,
+      textColor: "ui.black",
+    },
+  ],
   dark: [
     {
       colorSource: "ui.gray.xxxx-dark",
@@ -836,6 +887,43 @@ export const cssVars = {
       textColor: "ui.black",
     },
   ],
+  darkHighlighter: [
+    {
+      name: "dark.ui.highlighter.red",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+    {
+      name: "dark.ui.highlighter.burgundy",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+    {
+      name: "dark.ui.highlighter.orange",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+    {
+      name: "dark.ui.highlighter.yellow",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+    {
+      name: "dark.ui.highlighter.green",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+    {
+      name: "dark.ui.highlighter.blue",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+    {
+      name: "dark.ui.highlighter.purple",
+      showColorDataTable: false,
+      textColor: "ui.white",
+    },
+  ],
 };
 
 export const makeColorCard = function (data) {
@@ -853,6 +941,7 @@ export const makeColorCard = function (data) {
     dataBodyColor,
     name,
     notes,
+    showColorDataTable,
     textColor,
   } = data;
   const card = (
@@ -871,6 +960,7 @@ export const makeColorCard = function (data) {
       dataBrandPrimaryColor={dataBrandPrimaryColor}
       dataBrandSecondaryColor={dataBrandSecondaryColor}
       notes={notes}
+      showColorDataTable={showColorDataTable}
       textColor={textColor}
       key={name}
     />
@@ -879,7 +969,7 @@ export const makeColorCard = function (data) {
 };
 export const getColorCards = (category) => {
   const cards = [];
-  const catArr = cssVars[category];
+  const catArr = colorCardsData[category];
   if (category === "researchLibraries") {
     console.log(catArr);
   }
@@ -965,6 +1055,8 @@ export interface ColorCardProps extends DataTableProps {
   colorName: string;
   /** The name of the color that the current color is based on. */
   colorSource: string;
+  /** Show or hide the data table */
+  showColorDataTable: boolean;
   /** Details on how a color should be used. */
   notes?: string;
 }
@@ -1287,6 +1379,7 @@ export const ColorCard = (props: PropsWithChildren<ColorCardProps>) => {
     dataBrandPrimaryColor,
     dataBrandSecondaryColor,
     notes,
+    showColorDataTable = true,
     textColor = "ui.white",
   } = props;
   const cssVarName = `--nypl-colors-${colorName.replace(/\./g, "-")}`;
@@ -1351,19 +1444,21 @@ export const ColorCard = (props: PropsWithChildren<ColorCardProps>) => {
             </Text>
           )}
         </Box>
-        <DataTable
-          dataBgPageColor={dataBgPageColor}
-          dataBgDefaultColor={dataBgDefaultColor}
-          dataDarkBgPageColor={dataDarkBgPageColor}
-          dataDarkBgDefaultColor={dataDarkBgDefaultColor}
-          dataBlackColor={dataBlackColor}
-          dataDarkHeadingColor={dataDarkHeadingColor}
-          dataDarkBodyColor={dataDarkBodyColor}
-          dataWhiteColor={dataWhiteColor}
-          dataBrandPrimaryColor={dataBrandPrimaryColor}
-          dataBrandSecondaryColor={dataBrandSecondaryColor}
-          textColor={textColor}
-        />
+        {showColorDataTable && (
+          <DataTable
+            dataBgPageColor={dataBgPageColor}
+            dataBgDefaultColor={dataBgDefaultColor}
+            dataDarkBgPageColor={dataDarkBgPageColor}
+            dataDarkBgDefaultColor={dataDarkBgDefaultColor}
+            dataBlackColor={dataBlackColor}
+            dataDarkHeadingColor={dataDarkHeadingColor}
+            dataDarkBodyColor={dataDarkBodyColor}
+            dataWhiteColor={dataWhiteColor}
+            dataBrandPrimaryColor={dataBrandPrimaryColor}
+            dataBrandSecondaryColor={dataBrandSecondaryColor}
+            textColor={textColor}
+          />
+        )}
       </HStack>
     </Box>
   );

--- a/src/components/StyleGuide/Colors.mdx
+++ b/src/components/StyleGuide/Colors.mdx
@@ -54,9 +54,9 @@ contrast values and WCAG status.
 
 ## Primitives
 
-The primitive colors and the related colors scales were reverse engineered using
+The primitive colors and the related color scales were reverse engineered using
 the legacy semantic color palette. Because of that, the primitive colors are not
-used extensively throughout the semantic color assignments.
+used extensively throughout the semantic color values.
 
 <Banner
   content={

--- a/src/components/StyleGuide/Colors.mdx
+++ b/src/components/StyleGuide/Colors.mdx
@@ -20,7 +20,10 @@ import { getColorCards } from "./ColorCard";
 - {<Link href="#ui-colors" target="_self">UI Colors</Link>}
   - {<Link href="#semantic-colors" target="_self">Semantic Colors</Link>}
   - {<Link href="#grayscale-colors" target="_self">Grayscale Colors</Link>}
-- {<Link href="#dark-mode-ui-colors" target="_self">Dark Mode UI Colors</Link>}
+  - {<Link href="#highlighter-colors" target="_self">Highlighter Colors</Link>}
+- {<Link href="#dark-mode" target="_self">Dark Mode</Link>}
+  - {<Link href="#dark-mode-ui-colors" target="_self">UI Colors</Link>}
+  - {<Link href="#dark-mode-highlighter-colors" target="_self">Highlighter Colors</Link>}
 - {<Link href="#figma-reference" target="_self">Figma Reference</Link>}
 
 ## Overview
@@ -248,7 +251,26 @@ and coding.
   </SimpleGrid>
 </Box>
 
-## Dark Mode UI Colors
+### Highlighter Colors
+
+The `highlighter` colors should be used to highlight text which is of special
+interest, comparable to using a highlighter pen.
+
+<Box
+  border="1px"
+  borderColor="ui.border.default"
+  borderRadius="5px"
+  mb="m"
+  p="s"
+>
+  <SimpleGrid columns={1} gap="s">
+    {getColorCards("highlighter")}
+  </SimpleGrid>
+</Box>
+
+## Dark Mode
+
+### Dark Mode UI Colors
 
 The following "dark mode" color fills are used for body copy and to communicate
 component and/or application state in dark mode.
@@ -264,6 +286,24 @@ These colors are not connected to the NYPL brand, but are intended to be generic
 >
   <SimpleGrid columns={1} gap="s" bg="dark.ui.bg.page" p="m">
     {getColorCards("dark")}
+  </SimpleGrid>
+</Box>
+
+### Dark Mode Highlighter Colors
+
+The dark mode `highlighter` colors should be used in a dark mode situation to
+highlight text which is of special interest, comparable to using a highlighter
+pen.
+
+<Box
+  border="1px"
+  borderColor="ui.border.default"
+  borderRadius="5px"
+  mb="m"
+  p="s"
+>
+  <SimpleGrid columns={1} gap="s" bg="dark.ui.bg.page" p="m">
+    {getColorCards("darkHighlighter")}
   </SimpleGrid>
 </Box>
 

--- a/src/components/StyleGuide/Colors.mdx
+++ b/src/components/StyleGuide/Colors.mdx
@@ -1,11 +1,13 @@
 import { Box } from "@chakra-ui/react";
 import { Meta } from "@storybook/blocks";
 
+import Banner from "../Banner/Banner";
 import Heading from "../Heading/Heading";
 import Link from "../Link/Link";
 import SimpleGrid from "../Grid/SimpleGrid";
 import Text from "../Text/Text";
-import { getColorCards } from "./ColorCard";
+import { getColorCards, ColorBox, ColorScale } from "./ColorCard";
+import { primitives } from "../../theme/foundations/colors";
 
 <Meta title="Style Guide/Colors" />
 
@@ -14,6 +16,7 @@ import { getColorCards } from "./ColorCard";
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}
+- {<Link href="#primitives" target="_self">Primitives</Link>}
 - {<Link href="#brand-colors" target="_self">Brand Colors</Link>}
   - {<Link href="#nypl-brand-colors" target="_self">NYPL Brand Colors</Link>}
   - {<Link href="#nypl-section-colors" target="_self">NYPL Section Colors</Link>}
@@ -48,6 +51,59 @@ NOTE: There are a handful of colors that are semi-transpararent. Colors that use
 transparency are tough to talk about when it comes to color combinations and
 color contrast. That being the case, we have used question marks for the
 contrast values and WCAG status.
+
+## Primitives
+
+The primitive colors and the related colors scales were reverse engineered using
+the legacy semantic color palette. Because of that, the primitive colors are not
+used extensively throughout the semantic color assignments.
+
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> Primitive color values are not available to
+      consuming apps.
+    </>
+  }
+  mb="s"
+  type="warning"
+/>
+
+### NYPL red
+
+{<ColorScale colorName="nyplRed" />}
+
+### Fluorescent pink
+
+{<ColorScale colorName="fluorescentPink" />}
+
+### Vivid burgundy (error)
+
+{<ColorScale colorName="vividBurgundy" />}
+
+### Carrot orange (warning)
+
+{<ColorScale colorName="carrotOrange" />}
+
+### Flavescent (status)
+
+{<ColorScale colorName="flavescent" />}
+
+### Tree green (success)
+
+{<ColorScale colorName="treeGreen" />}
+
+### Science blue (link)
+
+{<ColorScale colorName="scienceBlue" />}
+
+### Blueberry (focus)
+
+{<ColorScale colorName="blueberry" />}
+
+### Iris purple (link tertiary)
+
+{<ColorScale colorName="irisPurple" />}
 
 ## Brand Colors
 

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -22,7 +22,7 @@ import { hexToRGB } from "../../utils/utils";
 
 /** Reusable variables: */
 // Primitives
-const primivites = {
+export const primitives = {
   nyplRed: {
     DEFAULT: "#C60917",
     "25": "#FCF3F3",
@@ -175,16 +175,16 @@ const grayLightCool = "#E9E9E9";
 const grayxLightCool = "#F5F5F5";
 const grayxxLightCool = "#FAFAFA";
 // semantic
-const errorPrimary = primivites.nyplRed.DEFAULT;
+const errorPrimary = primitives.nyplRed.DEFAULT;
 const errorSecondary = "#6F0106";
-const linkPrimary = primivites.scienceBlue.DEFAULT;
+const linkPrimary = primitives.scienceBlue.DEFAULT;
 const linkSecondary = "#004B98";
-const linkTertiary = primivites.irisPurple.DEFAULT;
-const statusPrimary = primivites.flavescent.DEFAULT;
+const linkTertiary = primitives.irisPurple.DEFAULT;
+const statusPrimary = primitives.flavescent.DEFAULT;
 const statusSecondary = "#FBE7E1";
-const successPrimary = primivites.treeGreen.DEFAULT;
+const successPrimary = primitives.treeGreen.DEFAULT;
 const successSecondary = "#095212";
-const warningPrimary = primivites.carrotOrange.DEFAULT;
+const warningPrimary = primitives.carrotOrange.DEFAULT;
 const warningSecondary = "#E36D17";
 const warningTertiary = "#CD4D05";
 const errorPrimaryDark = "#E1767B";
@@ -199,7 +199,7 @@ const successSecondaryDark = "#81C88A";
 const warningPrimaryDark = "#DC8034";
 const warningSecondaryDark = "#EC7B1F";
 // brand
-const brandPrimary = primivites.nyplRed.DEFAULT;
+const brandPrimary = primitives.nyplRed.DEFAULT;
 const brandSecondary = "#760000";
 const blogsPrimary = grayLightCool;
 const blogsSecondary = grayMedium;
@@ -362,16 +362,16 @@ const colors: Colors = {
       "primary-10": hexToRGB(errorPrimary, 0.1),
       secondary: errorSecondary,
     },
-    focus: primivites.blueberry.DEFAULT,
+    focus: primitives.blueberry.DEFAULT,
     highlighter: {
-      red: primivites.nyplRed[100],
-      pink: primivites.fluorescentPink[100],
-      burgundy: primivites.vividBurgundy[100],
-      orange: primivites.carrotOrange[100],
-      yellow: primivites.flavescent[100],
-      green: primivites.treeGreen[100],
-      blue: primivites.scienceBlue[100],
-      purple: primivites.irisPurple[100],
+      red: primitives.nyplRed[100],
+      pink: primitives.fluorescentPink[100],
+      burgundy: primitives.vividBurgundy[100],
+      orange: primitives.carrotOrange[100],
+      yellow: primitives.flavescent[100],
+      green: primitives.treeGreen[100],
+      blue: primitives.scienceBlue[100],
+      purple: primitives.irisPurple[100],
     },
     link: {
       primary: linkPrimary,
@@ -466,14 +466,14 @@ const colors: Colors = {
       },
       focus: "#6090E3",
       highlighter: {
-        red: primivites.nyplRed[800],
-        pink: primivites.fluorescentPink[800],
-        burgundy: primivites.vividBurgundy[800],
-        orange: primivites.carrotOrange[800],
-        yellow: primivites.flavescent[800],
-        green: primivites.treeGreen[800],
-        blue: primivites.scienceBlue[800],
-        purple: primivites.irisPurple[800],
+        red: primitives.nyplRed[800],
+        pink: primitives.fluorescentPink[800],
+        burgundy: primitives.vividBurgundy[800],
+        orange: primitives.carrotOrange[800],
+        yellow: primitives.flavescent[800],
+        green: primitives.treeGreen[800],
+        blue: primitives.scienceBlue[800],
+        purple: primitives.irisPurple[800],
       },
       link: {
         primary: linkPrimaryDark,

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -21,6 +21,145 @@ import { hexToRGB } from "../../utils/utils";
  */
 
 /** Reusable variables: */
+// Primitives
+const primivites = {
+  nyplRed: {
+    DEFAULT: "#C60917",
+    "25": "#FCF3F3",
+    "50": "#F9E6E8",
+    "100": "#F4CED1",
+    "200": "#E89DA2",
+    "300": "#DD6B74",
+    "400": "#D13A45",
+    "500": "#C60917",
+    "600": "#A20410",
+    "700": "#7C000A",
+    "800": "#540005",
+    "900": "#2B0002",
+    "950": "#160001",
+  },
+  fluorescentPink: {
+    DEFAULT: "#FF389C",
+    "25": "#FFF5FA",
+    "50": "#FFE8F4",
+    "100": "#FFCFE7",
+    "200": "#FF9DCE",
+    "300": "#FF6AB5",
+    "400": "#FF389C",
+    "500": "#D52C83",
+    "600": "#AC2169",
+    "700": "#82174F",
+    "800": "#580E36",
+    "900": "#2E071C",
+    "950": "#1A0410",
+  },
+  vividBurgundy: {
+    DEFAULT: "#97272C",
+    "25": "#FAF4F4",
+    "50": "#F6EBEC",
+    "100": "#EDD9DA",
+    "200": "#DCB6B7",
+    "300": "#CB9295",
+    "400": "#B96E72",
+    "500": "#A84B4F",
+    "600": "#97272C",
+    "700": "#731B1F",
+    "800": "#4D1013",
+    "900": "#250708",
+    "950": "#100303",
+  },
+  carrotOrange: {
+    DEFAULT: "#F88820",
+    "25": "#FFF9F4",
+    "50": "#FEF2E6",
+    "100": "#FDE2CA",
+    "200": "#FCC491",
+    "300": "#FAA659",
+    "400": "#F88820",
+    "500": "#D37218",
+    "600": "#AC5B10",
+    "700": "#82450A",
+    "800": "#582F06",
+    "900": "#2E1902",
+    "950": "#1A0E01",
+  },
+  flavescent: {
+    DEFAULT: "#F9E08E",
+    "25": "#FFFEF9",
+    "50": "#FEF9EA",
+    "100": "#FCF1CB",
+    "200": "#F9E08E",
+    "300": "#DCC67C",
+    "400": "#BFAB6A",
+    "500": "#A29158",
+    "600": "#847647",
+    "700": "#665B36",
+    "800": "#474025",
+    "900": "#292515",
+    "950": "#1A170D",
+  },
+  treeGreen: {
+    DEFAULT: "#077719",
+    "25": "#F3F8F4",
+    "50": "#E6F1E8",
+    "100": "#CDE4D1",
+    "200": "#9CC9A3",
+    "300": "#6AAD75",
+    "400": "#399247",
+    "500": "#077719",
+    "600": "#046113",
+    "700": "#014A0D",
+    "800": "#003308",
+    "900": "#001A04",
+    "950": "#000D02",
+  },
+  scienceBlue: {
+    DEFAULT: "#0069BF",
+    "25": "#F2F8FC",
+    "50": "#E6F0F9",
+    "100": "#CCE1F2",
+    "200": "#99C3E5",
+    "300": "#66A5D9",
+    "400": "#3387CC",
+    "500": "#0069BF",
+    "600": "#00549C",
+    "700": "#004078",
+    "800": "#002B52",
+    "900": "#00152A",
+    "950": "#000B15",
+  },
+  blueberry: {
+    DEFAULT: "#4181F1",
+    "25": "#F6F9FE",
+    "50": "#ECF2FE",
+    "100": "#D9E6FC",
+    "200": "#B3CDF9",
+    "300": "#8DB3F7",
+    "400": "#679AF4",
+    "500": "#4181F1",
+    "600": "#3166C4",
+    "700": "#224C95",
+    "800": "#153265",
+    "900": "#0A1933",
+    "950": "#050C1A",
+  },
+  irisPurple: {
+    DEFAULT: "#551A8B",
+    "25": "#F7F4F9",
+    "50": "#F0EAF4",
+    "100": "#E1D7EB",
+    "200": "#C5B1D8",
+    "300": "#A98CC5",
+    "400": "#8D66B1",
+    "500": "#71409E",
+    "600": "#551A8B",
+    "700": "#3F116A",
+    "800": "#290A47",
+    "900": "#140422",
+    "950": "#09020F",
+  },
+};
+
 // grayscale
 const black = "#000";
 const white = "#fff";
@@ -36,16 +175,16 @@ const grayLightCool = "#E9E9E9";
 const grayxLightCool = "#F5F5F5";
 const grayxxLightCool = "#FAFAFA";
 // semantic
-const errorPrimary = "#97272C";
+const errorPrimary = primivites.nyplRed.DEFAULT;
 const errorSecondary = "#6F0106";
-const linkPrimary = "#0069BF";
+const linkPrimary = primivites.scienceBlue.DEFAULT;
 const linkSecondary = "#004B98";
-const linkTertiary = "#551A8B";
-const statusPrimary = "#F9E08E";
+const linkTertiary = primivites.irisPurple.DEFAULT;
+const statusPrimary = primivites.flavescent.DEFAULT;
 const statusSecondary = "#FBE7E1";
-const successPrimary = "#077719";
+const successPrimary = primivites.treeGreen.DEFAULT;
 const successSecondary = "#095212";
-const warningPrimary = "#F88820";
+const warningPrimary = primivites.carrotOrange.DEFAULT;
 const warningSecondary = "#E36D17";
 const warningTertiary = "#CD4D05";
 const errorPrimaryDark = "#E1767B";
@@ -60,7 +199,7 @@ const successSecondaryDark = "#81C88A";
 const warningPrimaryDark = "#DC8034";
 const warningSecondaryDark = "#EC7B1F";
 // brand
-const brandPrimary = "#C60917";
+const brandPrimary = primivites.nyplRed.DEFAULT;
 const brandSecondary = "#760000";
 const blogsPrimary = grayLightCool;
 const blogsSecondary = grayMedium;
@@ -223,7 +362,17 @@ const colors: Colors = {
       "primary-10": hexToRGB(errorPrimary, 0.1),
       secondary: errorSecondary,
     },
-    focus: "#4181F1",
+    focus: primivites.blueberry.DEFAULT,
+    highlighter: {
+      red: primivites.nyplRed[100],
+      pink: primivites.fluorescentPink[100],
+      burgundy: primivites.vividBurgundy[100],
+      orange: primivites.carrotOrange[100],
+      yellow: primivites.flavescent[100],
+      green: primivites.treeGreen[100],
+      blue: primivites.scienceBlue[100],
+      purple: primivites.irisPurple[100],
+    },
     link: {
       primary: linkPrimary,
       "primary-05": hexToRGB(linkPrimary, 0.05),
@@ -316,6 +465,16 @@ const colors: Colors = {
         secondary: errorSecondaryDark,
       },
       focus: "#6090E3",
+      highlighter: {
+        red: primivites.nyplRed[800],
+        pink: primivites.fluorescentPink[800],
+        burgundy: primivites.vividBurgundy[800],
+        orange: primivites.carrotOrange[800],
+        yellow: primivites.flavescent[800],
+        green: primivites.treeGreen[800],
+        blue: primivites.scienceBlue[800],
+        purple: primivites.irisPurple[800],
+      },
       link: {
         primary: linkPrimaryDark,
         "primary-05": hexToRGB(linkPrimaryDark, 0.05),


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2011](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2011)

## This PR does the following:

- Adds the `primitives` color object.
- Adds the `highlighter` colors to the `colors` theme object.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2011]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ