### PR TITLE
DSD-2027: TagSet overflow bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Fixes
 
 - Fixes `Accordion` styles, including padding and active hover state, and double-border issue.
+- Fixes an overflow bug in the `filter` variant of the `TagSet` component when `isDismissible` is false.
 
 ## 3.5.5 (March 20, 2025)
 

--- a/src/components/TagSet/TagSet.mdx
+++ b/src/components/TagSet/TagSet.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./tagSetChangelogData";
 
 # TagSet
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `3.5.5`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
@@ -113,6 +113,12 @@ Notes:
   `{ label: "Clear Filters", id: "clear-filters" }`
 - When `isDismissible` is false, the tags will not render as buttons, since they
   have no `onClick`. In this case, they should be used as a static list of keywords.
+
+### Dismissible
+
+<Canvas of={TagSetStories.FilterVariantDismiss} />
+
+### Not dismissible
 
 <Canvas of={TagSetStories.FilterVariant} />
 

--- a/src/components/TagSet/TagSet.stories.tsx
+++ b/src/components/TagSet/TagSet.stories.tsx
@@ -124,7 +124,7 @@ const FilterVariantStory = () => {
 
   return (
     <TagSet
-      id="tagSet-id-filter"
+      id="tagSet-id-filter-dismissible"
       isDismissible
       onClick={handleOnClick}
       tagSetData={tagSetData}
@@ -133,8 +133,17 @@ const FilterVariantStory = () => {
   );
 };
 
-export const FilterVariant: Story = {
+export const FilterVariantDismiss: Story = {
   render: (_args) => <FilterVariantStory />,
+};
+export const FilterVariant: Story = {
+  render: (_args) => (
+    <TagSet
+      id="tagSet-id-filter"
+      tagSetData={defaultTagSetData}
+      type="filter"
+    />
+  ),
 };
 
 // The following are additional TagSet example Stories.

--- a/src/components/TagSet/TagSetFilter.tsx
+++ b/src/components/TagSet/TagSetFilter.tsx
@@ -119,7 +119,7 @@ export const TagSetFilter: React.FC<TagSetFilterProps> = chakra(
                     />
                   ) : null}
 
-                  {tagSet.label}
+                  <span>{tagSet.label}</span>
                 </Box>
               )}
             </TooltipWrapper>

--- a/src/components/TagSet/tagSetChangelogData.ts
+++ b/src/components/TagSet/tagSetChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: [
+      "Fixes an overflow bug in the `filter` variant when `isDismissible` is false.",
+    ],
+  },
+  {
     date: "2025-03-20",
     version: "3.5.5",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket DSD[-2027](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2027)

## This PR does the following:

- Fixes an overflow bug in the `filter` variant of the `TagSet` component when `isDismissible` is false.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
