### PR TITLE
DSD-2025: `Notification` color update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates `Notification` variant font colors to sync with VDL.
+
 ## 3.6.0 (April 10, 2025)
 
 ### Adds

--- a/src/components/Notification/Notification.mdx
+++ b/src/components/Notification/Notification.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./notificationChangelogData";
 
 # Notification
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `3.6.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.2`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Notification/Notification.tsx
+++ b/src/components/Notification/Notification.tsx
@@ -211,7 +211,7 @@ export const Notification: ChakraComponent<
           color:
             colorMode === "dark"
               ? "dark.ui.success.primary"
-              : "section.research.secondary",
+              : "ui.success.primary",
           name: "speakerNotes",
           title: "Notification announcement icon",
         } as IconProps,
@@ -222,7 +222,7 @@ export const Notification: ChakraComponent<
         } as IconProps,
         warning: {
           color:
-            colorMode === "dark" ? "dark.ui.error.primary" : "brand.primary",
+            colorMode === "dark" ? "dark.ui.error.primary" : "ui.error.primary",
           name: "errorFilled",
           title: "Notification warning icon",
         } as IconProps,

--- a/src/components/Notification/__snapshots__/Notification.test.tsx.snap
+++ b/src/components/Notification/__snapshots__/Notification.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`Notification renders the UI snapshot correctly 2`] = `
     >
       <svg
         aria-hidden={true}
-        className="chakra-icon notification-icon css-nfdupq"
+        className="chakra-icon notification-icon css-f7lbg8"
         data-file-name="SvgSpeakerNotes"
         focusable={false}
         id="notificationID2-notification-icon"
@@ -96,7 +96,7 @@ exports[`Notification renders the UI snapshot correctly 3`] = `
     >
       <svg
         aria-hidden={true}
-        className="chakra-icon notification-icon css-1n65kn3"
+        className="chakra-icon notification-icon css-3u73el"
         data-file-name="SvgErrorFilled"
         focusable={false}
         id="notificationID3-notification-icon"

--- a/src/components/Notification/notificationChangelogData.ts
+++ b/src/components/Notification/notificationChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Variant font colors updated to sync with the VDL."],
+  },
+  {
     date: "2025-04-10",
     version: "3.6.0",
     type: "Update",

--- a/src/theme/components/notificationContent.ts
+++ b/src/theme/components/notificationContent.ts
@@ -25,7 +25,7 @@ const baseStyle = definePartsStyle(
       justifyContent: "center",
       content: {
         color:
-          notificationType === "warning" ? "brand.primary" : "currentColor",
+          notificationType === "warning" ? "ui.error.primary" : "currentColor",
         paddingStart:
           !isCentered && showIcon ? (notificationHeading ? "l" : "xs") : "0",
         pt: !isCentered ? "xxs" : "0",

--- a/src/theme/components/notificationHeading.ts
+++ b/src/theme/components/notificationHeading.ts
@@ -15,9 +15,9 @@ const baseStyle = definePartsStyle(
   ({ icon, isCentered, notificationType }: NotificationHeadingBaseStyle) => {
     let color = "ui.typography.heading";
     if (notificationType === "announcement") {
-      color = "section.research.secondary";
+      color = "ui.success.primary";
     } else if (notificationType === "warning") {
-      color = "brand.primary";
+      color = "ui.error.primary";
     }
     return {
       display: "flex",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2025](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2025)

## This PR does the following:

- Updates `warning` variant’s heading, icon, and text to `ui.error.primary` 
- Updates `announcement` variant’s heading and icon to `ui.success.primary`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2025]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2025?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ