### PR TITLE
DSD-1962: SubNav dark mode styles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Updates the `SubNav` component to add dark mode color styles.
+
 ## 3.6.0 (April 10, 2025)
 
 ### Adds

--- a/src/components/SubNav/SubNav.stories.tsx
+++ b/src/components/SubNav/SubNav.stories.tsx
@@ -310,8 +310,8 @@ export const CustomColors: Story = {
   render: () => (
     <>
       <SubNav
-        actionBackgroundColor="brand.primary-05"
-        highlightColor="brand.primary"
+        actionBackgroundColor="section.research.primary-05"
+        highlightColor="ui.warning.tertiary"
         id="subnav-colors"
         primaryActions={
           <>

--- a/src/components/SubNav/subNavChangelogData.ts
+++ b/src/components/SubNav/subNavChangelogData.ts
@@ -10,10 +10,17 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Added dark mode color styles."],
+  },
+  {
     date: "2024-12-05",
     version: "3.5.0",
     type: "New Feature",
     affects: ["Documentation", "Functionality"],
-    notes: ["Added the `SubNav` component"],
+    notes: ["Added the `SubNav` component."],
   },
 ];

--- a/src/theme/components/subnav.ts
+++ b/src/theme/components/subnav.ts
@@ -83,9 +83,7 @@ const SubNav = subNavDefineMultiStyleConfig({
 
       const highlightOrBorderColor = (colorMode: string = "light") => {
         const finalPrefix = colorMode === "dark" ? `${colorMode}.` : "";
-        return highlightColor
-          ? highlightColor
-          : `${finalPrefix}ui.border.default`;
+        return highlightColor || `${finalPrefix}ui.border.default`;
       };
 
       const defaultBgColor = "var(--nypl-colors-ui-link-primary-05)";
@@ -93,9 +91,7 @@ const SubNav = subNavDefineMultiStyleConfig({
       const finalBackgroundColor = (colorMode: string = "light") => {
         const finalForColorMode =
           colorMode === "dark" ? defaultBgColorDark : defaultBgColor;
-        return backgroundColor
-          ? backgroundColor
-          : `${finalForColorMode} !important`;
+        return backgroundColor || `${finalForColorMode} !important`;
       };
 
       const primaryActionsStyles = {

--- a/src/theme/components/subnav.ts
+++ b/src/theme/components/subnav.ts
@@ -55,77 +55,97 @@ const ulStyles = {
 const SubNav = subNavDefineMultiStyleConfig({
   baseStyle: subNavDefinePartsStyle(
     ({ backgroundColor, highlightColor }: SubNavStyleProps) => {
-      // const defaultLabelColor = "ui.typography.body";
-      const defaultLabelColor = "red";
-      const defaultLabelColorDark = "blue";
-      const highlightOrDefaultColor = (colorMode: string = "light") => {
-        const finalColor =
+      const defaultLabelColor = "var(--nypl-colors-ui-typography-body)";
+      const defaultLabelColorDark =
+        "var(--nypl-colors-dark-ui-typography-body)";
+      const defaultColor = (colorMode: string = "light") => {
+        const finalForColorMode =
           colorMode === "dark" ? defaultLabelColorDark : defaultLabelColor;
-        return highlightColor ? highlightColor : finalColor;
+        return `${finalForColorMode} !important`;
       };
-      const highlightOrLinkColor = highlightColor
-        ? highlightColor
-        : "ui.link.primary";
+      const highlightOrDefaultColor = (colorMode: string = "light") => {
+        const finalForColorMode =
+          colorMode === "dark" ? defaultLabelColorDark : defaultLabelColor;
+        return highlightColor
+          ? `${highlightColor} !important`
+          : `${finalForColorMode} !important`;
+      };
+
+      const defaultLinkColor = "var(--nypl-colors-ui-link-primary)";
+      const defaultLinkColorDark = "var(--nypl-colors-dark-ui-link-primary)";
+      const highlightOrLinkColor = (colorMode: string = "light") => {
+        const finalForColorMode =
+          colorMode === "dark" ? defaultLinkColorDark : defaultLinkColor;
+        return highlightColor
+          ? `${highlightColor} !important`
+          : `${finalForColorMode} !important`;
+      };
+
       const highlightOrBorderColor = (colorMode: string = "light") => {
         const finalPrefix = colorMode === "dark" ? `${colorMode}.` : "";
         return highlightColor
           ? highlightColor
           : `${finalPrefix}ui.border.default`;
       };
+
+      const defaultBgColor = "var(--nypl-colors-ui-link-primary-05)";
+      const defaultBgColorDark = "var(--nypl-colors-dark-ui-link-primary-10)";
       const finalBackgroundColor = (colorMode: string = "light") => {
-        const basedOnColorMode =
-          colorMode === "dark"
-            ? "var(--nypl-colors-dark-ui-link-primary-10)"
-            : "var(--nypl-colors-ui-link-primary-05)";
-        return backgroundColor ? backgroundColor : basedOnColorMode;
+        const finalForColorMode =
+          colorMode === "dark" ? defaultBgColorDark : defaultBgColor;
+        return backgroundColor
+          ? backgroundColor
+          : `${finalForColorMode} !important`;
       };
+
       const primaryActionsStyles = {
         ...commonStyles(),
         svg: {
-          fill: defaultLabelColor,
+          fill: defaultColor("light"),
           margin: { base: "0", md: null },
           _dark: {
-            fill: "ui.white",
+            fill: defaultColor("dark"),
           },
         },
         _hover: {
           backgroundColor: finalBackgroundColor("light"),
-          color: highlightOrDefaultColor,
+          color: defaultColor("light"),
           _dark: {
             backgroundColor: finalBackgroundColor("dark"),
+            color: defaultColor("dark"),
           },
           svg: {
-            fill: highlightOrDefaultColor,
+            fill: highlightOrDefaultColor("light"),
             _dark: {
-              fill:
-                backgroundColor !== undefined
-                  ? `${backgroundColor} `
-                  : "ui.white",
+              fill: highlightOrDefaultColor("dark"),
             },
           },
         },
       };
       const secondaryActionsStyles = {
         ...commonStyles(),
-        color: highlightOrLinkColor,
+        color: highlightOrLinkColor("light"),
+        _dark: {
+          color: highlightOrLinkColor("dark"),
+        },
         svg: {
-          fill: highlightOrLinkColor,
+          fill: highlightOrLinkColor("light"),
           margin: { base: "0", md: null },
           _dark: {
-            fill: backgroundColor
-              ? `${backgroundColor} !important`
-              : "dark.ui.link.primary-05 !important",
+            fill: highlightOrLinkColor("dark"),
           },
         },
         _hover: {
           background: finalBackgroundColor("light"),
-          color: highlightOrLinkColor,
+          color: highlightOrLinkColor("light"),
+          _dark: {
+            backgroundColor: finalBackgroundColor("dark"),
+            color: highlightOrLinkColor("dark"),
+          },
           svg: {
-            fill: highlightOrLinkColor,
+            fill: highlightOrLinkColor("light"),
             _dark: {
-              fill: backgroundColor
-                ? `${backgroundColor}`
-                : "dark.ui.link.primary-05",
+              fill: highlightOrLinkColor("dark"),
             },
           },
         },
@@ -133,11 +153,17 @@ const SubNav = subNavDefineMultiStyleConfig({
       return {
         base: {
           ".selectedItem": {
-            color: highlightOrLinkColor,
+            color: highlightOrLinkColor("light"),
             fontWeight: "bold",
             backgroundColor: finalBackgroundColor("light"),
             "&:hover": {
-              color: highlightOrLinkColor,
+              color: highlightOrLinkColor("light"),
+            },
+            _dark: {
+              color: highlightOrLinkColor("dark"),
+              "&:hover": {
+                color: highlightOrLinkColor("dark"),
+              },
             },
           },
           borderBottom: "1px solid",
@@ -164,18 +190,17 @@ const SubNav = subNavDefineMultiStyleConfig({
           ...ulStyles,
           width: "100%",
           button: {
-            color: highlightOrDefaultColor,
+            color: defaultColor("light"),
             ...primaryActionsStyles,
+            _dark: {
+              color: defaultColor("dark"),
+            },
           },
           a: {
-            color: `${highlightOrDefaultColor}`,
+            color: defaultColor("light"),
             ...primaryActionsStyles,
-            svg: {
-              fill: `${highlightOrDefaultColor}`,
-              margin: { base: "0", md: null },
-              _dark: {
-                fill: "ui.white !important",
-              },
+            _dark: {
+              color: defaultColor("dark"),
             },
           },
         },
@@ -183,8 +208,20 @@ const SubNav = subNavDefineMultiStyleConfig({
           ...ulStyles,
           width: "fit-content",
           whiteSpace: "nowrap",
-          button: secondaryActionsStyles,
-          a: secondaryActionsStyles,
+          button: {
+            color: highlightOrLinkColor("light"),
+            ...secondaryActionsStyles,
+            _dark: {
+              color: highlightOrLinkColor("dark"),
+            },
+          },
+          a: {
+            color: highlightOrLinkColor("light"),
+            ...secondaryActionsStyles,
+            _dark: {
+              color: highlightOrLinkColor("dark"),
+            },
+          },
         },
         fadeEffect: {
           position: "absolute",
@@ -196,6 +233,10 @@ const SubNav = subNavDefineMultiStyleConfig({
             "linear-gradient(to left, rgba(255, 255, 255, 1) 0%, rgba(255, 255, 255, 0) 100%)",
           pointerEvents: "none",
           zIndex: 1,
+          _dark: {
+            background:
+              "linear-gradient(to left, rgba(25, 25, 25, 1) 0%, rgba(25, 25, 25, 0) 100%)",
+          },
         },
         primaryList: {
           position: "relative",

--- a/src/theme/components/subnav.ts
+++ b/src/theme/components/subnav.ts
@@ -55,19 +55,30 @@ const ulStyles = {
 const SubNav = subNavDefineMultiStyleConfig({
   baseStyle: subNavDefinePartsStyle(
     ({ backgroundColor, highlightColor }: SubNavStyleProps) => {
-      const defaultLabelColor = "ui.typography.body";
-      const highlightOrDefaultColor = highlightColor
-        ? highlightColor
-        : `${defaultLabelColor}`;
+      // const defaultLabelColor = "ui.typography.body";
+      const defaultLabelColor = "red";
+      const defaultLabelColorDark = "blue";
+      const highlightOrDefaultColor = (colorMode: string = "light") => {
+        const finalColor =
+          colorMode === "dark" ? defaultLabelColorDark : defaultLabelColor;
+        return highlightColor ? highlightColor : finalColor;
+      };
       const highlightOrLinkColor = highlightColor
         ? highlightColor
         : "ui.link.primary";
-      const highlightOrBorderColor = highlightColor
-        ? highlightColor
-        : "ui.border.default";
-      const finalBackgroundColor = backgroundColor
-        ? backgroundColor
-        : "ui.link.primary-05";
+      const highlightOrBorderColor = (colorMode: string = "light") => {
+        const finalPrefix = colorMode === "dark" ? `${colorMode}.` : "";
+        return highlightColor
+          ? highlightColor
+          : `${finalPrefix}ui.border.default`;
+      };
+      const finalBackgroundColor = (colorMode: string = "light") => {
+        const basedOnColorMode =
+          colorMode === "dark"
+            ? "var(--nypl-colors-dark-ui-link-primary-10)"
+            : "var(--nypl-colors-ui-link-primary-05)";
+        return backgroundColor ? backgroundColor : basedOnColorMode;
+      };
       const primaryActionsStyles = {
         ...commonStyles(),
         svg: {
@@ -78,8 +89,11 @@ const SubNav = subNavDefineMultiStyleConfig({
           },
         },
         _hover: {
-          backgroundColor: finalBackgroundColor,
+          backgroundColor: finalBackgroundColor("light"),
           color: highlightOrDefaultColor,
+          _dark: {
+            backgroundColor: finalBackgroundColor("dark"),
+          },
           svg: {
             fill: highlightOrDefaultColor,
             _dark: {
@@ -104,7 +118,7 @@ const SubNav = subNavDefineMultiStyleConfig({
           },
         },
         _hover: {
-          background: finalBackgroundColor,
+          background: finalBackgroundColor("light"),
           color: highlightOrLinkColor,
           svg: {
             fill: highlightOrLinkColor,
@@ -121,15 +135,18 @@ const SubNav = subNavDefineMultiStyleConfig({
           ".selectedItem": {
             color: highlightOrLinkColor,
             fontWeight: "bold",
-            backgroundColor: finalBackgroundColor,
+            backgroundColor: finalBackgroundColor("light"),
             "&:hover": {
               color: highlightOrLinkColor,
             },
           },
           borderBottom: "1px solid",
-          borderColor: highlightOrBorderColor,
+          borderColor: highlightOrBorderColor("light"),
           display: "flex",
           justifyContent: "center",
+          _dark: {
+            borderColor: highlightOrBorderColor("dark"),
+          },
         },
         container: {
           maxWidth: "1280px",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1962](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1962)

## This PR does the following:

- Updates the dark mode styles for the `SubNav` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1962]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1962?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ