### PR TITLE
DSD-1966: TagSet border color styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Updates
 
-- Updates the `Notification` component's styles to sync with its VDL.
-- Updates the `ProgressIndicator` component's label margin to be consistent with VDL.
+- Updates the `Notification` component to sync styles with the VDL.
+- Updates the `ProgressIndicator` component's label margin to be consistent with the VDL.
 - Updates the `"dl"` variant of the `List` component to use `2rem` for column spacing and to set the width of the `term` columnm to be a full `"250px"` for `tablet` and `desktop` viewports.
+- Updates the `TagSet` component to sync the border color styles with the VDL.
 
 ### Fixes
 

--- a/src/components/TagSet/tagSetChangelogData.ts
+++ b/src/components/TagSet/tagSetChangelogData.ts
@@ -13,9 +13,10 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Functionality"],
+    affects: ["Functionality", "Styles"],
     notes: [
       "Fixes an overflow bug in the `filter` variant when `isDismissible` is false.",
+      "Syncs the border colors styles with the VDL.",
     ],
   },
   {

--- a/src/theme/components/tagSet.ts
+++ b/src/theme/components/tagSet.ts
@@ -56,7 +56,7 @@ const TagSetFilter = defineMultiStyleConfig({
         _hover: {
           bg: isDismissible ? "dark.ui.bg.hover" : "dark.ui.bg.default",
           borderColor: isDismissible
-            ? "dark.ui.border.active"
+            ? "dark.ui.border.hover"
             : "dark.ui.border.default",
           color: isDismissible
             ? "dark.ui.typography.heading"
@@ -105,6 +105,7 @@ const TagSetExplore = defineStyleConfig({
     },
     _hover: {
       bg: "ui.link.primary-10",
+      borderColor: "ui.link.secondary",
       a: {
         color: "ui.link.secondary",
       },
@@ -127,6 +128,7 @@ const TagSetExplore = defineStyleConfig({
       },
       _hover: {
         bg: "dark.ui.link.primary-10",
+        borderColor: "dark.ui.link.secondary",
         a: {
           color: "dark.ui.link.secondary",
         },


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1966](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1966)

## This PR does the following:

- Updates the `TagSet` component to sync the border color styles with the VDL.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- The updated colors make it easier to see the hover state.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1966]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1966?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ