### PR TITLE
DSD-1947: Radio focus color styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Notification` component's styles to sync with its VDL.
 - Updates the `ProgressIndicator` component's label margin to be consistent with VDL.
 - Updates the `"dl"` variant of the `List` component to use `2rem` for column spacing and to set the width of the `term` columnm to be a full `"250px"` for `tablet` and `desktop` viewports.
+- Updates the `Checkbox` component to sync the focus color styles with the VDL.
 
 ### Fixes
 

--- a/src/components/Radio/Radio.mdx
+++ b/src/components/Radio/Radio.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./radioChangelogData";
 
 # Radio
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.22.0`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.22.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Radio/radioChangelogData.ts
+++ b/src/components/Radio/radioChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Synced the focus color styles with the VDL."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/theme/components/radio.ts
+++ b/src/theme/components/radio.ts
@@ -71,7 +71,6 @@ const baseStyle = {
     _focus: {
       ...activeFocus(),
       boxShadow: "outline",
-      borderColor: "ui.focus",
     },
     _invalid: {
       borderColor: "ui.error.primary",
@@ -108,7 +107,6 @@ const baseStyle = {
 
       _focus: {
         boxShadow: "none",
-        outlineColor: "dark.ui.focus",
       },
 
       _invalid: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1947](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1947)

## This PR does the following:

- Updates the `Checkbox` component to sync the focus color styles with the VDL.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1947]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1947?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ