### PR TITLE
DSD-2045: Reimplementing the Tab's component use of mobile panel scrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Removes `isDarkMode` function from `Slider` and `Accordion`.
 - Removes `useNYPLBreakpoints` from final component, `SearchBar`, and removes `mediaMatchMock` from test setup since it is no longer necessary.
 - Removes explicit `className` and `children` props in favor of expanded prop type definitions in all components.
+- Removes the use of the `window`'s `scrollIntoView` dependency in the `Tabs` component.
 
 ## Prerelease
 

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -4,16 +4,20 @@ import * as TabsStories from "./Tabs.stories";
 import Banner from "../Banner/Banner";
 import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import { changelogData } from "./tabsChangelogData";
 
 <Meta of={TabsStories} />
 
-# Tabs
+<ComponentDocsHeader
+  category="Overlays & Switchers"
+  componentName="Tabs"
+  summary="Renders the Chakra `Tab` component to associate tab buttons with panels."
+  versionAdded="0.24.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.24.0`     |
-| Latest            | `Prerelease` |
+<Canvas of={TabsStories.WithControls} />
 
 ## Table of Contents
 
@@ -33,8 +37,6 @@ import { changelogData } from "./tabsChangelogData";
 <Description of={TabsStories} />
 
 ## Component Props
-
-<Canvas of={TabsStories.WithControls} />
 
 You may pass any Chakra `Box` props, as well as the props below.
 

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./tabsChangelogData";
 <ComponentDocsHeader
   category="Overlays & Switchers"
   componentName="Tabs"
-  summary="Renders the Chakra `Tab` component to associate tab buttons with panels."
+  summary="Displays related content in a tabbed interface"
   versionAdded="0.24.0"
   versionLatest="Prerelease"
 />

--- a/src/components/Tabs/Tabs.test.tsx
+++ b/src/components/Tabs/Tabs.test.tsx
@@ -137,7 +137,6 @@ describe("Tabs", () => {
   });
 
   it("switches between tabs", () => {
-    window.HTMLElement.prototype.scrollIntoView = jest.fn();
     render(<Tabs tabsData={animalCrossing} />);
     const isabelleTab = getTabByName("Isabelle");
     const kkSliderTab = getTabByName("K.K. Slider");

--- a/src/components/Tabs/tabsChangelogData.ts
+++ b/src/components/Tabs/tabsChangelogData.ts
@@ -16,6 +16,7 @@ export const changelogData: ChangelogData[] = [
     affects: ["Functionality"],
     notes: [
       "Extends prop interface to include Chakra props or HTML attributes.",
+      "Removes the use of the `window`'s `scrollIntoView` dependency.",
     ],
   },
   {

--- a/src/hooks/useScrollTabIntoView.ts
+++ b/src/hooks/useScrollTabIntoView.ts
@@ -7,14 +7,27 @@ import React, { useEffect, useRef } from "react";
  * Returns a ref for the TabList component.
  */
 export const useScrollTabIntoView = (index: number) => {
-  const tablistRef = useRef<HTMLDivElement>();
+  const tablistRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    const selectedTab = tablistRef?.current?.querySelector(
+    const container = tablistRef?.current;
+    const selectedTab = container?.querySelector(
       "[role=tab][aria-selected=true]"
     );
-    // scroll only horizontally
-    selectedTab?.scrollIntoView({ block: "nearest" });
+
+    if (!selectedTab) return;
+
+    const containerRect = container.getBoundingClientRect();
+    const tabRect = selectedTab.getBoundingClientRect();
+
+    const isTabPartiallyHiddenLeft = tabRect.left < containerRect.left;
+    const isTabPartiallyHiddenRight = tabRect.right > containerRect.right;
+
+    if (isTabPartiallyHiddenLeft) {
+      container.scrollLeft -= containerRect.left - tabRect.left;
+    } else if (isTabPartiallyHiddenRight) {
+      container.scrollLeft += tabRect.right - containerRect.right;
+    }
   }, [index]);
 
   return tablistRef;


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2045](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2045)

## This PR does the following:

- Refactors the internal `useScrollTabIntoView` hook and removes the `scrollIntoView` property. This removes the need to mock it in an app's unit tests.
- Make sure that the jump to scroll to the clicked tab works as it currently does.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- The jest mock was removed in `tabs.tests.tsx`. This means, once this is released, that consuming apps can remove the mock in their unit tests as well.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2045]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ