### PR TITLE
DSD-2056: 12-column grid using named grid lines syntax

### DIFF
--- a/src/theme/components/template.ts
+++ b/src/theme/components/template.ts
@@ -14,79 +14,41 @@ const Template = defineStyleConfig({
       minWidth: "288px",
       m: "0 auto",
       p: responsiveMargin,
-      gridTemplateAreas: `
-        "breakout"
-        "top"
-        "main"
-        "bottom"
-      `,
-      gridTemplateColumns: "100%",
-      gridTemplateRows: "auto",
+      // Using named grid lines to implicitly define grid template areas
+      gridTemplateColumns:
+        "[breakout-start top-start sidebar-start main-start bottom-start] 1fr [breakout-end top-end sidebar-end main-end bottom-end]",
+      gridTemplateRows:
+        "[breakout-start] auto [breakout-end top-start] auto [top-end main-start] auto [main-end sidebar-start] auto [sidebar-end bottom-start] auto [botom-end]",
       columnGap: responsiveGap,
       "& > *:not(:last-child)": { mb: responsiveGap },
     };
   }),
   variants: {
     left: {
-      gridTemplateAreas: {
-        base: `
-          "breakout"
-          "top"
-          "sidebar"
-          "main"
-          "bottom"
-        `,
-        sm: `
-          "breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout" 
-          "top top top top top top top top top top top top" 
-          "sidebar sidebar sidebar sidebar sidebar sidebar main main main main main main" 
-          "bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom"
-        `,
-        md: `
-          "breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout" 
-          "top top top top top top top top top top top top" 
-          "sidebar sidebar sidebar sidebar main main main main main main main main" 
-          "bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom"
-        `,
-        lg: `
-          "breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout" 
-          "top top top top top top top top top top top top" 
-          "sidebar sidebar sidebar main main main main main main main main main" 
-          "bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom"
-        `,
+      // Using named grid lines to implicitly define grid template areas
+      gridTemplateColumns: {
+        base: "[breakout-start top-start sidebar-start main-start bottom-start] 1fr [breakout-end top-end sidebar-end main-end bottom-end]",
+        sm: "[breakout-start top-start sidebar-start bottom-start] repeat(6, 1fr) [sidebar-end main-start] repeat(6, 1fr) [breakout-end top-end main-end bottom-end]",
+        md: "[breakout-start top-start sidebar-start bottom-start] repeat(4, 1fr) [sidebar-end main-start] repeat(8, 1fr) [breakout-end top-end main-end bottom-end]",
+        lg: "[breakout-start top-start sidebar-start bottom-start] repeat(3, 1fr) [sidebar-end main-start] repeat(9, 1fr) [breakout-end top-end main-end bottom-end]",
       },
-      gridTemplateColumns: { sm: "repeat(12, 1fr)" },
+      gridTemplateRows: {
+        base: "[breakout-start] auto [breakout-end top-start] auto [top-end sidebar-start] auto [sidebar-end main-start] auto [main-end bottom-start] auto [botom-end]",
+        sm: "[breakout-start] auto [breakout-end top-start] auto [top-end main-start sidebar-start] auto [main-end sidebar-end botton-start] auto [botom-end]",
+      },
     },
     right: {
-      gridTemplateAreas: {
-        base: `
-          "breakout"
-          "top"
-          "sidebar"
-          "main"
-          "bottom"
-        `,
-        sm: `
-          "breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout" 
-          "top top top top top top top top top top top top" 
-          "main main main main main main sidebar sidebar sidebar sidebar sidebar sidebar" 
-          "bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom"
-        `,
-        md: `
-          "breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout" 
-          "top top top top top top top top top top top top" 
-          "main main main main main main main main sidebar sidebar sidebar sidebar" 
-          "bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom"
-        `,
-        lg: `
-          "breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout breakout" 
-          "top top top top top top top top top top top top" 
-          "main main main main main main main main main sidebar sidebar sidebar" 
-          "bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom bottom"
-        `,
+      // Using named grid lines to implicitly define grid template areas
+      gridTemplateColumns: {
+        base: "[breakout-start top-start sidebar-start main-start bottom-start] 1fr [breakout-end top-end sidebar-end main-end bottom-end]",
+        sm: "[breakout-start top-start main-start bottom-start] repeat(6, 1fr) [main-end sidebar-start] repeat(6, 1fr) [breakout-end top-end sidebar-end bottom-end]",
+        md: "[breakout-start top-start main-start bottom-start] repeat(8, 1fr) [main-end sidebar-start] repeat(4, 1fr) [breakout-end top-end sidebar-end bottom-end]",
+        lg: "[breakout-start top-start main-start bottom-start] repeat(9, 1fr) [main-end sidebar-start] repeat(3, 1fr) [breakout-end top-end sidebar-end bottom-end]",
       },
-      gridTemplateColumns: { sm: "repeat(12, 1fr)" },
-      gridTemplateRows: "auto",
+      gridTemplateRows: {
+        base: "[breakout-start] auto [breakout-end top-start] auto [top-end main-start] auto [main-end sidebar-start] auto [sidebar-end bottom-start] auto [botom-end]",
+        sm: "[breakout-start] auto [breakout-end top-start] auto [top-end main-start sidebar-start] auto [main-end sidebar-end botton-start] auto [botom-end]",
+      },
     },
   },
 });
@@ -108,14 +70,12 @@ const TemplateMainNarrow = defineStyleConfig({
     return {
       columnGap: responsiveGap,
       display: "grid",
-      gridTemplateAreas: {
-        base: `"mainNarrow"`,
-        md: `". mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow ."`,
-        lg: `". . mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow mainNarrow . ."`,
+      // Using named grid lines to implicitly define grid template areas
+      gridTemplateColumns: {
+        base: "[mainNarrow-start] 1fr [mainNarrow-end]",
+        md: "1fr [mainNarrow-start] repeat(10, 1fr) [mainNarrow-end] 1fr",
+        lg: "1fr 1fr [mainNarrow-start] repeat(8, 1fr) [mainNarrow-end] 1fr 1fr",
       },
-      gridTemplateColumns: { base: "100%", md: "repeat(12, 1fr)" },
-      // maxWidth: "720px",
-      // m: "0 auto",
     };
   }),
 });


### PR DESCRIPTION
Fixes JIRA ticket DSD-2056

## This PR does the following:

- Use named grid lines instead of the grid template areas repeating syntax.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
