### PR TITLE
DSD-2057 (cont.): small cleanup of explicit role prop

### DIFF
--- a/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
+++ b/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
@@ -39,7 +39,6 @@ exports[`Renders the UI snapshot correctly 1`] = `
           <p
             aria-roledescription="Subtitle"
             className="chakra-text css-e3ddnr"
-            role="paragraph"
           >
             Featured
           </p>
@@ -104,7 +103,6 @@ exports[`Renders the UI snapshot correctly 2`] = `
           <p
             aria-roledescription="Subtitle"
             className="chakra-text css-e3ddnr"
-            role="paragraph"
           >
             Featured
           </p>
@@ -169,7 +167,6 @@ exports[`Renders the UI snapshot correctly 3`] = `
           <p
             aria-roledescription="Subtitle"
             className="chakra-text css-e3ddnr"
-            role="paragraph"
           >
             Featured
           </p>
@@ -234,7 +231,6 @@ exports[`Renders the UI snapshot correctly 4`] = `
           <p
             aria-roledescription="Subtitle"
             className="chakra-text css-e3ddnr"
-            role="paragraph"
           >
             Featured
           </p>
@@ -299,7 +295,6 @@ exports[`Renders the UI snapshot correctly 5`] = `
           <p
             aria-roledescription="Subtitle"
             className="chakra-text css-e3ddnr"
-            role="paragraph"
           >
             Featured
           </p>
@@ -364,7 +359,6 @@ exports[`Renders the UI snapshot correctly 6`] = `
           <p
             aria-roledescription="Subtitle"
             className="chakra-text css-e3ddnr"
-            role="paragraph"
           >
             Featured
           </p>

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -200,12 +200,7 @@ export const Heading: ChakraComponent<
       const finalContent = (
         <>
           {overline && (
-            <Text
-              aria-roledescription="Subtitle"
-              mb="xxs"
-              role="paragraph"
-              size={overlineSize}
-            >
+            <Text aria-roledescription="Subtitle" mb="xxs" size={overlineSize}>
               {overline}
             </Text>
           )}
@@ -225,7 +220,6 @@ export const Heading: ChakraComponent<
               aria-roledescription="Subtitle"
               mt="xs"
               noSpace
-              role="paragraph"
               size={subtitleSize}
             >
               {subtitle}

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -98,7 +98,6 @@ exports[`Heading renders the UI snapshot correctly 9`] = `
   <p
     aria-roledescription="Subtitle"
     className="chakra-text css-e3ddnr"
-    role="paragraph"
   >
     Overline
   </p>
@@ -126,7 +125,6 @@ exports[`Heading renders the UI snapshot correctly 10`] = `
   <p
     aria-roledescription="Subtitle"
     className="chakra-text css-dqoc1s"
-    role="paragraph"
   >
     This is the subtitle
   </p>
@@ -142,7 +140,6 @@ exports[`Heading renders the UI snapshot correctly 11`] = `
   <p
     aria-roledescription="Subtitle"
     className="chakra-text css-e3ddnr"
-    role="paragraph"
   >
     Overline
   </p>
@@ -155,7 +152,6 @@ exports[`Heading renders the UI snapshot correctly 11`] = `
   <p
     aria-roledescription="Subtitle"
     className="chakra-text css-dqoc1s"
-    role="paragraph"
   >
     This is the subtitle
   </p>

--- a/src/components/Text/Text.mdx
+++ b/src/components/Text/Text.mdx
@@ -41,9 +41,6 @@ You may pass any Chakra `Box` props, as well as the props below.
 The `Text` component renders paragraph `p` HTML elements which are inherently
 accessible and will be read by screen readers.
 
-You may pass an HTML `role` attribute if you need to explicitly set the ARIA
-role.
-
 Resources:
 
 - [Chakra UI Text](https://chakra-ui.com/docs/components/typography/text)


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2057](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2057)

## This PR does the following:

- Small additional tweak that should have been included in DSD-2057's PR ([some discussion here](https://github.com/NYPL/nypl-design-system/pull/1812#discussion_r2122121032), continued on Slack)
- Removes line in `Text` doc about adding a `role` because generally `role` is not needed for `<p>` elements. 
- Also removed the `role` from the `Text` components used in `Heading`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- With unit tests
- Will send Clare Vercel preview

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Will send Clare Vercel preview

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2057]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2057?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ