### PR TITLE
DSD-1946: ProgressIndicator label margin updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `ProgressIndicator` component's label margin to be consistent with VDL.
+
 ### Fixes
 
 - Fixes `Accordion` styles, including padding and active hover state, and double-border issue.

--- a/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # ProgressIndicator
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.25.4`   |
-| Latest            | `3.4.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.25.4`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/ProgressIndicator/ProgressIndicator.tsx
+++ b/src/components/ProgressIndicator/ProgressIndicator.tsx
@@ -140,7 +140,7 @@ export const ProgressIndicator: ChakraComponent<
       return (
         <>
           {showLabel && (
-            <Label id={`${id}-label`} htmlFor={id}>
+            <Label id={`${id}-label`} htmlFor={id} mb="xxs">
               {labelText}
             </Label>
           )}

--- a/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ProgressIndicator Renders the UI snapshot correctly 1`] = `
   className="css-1xdhyk6"
 >
   <label
-    className="css-1xdhyk6"
+    className="css-e3ddnr"
     htmlFor="linearBasic"
     id="linearBasic-label"
   >
@@ -173,7 +173,7 @@ exports[`ProgressIndicator Renders the UI snapshot correctly 5`] = `
   className="css-1xdhyk6"
 >
   <label
-    className="css-1xdhyk6"
+    className="css-e3ddnr"
     htmlFor="linearIndeterminate"
     id="linearIndeterminate-label"
   >
@@ -256,7 +256,7 @@ exports[`ProgressIndicator Renders the UI snapshot correctly 7`] = `
   className="css-10g9ftz"
 >
   <label
-    className="css-1xdhyk6"
+    className="css-e3ddnr"
     htmlFor="chakra"
     id="chakra-label"
   >
@@ -299,7 +299,7 @@ exports[`ProgressIndicator Renders the UI snapshot correctly 8`] = `
   data-testid="props"
 >
   <label
-    className="css-1xdhyk6"
+    className="css-e3ddnr"
     htmlFor="props"
     id="props-label"
   >

--- a/src/components/ProgressIndicator/progressIndicatorChangelogData.ts
+++ b/src/components/ProgressIndicator/progressIndicatorChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Margin style updates to sync with VDL."],
+  },
+  {
     date: "2024-10-24",
     version: "3.4.1",
     type: "Update",

--- a/src/theme/components/progressIndicator.ts
+++ b/src/theme/components/progressIndicator.ts
@@ -49,6 +49,7 @@ const getCircularContainerFlexDir = (labelPlacement) => {
 const ProgressIndicator = defineMultiStyleConfig({
   baseStyle: definePartsStyle(
     ({ darkMode, size, labelPlacement }: ProgressIndicatorBaseStyle) => {
+      const circularLabelMargin = size === "default" ? "xs" : "xxs";
       return {
         color: darkMode
           ? "dark.ui.typography.heading"
@@ -85,10 +86,10 @@ const ProgressIndicator = defineMultiStyleConfig({
           width: "fit-content",
         },
         circularLabel: {
-          marginBottom: labelPlacement === "top" ? "xxs" : 0,
-          marginLeft: labelPlacement === "right" ? "xxs" : 0,
-          marginRight: labelPlacement === "left" ? "xxs" : 0,
-          marginTop: labelPlacement === "bottom" ? "xxs" : 0,
+          marginBottom: labelPlacement === "top" ? circularLabelMargin : 0,
+          marginLeft: labelPlacement === "right" ? circularLabelMargin : 0,
+          marginRight: labelPlacement === "left" ? circularLabelMargin : 0,
+          marginTop: labelPlacement === "bottom" ? circularLabelMargin : 0,
           fontSize:
             size === "default"
               ? "desktop.label.label1"


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1946](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1946)

## This PR does the following:

- Updates the label's margin styles for various scenarios in the ticket.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1946]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1946?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ