### PR TITLE
DSD-2043: update tableTextSize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates the grid layout of the content for the `Hero` `"primary"` variant.
 - Changes the names of theme objects that conflict with Chakra's base names from `Custom` to `Reservoir` for consistency. This impacts theme objects for `Breadcrumbs`, `Button`, `Select`, `Slider`, and `Table`.
 - Replaces positional function args with object references in utility functions/components when there are 3 or more arguments.
+- Updates `Table`'s `tableTextSize` prop to accept `caption`.
 
 ### Removals
 
@@ -62,7 +63,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates Storybook and related npm packages to `v8.6.12`.
 - Updates `vite` to `v5.4.18`, `@vitejs/plugin-react` to `v4.4.1`, and `vite-plugin-svgr` to `v4.3.0`.
 - Updates the `Tabs` component to use the explicitly defined `tabs` design tokens for font size and weight.
-- Updates `Table`'s `tableTextSize` prop to accept `caption`.
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Updates Storybook and related npm packages to `v8.6.12`.
 - Updates `vite` to `v5.4.18`, `@vitejs/plugin-react` to `v4.4.1`, and `vite-plugin-svgr` to `v4.3.0`.
 - Updates the `Tabs` component to use the explicitly defined `tabs` design tokens for font size and weight.
+- Updates `Table`'s `tableTextSize` prop to accept `caption`.
 
 ### Fixes
 

--- a/src/components/Table/Table.tsx
+++ b/src/components/Table/Table.tsx
@@ -20,7 +20,7 @@ interface CustomColors {
   color?: string;
 }
 
-export const tableBodyTextSizesArray = ["body1", "body2"] as const;
+export const tableBodyTextSizesArray = ["body1", "body2", "caption"] as const;
 export type TableBodyTextSizes = typeof tableBodyTextSizesArray[number];
 
 export interface TableProps extends BoxProps {

--- a/src/components/Table/tableChangelogData.ts
+++ b/src/components/Table/tableChangelogData.ts
@@ -17,6 +17,7 @@ export const changelogData: ChangelogData[] = [
     notes: [
       "Changes theme name from `CustomTable` to `ReservoirTable` for consistency.",
       "Removes explicit `className` prop as interface can be extended to include Chakra prop or HTML attribute types.",
+      "Adds `caption` option for `tableTextSize` prop",
     ],
   },
   {

--- a/src/theme/components/table.ts
+++ b/src/theme/components/table.ts
@@ -56,16 +56,19 @@ export const fixedColumnStyles = (
   },
 });
 
-const tableTextSizes = (textSizeValue: string = "body1") => ({
-  columnHeading:
-    textSizeValue === "body1" ? "desktop.body.body2" : "desktop.caption",
-  tableBody:
-    textSizeValue === "body1"
-      ? "desktop.body.body1"
-      : textSizeValue === "body2"
-      ? "desktop.body.body2"
-      : "desktop.caption",
-});
+const tableTextSizes = (textSizeValue: string = "body1") => {
+  const fontSizeMap = {
+    body1: "desktop.body.body1",
+    body2: "desktop.body.body2",
+    caption: "desktop.caption",
+  };
+
+  return {
+    columnHeading:
+      textSizeValue === "body1" ? "desktop.body.body2" : "desktop.caption",
+    tableBody: fontSizeMap[textSizeValue],
+  };
+};
 
 export const baseTRStyles = (
   columnHeadersBackgroundColor = "",

--- a/src/theme/components/table.ts
+++ b/src/theme/components/table.ts
@@ -58,11 +58,13 @@ export const fixedColumnStyles = (
 
 const tableTextSizes = (textSizeValue: string = "body1") => ({
   columnHeading:
-    textSizeValue === "body2"
-      ? "desktop.caption.caption1"
-      : "desktop.body.body2",
+    textSizeValue === "body1" ? "desktop.body.body2" : "desktop.caption",
   tableBody:
-    textSizeValue === "body2" ? "desktop.body.body2" : "desktop.body.body1",
+    textSizeValue === "body1"
+      ? "desktop.body.body1"
+      : textSizeValue === "body2"
+      ? "desktop.body.body2"
+      : "desktop.caption",
 });
 
 export const baseTRStyles = (


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2043](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2043)

## This PR does the following:

- Updates `Table`'s `tableTextSize` prop to accept `caption`.
- Does NOT change prop's name to `fontSize` as requested in the ticket because we need to decide if/how we are going to use standard CSS properties in our components given how Chakra treats them

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- In Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2043]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2043?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ