### PR TITLE
DSD-2038: Consistent id and classname update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Changes the names of theme objects that conflict with Chakra's base names from `Custom` to `Reservoir` for consistency. This impacts theme objects for `Breadcrumbs`, `Button`, `Select`, `Slider`, and `Table`.
 - Replaces positional function args with object references in utility functions/components when there are 3 or more arguments.
 - Updates `Table`'s `tableTextSize` prop to accept `caption`.
+- Updates the `id` value for all components to use the `ds-[componentName]-${additionalUserID}` format.
 
 ### Removals
 

--- a/src/components/Accordion/Accordion.stories.tsx
+++ b/src/components/Accordion/Accordion.stories.tsx
@@ -138,7 +138,6 @@ const meta: Meta<typeof Accordion> = {
         faqData: faqContentData,
       },
     },
-    id: { control: false },
     isDefaultOpen: argsBooleanType(),
     isAlwaysRendered: argsBooleanType(),
     panelMaxHeight: { control: { type: "text" } },
@@ -155,7 +154,6 @@ type Story = StoryObj<typeof Accordion>;
 export const WithControls: Story = {
   args: {
     accordionData,
-    id: "accordion-id",
     isDefaultOpen: false,
     isAlwaysRendered: false,
     panelMaxHeight: undefined,

--- a/src/components/Accordion/Accordion.tsx
+++ b/src/components/Accordion/Accordion.tsx
@@ -8,9 +8,10 @@ import {
   chakra,
   ChakraComponent,
 } from "@chakra-ui/react";
-import React, { forwardRef, useEffect, useState } from "react";
+import { createRef, forwardRef, useEffect, useState } from "react";
 
 import Icon from "../Icons/Icon";
+import { generateComponentId } from "../../utils/utils";
 
 export type AccordionTypes = "default" | "warning" | "error";
 export interface AccordionDataProps {
@@ -25,8 +26,6 @@ export interface AccordionDataProps {
 export interface AccordionProps extends Omit<BoxProps, "onChange"> {
   /** Array of data to display, and an optional accordionType */
   accordionData: AccordionDataProps[];
-  /** ID that other components can cross reference for accessibility purposes */
-  id?: string;
   /** Whether the accordion is open by default only on its initial rendering */
   isDefaultOpen?: boolean;
   /** Whether the contents of the Accordion should always be rendered.
@@ -46,20 +45,20 @@ export interface AccordionProps extends Omit<BoxProps, "onChange"> {
  * Get the minus or plus icon depending on whether the accordion is open or closed.
  */
 const getIcon = ({
-  isExpanded = false,
-  index,
   id,
+  index,
+  isExpanded = false,
 }: {
-  isExpanded?: boolean;
-  index: number;
   id: string;
+  index: number;
+  isExpanded?: boolean;
 }) => {
   const iconName = isExpanded ? "minus" : "plus";
   return (
     <Icon
       className="accordion-icon"
       color="currentColor"
-      id={`accordion-${id}-icon-${index}`}
+      id={`${id}-icon-${index}`}
       name={iconName}
       size="small"
     />
@@ -72,20 +71,20 @@ const getIcon = ({
  * combination that is required for the Chakra `Accordion` component.
  */
 const getElementsFromData = ({
-  data = [],
   ariaLabel,
+  data = [],
+  hoveredButtonIndex,
   id,
   isAlwaysRendered = false,
   panelMaxHeight,
-  hoveredButtonIndex,
   setHoveredButtonIndex,
 }: {
-  data?: AccordionDataProps[];
   ariaLabel: string;
+  data?: AccordionDataProps[];
+  hoveredButtonIndex: number;
   id: string;
   isAlwaysRendered?: boolean;
   panelMaxHeight: string;
-  hoveredButtonIndex: number;
   setHoveredButtonIndex: React.Dispatch<React.SetStateAction<number>>;
 }) => {
   const colorMapLight = {
@@ -235,7 +234,6 @@ const getElementsFromData = ({
  * Accordion component that shows content on toggle. Can be used to display
  * multiple accordion items together.
  */
-
 export const Accordion: ChakraComponent<
   React.ForwardRefExoticComponent<
     AccordionProps & React.RefAttributes<HTMLDivElement>
@@ -254,6 +252,8 @@ export const Accordion: ChakraComponent<
       ...rest
     } = props;
 
+    const mainId = generateComponentId("accordion", id);
+
     // Pass `0` to open the first accordion in the 0-index based array.
     const [expandedPanels, setExpandedPanels] = useState<number[]>(
       isDefaultOpen ? [0] : []
@@ -267,7 +267,7 @@ export const Accordion: ChakraComponent<
     // buttons, add them now.
     const updatedAccordionData = accordionData.map((item) => ({
       ...item,
-      buttonInteractionRef: item.buttonInteractionRef || React.createRef(),
+      buttonInteractionRef: item.buttonInteractionRef || createRef(),
     }));
 
     const handleKeyDown = (e) => {
@@ -313,14 +313,14 @@ export const Accordion: ChakraComponent<
         index={expandedPanels}
         onChange={(expandedIdxs: number[]) => setExpandedPanels(expandedIdxs)}
         onKeyDown={handleKeyDown}
-        id={id}
+        id={mainId}
         ref={ref}
         {...rest}
       >
         {getElementsFromData({
           data: updatedAccordionData,
           ariaLabel,
-          id,
+          id: mainId,
           isAlwaysRendered,
           panelMaxHeight,
           hoveredButtonIndex,

--- a/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -3,18 +3,18 @@
 exports[`Accordion Renders the UI snapshot correctly 1`] = `
 <div
   className="chakra-accordion css-1xdhyk6"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-1rvudez"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -32,7 +32,7 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />
@@ -44,18 +44,18 @@ exports[`Accordion Renders the UI snapshot correctly 1`] = `
 exports[`Accordion Renders the UI snapshot correctly 2`] = `
 <div
   className="chakra-accordion css-1xdhyk6"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-1rvudez"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -73,7 +73,7 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />
@@ -85,18 +85,18 @@ exports[`Accordion Renders the UI snapshot correctly 2`] = `
 exports[`Accordion Renders the UI snapshot correctly 3`] = `
 <div
   className="chakra-accordion css-1t0bvx9"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-1rvudez"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -114,7 +114,7 @@ exports[`Accordion Renders the UI snapshot correctly 3`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />
@@ -127,18 +127,18 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
 <div
   className="chakra-accordion css-1xdhyk6"
   data-testid="testid"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-1rvudez"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -156,7 +156,7 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />
@@ -168,18 +168,18 @@ exports[`Accordion Renders the UI snapshot correctly 4`] = `
 exports[`Accordion Renders the UI snapshot correctly 5`] = `
 <div
   className="chakra-accordion css-1xdhyk6"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-1rvudez"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -197,7 +197,7 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />
@@ -209,18 +209,18 @@ exports[`Accordion Renders the UI snapshot correctly 5`] = `
 exports[`Accordion Renders the UI snapshot correctly 6`] = `
 <div
   className="chakra-accordion css-1xdhyk6"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-19i7nb2"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -238,7 +238,7 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />
@@ -250,18 +250,18 @@ exports[`Accordion Renders the UI snapshot correctly 6`] = `
 exports[`Accordion Renders the UI snapshot correctly 7`] = `
 <div
   className="chakra-accordion css-1xdhyk6"
-  id="accordian"
+  id="ds-accordion-accordian"
   onKeyDown={[Function]}
 >
   <div
     className="chakra-accordion__item css-1fsnuue"
   >
     <button
-      aria-controls="accordion-panel-accordian-item-0"
+      aria-controls="accordion-panel-ds-accordion-accordian-item-0"
       aria-expanded={false}
       className="chakra-accordion__button css-k7suym"
       disabled={false}
-      id="accordion-button-accordian-item-0"
+      id="accordion-button-ds-accordion-accordian-item-0"
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
@@ -279,7 +279,7 @@ exports[`Accordion Renders the UI snapshot correctly 7`] = `
         className="chakra-icon accordion-icon css-1b9sovw"
         data-file-name="SvgPlus"
         focusable={false}
-        id="accordion-accordian-icon-0"
+        id="ds-accordion-accordian-icon-0"
         role="img"
         title="plus icon"
       />

--- a/src/components/Accordion/accordionChangelogData.ts
+++ b/src/components/Accordion/accordionChangelogData.ts
@@ -19,6 +19,7 @@ export const changelogData: ChangelogData[] = [
       "Removes `isDarkMode` in favor of Chakra's `_dark` conditional key.",
       "Replaces positional function arguments with objects for `getIcon` and `getElementsFromData`.",
       "Extends prop definition to include Chakra's `BoxProps`",
+      "Sets the default id value to `ds-accordion`.",
     ],
   },
   {

--- a/src/components/AlphabetFilter/AlphabetFilter.stories.tsx
+++ b/src/components/AlphabetFilter/AlphabetFilter.stories.tsx
@@ -11,7 +11,6 @@ const meta: Meta<typeof AlphabetFilter> = {
   argTypes: {
     activeLetters: { control: false },
     currentLetter: { control: false },
-    id: { control: false },
     isDisabled: argsBooleanType(),
     onClick: { control: false },
   },
@@ -30,7 +29,6 @@ export const WithControls: Story = {
     currentLetter: undefined,
     descriptionText: "This is description text.",
     headingText: "AlphabetFilter",
-    id: "alphabet-filter-id",
     isDisabled: false,
     onClick: undefined,
   },
@@ -68,6 +66,7 @@ export const SetActiveLetters: Story = {
 export const WithCustomHeading: Story = {
   render: () => (
     <AlphabetFilter
+      id="custom-heading"
       onClick={undefined}
       headingText={<Heading level="h4">Custom H4 Heading</Heading>}
     />

--- a/src/components/AlphabetFilter/AlphabetFilter.tsx
+++ b/src/components/AlphabetFilter/AlphabetFilter.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef, useState } from "react";
+import { forwardRef, useEffect, useRef, useState } from "react";
 import {
   Box,
   BoxProps,
@@ -8,8 +8,10 @@ import {
   useColorModeValue,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
+
 import { Button } from "../Button/Button";
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { generateComponentId } from "../../utils/utils";
 
 export interface AlphabetFilterProps extends Omit<BoxProps, "onClick"> {
   /** Array of letters to specify which `Button` components should be set in an `enabled`
@@ -24,8 +26,6 @@ export interface AlphabetFilterProps extends Omit<BoxProps, "onClick"> {
    * a DS Heading component that can be passed in.
    */
   headingText?: string | JSX.Element;
-  /** ID that other components can cross reference for accessibility purposes. */
-  id?: string;
   /** Adds the `disabled` prop to the AlphabetFilter when true. */
   isDisabled?: boolean;
   /** The callback function called when a letter button or the Show All button is clicked. */
@@ -51,7 +51,7 @@ export const AlphabetFilter: ChakraComponent<
     } = props;
 
     const styles = useMultiStyleConfig("AlphabetFilter", {});
-
+    const mainId = generateComponentId("alphabetFilter", id);
     const filterButtons = [
       { text: "#", value: "#" },
       { text: "A", value: "a" },
@@ -82,13 +82,12 @@ export const AlphabetFilter: ChakraComponent<
       { text: "Z", value: "z" },
       { text: "Show All", value: "showAll" },
     ];
-
     const refCurrentLetter = useRef(currentLetter);
     const [selectedLetter, setSelectedLetter] = useState<string>(currentLetter);
 
     // If the parent passes down a new currentLetter, then set the internal state – selectedLetter –
     // to the new currentLetter and update the refCurrentLetter with that value.
-    React.useEffect(() => {
+    useEffect(() => {
       if (currentLetter && currentLetter !== refCurrentLetter.current) {
         setSelectedLetter(currentLetter);
         refCurrentLetter.current = currentLetter;
@@ -141,7 +140,7 @@ export const AlphabetFilter: ChakraComponent<
             item.text === "Show All" ? item.text : "Page " + item.text
           }
           buttonType="text"
-          id={`filter-${item.value}`}
+          id={`${mainId}-filter-${item.value}`}
           isDisabled={isButtonDisabled}
           key={item.value}
           sx={buttonStyles}
@@ -161,13 +160,13 @@ export const AlphabetFilter: ChakraComponent<
     };
 
     return (
-      <Box as="nav" ref={ref} aria-label="Filter by letter">
+      <Box as="nav" id={mainId} ref={ref} aria-label="Filter by letter">
         <ComponentWrapper
-          id={id}
-          __css={styles}
-          {...rest}
+          // @TODO update id so it doesn't render undefined
           headingText={headingText ? headingText : undefined}
           descriptionText={descriptionText ? descriptionText : undefined}
+          __css={styles}
+          {...rest}
         >
           <Flex wrap="wrap">{getFilterLetters()}</Flex>
         </ComponentWrapper>

--- a/src/components/AlphabetFilter/__snapshots__/AlphabetFilter.test.tsx.snap
+++ b/src/components/AlphabetFilter/__snapshots__/AlphabetFilter.test.tsx.snap
@@ -4,10 +4,11 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
 <nav
   aria-label="Filter by letter"
   className="css-0"
+  id="ds-alphabetFilter-alphabet-filter"
 >
   <div
     className="css-1u8qly9"
-    id="alphabet-filter-wrapper"
+    id="undefined-wrapper"
   >
     <div
       className="css-2imjyh"
@@ -16,7 +17,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page #"
         className="chakra-button css-lmduhw"
-        id="filter-#"
+        id="ds-alphabetFilter-alphabet-filter-filter-#"
         onClick={[Function]}
         type="button"
       >
@@ -26,7 +27,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page A"
         className="chakra-button css-lmduhw"
-        id="filter-a"
+        id="ds-alphabetFilter-alphabet-filter-filter-a"
         onClick={[Function]}
         type="button"
       >
@@ -36,7 +37,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page B"
         className="chakra-button css-lmduhw"
-        id="filter-b"
+        id="ds-alphabetFilter-alphabet-filter-filter-b"
         onClick={[Function]}
         type="button"
       >
@@ -46,7 +47,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page C"
         className="chakra-button css-lmduhw"
-        id="filter-c"
+        id="ds-alphabetFilter-alphabet-filter-filter-c"
         onClick={[Function]}
         type="button"
       >
@@ -56,7 +57,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page D"
         className="chakra-button css-lmduhw"
-        id="filter-d"
+        id="ds-alphabetFilter-alphabet-filter-filter-d"
         onClick={[Function]}
         type="button"
       >
@@ -66,7 +67,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page E"
         className="chakra-button css-lmduhw"
-        id="filter-e"
+        id="ds-alphabetFilter-alphabet-filter-filter-e"
         onClick={[Function]}
         type="button"
       >
@@ -76,7 +77,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page F"
         className="chakra-button css-lmduhw"
-        id="filter-f"
+        id="ds-alphabetFilter-alphabet-filter-filter-f"
         onClick={[Function]}
         type="button"
       >
@@ -86,7 +87,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page G"
         className="chakra-button css-lmduhw"
-        id="filter-g"
+        id="ds-alphabetFilter-alphabet-filter-filter-g"
         onClick={[Function]}
         type="button"
       >
@@ -96,7 +97,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page H"
         className="chakra-button css-lmduhw"
-        id="filter-h"
+        id="ds-alphabetFilter-alphabet-filter-filter-h"
         onClick={[Function]}
         type="button"
       >
@@ -106,7 +107,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page I"
         className="chakra-button css-lmduhw"
-        id="filter-i"
+        id="ds-alphabetFilter-alphabet-filter-filter-i"
         onClick={[Function]}
         type="button"
       >
@@ -116,7 +117,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page J"
         className="chakra-button css-lmduhw"
-        id="filter-j"
+        id="ds-alphabetFilter-alphabet-filter-filter-j"
         onClick={[Function]}
         type="button"
       >
@@ -126,7 +127,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page K"
         className="chakra-button css-lmduhw"
-        id="filter-k"
+        id="ds-alphabetFilter-alphabet-filter-filter-k"
         onClick={[Function]}
         type="button"
       >
@@ -136,7 +137,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page L"
         className="chakra-button css-lmduhw"
-        id="filter-l"
+        id="ds-alphabetFilter-alphabet-filter-filter-l"
         onClick={[Function]}
         type="button"
       >
@@ -146,7 +147,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page M"
         className="chakra-button css-lmduhw"
-        id="filter-m"
+        id="ds-alphabetFilter-alphabet-filter-filter-m"
         onClick={[Function]}
         type="button"
       >
@@ -156,7 +157,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page N"
         className="chakra-button css-lmduhw"
-        id="filter-n"
+        id="ds-alphabetFilter-alphabet-filter-filter-n"
         onClick={[Function]}
         type="button"
       >
@@ -166,7 +167,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page O"
         className="chakra-button css-lmduhw"
-        id="filter-o"
+        id="ds-alphabetFilter-alphabet-filter-filter-o"
         onClick={[Function]}
         type="button"
       >
@@ -176,7 +177,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page P"
         className="chakra-button css-lmduhw"
-        id="filter-p"
+        id="ds-alphabetFilter-alphabet-filter-filter-p"
         onClick={[Function]}
         type="button"
       >
@@ -186,7 +187,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page Q"
         className="chakra-button css-lmduhw"
-        id="filter-q"
+        id="ds-alphabetFilter-alphabet-filter-filter-q"
         onClick={[Function]}
         type="button"
       >
@@ -196,7 +197,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page R"
         className="chakra-button css-lmduhw"
-        id="filter-r"
+        id="ds-alphabetFilter-alphabet-filter-filter-r"
         onClick={[Function]}
         type="button"
       >
@@ -206,7 +207,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page S"
         className="chakra-button css-lmduhw"
-        id="filter-s"
+        id="ds-alphabetFilter-alphabet-filter-filter-s"
         onClick={[Function]}
         type="button"
       >
@@ -216,7 +217,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page T"
         className="chakra-button css-lmduhw"
-        id="filter-t"
+        id="ds-alphabetFilter-alphabet-filter-filter-t"
         onClick={[Function]}
         type="button"
       >
@@ -226,7 +227,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page U"
         className="chakra-button css-lmduhw"
-        id="filter-u"
+        id="ds-alphabetFilter-alphabet-filter-filter-u"
         onClick={[Function]}
         type="button"
       >
@@ -236,7 +237,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page V"
         className="chakra-button css-lmduhw"
-        id="filter-v"
+        id="ds-alphabetFilter-alphabet-filter-filter-v"
         onClick={[Function]}
         type="button"
       >
@@ -246,7 +247,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page W"
         className="chakra-button css-lmduhw"
-        id="filter-w"
+        id="ds-alphabetFilter-alphabet-filter-filter-w"
         onClick={[Function]}
         type="button"
       >
@@ -256,7 +257,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page X"
         className="chakra-button css-lmduhw"
-        id="filter-x"
+        id="ds-alphabetFilter-alphabet-filter-filter-x"
         onClick={[Function]}
         type="button"
       >
@@ -266,7 +267,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page Y"
         className="chakra-button css-lmduhw"
-        id="filter-y"
+        id="ds-alphabetFilter-alphabet-filter-filter-y"
         onClick={[Function]}
         type="button"
       >
@@ -276,7 +277,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Page Z"
         className="chakra-button css-lmduhw"
-        id="filter-z"
+        id="ds-alphabetFilter-alphabet-filter-filter-z"
         onClick={[Function]}
         type="button"
       >
@@ -286,7 +287,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 1`] = `
         aria-current={null}
         aria-label="Show All"
         className="chakra-button css-lmduhw"
-        id="filter-showAll"
+        id="ds-alphabetFilter-alphabet-filter-filter-showAll"
         onClick={[Function]}
         type="button"
       >
@@ -301,10 +302,11 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
 <nav
   aria-label="Filter by letter"
   className="css-0"
+  id="ds-alphabetFilter-alphabet-filter"
 >
   <div
     className="css-1u8qly9"
-    id="alphabet-filter-wrapper"
+    id="undefined-wrapper"
   >
     <div
       className="css-2imjyh"
@@ -314,7 +316,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page #"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-#"
+        id="ds-alphabetFilter-alphabet-filter-filter-#"
         onClick={[Function]}
         type="button"
       >
@@ -325,7 +327,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page A"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-a"
+        id="ds-alphabetFilter-alphabet-filter-filter-a"
         onClick={[Function]}
         type="button"
       >
@@ -336,7 +338,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page B"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-b"
+        id="ds-alphabetFilter-alphabet-filter-filter-b"
         onClick={[Function]}
         type="button"
       >
@@ -347,7 +349,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page C"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-c"
+        id="ds-alphabetFilter-alphabet-filter-filter-c"
         onClick={[Function]}
         type="button"
       >
@@ -358,7 +360,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page D"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-d"
+        id="ds-alphabetFilter-alphabet-filter-filter-d"
         onClick={[Function]}
         type="button"
       >
@@ -369,7 +371,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page E"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-e"
+        id="ds-alphabetFilter-alphabet-filter-filter-e"
         onClick={[Function]}
         type="button"
       >
@@ -380,7 +382,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page F"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-f"
+        id="ds-alphabetFilter-alphabet-filter-filter-f"
         onClick={[Function]}
         type="button"
       >
@@ -391,7 +393,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page G"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-g"
+        id="ds-alphabetFilter-alphabet-filter-filter-g"
         onClick={[Function]}
         type="button"
       >
@@ -402,7 +404,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page H"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-h"
+        id="ds-alphabetFilter-alphabet-filter-filter-h"
         onClick={[Function]}
         type="button"
       >
@@ -413,7 +415,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page I"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-i"
+        id="ds-alphabetFilter-alphabet-filter-filter-i"
         onClick={[Function]}
         type="button"
       >
@@ -424,7 +426,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page J"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-j"
+        id="ds-alphabetFilter-alphabet-filter-filter-j"
         onClick={[Function]}
         type="button"
       >
@@ -435,7 +437,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page K"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-k"
+        id="ds-alphabetFilter-alphabet-filter-filter-k"
         onClick={[Function]}
         type="button"
       >
@@ -446,7 +448,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page L"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-l"
+        id="ds-alphabetFilter-alphabet-filter-filter-l"
         onClick={[Function]}
         type="button"
       >
@@ -457,7 +459,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page M"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-m"
+        id="ds-alphabetFilter-alphabet-filter-filter-m"
         onClick={[Function]}
         type="button"
       >
@@ -468,7 +470,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page N"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-n"
+        id="ds-alphabetFilter-alphabet-filter-filter-n"
         onClick={[Function]}
         type="button"
       >
@@ -479,7 +481,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page O"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-o"
+        id="ds-alphabetFilter-alphabet-filter-filter-o"
         onClick={[Function]}
         type="button"
       >
@@ -490,7 +492,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page P"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-p"
+        id="ds-alphabetFilter-alphabet-filter-filter-p"
         onClick={[Function]}
         type="button"
       >
@@ -501,7 +503,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page Q"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-q"
+        id="ds-alphabetFilter-alphabet-filter-filter-q"
         onClick={[Function]}
         type="button"
       >
@@ -512,7 +514,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page R"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-r"
+        id="ds-alphabetFilter-alphabet-filter-filter-r"
         onClick={[Function]}
         type="button"
       >
@@ -523,7 +525,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page S"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-s"
+        id="ds-alphabetFilter-alphabet-filter-filter-s"
         onClick={[Function]}
         type="button"
       >
@@ -534,7 +536,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page T"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-t"
+        id="ds-alphabetFilter-alphabet-filter-filter-t"
         onClick={[Function]}
         type="button"
       >
@@ -545,7 +547,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page U"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-u"
+        id="ds-alphabetFilter-alphabet-filter-filter-u"
         onClick={[Function]}
         type="button"
       >
@@ -556,7 +558,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page V"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-v"
+        id="ds-alphabetFilter-alphabet-filter-filter-v"
         onClick={[Function]}
         type="button"
       >
@@ -567,7 +569,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page W"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-w"
+        id="ds-alphabetFilter-alphabet-filter-filter-w"
         onClick={[Function]}
         type="button"
       >
@@ -578,7 +580,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page X"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-x"
+        id="ds-alphabetFilter-alphabet-filter-filter-x"
         onClick={[Function]}
         type="button"
       >
@@ -589,7 +591,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page Y"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-y"
+        id="ds-alphabetFilter-alphabet-filter-filter-y"
         onClick={[Function]}
         type="button"
       >
@@ -600,7 +602,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Page Z"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-z"
+        id="ds-alphabetFilter-alphabet-filter-filter-z"
         onClick={[Function]}
         type="button"
       >
@@ -611,7 +613,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 2`] = `
         aria-label="Show All"
         className="chakra-button css-lmduhw"
         disabled={true}
-        id="filter-showAll"
+        id="ds-alphabetFilter-alphabet-filter-filter-showAll"
         onClick={[Function]}
         type="button"
       >
@@ -626,14 +628,14 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
 <nav
   aria-label="Filter by letter"
   className="css-0"
+  id="ds-alphabetFilter-alphabet-filter"
 >
   <div
     className="css-1u8qly9"
-    id="alphabet-filter-wrapper"
+    id="undefined-wrapper"
   >
     <h2
       className="chakra-heading css-1xdhyk6"
-      id="alphabet-filter-heading"
     >
       Heading
     </h2>
@@ -644,7 +646,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page #"
         className="chakra-button css-lmduhw"
-        id="filter-#"
+        id="ds-alphabetFilter-alphabet-filter-filter-#"
         onClick={[Function]}
         type="button"
       >
@@ -654,7 +656,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page A"
         className="chakra-button css-lmduhw"
-        id="filter-a"
+        id="ds-alphabetFilter-alphabet-filter-filter-a"
         onClick={[Function]}
         type="button"
       >
@@ -664,7 +666,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page B"
         className="chakra-button css-lmduhw"
-        id="filter-b"
+        id="ds-alphabetFilter-alphabet-filter-filter-b"
         onClick={[Function]}
         type="button"
       >
@@ -674,7 +676,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page C"
         className="chakra-button css-lmduhw"
-        id="filter-c"
+        id="ds-alphabetFilter-alphabet-filter-filter-c"
         onClick={[Function]}
         type="button"
       >
@@ -684,7 +686,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page D"
         className="chakra-button css-lmduhw"
-        id="filter-d"
+        id="ds-alphabetFilter-alphabet-filter-filter-d"
         onClick={[Function]}
         type="button"
       >
@@ -694,7 +696,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page E"
         className="chakra-button css-lmduhw"
-        id="filter-e"
+        id="ds-alphabetFilter-alphabet-filter-filter-e"
         onClick={[Function]}
         type="button"
       >
@@ -704,7 +706,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page F"
         className="chakra-button css-lmduhw"
-        id="filter-f"
+        id="ds-alphabetFilter-alphabet-filter-filter-f"
         onClick={[Function]}
         type="button"
       >
@@ -714,7 +716,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page G"
         className="chakra-button css-lmduhw"
-        id="filter-g"
+        id="ds-alphabetFilter-alphabet-filter-filter-g"
         onClick={[Function]}
         type="button"
       >
@@ -724,7 +726,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page H"
         className="chakra-button css-lmduhw"
-        id="filter-h"
+        id="ds-alphabetFilter-alphabet-filter-filter-h"
         onClick={[Function]}
         type="button"
       >
@@ -734,7 +736,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page I"
         className="chakra-button css-lmduhw"
-        id="filter-i"
+        id="ds-alphabetFilter-alphabet-filter-filter-i"
         onClick={[Function]}
         type="button"
       >
@@ -744,7 +746,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page J"
         className="chakra-button css-lmduhw"
-        id="filter-j"
+        id="ds-alphabetFilter-alphabet-filter-filter-j"
         onClick={[Function]}
         type="button"
       >
@@ -754,7 +756,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page K"
         className="chakra-button css-lmduhw"
-        id="filter-k"
+        id="ds-alphabetFilter-alphabet-filter-filter-k"
         onClick={[Function]}
         type="button"
       >
@@ -764,7 +766,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page L"
         className="chakra-button css-lmduhw"
-        id="filter-l"
+        id="ds-alphabetFilter-alphabet-filter-filter-l"
         onClick={[Function]}
         type="button"
       >
@@ -774,7 +776,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page M"
         className="chakra-button css-lmduhw"
-        id="filter-m"
+        id="ds-alphabetFilter-alphabet-filter-filter-m"
         onClick={[Function]}
         type="button"
       >
@@ -784,7 +786,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page N"
         className="chakra-button css-lmduhw"
-        id="filter-n"
+        id="ds-alphabetFilter-alphabet-filter-filter-n"
         onClick={[Function]}
         type="button"
       >
@@ -794,7 +796,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page O"
         className="chakra-button css-lmduhw"
-        id="filter-o"
+        id="ds-alphabetFilter-alphabet-filter-filter-o"
         onClick={[Function]}
         type="button"
       >
@@ -804,7 +806,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page P"
         className="chakra-button css-lmduhw"
-        id="filter-p"
+        id="ds-alphabetFilter-alphabet-filter-filter-p"
         onClick={[Function]}
         type="button"
       >
@@ -814,7 +816,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page Q"
         className="chakra-button css-lmduhw"
-        id="filter-q"
+        id="ds-alphabetFilter-alphabet-filter-filter-q"
         onClick={[Function]}
         type="button"
       >
@@ -824,7 +826,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page R"
         className="chakra-button css-lmduhw"
-        id="filter-r"
+        id="ds-alphabetFilter-alphabet-filter-filter-r"
         onClick={[Function]}
         type="button"
       >
@@ -834,7 +836,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page S"
         className="chakra-button css-lmduhw"
-        id="filter-s"
+        id="ds-alphabetFilter-alphabet-filter-filter-s"
         onClick={[Function]}
         type="button"
       >
@@ -844,7 +846,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page T"
         className="chakra-button css-lmduhw"
-        id="filter-t"
+        id="ds-alphabetFilter-alphabet-filter-filter-t"
         onClick={[Function]}
         type="button"
       >
@@ -854,7 +856,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page U"
         className="chakra-button css-lmduhw"
-        id="filter-u"
+        id="ds-alphabetFilter-alphabet-filter-filter-u"
         onClick={[Function]}
         type="button"
       >
@@ -864,7 +866,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page V"
         className="chakra-button css-lmduhw"
-        id="filter-v"
+        id="ds-alphabetFilter-alphabet-filter-filter-v"
         onClick={[Function]}
         type="button"
       >
@@ -874,7 +876,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page W"
         className="chakra-button css-lmduhw"
-        id="filter-w"
+        id="ds-alphabetFilter-alphabet-filter-filter-w"
         onClick={[Function]}
         type="button"
       >
@@ -884,7 +886,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page X"
         className="chakra-button css-lmduhw"
-        id="filter-x"
+        id="ds-alphabetFilter-alphabet-filter-filter-x"
         onClick={[Function]}
         type="button"
       >
@@ -894,7 +896,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page Y"
         className="chakra-button css-lmduhw"
-        id="filter-y"
+        id="ds-alphabetFilter-alphabet-filter-filter-y"
         onClick={[Function]}
         type="button"
       >
@@ -904,7 +906,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Page Z"
         className="chakra-button css-lmduhw"
-        id="filter-z"
+        id="ds-alphabetFilter-alphabet-filter-filter-z"
         onClick={[Function]}
         type="button"
       >
@@ -914,7 +916,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 3`] = `
         aria-current={null}
         aria-label="Show All"
         className="chakra-button css-lmduhw"
-        id="filter-showAll"
+        id="ds-alphabetFilter-alphabet-filter-filter-showAll"
         onClick={[Function]}
         type="button"
       >
@@ -929,10 +931,11 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
 <nav
   aria-label="Filter by letter"
   className="css-0"
+  id="ds-alphabetFilter-alphabet-filter"
 >
   <div
     className="css-1u8qly9"
-    id="alphabet-filter-wrapper"
+    id="undefined-wrapper"
   >
     <p
       className="chakra-text css-1xdhyk6"
@@ -946,7 +949,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page #"
         className="chakra-button css-lmduhw"
-        id="filter-#"
+        id="ds-alphabetFilter-alphabet-filter-filter-#"
         onClick={[Function]}
         type="button"
       >
@@ -956,7 +959,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page A"
         className="chakra-button css-lmduhw"
-        id="filter-a"
+        id="ds-alphabetFilter-alphabet-filter-filter-a"
         onClick={[Function]}
         type="button"
       >
@@ -966,7 +969,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page B"
         className="chakra-button css-lmduhw"
-        id="filter-b"
+        id="ds-alphabetFilter-alphabet-filter-filter-b"
         onClick={[Function]}
         type="button"
       >
@@ -976,7 +979,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page C"
         className="chakra-button css-lmduhw"
-        id="filter-c"
+        id="ds-alphabetFilter-alphabet-filter-filter-c"
         onClick={[Function]}
         type="button"
       >
@@ -986,7 +989,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page D"
         className="chakra-button css-lmduhw"
-        id="filter-d"
+        id="ds-alphabetFilter-alphabet-filter-filter-d"
         onClick={[Function]}
         type="button"
       >
@@ -996,7 +999,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page E"
         className="chakra-button css-lmduhw"
-        id="filter-e"
+        id="ds-alphabetFilter-alphabet-filter-filter-e"
         onClick={[Function]}
         type="button"
       >
@@ -1006,7 +1009,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page F"
         className="chakra-button css-lmduhw"
-        id="filter-f"
+        id="ds-alphabetFilter-alphabet-filter-filter-f"
         onClick={[Function]}
         type="button"
       >
@@ -1016,7 +1019,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page G"
         className="chakra-button css-lmduhw"
-        id="filter-g"
+        id="ds-alphabetFilter-alphabet-filter-filter-g"
         onClick={[Function]}
         type="button"
       >
@@ -1026,7 +1029,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page H"
         className="chakra-button css-lmduhw"
-        id="filter-h"
+        id="ds-alphabetFilter-alphabet-filter-filter-h"
         onClick={[Function]}
         type="button"
       >
@@ -1036,7 +1039,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page I"
         className="chakra-button css-lmduhw"
-        id="filter-i"
+        id="ds-alphabetFilter-alphabet-filter-filter-i"
         onClick={[Function]}
         type="button"
       >
@@ -1046,7 +1049,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page J"
         className="chakra-button css-lmduhw"
-        id="filter-j"
+        id="ds-alphabetFilter-alphabet-filter-filter-j"
         onClick={[Function]}
         type="button"
       >
@@ -1056,7 +1059,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page K"
         className="chakra-button css-lmduhw"
-        id="filter-k"
+        id="ds-alphabetFilter-alphabet-filter-filter-k"
         onClick={[Function]}
         type="button"
       >
@@ -1066,7 +1069,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page L"
         className="chakra-button css-lmduhw"
-        id="filter-l"
+        id="ds-alphabetFilter-alphabet-filter-filter-l"
         onClick={[Function]}
         type="button"
       >
@@ -1076,7 +1079,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page M"
         className="chakra-button css-lmduhw"
-        id="filter-m"
+        id="ds-alphabetFilter-alphabet-filter-filter-m"
         onClick={[Function]}
         type="button"
       >
@@ -1086,7 +1089,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page N"
         className="chakra-button css-lmduhw"
-        id="filter-n"
+        id="ds-alphabetFilter-alphabet-filter-filter-n"
         onClick={[Function]}
         type="button"
       >
@@ -1096,7 +1099,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page O"
         className="chakra-button css-lmduhw"
-        id="filter-o"
+        id="ds-alphabetFilter-alphabet-filter-filter-o"
         onClick={[Function]}
         type="button"
       >
@@ -1106,7 +1109,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page P"
         className="chakra-button css-lmduhw"
-        id="filter-p"
+        id="ds-alphabetFilter-alphabet-filter-filter-p"
         onClick={[Function]}
         type="button"
       >
@@ -1116,7 +1119,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page Q"
         className="chakra-button css-lmduhw"
-        id="filter-q"
+        id="ds-alphabetFilter-alphabet-filter-filter-q"
         onClick={[Function]}
         type="button"
       >
@@ -1126,7 +1129,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page R"
         className="chakra-button css-lmduhw"
-        id="filter-r"
+        id="ds-alphabetFilter-alphabet-filter-filter-r"
         onClick={[Function]}
         type="button"
       >
@@ -1136,7 +1139,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page S"
         className="chakra-button css-lmduhw"
-        id="filter-s"
+        id="ds-alphabetFilter-alphabet-filter-filter-s"
         onClick={[Function]}
         type="button"
       >
@@ -1146,7 +1149,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page T"
         className="chakra-button css-lmduhw"
-        id="filter-t"
+        id="ds-alphabetFilter-alphabet-filter-filter-t"
         onClick={[Function]}
         type="button"
       >
@@ -1156,7 +1159,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page U"
         className="chakra-button css-lmduhw"
-        id="filter-u"
+        id="ds-alphabetFilter-alphabet-filter-filter-u"
         onClick={[Function]}
         type="button"
       >
@@ -1166,7 +1169,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page V"
         className="chakra-button css-lmduhw"
-        id="filter-v"
+        id="ds-alphabetFilter-alphabet-filter-filter-v"
         onClick={[Function]}
         type="button"
       >
@@ -1176,7 +1179,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page W"
         className="chakra-button css-lmduhw"
-        id="filter-w"
+        id="ds-alphabetFilter-alphabet-filter-filter-w"
         onClick={[Function]}
         type="button"
       >
@@ -1186,7 +1189,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page X"
         className="chakra-button css-lmduhw"
-        id="filter-x"
+        id="ds-alphabetFilter-alphabet-filter-filter-x"
         onClick={[Function]}
         type="button"
       >
@@ -1196,7 +1199,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page Y"
         className="chakra-button css-lmduhw"
-        id="filter-y"
+        id="ds-alphabetFilter-alphabet-filter-filter-y"
         onClick={[Function]}
         type="button"
       >
@@ -1206,7 +1209,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Page Z"
         className="chakra-button css-lmduhw"
-        id="filter-z"
+        id="ds-alphabetFilter-alphabet-filter-filter-z"
         onClick={[Function]}
         type="button"
       >
@@ -1216,7 +1219,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 4`] = `
         aria-current={null}
         aria-label="Show All"
         className="chakra-button css-lmduhw"
-        id="filter-showAll"
+        id="ds-alphabetFilter-alphabet-filter-filter-showAll"
         onClick={[Function]}
         type="button"
       >
@@ -1231,10 +1234,11 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
 <nav
   aria-label="Filter by letter"
   className="css-0"
+  id="ds-alphabetFilter-alphabet-filter"
 >
   <div
     className="css-2bbtg1"
-    id="alphabet-filter-wrapper"
+    id="undefined-wrapper"
   >
     <div
       className="css-2imjyh"
@@ -1243,7 +1247,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page #"
         className="chakra-button css-lmduhw"
-        id="filter-#"
+        id="ds-alphabetFilter-alphabet-filter-filter-#"
         onClick={[Function]}
         type="button"
       >
@@ -1253,7 +1257,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page A"
         className="chakra-button css-lmduhw"
-        id="filter-a"
+        id="ds-alphabetFilter-alphabet-filter-filter-a"
         onClick={[Function]}
         type="button"
       >
@@ -1263,7 +1267,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page B"
         className="chakra-button css-lmduhw"
-        id="filter-b"
+        id="ds-alphabetFilter-alphabet-filter-filter-b"
         onClick={[Function]}
         type="button"
       >
@@ -1273,7 +1277,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page C"
         className="chakra-button css-lmduhw"
-        id="filter-c"
+        id="ds-alphabetFilter-alphabet-filter-filter-c"
         onClick={[Function]}
         type="button"
       >
@@ -1283,7 +1287,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page D"
         className="chakra-button css-lmduhw"
-        id="filter-d"
+        id="ds-alphabetFilter-alphabet-filter-filter-d"
         onClick={[Function]}
         type="button"
       >
@@ -1293,7 +1297,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page E"
         className="chakra-button css-lmduhw"
-        id="filter-e"
+        id="ds-alphabetFilter-alphabet-filter-filter-e"
         onClick={[Function]}
         type="button"
       >
@@ -1303,7 +1307,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page F"
         className="chakra-button css-lmduhw"
-        id="filter-f"
+        id="ds-alphabetFilter-alphabet-filter-filter-f"
         onClick={[Function]}
         type="button"
       >
@@ -1313,7 +1317,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page G"
         className="chakra-button css-lmduhw"
-        id="filter-g"
+        id="ds-alphabetFilter-alphabet-filter-filter-g"
         onClick={[Function]}
         type="button"
       >
@@ -1323,7 +1327,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page H"
         className="chakra-button css-lmduhw"
-        id="filter-h"
+        id="ds-alphabetFilter-alphabet-filter-filter-h"
         onClick={[Function]}
         type="button"
       >
@@ -1333,7 +1337,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page I"
         className="chakra-button css-lmduhw"
-        id="filter-i"
+        id="ds-alphabetFilter-alphabet-filter-filter-i"
         onClick={[Function]}
         type="button"
       >
@@ -1343,7 +1347,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page J"
         className="chakra-button css-lmduhw"
-        id="filter-j"
+        id="ds-alphabetFilter-alphabet-filter-filter-j"
         onClick={[Function]}
         type="button"
       >
@@ -1353,7 +1357,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page K"
         className="chakra-button css-lmduhw"
-        id="filter-k"
+        id="ds-alphabetFilter-alphabet-filter-filter-k"
         onClick={[Function]}
         type="button"
       >
@@ -1363,7 +1367,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page L"
         className="chakra-button css-lmduhw"
-        id="filter-l"
+        id="ds-alphabetFilter-alphabet-filter-filter-l"
         onClick={[Function]}
         type="button"
       >
@@ -1373,7 +1377,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page M"
         className="chakra-button css-lmduhw"
-        id="filter-m"
+        id="ds-alphabetFilter-alphabet-filter-filter-m"
         onClick={[Function]}
         type="button"
       >
@@ -1383,7 +1387,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page N"
         className="chakra-button css-lmduhw"
-        id="filter-n"
+        id="ds-alphabetFilter-alphabet-filter-filter-n"
         onClick={[Function]}
         type="button"
       >
@@ -1393,7 +1397,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page O"
         className="chakra-button css-lmduhw"
-        id="filter-o"
+        id="ds-alphabetFilter-alphabet-filter-filter-o"
         onClick={[Function]}
         type="button"
       >
@@ -1403,7 +1407,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page P"
         className="chakra-button css-lmduhw"
-        id="filter-p"
+        id="ds-alphabetFilter-alphabet-filter-filter-p"
         onClick={[Function]}
         type="button"
       >
@@ -1413,7 +1417,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page Q"
         className="chakra-button css-lmduhw"
-        id="filter-q"
+        id="ds-alphabetFilter-alphabet-filter-filter-q"
         onClick={[Function]}
         type="button"
       >
@@ -1423,7 +1427,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page R"
         className="chakra-button css-lmduhw"
-        id="filter-r"
+        id="ds-alphabetFilter-alphabet-filter-filter-r"
         onClick={[Function]}
         type="button"
       >
@@ -1433,7 +1437,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page S"
         className="chakra-button css-lmduhw"
-        id="filter-s"
+        id="ds-alphabetFilter-alphabet-filter-filter-s"
         onClick={[Function]}
         type="button"
       >
@@ -1443,7 +1447,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page T"
         className="chakra-button css-lmduhw"
-        id="filter-t"
+        id="ds-alphabetFilter-alphabet-filter-filter-t"
         onClick={[Function]}
         type="button"
       >
@@ -1453,7 +1457,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page U"
         className="chakra-button css-lmduhw"
-        id="filter-u"
+        id="ds-alphabetFilter-alphabet-filter-filter-u"
         onClick={[Function]}
         type="button"
       >
@@ -1463,7 +1467,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page V"
         className="chakra-button css-lmduhw"
-        id="filter-v"
+        id="ds-alphabetFilter-alphabet-filter-filter-v"
         onClick={[Function]}
         type="button"
       >
@@ -1473,7 +1477,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page W"
         className="chakra-button css-lmduhw"
-        id="filter-w"
+        id="ds-alphabetFilter-alphabet-filter-filter-w"
         onClick={[Function]}
         type="button"
       >
@@ -1483,7 +1487,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page X"
         className="chakra-button css-lmduhw"
-        id="filter-x"
+        id="ds-alphabetFilter-alphabet-filter-filter-x"
         onClick={[Function]}
         type="button"
       >
@@ -1493,7 +1497,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page Y"
         className="chakra-button css-lmduhw"
-        id="filter-y"
+        id="ds-alphabetFilter-alphabet-filter-filter-y"
         onClick={[Function]}
         type="button"
       >
@@ -1503,7 +1507,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Page Z"
         className="chakra-button css-lmduhw"
-        id="filter-z"
+        id="ds-alphabetFilter-alphabet-filter-filter-z"
         onClick={[Function]}
         type="button"
       >
@@ -1513,7 +1517,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 5`] = `
         aria-current={null}
         aria-label="Show All"
         className="chakra-button css-lmduhw"
-        id="filter-showAll"
+        id="ds-alphabetFilter-alphabet-filter-filter-showAll"
         onClick={[Function]}
         type="button"
       >
@@ -1528,11 +1532,12 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
 <nav
   aria-label="Filter by letter"
   className="css-0"
+  id="ds-alphabetFilter-alphabet-filter"
 >
   <div
     className="css-1u8qly9"
     data-testid="testid"
-    id="alphabet-filter-wrapper"
+    id="undefined-wrapper"
   >
     <div
       className="css-2imjyh"
@@ -1541,7 +1546,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page #"
         className="chakra-button css-lmduhw"
-        id="filter-#"
+        id="ds-alphabetFilter-alphabet-filter-filter-#"
         onClick={[Function]}
         type="button"
       >
@@ -1551,7 +1556,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page A"
         className="chakra-button css-lmduhw"
-        id="filter-a"
+        id="ds-alphabetFilter-alphabet-filter-filter-a"
         onClick={[Function]}
         type="button"
       >
@@ -1561,7 +1566,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page B"
         className="chakra-button css-lmduhw"
-        id="filter-b"
+        id="ds-alphabetFilter-alphabet-filter-filter-b"
         onClick={[Function]}
         type="button"
       >
@@ -1571,7 +1576,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page C"
         className="chakra-button css-lmduhw"
-        id="filter-c"
+        id="ds-alphabetFilter-alphabet-filter-filter-c"
         onClick={[Function]}
         type="button"
       >
@@ -1581,7 +1586,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page D"
         className="chakra-button css-lmduhw"
-        id="filter-d"
+        id="ds-alphabetFilter-alphabet-filter-filter-d"
         onClick={[Function]}
         type="button"
       >
@@ -1591,7 +1596,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page E"
         className="chakra-button css-lmduhw"
-        id="filter-e"
+        id="ds-alphabetFilter-alphabet-filter-filter-e"
         onClick={[Function]}
         type="button"
       >
@@ -1601,7 +1606,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page F"
         className="chakra-button css-lmduhw"
-        id="filter-f"
+        id="ds-alphabetFilter-alphabet-filter-filter-f"
         onClick={[Function]}
         type="button"
       >
@@ -1611,7 +1616,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page G"
         className="chakra-button css-lmduhw"
-        id="filter-g"
+        id="ds-alphabetFilter-alphabet-filter-filter-g"
         onClick={[Function]}
         type="button"
       >
@@ -1621,7 +1626,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page H"
         className="chakra-button css-lmduhw"
-        id="filter-h"
+        id="ds-alphabetFilter-alphabet-filter-filter-h"
         onClick={[Function]}
         type="button"
       >
@@ -1631,7 +1636,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page I"
         className="chakra-button css-lmduhw"
-        id="filter-i"
+        id="ds-alphabetFilter-alphabet-filter-filter-i"
         onClick={[Function]}
         type="button"
       >
@@ -1641,7 +1646,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page J"
         className="chakra-button css-lmduhw"
-        id="filter-j"
+        id="ds-alphabetFilter-alphabet-filter-filter-j"
         onClick={[Function]}
         type="button"
       >
@@ -1651,7 +1656,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page K"
         className="chakra-button css-lmduhw"
-        id="filter-k"
+        id="ds-alphabetFilter-alphabet-filter-filter-k"
         onClick={[Function]}
         type="button"
       >
@@ -1661,7 +1666,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page L"
         className="chakra-button css-lmduhw"
-        id="filter-l"
+        id="ds-alphabetFilter-alphabet-filter-filter-l"
         onClick={[Function]}
         type="button"
       >
@@ -1671,7 +1676,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page M"
         className="chakra-button css-lmduhw"
-        id="filter-m"
+        id="ds-alphabetFilter-alphabet-filter-filter-m"
         onClick={[Function]}
         type="button"
       >
@@ -1681,7 +1686,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page N"
         className="chakra-button css-lmduhw"
-        id="filter-n"
+        id="ds-alphabetFilter-alphabet-filter-filter-n"
         onClick={[Function]}
         type="button"
       >
@@ -1691,7 +1696,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page O"
         className="chakra-button css-lmduhw"
-        id="filter-o"
+        id="ds-alphabetFilter-alphabet-filter-filter-o"
         onClick={[Function]}
         type="button"
       >
@@ -1701,7 +1706,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page P"
         className="chakra-button css-lmduhw"
-        id="filter-p"
+        id="ds-alphabetFilter-alphabet-filter-filter-p"
         onClick={[Function]}
         type="button"
       >
@@ -1711,7 +1716,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page Q"
         className="chakra-button css-lmduhw"
-        id="filter-q"
+        id="ds-alphabetFilter-alphabet-filter-filter-q"
         onClick={[Function]}
         type="button"
       >
@@ -1721,7 +1726,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page R"
         className="chakra-button css-lmduhw"
-        id="filter-r"
+        id="ds-alphabetFilter-alphabet-filter-filter-r"
         onClick={[Function]}
         type="button"
       >
@@ -1731,7 +1736,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page S"
         className="chakra-button css-lmduhw"
-        id="filter-s"
+        id="ds-alphabetFilter-alphabet-filter-filter-s"
         onClick={[Function]}
         type="button"
       >
@@ -1741,7 +1746,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page T"
         className="chakra-button css-lmduhw"
-        id="filter-t"
+        id="ds-alphabetFilter-alphabet-filter-filter-t"
         onClick={[Function]}
         type="button"
       >
@@ -1751,7 +1756,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page U"
         className="chakra-button css-lmduhw"
-        id="filter-u"
+        id="ds-alphabetFilter-alphabet-filter-filter-u"
         onClick={[Function]}
         type="button"
       >
@@ -1761,7 +1766,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page V"
         className="chakra-button css-lmduhw"
-        id="filter-v"
+        id="ds-alphabetFilter-alphabet-filter-filter-v"
         onClick={[Function]}
         type="button"
       >
@@ -1771,7 +1776,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page W"
         className="chakra-button css-lmduhw"
-        id="filter-w"
+        id="ds-alphabetFilter-alphabet-filter-filter-w"
         onClick={[Function]}
         type="button"
       >
@@ -1781,7 +1786,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page X"
         className="chakra-button css-lmduhw"
-        id="filter-x"
+        id="ds-alphabetFilter-alphabet-filter-filter-x"
         onClick={[Function]}
         type="button"
       >
@@ -1791,7 +1796,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page Y"
         className="chakra-button css-lmduhw"
-        id="filter-y"
+        id="ds-alphabetFilter-alphabet-filter-filter-y"
         onClick={[Function]}
         type="button"
       >
@@ -1801,7 +1806,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Page Z"
         className="chakra-button css-lmduhw"
-        id="filter-z"
+        id="ds-alphabetFilter-alphabet-filter-filter-z"
         onClick={[Function]}
         type="button"
       >
@@ -1811,7 +1816,7 @@ exports[`AlphabetFilter Snapshot Renders the UI snapshot correctly 6`] = `
         aria-current={null}
         aria-label="Show All"
         className="chakra-button css-lmduhw"
-        id="filter-showAll"
+        id="ds-alphabetFilter-alphabet-filter-filter-showAll"
         onClick={[Function]}
         type="button"
       >

--- a/src/components/AlphabetFilter/alphabetFilterChangelogData.ts
+++ b/src/components/AlphabetFilter/alphabetFilterChangelogData.ts
@@ -14,7 +14,10 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Functionality"],
-    notes: ["Removed explicit `classname` prop."],
+    notes: [
+      "Removed explicit `classname` prop.",
+      "Sets the default id value to `ds-alphabetFilter`.",
+    ],
   },
   {
     date: "2025-02-13",

--- a/src/components/AudioPlayer/AudioPlayer.stories.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.stories.tsx
@@ -15,7 +15,6 @@ const meta: Meta<typeof AudioPlayer> = {
     embedCode: { control: false },
     headingText: { control: "text" },
     helperText: { control: "text" },
-    id: { control: false },
     iframeTitle: { control: "text" },
   },
 };
@@ -38,7 +37,6 @@ export const WithControls: Story = {
     embedCode: libsynPlayerEmbedCode,
     headingText: "Audio Title",
     helperText: "Audio helper text lorem ipsum dolor simet.",
-    id: "audioplayer-id",
     iframeTitle: "Libsyn Audio",
   },
   parameters: {

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -8,6 +8,7 @@ import {
 import React, { useState, forwardRef, useEffect } from "react";
 
 import ComponentWrapper from "../ComponentWrapper/ComponentWrapper";
+import { generateComponentId } from "../../utils/utils";
 
 /*
  * List all the third-party services to be used for basic type checks
@@ -38,8 +39,6 @@ export interface AudioPlayerProps extends BoxProps {
   headingText?: string | JSX.Element;
   /** Optional string to set the text for a `HelperErrorText` component. */
   helperText?: string;
-  /** ID that other components can cross reference for accessibility purposes. */
-  id?: string;
   /** Optional title to added to the `<iframe>` element for improved accessibility. If omitted, a
    * generic title will be added.
    */
@@ -69,7 +68,7 @@ export const AudioPlayer: ChakraComponent<
         iframeTitle = null,
         ...rest
       } = props;
-
+      const mainId = generateComponentId("audioPlayer", id);
       const [invalidEmbed, setInvalidEmbed] = useState<boolean>(false);
       const [iframeDoc, setIframeDoc] = useState<HTMLIFrameElement | undefined>(
         undefined
@@ -140,7 +139,7 @@ export const AudioPlayer: ChakraComponent<
           headingText={headingText}
           descriptionText={descriptionText}
           helperText={helperText}
-          id={`${id}-componentWrapper`}
+          id={mainId}
           data-testid="audio-player-component"
           ref={ref}
           __css={styles.base}

--- a/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
+++ b/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`AudioPlay Snapshots Renders the errored AudioPlayer UI 1`] = `
 <div
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
-  id="undefined-componentWrapper-wrapper"
+  id="ds-audioPlayer-wrapper"
 />
 `;
 
@@ -12,11 +12,11 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
 <div
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
-  id="undefined-componentWrapper-wrapper"
+  id="ds-audioPlayer-wrapper"
 >
   <h2
     className="chakra-heading css-1xdhyk6"
-    id="undefined-componentWrapper-heading"
+    id="ds-audioPlayer-heading"
   >
     Audio Player Heading
   </h2>
@@ -30,7 +30,7 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
     aria-live="polite"
     className="css-1xdhyk6"
     data-isinvalid={false}
-    id="undefined-componentWrapper-helperText"
+    id="ds-audioPlayer-helperText"
   >
     <div
       className="css-0"
@@ -48,7 +48,7 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  2`] = `
 <div
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
-  id="undefined-componentWrapper-wrapper"
+  id="ds-audioPlayer-wrapper"
 >
   <div
     className="css-0"
@@ -65,7 +65,7 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  3`] = `
 <div
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
-  id="undefined-componentWrapper-wrapper"
+  id="ds-audioPlayer-wrapper"
 />
 `;
 
@@ -73,7 +73,7 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  4`] = `
 <div
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
-  id="undefined-componentWrapper-wrapper"
+  id="ds-audioPlayer-wrapper"
 >
   <div
     className="css-0"

--- a/src/components/AudioPlayer/audioPlayerChangelogData.ts
+++ b/src/components/AudioPlayer/audioPlayerChangelogData.ts
@@ -16,6 +16,7 @@ export const changelogData: ChangelogData[] = [
     affects: ["Functionality"],
     notes: [
       "Removed explicit `className` prop as interface can be extended to include Chakra prop or HTML attribute types.",
+      "Sets the default id value to `ds-audioPlayer`.",
     ],
   },
   {

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -29,7 +29,6 @@ const meta: Meta<typeof Banner> = {
       options: bannerHighlightColorsArray,
     },
     icon: { control: false },
-    id: { control: false },
     isDismissible: { control: { type: "boolean" } },
     type: {
       control: { type: "select" },
@@ -57,8 +56,7 @@ export const WithControls: Story = {
     heading: "Heading text",
     highlightColor: undefined,
     icon: undefined,
-    id: undefined,
-    isDismissible: false,
+    isDismissible: true,
     type: "neutral",
   },
   parameters: {

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -47,7 +47,6 @@ describe("Banner", () => {
         aria-label="Banner label"
         content={<>Banner content.</>}
         heading="Banner Heading"
-        id="bannerID"
       />
     );
   });
@@ -60,7 +59,6 @@ describe("Banner", () => {
     utils.rerender(
       <Banner
         aria-label="Banner label"
-        id="bannerID"
         content={<>Banner content.</>}
         heading={<Heading level="h4">Custom H4 Heading</Heading>}
       />
@@ -75,7 +73,7 @@ describe("Banner", () => {
   it("renders with an Icon", () => {
     // Since the icon has aria-hidden set to true, we can't get it
     // by its "img" role.
-    const icon = screen.getByTestId("bannerID-banner-icon");
+    const icon = screen.getByTestId("ds-banner-icon");
     expect(icon).toBeInTheDocument();
 
     expect(screen.getByTitle("Banner neutral icon")).toHaveAttribute(
@@ -123,13 +121,14 @@ describe("Banner", () => {
     utils.rerender(
       <Banner
         isDismissible
-        id="bannerID"
         content={<>Banner content.</>}
         heading="Banner Heading"
       />
     );
 
-    expect(screen.getByTestId("bannerID-dismissible-icon")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("ds-banner-dismissible-icon")
+    ).toBeInTheDocument();
     expect(screen.getByTitle("Banner close icon")).toBeInTheDocument();
     expect(screen.getByTitle("Banner close icon")).toHaveAttribute(
       "data-file-name",

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -197,7 +197,7 @@ export const Banner: ChakraComponent<
     const finalIcon = icon || (
       <Icon
         className="banner-icon"
-        data-testid={`${mainId}-banner-icon`}
+        data-testid={`${mainId}-icon`}
         title="Banner announcement icon"
         size="large"
         {...iconProps[type]}

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -5,11 +5,12 @@ import {
   ChakraComponent,
   useMultiStyleConfig,
 } from "@chakra-ui/react";
-import React, { forwardRef, useState } from "react";
+import { cloneElement, forwardRef, useState } from "react";
 
 import Button from "../Button/Button";
 import Heading, { HeadingSizes } from "../Heading/Heading";
 import Icon, { IconProps } from "../Icons/Icon";
+import { generateComponentId } from "../../utils/utils";
 
 export const bannerTypesArray = [
   "informative",
@@ -86,8 +87,6 @@ export interface BannerProps extends Omit<BoxProps, "content"> {
   highlightColor?: BannerHighlightColors;
   /** Optional custom `Icon` that will override the default `Icon`. */
   icon?: JSX.Element;
-  /** ID that other components can cross reference for accessibility purposes. */
-  id?: string;
   /** Optional prop to control whether a `Banner` can be dismissed
    * (closed) by a user. */
   isDismissible?: boolean;
@@ -150,6 +149,7 @@ export const Banner: ChakraComponent<
     } = props;
     const [isOpen, setIsOpen] = useState(true);
     const handleClose = () => setIsOpen(false);
+    const mainId = generateComponentId("banner", id);
     const overrideType = !!(backgroundColor && highlightColor);
     const styles = useMultiStyleConfig("Banner", {
       // Only set the custom `backgroundColor` and `highlightColor` values
@@ -175,19 +175,19 @@ export const Banner: ChakraComponent<
       typeof heading === "string" ? (
         <Heading level="h2" text={heading} {...generalHeadingProps} />
       ) : (
-        React.cloneElement(heading, generalHeadingProps)
+        cloneElement(heading, generalHeadingProps)
       )
     ) : null;
     const dismissibleButton = (
       <Button
         aria-label="Close the banner"
         buttonType="text"
-        id={`${id}-dismissible-button`}
+        id={`${mainId}-dismissible-button`}
         onClick={handleClose}
         __css={styles.dismissibleButton}
       >
         <Icon
-          data-testid={`${id}-dismissible-icon`}
+          data-testid={`${mainId}-dismissible-icon`}
           name="close"
           size="large"
           title="Banner close icon"
@@ -197,7 +197,7 @@ export const Banner: ChakraComponent<
     const finalIcon = icon || (
       <Icon
         className="banner-icon"
-        data-testid={`${id}-banner-icon`}
+        data-testid={`${mainId}-banner-icon`}
         title="Banner announcement icon"
         size="large"
         {...iconProps[type]}
@@ -229,7 +229,7 @@ export const Banner: ChakraComponent<
       <Box
         as="aside"
         data-type={type}
-        id={id}
+        id={mainId}
         ref={ref}
         __css={styles.base}
         {...rest}

--- a/src/components/Banner/__snapshots__/Banner.test.tsx.snap
+++ b/src/components/Banner/__snapshots__/Banner.test.tsx.snap
@@ -4,12 +4,13 @@ exports[`Banner renders the UI snapshot correctly 1`] = `
 <aside
   className="css-1xdhyk6"
   data-type="informative"
+  id="ds-banner"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgErrorOutline"
-    data-testid="undefined-banner-icon"
+    data-testid="ds-banner-icon"
     focusable={false}
     role="img"
     title="Banner informative icon"
@@ -31,13 +32,13 @@ exports[`Banner renders the UI snapshot correctly 2`] = `
 <aside
   className="css-1xdhyk6"
   data-type="negative"
-  id="bannerID3"
+  id="ds-banner-bannerID3"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgErrorOutline"
-    data-testid="bannerID3-banner-icon"
+    data-testid="ds-banner-bannerID3-icon"
     focusable={false}
     role="img"
     title="Banner negative icon"
@@ -59,13 +60,13 @@ exports[`Banner renders the UI snapshot correctly 3`] = `
 <aside
   className="css-1xdhyk6"
   data-type="neutral"
-  id="bannerID3"
+  id="ds-banner-bannerID3"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgErrorOutline"
-    data-testid="bannerID3-banner-icon"
+    data-testid="ds-banner-bannerID3-icon"
     focusable={false}
     role="img"
     title="Banner neutral icon"
@@ -87,13 +88,13 @@ exports[`Banner renders the UI snapshot correctly 4`] = `
 <aside
   className="css-1xdhyk6"
   data-type="positive"
-  id="bannerID3"
+  id="ds-banner-bannerID3"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgActionCheckCircle"
-    data-testid="bannerID3-banner-icon"
+    data-testid="ds-banner-bannerID3-icon"
     focusable={false}
     role="img"
     title="Banner positive icon"
@@ -115,13 +116,13 @@ exports[`Banner renders the UI snapshot correctly 5`] = `
 <aside
   className="css-1xdhyk6"
   data-type="recommendation"
-  id="bannerID3"
+  id="ds-banner-bannerID3"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgActionLightbulb"
-    data-testid="bannerID3-banner-icon"
+    data-testid="ds-banner-bannerID3-icon"
     focusable={false}
     role="img"
     title="Banner recommendation icon"
@@ -143,13 +144,13 @@ exports[`Banner renders the UI snapshot correctly 6`] = `
 <aside
   className="css-1xdhyk6"
   data-type="warning"
-  id="bannerID3"
+  id="ds-banner-bannerID3"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgAlertNotificationImportant"
-    data-testid="bannerID3-banner-icon"
+    data-testid="ds-banner-bannerID3-icon"
     focusable={false}
     role="img"
     title="Banner warning icon"
@@ -171,13 +172,13 @@ exports[`Banner renders the UI snapshot correctly 7`] = `
 <aside
   className="css-1xdhyk6"
   data-type="neutral"
-  id="bannerID4"
+  id="ds-banner-bannerID4"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1vgifmd"
     data-file-name="SvgErrorOutline"
-    data-testid="bannerID4-banner-icon"
+    data-testid="ds-banner-bannerID4-icon"
     focusable={false}
     role="img"
     title="Banner neutral icon"
@@ -194,13 +195,13 @@ exports[`Banner renders the UI snapshot correctly 8`] = `
 <aside
   className="css-1xdhyk6"
   data-type="neutral"
-  id="bannerID7"
+  id="ds-banner-bannerID7"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1vgifmd"
     data-file-name="SvgErrorOutline"
-    data-testid="bannerID7-banner-icon"
+    data-testid="ds-banner-bannerID7-icon"
     focusable={false}
     role="img"
     title="Banner neutral icon"
@@ -213,7 +214,7 @@ exports[`Banner renders the UI snapshot correctly 8`] = `
   <button
     aria-label="Close the banner"
     className="chakra-button css-8bx9xp"
-    id="bannerID7-dismissible-button"
+    id="ds-banner-bannerID7-dismissible-button"
     onClick={[Function]}
     type="button"
   >
@@ -221,7 +222,7 @@ exports[`Banner renders the UI snapshot correctly 8`] = `
       aria-hidden={true}
       className="chakra-icon css-1vgifmd"
       data-file-name="SvgClose"
-      data-testid="bannerID7-dismissible-icon"
+      data-testid="ds-banner-bannerID7-dismissible-icon"
       focusable={false}
       role="img"
       title="Banner close icon"
@@ -234,13 +235,13 @@ exports[`Banner renders the UI snapshot correctly 9`] = `
 <aside
   className="css-16h1ce8"
   data-type="neutral"
-  id="chakra"
+  id="ds-banner-chakra"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgErrorOutline"
-    data-testid="chakra-banner-icon"
+    data-testid="ds-banner-chakra-icon"
     focusable={false}
     role="img"
     title="Banner neutral icon"
@@ -263,13 +264,13 @@ exports[`Banner renders the UI snapshot correctly 10`] = `
   className="css-1xdhyk6"
   data-testid="props"
   data-type="neutral"
-  id="props"
+  id="ds-banner-props"
 >
   <svg
     aria-hidden={true}
     className="chakra-icon banner-icon css-1976tye"
     data-file-name="SvgErrorOutline"
-    data-testid="props-banner-icon"
+    data-testid="ds-banner-props-icon"
     focusable={false}
     role="img"
     title="Banner neutral icon"

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -16,6 +16,7 @@ export const changelogData: ChangelogData[] = [
     affects: ["Functionality"],
     notes: [
       "Removes explicit `className` prop as interface can be extended to include Chakra prop or HTML attribute types.",
+      "Sets the default id value to `ds-banner`.",
     ],
   },
   {

--- a/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.stories.tsx
@@ -42,7 +42,6 @@ const meta: Meta<typeof Breadcrumbs> = {
       },
       options: breadcrumbTypeArray,
     },
-    id: { control: false },
   },
 };
 
@@ -58,7 +57,6 @@ export const WithControls: Story = {
     breadcrumbsData,
     breadcrumbsType: "whatsOn",
     customLinkComponent: undefined,
-    id: "breadcrumbs-id",
   },
   parameters: {
     design: {

--- a/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -7,11 +7,11 @@ import {
   useStyleConfig,
   ChakraComponent,
 } from "@chakra-ui/react";
-import React, { forwardRef } from "react";
+import { forwardRef } from "react";
 
 import Icon from "../Icons/Icon";
 import Tooltip from "../Tooltip/Tooltip";
-import { truncateText } from "../../utils/utils";
+import { generateComponentId, truncateText } from "../../utils/utils";
 
 export const breadcrumbTypeArray = [
   "blogs",
@@ -36,8 +36,6 @@ export interface BreadcrumbProps extends BoxProps {
   breadcrumbsData: BreadcrumbsDataProps[];
   /** Used to control how the `Hero` component will be rendered. */
   breadcrumbsType?: BreadcrumbsTypes;
-  /** ID that other components can cross reference for accessibility purposes */
-  id?: string;
   /** Custom Link component for apps with internal routing, defaults to BreadcrumbLink if not passed */
   customLinkComponent?: React.ElementType;
 }
@@ -50,15 +48,15 @@ const breadcrumbTextLength = 40;
  */
 const tooltipWrapperOrText = ({
   breadcrumbsData,
-  breadcrumbsID,
   customLinkComponent,
   renderIcon = false,
+  id,
   isCurrentPage = false,
 }: {
   breadcrumbsData: BreadcrumbsDataProps;
-  breadcrumbsID: string;
   customLinkComponent: React.ElementType;
   renderIcon?: boolean;
+  id: string;
   isCurrentPage?: boolean;
 }) => {
   const textLength = (breadcrumbsData.text as string).length;
@@ -80,7 +78,7 @@ const tooltipWrapperOrText = ({
           name="arrow"
           size="small"
           iconRotation="rotate90"
-          id={`${breadcrumbsID}__backarrow`}
+          id={`${id}-backarrow`}
           className="breadcrumbs-icon"
           type="breadcrumbs"
         />
@@ -92,10 +90,7 @@ const tooltipWrapperOrText = ({
   // component wrapped *directly* around the anchor element for
   // accessibility purposes.
   const breadcrumbLink = renderTooltip ? (
-    <Tooltip
-      content={breadcrumbsData.text}
-      id={`breadcrumb-${breadcrumbsID}-tooltip`}
-    >
+    <Tooltip content={breadcrumbsData.text} id={`${id}-tooltip`}>
       {linkWrapper}
     </Tooltip>
   ) : (
@@ -106,13 +101,13 @@ const tooltipWrapperOrText = ({
 };
 
 const getElementsFromData = ({
-  data,
-  breadcrumbsID,
   customLinkComponent,
+  data,
+  id,
 }: {
-  data: BreadcrumbsDataProps[];
-  breadcrumbsID?: string;
   customLinkComponent?: React.ElementType;
+  data: BreadcrumbsDataProps[];
+  id?: string;
 }) => {
   if (!data?.length) {
     return null;
@@ -129,9 +124,9 @@ const getElementsFromData = ({
       <BreadcrumbItem key={index}>
         {tooltipWrapperOrText({
           breadcrumbsData,
-          breadcrumbsID,
           customLinkComponent,
           renderIcon,
+          id,
           isCurrentPage,
         })}
       </BreadcrumbItem>
@@ -168,19 +163,20 @@ export const Breadcrumbs: ChakraComponent<
       );
     }
 
+    const mainId = generateComponentId("breadcrumbs", id);
     const styles = useStyleConfig("ReservoirBreadcrumb", {
       variant: breadcrumbsType,
     });
     const breadcrumbItems = getElementsFromData({
-      data: breadcrumbsData,
-      breadcrumbsID: id,
       customLinkComponent,
+      data: breadcrumbsData,
+      id: mainId,
     });
 
     return (
       <ChakraBreadcrumb
         aria-label="Breadcrumb"
-        id={id}
+        id={mainId}
         ref={ref}
         __css={styles}
         {...rest}

--- a/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
+++ b/src/components/Breadcrumbs/__snapshots__/Breadcrumbs.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 1`] = `
 <nav
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1xdhyk6"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -41,7 +41,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 1`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />
@@ -81,7 +81,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 2`] = `
 <nav
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1xdhyk6"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -118,7 +118,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 2`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />
@@ -158,7 +158,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 3`] = `
 <nav
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1xdhyk6"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -195,7 +195,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 3`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />
@@ -235,7 +235,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 4`] = `
 <nav
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1xdhyk6"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -272,7 +272,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 4`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />
@@ -312,7 +312,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 5`] = `
 <nav
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1xdhyk6"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -349,7 +349,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 5`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />
@@ -389,7 +389,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 6`] = `
 <nav
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1t0bvx9"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -426,7 +426,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 6`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />
@@ -467,7 +467,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 7`] = `
   aria-label="Breadcrumb"
   className="chakra-breadcrumb css-1xdhyk6"
   data-testid="testid"
-  id="breadcrumbs-test"
+  id="ds-breadcrumbs-breadcrumbs-test"
 >
   <ol
     className="chakra-breadcrumb__list css-70qvj9"
@@ -504,7 +504,7 @@ exports[`Breadcrumbs Snapshot Renders the UI snapshot correctly 7`] = `
           className="chakra-icon breadcrumbs-icon css-1vgifmd"
           data-file-name="SvgArrow"
           focusable={false}
-          id="breadcrumbs-test__backarrow"
+          id="ds-breadcrumbs-breadcrumbs-test-backarrow"
           role="img"
           title="arrow icon"
         />

--- a/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
+++ b/src/components/Breadcrumbs/breadcrumbsChangelogData.ts
@@ -19,6 +19,7 @@ export const changelogData: ChangelogData[] = [
       "Changes theme name from `CustomBreadcrumbs` to `ReservoirBreadcrumbs` for consistency.",
       "Replaces positional function arguments with objects for `tooltipWrapperOrText` and `getElementsFromData`.",
       "Removes explicit `className` prop as interface can be extended to include Chakra prop or HTML attribute types.",
+      "Sets the default id value to `ds-breadcrumbs`.",
     ],
   },
   {

--- a/src/components/FilterBarInline/__snapshots__/FilterBarInline.test.tsx.snap
+++ b/src/components/FilterBarInline/__snapshots__/FilterBarInline.test.tsx.snap
@@ -32,19 +32,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-colors"
+            id="ds-accordion-multi-select-accordion-colors"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-colors-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-colors-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -67,7 +67,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-colors-icon-0"
+                  id="ds-accordion-multi-select-accordion-colors-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -84,9 +84,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-colors-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-colors-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                   role="region"
                 >
                   <div
@@ -293,19 +293,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-pets"
+            id="ds-accordion-multi-select-accordion-pets"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-pets-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-pets-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -328,7 +328,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-pets-icon-0"
+                  id="ds-accordion-multi-select-accordion-pets-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -345,9 +345,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-pets-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-pets-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                   role="region"
                 >
                   <div
@@ -713,19 +713,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-tools"
+            id="ds-accordion-multi-select-accordion-tools"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-tools-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-tools-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -748,7 +748,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-tools-icon-0"
+                  id="ds-accordion-multi-select-accordion-tools-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -765,9 +765,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-tools-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-tools-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                   role="region"
                 >
                   <div
@@ -1164,19 +1164,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-colors"
+            id="ds-accordion-multi-select-accordion-colors"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-colors-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-colors-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1199,7 +1199,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-colors-icon-0"
+                  id="ds-accordion-multi-select-accordion-colors-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -1216,9 +1216,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-colors-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-colors-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                   role="region"
                 >
                   <div
@@ -1425,19 +1425,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-pets"
+            id="ds-accordion-multi-select-accordion-pets"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-pets-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-pets-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1460,7 +1460,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-pets-icon-0"
+                  id="ds-accordion-multi-select-accordion-pets-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -1477,9 +1477,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-pets-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-pets-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                   role="region"
                 >
                   <div
@@ -1845,19 +1845,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-tools"
+            id="ds-accordion-multi-select-accordion-tools"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-tools-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-tools-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -1880,7 +1880,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-tools-icon-0"
+                  id="ds-accordion-multi-select-accordion-tools-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -1897,9 +1897,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-tools-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-tools-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                   role="region"
                 >
                   <div
@@ -2308,19 +2308,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-colors"
+            id="ds-accordion-multi-select-accordion-colors"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-colors-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-colors-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -2343,7 +2343,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-colors-icon-0"
+                  id="ds-accordion-multi-select-accordion-colors-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -2360,9 +2360,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-colors-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-colors-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                   role="region"
                 >
                   <div
@@ -2569,19 +2569,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-pets"
+            id="ds-accordion-multi-select-accordion-pets"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-pets-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-pets-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -2604,7 +2604,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-pets-icon-0"
+                  id="ds-accordion-multi-select-accordion-pets-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -2621,9 +2621,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-pets-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-pets-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                   role="region"
                 >
                   <div
@@ -2989,19 +2989,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-tools"
+            id="ds-accordion-multi-select-accordion-tools"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-tools-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-tools-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -3024,7 +3024,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-tools-icon-0"
+                  id="ds-accordion-multi-select-accordion-tools-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -3041,9 +3041,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-tools-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-tools-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                   role="region"
                 >
                   <div
@@ -3452,19 +3452,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-colors"
+            id="ds-accordion-multi-select-accordion-colors"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-colors-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-colors-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -3487,7 +3487,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-colors-icon-0"
+                  id="ds-accordion-multi-select-accordion-colors-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -3504,9 +3504,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-colors-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-colors-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
                   role="region"
                 >
                   <div
@@ -3713,19 +3713,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-pets"
+            id="ds-accordion-multi-select-accordion-pets"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-pets-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-pets-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -3748,7 +3748,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-pets-icon-0"
+                  id="ds-accordion-multi-select-accordion-pets-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -3765,9 +3765,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-pets-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-pets-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
                   role="region"
                 >
                   <div
@@ -4133,19 +4133,19 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
         >
           <div
             className="chakra-accordion css-1xdhyk6"
-            id="multi-select-accordion-tools"
+            id="ds-accordion-multi-select-accordion-tools"
             onKeyDown={[Function]}
           >
             <div
               className="chakra-accordion__item css-1fsnuue"
             >
               <button
-                aria-controls="accordion-panel-multi-select-accordion-tools-item-0"
+                aria-controls="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                 aria-expanded={false}
                 aria-label="MultiSelect, 0 items currently selected"
                 className="chakra-accordion__button css-1rvudez"
                 disabled={false}
-                id="accordion-button-multi-select-accordion-tools-item-0"
+                id="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                 onClick={[Function]}
                 onFocus={[Function]}
                 onKeyDown={[Function]}
@@ -4168,7 +4168,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                   className="chakra-icon accordion-icon css-1b9sovw"
                   data-file-name="SvgPlus"
                   focusable={false}
-                  id="accordion-multi-select-accordion-tools-icon-0"
+                  id="ds-accordion-multi-select-accordion-tools-icon-0"
                   role="img"
                   title="plus icon"
                 />
@@ -4185,9 +4185,9 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
                 }
               >
                 <div
-                  aria-labelledby="accordion-button-multi-select-accordion-tools-item-0"
+                  aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
                   className="chakra-accordion__panel css-e7ng5h"
-                  id="accordion-panel-multi-select-accordion-tools-item-0"
+                  id="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
                   role="region"
                 >
                   <div

--- a/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
+++ b/src/components/MultiSelect/__snapshots__/MultiSelect.test.tsx.snap
@@ -8,19 +8,19 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-multiselect-test-id"
+    id="ds-accordion-multi-select-accordion-multiselect-test-id"
     onKeyDown={[Function]}
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+        aria-controls="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 0 items currently selected"
         className="chakra-accordion__button css-1rvudez"
         disabled={false}
-        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+        id="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -43,7 +43,7 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
           className="chakra-icon accordion-icon css-1b9sovw"
           data-file-name="SvgPlus"
           focusable={false}
-          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
+          id="ds-accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
         />
@@ -60,9 +60,9 @@ exports[`MultiSelect should render the UI snapshot correctly 1`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+          aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+          id="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -540,19 +540,19 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-multiselect-test-id"
+    id="ds-accordion-multi-select-accordion-multiselect-test-id"
     onKeyDown={[Function]}
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+        aria-controls="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 0 items currently selected"
         className="chakra-accordion__button css-1rvudez"
         disabled={false}
-        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+        id="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -575,7 +575,7 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
           className="chakra-icon accordion-icon css-1b9sovw"
           data-file-name="SvgPlus"
           focusable={false}
-          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
+          id="ds-accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
         />
@@ -592,9 +592,9 @@ exports[`MultiSelect should render the UI snapshot correctly 2`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+          aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+          id="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -1072,19 +1072,19 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-multiselect-test-id"
+    id="ds-accordion-multi-select-accordion-multiselect-test-id"
     onKeyDown={[Function]}
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+        aria-controls="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 1 item currently selected"
         className="chakra-accordion__button css-1rvudez"
         disabled={false}
-        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+        id="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1107,7 +1107,7 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
           className="chakra-icon accordion-icon css-1b9sovw"
           data-file-name="SvgPlus"
           focusable={false}
-          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
+          id="ds-accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
         />
@@ -1124,9 +1124,9 @@ exports[`MultiSelect should render the UI snapshot correctly 3`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+          aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+          id="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div
@@ -1666,19 +1666,19 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
 >
   <div
     className="chakra-accordion css-1xdhyk6"
-    id="multi-select-accordion-multiselect-test-id"
+    id="ds-accordion-multi-select-accordion-multiselect-test-id"
     onKeyDown={[Function]}
   >
     <div
       className="chakra-accordion__item css-1fsnuue"
     >
       <button
-        aria-controls="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+        aria-controls="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         aria-expanded={false}
         aria-label="multiselect-button-text, 2 items currently selected"
         className="chakra-accordion__button css-1rvudez"
         disabled={false}
-        id="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+        id="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
         onClick={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}
@@ -1701,7 +1701,7 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
           className="chakra-icon accordion-icon css-1b9sovw"
           data-file-name="SvgPlus"
           focusable={false}
-          id="accordion-multi-select-accordion-multiselect-test-id-icon-0"
+          id="ds-accordion-multi-select-accordion-multiselect-test-id-icon-0"
           role="img"
           title="plus icon"
         />
@@ -1718,9 +1718,9 @@ exports[`MultiSelect should render the UI snapshot correctly 4`] = `
         }
       >
         <div
-          aria-labelledby="accordion-button-multi-select-accordion-multiselect-test-id-item-0"
+          aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           className="chakra-accordion__panel css-e7ng5h"
-          id="accordion-panel-multi-select-accordion-multiselect-test-id-item-0"
+          id="accordion-panel-ds-accordion-multi-select-accordion-multiselect-test-id-item-0"
           role="region"
         >
           <div

--- a/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
+++ b/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
@@ -20,19 +20,19 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
     >
       <div
         className="chakra-accordion css-1xdhyk6"
-        id="multi-select-accordion-colors"
+        id="ds-accordion-multi-select-accordion-colors"
         onKeyDown={[Function]}
       >
         <div
           className="chakra-accordion__item css-1fsnuue"
         >
           <button
-            aria-controls="accordion-panel-multi-select-accordion-colors-item-0"
+            aria-controls="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
             aria-expanded={false}
             aria-label="MultiSelect, 0 items currently selected"
             className="chakra-accordion__button css-1rvudez"
             disabled={false}
-            id="accordion-button-multi-select-accordion-colors-item-0"
+            id="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
             onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -55,7 +55,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
               className="chakra-icon accordion-icon css-1b9sovw"
               data-file-name="SvgPlus"
               focusable={false}
-              id="accordion-multi-select-accordion-colors-icon-0"
+              id="ds-accordion-multi-select-accordion-colors-icon-0"
               role="img"
               title="plus icon"
             />
@@ -72,9 +72,9 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
             }
           >
             <div
-              aria-labelledby="accordion-button-multi-select-accordion-colors-item-0"
+              aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
               className="chakra-accordion__panel css-e7ng5h"
-              id="accordion-panel-multi-select-accordion-colors-item-0"
+              id="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
               role="region"
             >
               <div
@@ -281,19 +281,19 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
     >
       <div
         className="chakra-accordion css-1xdhyk6"
-        id="multi-select-accordion-pets"
+        id="ds-accordion-multi-select-accordion-pets"
         onKeyDown={[Function]}
       >
         <div
           className="chakra-accordion__item css-1fsnuue"
         >
           <button
-            aria-controls="accordion-panel-multi-select-accordion-pets-item-0"
+            aria-controls="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
             aria-expanded={false}
             aria-label="MultiSelect, 0 items currently selected"
             className="chakra-accordion__button css-1rvudez"
             disabled={false}
-            id="accordion-button-multi-select-accordion-pets-item-0"
+            id="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
             onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -316,7 +316,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
               className="chakra-icon accordion-icon css-1b9sovw"
               data-file-name="SvgPlus"
               focusable={false}
-              id="accordion-multi-select-accordion-pets-icon-0"
+              id="ds-accordion-multi-select-accordion-pets-icon-0"
               role="img"
               title="plus icon"
             />
@@ -333,9 +333,9 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
             }
           >
             <div
-              aria-labelledby="accordion-button-multi-select-accordion-pets-item-0"
+              aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
               className="chakra-accordion__panel css-e7ng5h"
-              id="accordion-panel-multi-select-accordion-pets-item-0"
+              id="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
               role="region"
             >
               <div
@@ -701,19 +701,19 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
     >
       <div
         className="chakra-accordion css-1xdhyk6"
-        id="multi-select-accordion-tools"
+        id="ds-accordion-multi-select-accordion-tools"
         onKeyDown={[Function]}
       >
         <div
           className="chakra-accordion__item css-1fsnuue"
         >
           <button
-            aria-controls="accordion-panel-multi-select-accordion-tools-item-0"
+            aria-controls="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
             aria-expanded={false}
             aria-label="MultiSelect, 0 items currently selected"
             className="chakra-accordion__button css-1rvudez"
             disabled={false}
-            id="accordion-button-multi-select-accordion-tools-item-0"
+            id="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
             onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -736,7 +736,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
               className="chakra-icon accordion-icon css-1b9sovw"
               data-file-name="SvgPlus"
               focusable={false}
-              id="accordion-multi-select-accordion-tools-icon-0"
+              id="ds-accordion-multi-select-accordion-tools-icon-0"
               role="img"
               title="plus icon"
             />
@@ -753,9 +753,9 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
             }
           >
             <div
-              aria-labelledby="accordion-button-multi-select-accordion-tools-item-0"
+              aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
               className="chakra-accordion__panel css-e7ng5h"
-              id="accordion-panel-multi-select-accordion-tools-item-0"
+              id="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
               role="region"
             >
               <div
@@ -1138,19 +1138,19 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     >
       <div
         className="chakra-accordion css-1xdhyk6"
-        id="multi-select-accordion-colors"
+        id="ds-accordion-multi-select-accordion-colors"
         onKeyDown={[Function]}
       >
         <div
           className="chakra-accordion__item css-1fsnuue"
         >
           <button
-            aria-controls="accordion-panel-multi-select-accordion-colors-item-0"
+            aria-controls="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
             aria-expanded={false}
             aria-label="MultiSelect, 0 items currently selected"
             className="chakra-accordion__button css-1rvudez"
             disabled={false}
-            id="accordion-button-multi-select-accordion-colors-item-0"
+            id="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
             onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -1173,7 +1173,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
               className="chakra-icon accordion-icon css-1b9sovw"
               data-file-name="SvgPlus"
               focusable={false}
-              id="accordion-multi-select-accordion-colors-icon-0"
+              id="ds-accordion-multi-select-accordion-colors-icon-0"
               role="img"
               title="plus icon"
             />
@@ -1190,9 +1190,9 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
             }
           >
             <div
-              aria-labelledby="accordion-button-multi-select-accordion-colors-item-0"
+              aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-colors-item-0"
               className="chakra-accordion__panel css-e7ng5h"
-              id="accordion-panel-multi-select-accordion-colors-item-0"
+              id="accordion-panel-ds-accordion-multi-select-accordion-colors-item-0"
               role="region"
             >
               <div
@@ -1399,19 +1399,19 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     >
       <div
         className="chakra-accordion css-1xdhyk6"
-        id="multi-select-accordion-pets"
+        id="ds-accordion-multi-select-accordion-pets"
         onKeyDown={[Function]}
       >
         <div
           className="chakra-accordion__item css-1fsnuue"
         >
           <button
-            aria-controls="accordion-panel-multi-select-accordion-pets-item-0"
+            aria-controls="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
             aria-expanded={false}
             aria-label="MultiSelect, 0 items currently selected"
             className="chakra-accordion__button css-1rvudez"
             disabled={false}
-            id="accordion-button-multi-select-accordion-pets-item-0"
+            id="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
             onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -1434,7 +1434,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
               className="chakra-icon accordion-icon css-1b9sovw"
               data-file-name="SvgPlus"
               focusable={false}
-              id="accordion-multi-select-accordion-pets-icon-0"
+              id="ds-accordion-multi-select-accordion-pets-icon-0"
               role="img"
               title="plus icon"
             />
@@ -1451,9 +1451,9 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
             }
           >
             <div
-              aria-labelledby="accordion-button-multi-select-accordion-pets-item-0"
+              aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-pets-item-0"
               className="chakra-accordion__panel css-e7ng5h"
-              id="accordion-panel-multi-select-accordion-pets-item-0"
+              id="accordion-panel-ds-accordion-multi-select-accordion-pets-item-0"
               role="region"
             >
               <div
@@ -1819,19 +1819,19 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
     >
       <div
         className="chakra-accordion css-1xdhyk6"
-        id="multi-select-accordion-tools"
+        id="ds-accordion-multi-select-accordion-tools"
         onKeyDown={[Function]}
       >
         <div
           className="chakra-accordion__item css-1fsnuue"
         >
           <button
-            aria-controls="accordion-panel-multi-select-accordion-tools-item-0"
+            aria-controls="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
             aria-expanded={false}
             aria-label="MultiSelect, 0 items currently selected"
             className="chakra-accordion__button css-1rvudez"
             disabled={false}
-            id="accordion-button-multi-select-accordion-tools-item-0"
+            id="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
             onClick={[Function]}
             onFocus={[Function]}
             onKeyDown={[Function]}
@@ -1854,7 +1854,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
               className="chakra-icon accordion-icon css-1b9sovw"
               data-file-name="SvgPlus"
               focusable={false}
-              id="accordion-multi-select-accordion-tools-icon-0"
+              id="ds-accordion-multi-select-accordion-tools-icon-0"
               role="img"
               title="plus icon"
             />
@@ -1871,9 +1871,9 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] =
             }
           >
             <div
-              aria-labelledby="accordion-button-multi-select-accordion-tools-item-0"
+              aria-labelledby="accordion-button-ds-accordion-multi-select-accordion-tools-item-0"
               className="chakra-accordion__panel css-e7ng5h"
-              id="accordion-panel-multi-select-accordion-tools-item-0"
+              id="accordion-panel-ds-accordion-multi-select-accordion-tools-item-0"
               role="region"
             >
               <div

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -220,3 +220,7 @@ export const getTextFromElement = (
   }
   return getTextFromElement(children);
 };
+
+export const generateComponentId = (name: string, id: string | undefined) => {
+  return `ds-${name}${id ? `-${id}` : ""}`;
+};


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2038](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2038)

## This PR does the following:

- This is the "main" feature branch for updating all component's `id`s and `classname`s to a consistent pattern which will be `ds-[componentName][-additionalUserPassedId]` for ids. For class names, we won't be combining the passed classname value with the component's because they can be separate for various styling purposes.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Unit tests.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Will make a separate PR to address recommendation for the set of components that should have unique ids.

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2038]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2038?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ