### PR TITLE
DSD-1974: `Tooltip` text color update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates `Tooltip` text color.
+
 ## 3.6.0 (April 10, 2025)
 
 ### Adds

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -9,10 +9,10 @@ import Link from "../Link/Link";
 
 # Tooltip
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.1.0`    |
-| Latest            | `3.3.1`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.1.0`      |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Tooltip/tooltipChangelogData.ts
+++ b/src/components/Tooltip/tooltipChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: [
+      "Updates text color to `ui.typography.inverse.heading` on light mode.",
+    ],
+  },
+  {
     date: "2024-09-05",
     version: "3.3.1",
     type: "Update",

--- a/src/theme/components/tooltip.ts
+++ b/src/theme/components/tooltip.ts
@@ -9,7 +9,7 @@ const Tooltip = defineStyleConfig({
     [$bg.variable]: "colors.ui.gray.xx-dark",
     borderRadius: "4px",
     boxShadow: "none",
-    color: "ui.typography.inverse.body",
+    color: "ui.typography.inverse.heading",
     fontSize: "desktop.caption",
     marginBottom: "xxs",
     maxWidth: "240px",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1974](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1974)

## This PR does the following:

- Updates tooltip's text color to `ui.typography.inverse.heading` on light mode

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-1974]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1974?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ