### PR TITLE
DSD-1916: `Button` height sync with VDL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the `Notification` component's styles to sync with its VDL.
 - Updates the `ProgressIndicator` component's label margin to be consistent with VDL.
+- Updates the `Button`'s height values to sync with its VDL.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates the `Notification` component's styles to sync with its VDL.
 - Updates the `ProgressIndicator` component's label margin to be consistent with VDL.
-- Updates the `Button`'s height values to sync with its VDL.
+- Updates the `Button`'s height for each size option to align with VDL.
 
 ### Fixes
 

--- a/src/components/Button/Button.mdx
+++ b/src/components/Button/Button.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Button
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.0.4`    |
-| Latest            | `3.2.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.0.4`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Button/buttonChangelogData.ts
+++ b/src/components/Button/buttonChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Explicitly assigns the height value for each size option to align with VDL.",
+    ],
+  },
+  {
     date: "2024-07-25",
     version: "3.2.0",
     type: "Update",

--- a/src/components/DevelopmentGuide/DesignTokens.mdx
+++ b/src/components/DevelopmentGuide/DesignTokens.mdx
@@ -432,7 +432,7 @@ The `radii` design tokens can be used for the `borderRadius` (js) and
 
 ### Sizes
 
-The `sizes` design tokens can be used for the `height` attributes.
+The `sizes` design tokens can be used for the `height` (css/js) attribute.
 
 |            | JS Token              | CSS Token                          | Value |
 | ---------- | :-------------------- | :--------------------------------- | :---- |

--- a/src/components/DevelopmentGuide/DesignTokens.mdx
+++ b/src/components/DevelopmentGuide/DesignTokens.mdx
@@ -209,6 +209,7 @@ The DS design tokens are broken into the following categories:
 - {<Link href="#breakpoints" target="_self">Breakpoints</Link>}
 - {<Link href="#color" target="_self">Color</Link>}
 - {<Link href="#radii" target="_self">Radii</Link>}
+- {<Link href="#sizes" target="_self">Sizes</Link>}
 - {<Link href="#space" target="_self">Space</Link>}
 - {<Link href="#typography" target="_self">Typography</Link>}
 
@@ -428,6 +429,17 @@ The `radii` design tokens can be used for the `borderRadius` (js) and
 | **Pill**          | pill           | --nypl-radii-pill           | 20px   |
 |                   |                |                             |        |
 | **Round**         | round          | --nypl-radii-round          | 100%   |
+
+### Sizes
+
+The `sizes` design tokens can be used for the `height` attributes.
+
+|            | JS Token              | CSS Token                          | Value |
+| ---------- | :-------------------- | :--------------------------------- | :---- |
+| **Button** | button.default.height | --nypl-sizes-button-default-height | 40px  |
+|            | button.small.height   | --nypl-sizes-button-small-height   | 26px  |
+|            | button.medium.height  | --nypl-sizes-button-medium-height  | 40px  |
+|            | button.large.height   | --nypl-sizes-button-large-height   | 56px  |
 
 ### Space
 

--- a/src/hooks/__tests__/useNYPLTheme.test.tsx
+++ b/src/hooks/__tests__/useNYPLTheme.test.tsx
@@ -29,6 +29,7 @@ describe("useNYPLTheme", () => {
       "fontWeights",
       "fonts",
       "radii",
+      "sizes",
       "space",
     ]);
     expect(colorsKeys).toEqual([

--- a/src/hooks/useNYPLTheme.ts
+++ b/src/hooks/useNYPLTheme.ts
@@ -97,6 +97,7 @@ function useNYPLTheme() {
       heading: theme.fonts.heading,
     },
     radii: theme.radii,
+    sizes: theme.sizes,
     space: {
       xxs: theme.space.xxs,
       xs: theme.space.xs,

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -69,13 +69,13 @@ const generalSizeValues = (size = "medium", isPill = false) => {
   const sizes = {
     small: {
       fontSize: "desktop.button.small",
-      height: isPill ? "fit-content" : "26px",
+      height: isPill ? "fit-content" : "button.small.height",
       px: isPill ? "s" : "button.small.px",
       py: isPill ? "xxxs" : "button.small.py",
     },
     medium: {
       fontSize: "desktop.button.default",
-      height: isPill ? "fit-content" : "10",
+      height: isPill ? "fit-content" : "button.medium.height",
       minHeight: isPill
         ? "auto"
         : { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
@@ -84,7 +84,7 @@ const generalSizeValues = (size = "medium", isPill = false) => {
     },
     large: {
       fontSize: "desktop.button.large",
-      height: isPill ? "fit-content" : "56px",
+      height: isPill ? "fit-content" : "button.large.height",
       px: isPill ? "l" : "button.large.px",
       py: isPill ? "xxs" : "button.large.py",
     },

--- a/src/theme/components/button.ts
+++ b/src/theme/components/button.ts
@@ -69,14 +69,13 @@ const generalSizeValues = (size = "medium", isPill = false) => {
   const sizes = {
     small: {
       fontSize: "desktop.button.small",
-      height: "fit-content",
-      minHeight: "auto",
+      height: isPill ? "fit-content" : "26px",
       px: isPill ? "s" : "button.small.px",
       py: isPill ? "xxxs" : "button.small.py",
     },
     medium: {
       fontSize: "desktop.button.default",
-      height: isPill ? "fit-content" : undefined,
+      height: isPill ? "fit-content" : "10",
       minHeight: isPill
         ? "auto"
         : { base: defaultElementSizes.mobileFieldHeight, md: "auto" },
@@ -85,8 +84,7 @@ const generalSizeValues = (size = "medium", isPill = false) => {
     },
     large: {
       fontSize: "desktop.button.large",
-      height: "fit-content",
-      minHeight: "auto",
+      height: isPill ? "fit-content" : "56px",
       px: isPill ? "l" : "button.large.px",
       py: isPill ? "xxs" : "button.large.py",
     },

--- a/src/theme/foundations/sizes.ts
+++ b/src/theme/foundations/sizes.ts
@@ -1,0 +1,17 @@
+const sizes = {
+  button: {
+    default: {
+      height: "40px",
+    },
+    small: {
+      height: "26px",
+    },
+    medium: {
+      height: "40px",
+    },
+    large: {
+      height: "56px",
+    },
+  },
+};
+export default sizes;

--- a/src/theme/index.ts
+++ b/src/theme/index.ts
@@ -4,6 +4,7 @@ import breakpoints from "./foundations/breakpoints";
 import colors from "./foundations/colors";
 import radii from "./foundations/radii";
 import shadows from "./foundations/shadows";
+import sizes from "./foundations/sizes";
 import { spacing } from "./foundations/spacing";
 import typography from "./foundations/typography";
 /** Component styles */
@@ -100,6 +101,7 @@ const theme: any = {
   breakpoints,
   colors,
   radii,
+  sizes,
   shadows,
   space: spacing,
   ...typography,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1916](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1916)

## This PR does the following:

- Assigns each `Button` variant a height value to align with VDL (except `pill` buttons which still fit content)
- Creates `sizes` design tokens which so far only are used for button height

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

The ticket mentions adding these as tokens– does that mean each of the 3 button height values should be added as a design token separate from the button sizes?

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1916]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1916?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ