### PR TITLE
DSD-1951: updates how labelPosition renders in storybook for Select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Fixes `Accordion` styles, including padding and active hover state, and double-border issue.
 - Fixes an overflow bug in the `filter` variant of the `TagSet` component when `isDismissible` is false.
+- Fixes the vertical alignment of the label for the `inline` variant of the `Select` component.
 
 ## 3.5.5 (March 20, 2025)
 

--- a/src/components/MultiSelect/MultiSelect.mdx
+++ b/src/components/MultiSelect/MultiSelect.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./multiSelectChangelogData";
 
 # MultiSelect
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.4.0`    |
-| Latest            | `3.5.3`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.4.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Styles"],
+    notes: [
+      "Fixes the vertical alignment of the label for the `inline` variant.",
+    ],
+  },
+  {
     date: "2025-01-30",
     version: "3.5.3",
     type: "Update",

--- a/src/components/Select/Select.stories.tsx
+++ b/src/components/Select/Select.stories.tsx
@@ -25,6 +25,7 @@ const meta: Meta<typeof Select> = {
       controls: { type: "select" },
       options: labelPositionsArray,
       table: { defaultValue: { summary: "default" } },
+      control: { type: "radio" },
     },
     name: { control: false },
     onChange: { control: false },

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -70,7 +70,7 @@ const Select = defineMultiStyleConfig({
       inline: {
         display: { md: "flex" },
         gap: { md: "xs" },
-        alignItems: { md: "flex-end" },
+        alignItems: { md: "center" },
       },
       label: labelLegendTextSpecialSpacing,
       select: select(labelPosition),


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1951](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1951)

## This PR does the following:

- Updates `Select`'s `labelPosition` options for storybook.
- Fixes the vertical alignment of the label for the `inline` variant of the `Select` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Storybook.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1951]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ