### PR TITLE
DSD-2049: Updates CHANGELOG per feedback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Replaces the error thrown with a console.warn for the `Breadcrumbs`, `Heading`, and `Image` components.
 - Removes props with HTML equivalents and instructs devs to use the native attributes
 - Updates the grid layout of the content for the `Hero` `"primary"` variant.
-- Changes the names of theme objects that conflict with Chakra's base names from `Custom` to `Reservoir` for consistency.
+- Changes the names of theme objects that conflict with Chakra's base names from `Custom` to `Reservoir` for consistency. This impacts theme objects for `Breadcrumbs`, `Button`, `Select`, `Slider`, and `Table`.
 
 ### Removals
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Replaces the error thrown with a console.warn for the `Breadcrumbs`, `Heading`, and `Image` components.
 - Removes props with HTML equivalents and instructs devs to use the native attributes
 - Updates the grid layout of the content for the `Hero` `"primary"` variant.
+- Changes the names of theme objects that conflict with Chakra's base names from `Custom` to `Reservoir` for consistency.
 
 ### Removals
 
@@ -56,7 +57,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the `Heading` component to increase the font weight for the `size` styles.
 - Updates the Storybook docs for the `Tooltip` component to clarify how a tooltip should be used.
 - Updates the Storybook docs for the `Tabs` component to improve details about the mobile carousel and horizontal scrolling.
-- Changes the names of theme objects that conflict with Chakra's base names from `Custom` to `Reservoir` for consistency.
 
 ### Fixes
 


### PR DESCRIPTION
Fixes JIRA ticket DSD-2049

## This PR does the following:

- Missed small piece of feedback from Marty about updating the changelog: https://github.com/NYPL/nypl-design-system/pull/1816/files#r2103495424

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

-

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
