### PR TITLE
DSD-2044: Removes the need for consuming apps to import mediaMatchMock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
   - `StyledList`'s "tag", "mini" values in `textSizesArray`
 - Removes `role="search"` from `Searchbar` wrapper.
 - Removes use of `useNYPLBreakpoints` hook in `FilterBarInline` and `MultiSelectGroup`.
+- Removes `useNYPLBreakpoints` from final component, `SearchBar`, and removes `mediaMatchMock` from test setup since it is no longer necessary.
 
 ## Prerelease
 

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -4,8 +4,6 @@ import "@testing-library/jest-dom/extend-expect";
 // expect(...).toHaveNoViolations();
 import "jest-axe/extend-expect";
 
-import MatchMedia from "./mediaMatchMock";
-
 jest.setTimeout(35000);
 
 // We expect an error to be thrown and we do catch, but it still gets
@@ -13,7 +11,7 @@ jest.setTimeout(35000);
 jest.spyOn(global.console, "error").mockImplementation(() => jest.fn());
 jest.spyOn(global.console, "warn").mockImplementation(() => jest.fn());
 
-// Mock match media and resize observer
+// Mock resize observer
 class ResizeObserver {
   observe() {}
   unobserve() {}
@@ -21,4 +19,3 @@ class ResizeObserver {
 }
 
 window.ResizeObserver = ResizeObserver;
-new MatchMedia();

--- a/src/components/SearchBar/SearchBar.tsx
+++ b/src/components/SearchBar/SearchBar.tsx
@@ -14,7 +14,6 @@ import Select, { SelectProps as InitialSelectProps } from "../Select/Select";
 import TextInput, {
   InputProps as InitialInputProps,
 } from "../TextInput/TextInput";
-import useNYPLBreakpoints from "../../hooks/useNYPLBreakpoints";
 
 interface SelectOptionsProps {
   text: string;
@@ -143,7 +142,6 @@ export const SearchBar: ChakraComponent<
       isRequired ? "(required)" : ""
     }`;
     const buttonType = noBrandButtonType ? "noBrand" : "primary";
-    const { isLargerThanMobile } = useNYPLBreakpoints();
 
     if (!id) {
       console.warn(
@@ -204,7 +202,6 @@ export const SearchBar: ChakraComponent<
         type="submit"
         sx={styles.button}
         data-button
-        aria-label={isLargerThanMobile ? "" : "Search"}
       >
         <Icon align="left" id={`searchbar-icon-${id}`} name="search" />
         <span>Search</span>

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -40,7 +40,6 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
         </div>
       </div>
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-basic"
@@ -217,7 +216,6 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
         </div>
       </div>
       <button
-        aria-label=""
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-withSelect"
@@ -296,7 +294,6 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
         </div>
       </div>
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-withoutHelperText"
@@ -360,7 +357,6 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
         </div>
       </div>
       <button
-        aria-label=""
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-withClearButton"
@@ -448,7 +444,6 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
         />
       </div>
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-invalidState"
@@ -511,7 +506,6 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
         </div>
       </div>
       <button
-        aria-label=""
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         disabled={true}
@@ -576,7 +570,6 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
         </div>
       </div>
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         disabled={true}
@@ -641,7 +634,6 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
         </div>
       </div>
       <button
-        aria-label=""
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         disabled={true}
@@ -687,7 +679,6 @@ exports[`SearchBar renders the UI snapshot correctly 9`] = `
       className="css-1ik4laa"
     >
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-withHeading"
@@ -731,7 +722,6 @@ exports[`SearchBar renders the UI snapshot correctly 10`] = `
       className="css-1ik4laa"
     >
       <button
-        aria-label=""
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-withDescription"
@@ -781,7 +771,6 @@ exports[`SearchBar renders the UI snapshot correctly 11`] = `
       className="css-1ik4laa"
     >
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-withHeadingAndDescription"
@@ -845,7 +834,6 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
         </div>
       </div>
       <button
-        aria-label=""
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-chakra"
@@ -926,7 +914,6 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
         </div>
       </div>
       <button
-        aria-label="Search"
         className="chakra-button searchButton css-8bx9xp"
         data-button={true}
         id="searchbar-button-props"

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -13,8 +13,11 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Accessibility", "Documentation"],
-    notes: ["Removes role=search on the component wrapper."],
+    affects: ["Accessibility", "Documentation", "Functionality", "Styles"],
+    notes: [
+      "Removes role=search on the component wrapper.",
+      "Removes use of `useNYPLBreakpoints` and replaces with screenreader only styles.",
+    ],
   },
   {
     date: "2025-05-22",

--- a/src/components/SearchBar/searchBarChangelogData.ts
+++ b/src/components/SearchBar/searchBarChangelogData.ts
@@ -16,7 +16,7 @@ export const changelogData: ChangelogData[] = [
     affects: ["Accessibility", "Documentation", "Functionality", "Styles"],
     notes: [
       "Removes role=search on the component wrapper.",
-      "Removes use of `useNYPLBreakpoints` and replaces with screenreader only styles.",
+      "Removes use of `useNYPLBreakpoints` and replaces `aria-label` with screenreader only styles.",
     ],
   },
   {

--- a/src/hooks/__tests__/useNYPLBreakpoints.test.ts
+++ b/src/hooks/__tests__/useNYPLBreakpoints.test.ts
@@ -1,8 +1,11 @@
 import { act, renderHook } from "@testing-library/react-hooks";
+import MatchMedia from "../../__tests__/mediaMatchMock";
 import useNYPLBreakpoints from "../useNYPLBreakpoints";
 
 describe("useNYPLBreakpoints", () => {
   beforeAll(() => {
+    new MatchMedia();
+
     window.resizeTo = function resizeTo(width, height) {
       Object.assign(this, {
         innerWidth: width,

--- a/src/hooks/useNYPLBreakpoints.mdx
+++ b/src/hooks/useNYPLBreakpoints.mdx
@@ -83,8 +83,8 @@ When development needs more granular control when targetting viewports:
 
 ## Testing
 
-Because `useNYPLBreakpoints` uses the `MediaMatch` API, you will need to mock the
-API when unit testing. There is a mock you can import from Reservoir if you'd like.
+Because `useNYPLBreakpoints` uses the `MediaMatch` API, you will need to mock the API
+when unit testing. There is a mock you may import from Reservoir, or you can use your own.
 
 <Source
   code={`

--- a/src/hooks/useNYPLBreakpoints.mdx
+++ b/src/hooks/useNYPLBreakpoints.mdx
@@ -81,6 +81,20 @@ When development needs more granular control when targetting viewports:
 - use `isLargerThanSmallTablet` to conditionally target the `large tablet` viewport
 - use `isLargerThanLargeTablet` to conditionally target the `desktop` viewport
 
+## Testing
+
+Because `useNYPLBreakpoints` uses the `MediaMatch` API, you will need to mock the
+API when testing. There is a mock you can import from Reservoir if you'd like.
+
+<Source
+  code={`
+import { MatchMedia } from "@nypl/design-system-react-components";
+
+new MatchMedia();
+`}
+language="jsx"
+/>
+
 ## Code Example
 
 Conditionally render different components based on the current size of the

--- a/src/hooks/useNYPLBreakpoints.mdx
+++ b/src/hooks/useNYPLBreakpoints.mdx
@@ -84,7 +84,7 @@ When development needs more granular control when targetting viewports:
 ## Testing
 
 Because `useNYPLBreakpoints` uses the `MediaMatch` API, you will need to mock the
-API when testing. There is a mock you can import from Reservoir if you'd like.
+API when unit testing. There is a mock you can import from Reservoir if you'd like.
 
 <Source
   code={`

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -1,6 +1,7 @@
 import { createMultiStyleConfigHelpers } from "@chakra-ui/styled-system";
 import { setContainerStyles } from "../../utils/setContainerStyles";
 import { iconSizeStyles } from "../sharedStyles";
+import { screenreaderOnly } from "./globalMixins";
 
 const { defineMultiStyleConfig, definePartsStyle } =
   createMultiStyleConfigHelpers(["button", "select"]);
@@ -19,9 +20,11 @@ const SearchBar = defineMultiStyleConfig({
         },
         "[data-button]": {
           padding: "xs",
-          " > span": {
-            display: "none",
-          },
+          // Even though we only want to apply these styles on mobile, we
+          // cannot pass `isMobileOnly` to this function because the
+          // function uses media queries and this component uses container
+          // queries so styles would switch at slightly different moments.
+          " > span": screenreaderOnly(),
           "> svg": {
             ...iconSizeStyles["medium"],
           },
@@ -54,7 +57,10 @@ const SearchBar = defineMultiStyleConfig({
           paddingBottom: "xs",
           paddingRight: "s",
           " > span": {
-            display: "block",
+            height: "auto",
+            overflow: "unset",
+            position: "relative !important",
+            width: "100%",
           },
           "> svg": {
             ...iconSizeStyles["small"],


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2044](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2044)

## This PR does the following:

- Removes `useNYPLBreakpoints` from final component, `SearchBar` so that consuming apps are no longer required to import the MatchMedia API mock to test. 
- Now, instead of an `aria-label` being applied or removed based on whether the button is big enough to contain the word "Search", the word "Search" is always present and simply hidden with screenreader-only styles on mobile.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Using the unit tests in the repo.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- None, although it should be noted that the device used to make the `SearchBar` button accessible to screen readers has changed - instead of an `aria-label`, the word "Search" is always present and simply made visible or hidden depending on the the screen size.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2044]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ