### PR TITLE
DSD-1964: Tabs border color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates `Tooltip` text color.
 - Updates the `SearchBar` component to remove the text input right border.
 - Updates the `SkeletonLoader` component to make the button placeholder look more like a button.
+- Updates the `Tabs` component to sync the border color with the VDL.
 
 ## 3.6.0 (April 10, 2025)
 

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./tabsChangelogData";
 
 # Tabs
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.24.0`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.24.0`     |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/Tabs/tabsChangelogData.ts
+++ b/src/components/Tabs/tabsChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Updates the border color to sync with the VDL."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/theme/components/tabs.ts
+++ b/src/theme/components/tabs.ts
@@ -110,7 +110,7 @@ const tablistWrapper = {
   alignItems: "center",
   borderBottom: {
     base: "0",
-    md: "1px solid black",
+    md: "1px solid var(--nypl-colors-ui-gray-xx-dark)",
   },
   height: { base: "58px", md: "auto" },
   margin: "0",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1964](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1964)

## This PR does the following:

- Updates the `Tabs` component to sync the border color with the VDL.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1964]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1964?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ