### PR TITLE
DSD-2013: Multiselect visibility of item count zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `ProgressIndicator` component's label margin to be consistent with the VDL.
 - Updates the `"dl"` variant of the `List` component to use `2rem` for column spacing and to set the width of the `term` columnm to be a full `"250px"` for `tablet` and `desktop` viewports.
 - Updates the `TagSet` component to sync the border color styles with the VDL.
+- Updates the `MultiSelect` component to now allow 0 to be rendered for `itemCount`.
 
 ### Fixes
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -470,6 +470,8 @@ by passing the `itemCount` data property to the `items` prop.
   type="recommendation"
 />
 
+<Canvas of={MultiSelectStories.itemCountListItems} />
+
 <Source
   code={`
 <MultiSelect
@@ -525,8 +527,6 @@ by passing the `itemCount` data property to the `items` prop.
 `}
   language="jsx"
 />
-
-<Canvas of={MultiSelectStories.itemCountListItems} />
 
 ## Block Element or Float
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -1,5 +1,6 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
+import Banner from "../Banner/Banner";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as MultiSelectStories from "./MultiSelect.stories";
 import Link from "../Link/Link";
@@ -24,7 +25,7 @@ import { changelogData } from "./multiSelectChangelogData";
 - {<Link href="#nested-list-items" target="_self">Nested List Items</Link>}
 - {<Link href="#disabled-list-items" target="_self">Disabled List Items</Link>}
 - {<Link href="#search-input-field" target="_self">Search Input Field</Link>}
-- {<Link href="#show-item-count" target="_self">Show Item Count</Link>}
+- {<Link href="#item-count" target="_self">Item Count</Link>}
 - {<Link href="#block-element-or-float" target="_self">Block Element or Float</Link>}
 - {<Link href="#width" target="_self">Width</Link>}
 - {<Link href="#default-open-state" target="_self">Default Open State</Link>}
@@ -183,7 +184,15 @@ will be visible when the list is first opened. The default value is `5`.
 When there are nested list items, only the parent items will be considered when
 counting the items to display.
 
-**IMPORTANT:** This prop can only be used with `listOverflow="expand"`.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> This prop can only be used with{" "}
+      <code>listOverflow="expand"</code>.
+    </>
+  }
+  type="informative"
+/>
 
 <Canvas of={MultiSelectStories.visibleListItems} />
 
@@ -444,11 +453,22 @@ the component to allow users to search the available checkbox items.
   language="jsx"
 />
 
-## Show Item Count
+## Item Count
 
 The recommended UX pattern for filtering is to include an item count associated
 with each option in a `MultiSelect` component. The item counts can be rendered
 by passing the `itemCount` data property to the `items` prop.
+
+<Banner
+  content={
+    <>
+      <strong>RECOMMENDATION:</strong> When the <code>itemCount</code> data
+      property is set as 0, the <code>isDisabled</code> data property should be
+      used to disable the option.
+    </>
+  }
+  type="recommendation"
+/>
 
 <Source
   code={`
@@ -468,29 +488,27 @@ by passing the `itemCount` data property to the `items` prop.
           itemCount: 20,
         },
         {
+          id: "creativity",
+          name: "Creativity",
+          isDisabled: true,
+          itemCount: 0,
+        },
+        {
           id: "design",
           name: "Design",
           children: [
+            {
+              id: "bauhaus",
+              name: "Bauhaus",
+              isDisabled: true,
+              itemCount: 0,
+            },
             {
               id: "fashion",
               name: "Fashion",
               itemCount: 2,
             },
-            {
-              id: "ux",
-              name: "User Experience",
-              itemCount: 5,
-            },
-            {
-              id: "architecture_design",
-              name: "Architecture",
-              itemCount: 3,
-            },
-            {
-              id: "home",
-              name: "Home",
-              itemCount: 1,
-            },
+            ...
           ],
           itemCount: 11,
         },
@@ -572,8 +590,15 @@ When `width` is set to `full`, the button and list elements will expand to fill
 the full width of the component's parent element and the width of the two
 elements will always be identical.
 
-**IMPORTANT:** For a mobile viewport, the component will always render with
-`width` set to `full`.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> For a mobile viewport, the component will
+      always render with <code>width</code> set to <code>full</code>.
+    </>
+  }
+  type="informative"
+/>
 
 <Canvas of={MultiSelectStories.width} />
 
@@ -709,7 +734,15 @@ The `MultiSelect` component does _NOT_ have an `onClearAll` prop. Instead, the
 Alternatively, use the `MultiSelectGroup` or `FilterBar` (name TBD) components
 in future releases.
 
-**IMPORTANT**: Make sure to give each `MultiSelect` component a unique `id`.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> Make sure to give each{" "}
+      <code>MultiSelect</code> component a unique <code>id</code>.
+    </>
+  }
+  type="informative"
+/>
 
 <Canvas of={MultiSelectStories.InAGroup} />
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -4,7 +4,6 @@ import Banner from "../Banner/Banner";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as MultiSelectStories from "./MultiSelect.stories";
 import Link from "../Link/Link";
-import Banner from "../Banner/Banner";
 import { changelogData } from "./multiSelectChangelogData";
 
 <Meta of={MultiSelectStories} />

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -214,9 +214,21 @@ const withItemCountItems = [
     itemCount: 20,
   },
   {
+    id: "creativity",
+    name: "Creativity",
+    isDisabled: true,
+    itemCount: 0,
+  },
+  {
     id: "design",
     name: "Design",
     children: [
+      {
+        id: "bauhaus",
+        name: "Bauhaus",
+        isDisabled: true,
+        itemCount: 0,
+      },
       {
         id: "fashion",
         name: "Fashion",
@@ -228,23 +240,14 @@ const withItemCountItems = [
         itemCount: 5,
       },
       {
-        id: "architecture_design",
-        name: "Architecture",
-        itemCount: 3,
-      },
-      {
         id: "home",
         name: "Home",
         itemCount: 1,
       },
       {
-        id: "shopping_mall",
-        name: "Shopping Mall",
-        itemCount: 0,
-      },
-      {
-        id: "school",
-        name: "School",
+        id: "standards",
+        name: "Standards",
+        isDisabled: true,
         itemCount: 0,
       },
     ],

--- a/src/components/MultiSelect/MultiSelect.stories.tsx
+++ b/src/components/MultiSelect/MultiSelect.stories.tsx
@@ -237,6 +237,16 @@ const withItemCountItems = [
         name: "Home",
         itemCount: 1,
       },
+      {
+        id: "shopping_mall",
+        name: "Shopping Mall",
+        itemCount: 0,
+      },
+      {
+        id: "school",
+        name: "School",
+        itemCount: 0,
+      },
     ],
     itemCount: 11,
   },

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -58,7 +58,6 @@ const itemsWithCount = [
   { id: "home", name: "Home", itemCount: 0 },
 ];
 
-
 const defaultItemsVisible = 5;
 
 const MultiSelectTestComponent = ({

--- a/src/components/MultiSelect/MultiSelect.test.tsx
+++ b/src/components/MultiSelect/MultiSelect.test.tsx
@@ -55,7 +55,9 @@ const itemsWithCount = [
   },
   { id: "plants", name: "Plants", itemCount: 4 },
   { id: "furniture", name: "Furniture", itemCount: 6 },
+  { id: "home", name: "Home", itemCount: 0 },
 ];
+
 
 const defaultItemsVisible = 5;
 
@@ -253,11 +255,12 @@ describe("MultiSelect", () => {
     expect(screen.getByRole("button").getAttribute("aria-expanded")).toEqual(
       "true"
     );
-    expect(screen.getAllByRole("checkbox")).toHaveLength(8);
+    expect(screen.getAllByRole("checkbox")).toHaveLength(9);
     expect(screen.getByLabelText("Dogs5")).toBeInTheDocument();
     expect(screen.getByLabelText("Cats11")).toBeInTheDocument();
     expect(screen.getByLabelText("Cars7")).toBeInTheDocument();
     expect(screen.getByLabelText("Red8")).toBeInTheDocument();
+    expect(screen.getByLabelText("Home0")).toBeInTheDocument();
   });
 
   it("should initially render with open menu if isDefaultOpen prop is true", () => {

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -308,7 +308,7 @@ export const MultiSelect: ChakraComponent<
       const getItemLabelText = (
         item: MultiSelectItem
       ): string | JSX.Element => {
-        return item.itemCount ? (
+        return item.itemCount >= 0 ? (
           <Flex gap="s" justify="space-between">
             <Box>{item.name}</Box>
             <Box>{item.itemCount}</Box>

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -19,11 +19,13 @@ export const changelogData: ChangelogData[] = [
     ],
   },
   {
-    date: "2025-01-30",
-    version: "3.5.3",
-    type: "Update",
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
     affects: ["Styles"],
-    notes: ["Updates the text and size styles for the search input field."],
+    notes: [
+      "Fixes the vertical alignment of the label for the `inline` variant.",
+    ],
   },
   {
     date: "2024-12-05",

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -12,10 +12,10 @@ export const changelogData: ChangelogData[] = [
   {
     date: "Prerelease",
     version: "Prerelease",
-    type: "Bug Fix",
-    affects: ["Styles"],
+    type: "Update",
+    affects: ["Functionality"],
     notes: [
-      "Fixes the vertical alignment of the label for the `inline` variant.",
+      "Updates condition and now allows 0 to be rendered for `itemsCount`.",
     ],
   },
   {

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -16,7 +16,7 @@ export const changelogData: ChangelogData[] = [
     affects: ["Styles"],
     notes: [
       "Fixes the search input field to the top of the panel so it remains visible on scroll.",
-      ],
+    ],
   },
   {
     date: "Prerelease",

--- a/src/components/Select/selectChangelogData.ts
+++ b/src/components/Select/selectChangelogData.ts
@@ -17,6 +17,7 @@ export const changelogData: ChangelogData[] = [
     notes: [
       "Adds the `autoComplete` prop to the select element.",
       "Adds `requiredLabelText` prop to allow customization of the '(required)' text.",
+      "Fixes the vertical alignment of the label for the `inline` variant.",
     ],
   },
   {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2013](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2013)

## This PR does the following:

- Updates the `MultiSelect` component to now allow `0` to be rendered for `itemCount`.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2013]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2013?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ