### PR TITLE
DSD-1956: adds more info to X socialMediaLink example

### DIFF
--- a/src/components/SocialMediaLinks/SocialMediaLinks.stories.tsx
+++ b/src/components/SocialMediaLinks/SocialMediaLinks.stories.tsx
@@ -54,7 +54,7 @@ const exampleAllLinkData: SocialMediaLinkDataProps[] = [
   },
   {
     icon: "socialX",
-    labelText: "X",
+    labelText: "X, formerly Twitter",
     url: "https://x.com/nypl",
   },
   {
@@ -71,7 +71,7 @@ const exampleLinkData: SocialMediaLinkDataProps[] = [
   },
   {
     icon: "socialX",
-    labelText: "X",
+    labelText: "X, formerly Twitter",
     url: "https://x.com/nypl",
   },
   {
@@ -99,7 +99,7 @@ const exampleTwoLinkData: SocialMediaLinkDataProps[] = [
   },
   {
     icon: "socialX",
-    labelText: "X",
+    labelText: "X, formerly Twitter",
     url: "https://x.com/nypl",
   },
   {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1956](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1956)

## This PR does the following:

- Adds clearer info about "X".
- This does not update the component so there is no need for changelog updates.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Storybook.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1956]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ