### PR TITLE
DSD-2007: replacing errors thrown with console.warn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `viewport` preview options in Storybook to align with the Reservoir breakpoints.
 - Updates the Storybook font styles.
 - Updates the docs for the `Template` component.
+- Replaces the error thrown with a console.warn for the `Breadcrumbs`, `Heading`, and `Image` components.
 
 ## Prerelease
 
@@ -34,7 +35,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Card`, `FeaturedContent`, and `SearchBar` components to use container queries.
 - Updated the `"filter"` variant of `TagSet` to remove tag button wrapper when `isDismissible` and `onClick` are false.
 - Updates `Image` to include 'fourByOne' and 'twoByThree' aspect ratio options.
-
 
 ## 3.5.4 (February 13, 2025)
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as BreadcrumbsStories from "./Breadcrumbs.stories";
-import { changelogData } from "./breadcrumbsChangelogData";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./breadcrumbsChangelogData";
 
 <Meta of={BreadcrumbsStories} />
 
-# Breadcrumbs
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="Breadcrumbs"
+  summary="Navigational component that displays the current page's location within a hierarchy of pages."
+  versionAdded="0.0.3"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.0.3`      |
-| Latest            | `Prerelease` |
+<Canvas of={BreadcrumbsStories.WithControls} />
 
 ## Table of Contents
 
@@ -42,8 +46,6 @@ const breadcrumbsData = [
 />
 
 ## Component Props
-
-<Canvas of={BreadcrumbsStories.WithControls} />
 
 <ArgTypes of={BreadcrumbsStories.WithControls} />
 

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Breadcrumbs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.3`    |
-| Latest            | `3.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.3`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.test.tsx
@@ -76,8 +76,11 @@ describe("Breadcrumbs", () => {
     expect(container.querySelector(".breadcrumbs-icon")).toBeInTheDocument();
   });
 
-  it("Throws error when nothing is passed into Breadcrumb", () => {
-    expect(() => render(<Breadcrumbs breadcrumbsData={[]} />)).toThrowError(
+  it("logs a warning when nothing is passed into Breadcrumb", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(<Breadcrumbs breadcrumbsData={[]} />);
+
+    expect(warn).toHaveBeenCalledWith(
       "NYPL Reservoir Breadcrumbs: No data was passed to the `breadcrumbsData` prop."
     );
   });

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -155,7 +155,7 @@ export const Breadcrumbs: ChakraComponent<
     } = props;
 
     if (!breadcrumbsData || breadcrumbsData.length === 0) {
-      throw new Error(
+      console.warn(
         "NYPL Reservoir Breadcrumbs: No data was passed to the `breadcrumbsData` prop."
       );
     }

--- a/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
+++ b/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Replaces the error thrown with a console.warn."],
+  },
+  {
     date: "2025-01-30",
     version: "3.5.3",
     type: "Update",

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./headingChangelogData";
 | Component Version | DS Version |
 | ----------------- | ---------- |
 | Added             | `0.0.4`    |
-| Latest            | `3.5.3`    |
+| Latest            | `Prelease` |
 
 ## Table of Contents
 

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import * as HeadingStories from "./Heading.stories";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import { changelogData } from "./headingChangelogData";
 
 <Meta of={HeadingStories} />
 
-# Heading
+<ComponentDocsHeader
+  category="Typography & styles component"
+  componentName="Heading"
+  summary="Component that renders a standard HTML heading element with DS styles."
+  versionAdded="0.0.4"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `Prelease` |
+<Canvas of={HeadingStories.WithControls} />
 
 ## Table of Contents
 
@@ -36,8 +40,6 @@ text can be passed in through a `text` prop or as a child. Default styles for
 semantic elements can be overwritten using the `size` prop.
 
 ## Component Props
-
-<Canvas of={HeadingStories.WithControls} />
 
 <ArgTypes of={HeadingStories.WithControls} />
 

--- a/src/components/Heading/Heading.test.tsx
+++ b/src/components/Heading/Heading.test.tsx
@@ -95,21 +95,25 @@ describe("Heading", () => {
     );
   });
 
-  it("throws error when neither child nor text is passed", () => {
-    expect(() => render(<Heading id="h1" level="h1" />)).toThrow(
+  it("logs a warning when neither child nor text is passed", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(<Heading id="h1" level="h1" />);
+    expect(warn).toHaveBeenCalledWith(
       "NYPL Reservoir Heading: No children or value was passed to the `text` prop."
     );
   });
 
-  it("throws error when heading with many children is passed", () => {
-    expect(() =>
-      render(
-        <Heading id="h1" level="h4">
-          <span>too</span>
-          <span>many</span>
-        </Heading>
-      )
-    ).toThrow("NYPL Reservoir Heading: Only pass one child into Heading.");
+  it("logs a warning when heading with many children is passed", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      <Heading id="h1" level="h4">
+        <span>too</span>
+        <span>many</span>
+      </Heading>
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Heading: Only pass one child into Heading."
+    );
   });
 
   it("uses custom display size", () => {

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -138,14 +138,14 @@ export const Heading: ChakraComponent<
       const asHeading: any = finalLevel;
 
       if (!props.children && !text) {
-        throw new Error(
+        console.warn(
           "NYPL Reservoir Heading: No children or value was passed to the `text` prop."
         );
       }
 
       if (React.Children.count(props.children) > 1) {
         // Catching the error because React's error isn't as helpful.
-        throw new Error(
+        console.warn(
           "NYPL Reservoir Heading: Only pass one child into Heading."
         );
       }

--- a/src/components/Heading/headingChangelogData.ts
+++ b/src/components/Heading/headingChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Replaces the error thrown with a console.warn."],
+  },
+  {
     date: "2025-01-30",
     version: "3.5.3",
     type: "Update",

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -1,19 +1,23 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import Banner from "../Banner/Banner";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import * as ImageStories from "./Image.stories";
 import Link from "../Link/Link";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import { changelogData } from "./imageChangelogData";
 
 <Meta of={ImageStories} />
 
-# Image
+<ComponentDocsHeader
+  category="Media & icon component"
+  componentName="Image"
+  summary="Component that renders an image with DS styles."
+  versionAdded="0.0.6"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.0.6`      |
-| Latest            | `Prerelease` |
+<Canvas of={ImageStories.WithControls} />
 
 ## Table of Contents
 
@@ -37,8 +41,6 @@ If you want a simple HTML `img` element then don't pass in values for the
 `aspectRatio` or `size` props.
 
 ## Component Props
-
-<Canvas of={ImageStories.WithControls} />
 
 <ArgTypes of={ImageStories.WithControls} />
 

--- a/src/components/Image/Image.test.tsx
+++ b/src/components/Image/Image.test.tsx
@@ -93,10 +93,10 @@ describe("Image", () => {
     expect(screen.getByText("credit")).toBeInTheDocument();
   });
 
-  it("throws error when alt text is too long", () => {
-    expect(() =>
-      render(<Image src="test.png" alt={tooManyChars} />)
-    ).toThrowError(
+  it("logs an error when alt text is too long", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(<Image src="test.png" alt={tooManyChars} />);
+    expect(warn).toHaveBeenCalledWith(
       "NYPL Reservoir Image: Alt text must be less than 300 characters."
     );
   });

--- a/src/components/Image/Image.tsx
+++ b/src/components/Image/Image.tsx
@@ -202,7 +202,7 @@ export const Image: ChakraComponent<
     let srcProp = isLazy ? {} : { src };
 
     if (alt && alt.length > 300) {
-      throw new Error(
+      console.warn(
         "NYPL Reservoir Image: Alt text must be less than 300 characters."
       );
     }

--- a/src/components/Image/imageChangelogData.ts
+++ b/src/components/Image/imageChangelogData.ts
@@ -14,7 +14,10 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Styles", "Functionality"],
-    notes: ["Adds 'fourByOne' and 'twoByThree' aspect ratios."],
+    notes: [
+      "Adds 'fourByOne' and 'twoByThree' aspect ratios.",
+      "Replaces the error thrown with a console.warn.",
+    ],
   },
   {
     date: "2025-01-16",

--- a/src/components/Template/Template.mdx
+++ b/src/components/Template/Template.mdx
@@ -1,6 +1,5 @@
+import { Box } from "@chakra-ui/react";
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import { changelogData } from "./templateChangelogData";
 
 import * as TemplateStories from "./Template.stories";
 import {
@@ -13,7 +12,6 @@ import {
   TemplateBottom,
 } from "./Template";
 import Banner from "../Banner/Banner";
-import { Box } from "@chakra-ui/react";
 import Heading from "../Heading/Heading";
 import Image from "../Image/Image";
 import Link from "../Link/Link";
@@ -30,9 +28,11 @@ import templateSidebarLeft from "/template/templateSidebarLeft.png";
 import templateSidebarRight from "/template/templateSidebarRight.png";
 import templateTop from "/template/templateTop.png";
 import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
-import ComponentVersionTable from "../../utils/components/ComponentVersionTable";
 import DocsWithImage from "../../utils/components/DocsWithImage";
 import { exampleWrapperStyles } from "../../utils/utils.ts";
+
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import { changelogData } from "./templateChangelogData";
 
 <Meta of={TemplateStories} />
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2007](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2007)

## This PR does the following:

- Replaces the errors thrown with console.warn for the `Breadcrumbs`, `Heading`, and `Image` components.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Storybook and tests.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2007]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ