### PR TITLE
DSD-1953: SkeletonLoader style fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `SkeletonLoader` component to make the button placeholder look more like a button.
+
 ## 3.6.0 (April 10, 2025)
 
 ### Adds

--- a/src/components/SkeletonLoader/SkeletonLoader.mdx
+++ b/src/components/SkeletonLoader/SkeletonLoader.mdx
@@ -9,18 +9,19 @@ import Link from "../Link/Link";
 
 # SkeletonLoader
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.17.3`   |
-| Latest            | `3.1.2`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.17.3`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}
 - {<Link href="#component-props" target="_self">Component Props</Link>}
 - {<Link href="#accessibility" target="_self">Accessibility</Link>}
-- {<Link href="#card-placeholders-in-a-grid" target="_self">Card Placeholders in a Grid</Link>}
-- {<Link href="#text-placeholders-in-a-list" target="_self">Text Placeholders in a List</Link>}
+- {<Link href="#in-a-grid" target="_self">In a Grid</Link>}
+- {<Link href="#in-a-list" target="_self">In a List</Link>}
+- {<Link href="#with-buttons" target="_self">With Buttons</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
@@ -59,13 +60,17 @@ Resources:
 - [W3C Perceivable Pause, Stop, Hide](https://www.w3.org/TR/WCAG/#pause-stop-hide)
 - [More Accessible Skeletons](https://adrianroselli.com/2020/11/more-accessible-skeletons.html)
 
-## Card Placeholders in a Grid
+## In a Grid
 
 <Canvas of={SkeletonLoaderStories.GridExample} />
 
-## Text Placeholders in a List
+## In a List
 
 <Canvas of={SkeletonLoaderStories.ListExample} />
+
+## With Buttons
+
+<Canvas of={SkeletonLoaderStories.WithButtons} />
 
 ## Changelog
 

--- a/src/components/SkeletonLoader/SkeletonLoader.stories.tsx
+++ b/src/components/SkeletonLoader/SkeletonLoader.stories.tsx
@@ -88,3 +88,46 @@ export const ListExample: Story = {
     </SimpleGrid>
   ),
 };
+export const WithButtons: Story = {
+  render: () => (
+    <SimpleGrid columns={1}>
+      <SimpleGrid columns={3}>
+        <SkeletonLoader
+          contentSize={2}
+          imageAspectRatio="landscape"
+          showButton
+        />
+        <SkeletonLoader
+          contentSize={2}
+          imageAspectRatio="landscape"
+          showButton
+        />
+        <SkeletonLoader
+          contentSize={2}
+          imageAspectRatio="landscape"
+          showButton
+        />
+      </SimpleGrid>
+      <SimpleGrid columns={1}>
+        <SkeletonLoader
+          contentSize={4}
+          imageAspectRatio="square"
+          layout="row"
+          showButton
+        />
+        <SkeletonLoader
+          contentSize={4}
+          imageAspectRatio="square"
+          layout="row"
+          showButton
+        />
+        <SkeletonLoader
+          contentSize={4}
+          imageAspectRatio="square"
+          layout="row"
+          showButton
+        />
+      </SimpleGrid>
+    </SimpleGrid>
+  ),
+};

--- a/src/components/SkeletonLoader/SkeletonLoader.tsx
+++ b/src/components/SkeletonLoader/SkeletonLoader.tsx
@@ -140,7 +140,7 @@ export const SkeletonLoader: ChakraComponent<
             )}
             {showButton && (
               <Box __css={{ ...styles.section, ...styles.button }}>
-                <ChakraSkeleton borderRadius="16px" sx={styles.loader}>
+                <ChakraSkeleton sx={styles.loader} borderRadius="20px">
                   <Box __css={styles.button} />
                 </ChakraSkeleton>
               </Box>

--- a/src/components/SkeletonLoader/__snapshots__/SkeletonLoader.test.tsx.snap
+++ b/src/components/SkeletonLoader/__snapshots__/SkeletonLoader.test.tsx.snap
@@ -490,7 +490,7 @@ exports[`SkeletonLoader renders the UI snapshot correctly 7`] = `
       className="css-0"
     >
       <div
-        className="chakra-skeleton css-du76nm"
+        className="chakra-skeleton css-wiuxn8"
       >
         <div
           className="css-0"

--- a/src/components/SkeletonLoader/skeletonLoaderChangelogData.ts
+++ b/src/components/SkeletonLoader/skeletonLoaderChangelogData.ts
@@ -14,7 +14,9 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Styles"],
-    notes: ["Updates the styles to make the button placeholder look more like a button."],
+    notes: [
+      "Updates the styles to make the button placeholder look more like a button.",
+    ],
   },
   {
     date: "2024-05-09",

--- a/src/components/SkeletonLoader/skeletonLoaderChangelogData.ts
+++ b/src/components/SkeletonLoader/skeletonLoaderChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Updates the styles to make the button placeholder look more like a button."],
+  },
+  {
     date: "2024-05-09",
     version: "3.1.2",
     type: "Update",

--- a/src/theme/components/skeletonLoader.ts
+++ b/src/theme/components/skeletonLoader.ts
@@ -64,9 +64,10 @@ const SkeletonLoader = defineMultiStyleConfig({
           ...borderStyles,
         },
         button: {
-          height: "32px",
-          margin: "auto",
+          borderRadius: "20px",
+          height: "40px",
           maxWidth: "160px",
+          overflow: "hidden",
           width: "100%",
         },
         container: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1953](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1953)

## This PR does the following:

- Updates the `SkeletonLoader` component to make the button placeholder look more like a button.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1953]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1953?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ