### PR TITLE
DSD-2053 & DSD-2054: Add JavaScript disabled fallback warning to AudioPlayer and VideoPlayer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ### Adds
 
-- Adds a fallback warning message to the `AudioPlayer` component for browsers with JavaScript disabled.
+- Adds fallback warning messages to the `AudioPlayer` and `VideoPlayer` components on browsers with JavaScript disabled.
 
 ## 3.6.3 (June 9, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds a fallback warning message to the `AudioPlayer` component for browsers with JavaScript disabled.
+
 ## 3.6.3 (June 9, 2025)
 
 ### Adds

--- a/src/components/AudioPlayer/AudioPlayer.mdx
+++ b/src/components/AudioPlayer/AudioPlayer.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./audioPlayerChangelogData";
 
 # Audio Player
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `1.2.0`    |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `1.2.0`      |
+| Latest            | `prerelease` |
 
 ## Table of Contents
 

--- a/src/components/AudioPlayer/AudioPlayer.mdx
+++ b/src/components/AudioPlayer/AudioPlayer.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./audioPlayerChangelogData";
 | Component Version | DS Version   |
 | ----------------- | ------------ |
 | Added             | `1.2.0`      |
-| Latest            | `prerelease` |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -155,7 +155,9 @@ export const AudioPlayer: ChakraComponent<
           ) : (
             <>{embedElement}</>
           )}
-          {/* Displays a fallback message to users when JavaScript is disabled. */}
+          {/* Displays a fallback message to users when JavaScript is disabled.
+              NOTE: This relies on the component being Server-Side Rendered (SSR) or Statically Generated (SSG).
+          */}
           <noscript>
             <Box __css={styles.invalid}>
               The audio player requires JavaScript to function. Please enable

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -157,11 +157,9 @@ export const AudioPlayer: ChakraComponent<
           )}
           {/* Displays a fallback message to users when JavaScript is disabled. */}
           <noscript>
-            <Box 
-              __css={styles.invalid} 
-            >
-              The audio player requires JavaScript to function. 
-              Please enable JavaScript in your browser settings and refresh the page.
+            <Box __css={styles.invalid}>
+              The audio player requires JavaScript to function. Please enable
+              JavaScript in your browser settings and refresh the page.
             </Box>
           </noscript>
         </ComponentWrapper>

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -159,10 +159,17 @@ export const AudioPlayer: ChakraComponent<
               NOTE: This relies on the component being Server-Side Rendered (SSR) or Statically Generated (SSG).
           */}
           <noscript>
-            <Box __css={styles.invalid}>
+            <div
+              style={{
+                margin: "1rem 0",
+                backgroundColor: "var(--nypl-colors-ui-bg-default)",
+                border: "1px solid var(--nypl-colors-ui-border-default)",
+                padding: "var(--nypl-space-s)",
+              }}
+            >
               The audio player requires JavaScript to function. Please enable
               JavaScript in your browser settings and refresh the page.
-            </Box>
+            </div>
           </noscript>
         </ComponentWrapper>
       );

--- a/src/components/AudioPlayer/AudioPlayer.tsx
+++ b/src/components/AudioPlayer/AudioPlayer.tsx
@@ -155,6 +155,15 @@ export const AudioPlayer: ChakraComponent<
           ) : (
             <>{embedElement}</>
           )}
+          {/* Displays a fallback message to users when JavaScript is disabled. */}
+          <noscript>
+            <Box 
+              __css={styles.invalid} 
+            >
+              The audio player requires JavaScript to function. 
+              Please enable JavaScript in your browser settings and refresh the page.
+            </Box>
+          </noscript>
         </ComponentWrapper>
       );
     }

--- a/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
+++ b/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
@@ -8,7 +8,14 @@ exports[`AudioPlay Snapshots Renders the errored AudioPlayer UI 1`] = `
 >
   <noscript>
     <div
-      className="css-0"
+      style={
+        {
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
+        }
+      }
     >
       The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
     </div>
@@ -35,7 +42,14 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
   </p>
   <noscript>
     <div
-      className="css-0"
+      style={
+        {
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
+        }
+      }
     >
       The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
     </div>
@@ -75,7 +89,14 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  2`] = `
   />
   <noscript>
     <div
-      className="css-0"
+      style={
+        {
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
+        }
+      }
     >
       The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
     </div>
@@ -91,7 +112,14 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  3`] = `
 >
   <noscript>
     <div
-      className="css-0"
+      style={
+        {
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
+        }
+      }
     >
       The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
     </div>
@@ -115,7 +143,14 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  4`] = `
   />
   <noscript>
     <div
-      className="css-0"
+      style={
+        {
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
+        }
+      }
     >
       The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
     </div>

--- a/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
+++ b/src/components/AudioPlayer/__snapshots__/AudioPlayer.test.tsx.snap
@@ -5,7 +5,15 @@ exports[`AudioPlay Snapshots Renders the errored AudioPlayer UI 1`] = `
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
   id="undefined-componentWrapper-wrapper"
-/>
+>
+  <noscript>
+    <div
+      className="css-0"
+    >
+      The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
+</div>
 `;
 
 exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
@@ -25,6 +33,13 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  1`] = `
   >
     Audio Player description text.
   </p>
+  <noscript>
+    <div
+      className="css-0"
+    >
+      The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
   <div
     aria-atomic={true}
     aria-live="polite"
@@ -58,6 +73,13 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  2`] = `
       }
     }
   />
+  <noscript>
+    <div
+      className="css-0"
+    >
+      The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;
 
@@ -66,7 +88,15 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  3`] = `
   className="audioplayer css-1u8qly9"
   data-testid="audio-player-component"
   id="undefined-componentWrapper-wrapper"
-/>
+>
+  <noscript>
+    <div
+      className="css-0"
+    >
+      The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
+</div>
 `;
 
 exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  4`] = `
@@ -83,5 +113,12 @@ exports[`AudioPlay Snapshots Renders the well formatted AudioPlayer UI  4`] = `
       }
     }
   />
+  <noscript>
+    <div
+      className="css-0"
+    >
+      The audio player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;

--- a/src/components/AudioPlayer/audioPlayerChangelogData.ts
+++ b/src/components/AudioPlayer/audioPlayerChangelogData.ts
@@ -14,7 +14,9 @@ export const changelogData: ChangelogData[] = [
     version: "3.6.3",
     type: "Update",
     affects: ["Accessibility"],
-    notes: ["Display a fallback warning message on JavaScript-disabled browsers."],
+    notes: [
+      "Display a fallback warning message on JavaScript-disabled browsers.",
+    ],
   },
   {
     date: "2024-03-14",

--- a/src/components/AudioPlayer/audioPlayerChangelogData.ts
+++ b/src/components/AudioPlayer/audioPlayerChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2025-06-12",
+    version: "3.6.3",
+    type: "Update",
+    affects: ["Accessibility"],
+    notes: ["Display a fallback warning message on JavaScript-disabled browsers."],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/AudioPlayer/audioPlayerChangelogData.ts
+++ b/src/components/AudioPlayer/audioPlayerChangelogData.ts
@@ -11,7 +11,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 export const changelogData: ChangelogData[] = [
   {
     date: "2025-06-12",
-    version: "3.6.3",
+    version: "Prerelease",
     type: "Update",
     affects: ["Accessibility"],
     notes: [

--- a/src/components/VideoPlayer/VideoPlayer.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./videoPlayerChangelogData";
 | Component Version | DS Version   |
 | ----------------- | ------------ |
 | Added             | `0.23.2`     |
-| Latest            | `prerelease` |
+| Latest            | `Prerelease` |
 
 ## Table of Contents
 

--- a/src/components/VideoPlayer/VideoPlayer.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.mdx
@@ -9,10 +9,10 @@ import { changelogData } from "./videoPlayerChangelogData";
 
 # Video Player
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.23.2`   |
-| Latest            | `3.0.0`    |
+| Component Version | DS Version   |
+| ----------------- | ------------ |
+| Added             | `0.23.2`     |
+| Latest            | `prerelease` |
 
 ## Table of Contents
 

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -203,10 +203,18 @@ export const VideoPlayer: ChakraComponent<
               NOTE: This relies on the component being Server-Side Rendered (SSR) or Statically Generated (SSG).
           */}
           <noscript>
-            <Box __css={styles.invalid} style={{ marginTop: "1rem" }}>
+            <div
+              style={{
+                margin: "1rem 0",
+                backgroundColor: "var(--nypl-colors-ui-bg-default)",
+                border: "1px solid var(--nypl-colors-ui-border-default)",
+                padding: "var(--nypl-space-s)",
+                height: "auto",
+              }}
+            >
               The video player requires JavaScript to function. Please enable
               JavaScript in your browser settings and refresh the page.
-            </Box>
+            </div>
           </noscript>
         </Box>
       );

--- a/src/components/VideoPlayer/VideoPlayer.tsx
+++ b/src/components/VideoPlayer/VideoPlayer.tsx
@@ -199,6 +199,15 @@ export const VideoPlayer: ChakraComponent<
               <Box __css={styles.inside}>{embedElement}</Box>
             </ComponentWrapper>
           )}
+          {/* Displays a fallback message to users when JavaScript is disabled.
+              NOTE: This relies on the component being Server-Side Rendered (SSR) or Statically Generated (SSG).
+          */}
+          <noscript>
+            <Box __css={styles.invalid} style={{ marginTop: "1rem" }}>
+              The video player requires JavaScript to function. Please enable
+              JavaScript in your browser settings and refresh the page.
+            </Box>
+          </noscript>
         </Box>
       );
     }

--- a/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
+++ b/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
@@ -23,6 +23,18 @@ exports[`VideoPlayer renders the UI snapshot correctly 1`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="css-0"
+      style={
+        {
+          "marginTop": "1rem",
+        }
+      }
+    >
+      The video player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;
 
@@ -76,6 +88,18 @@ exports[`VideoPlayer renders the UI snapshot correctly 2`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="css-0"
+      style={
+        {
+          "marginTop": "1rem",
+        }
+      }
+    >
+      The video player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;
 
@@ -128,6 +152,18 @@ exports[`VideoPlayer renders the UI snapshot correctly 3`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="css-0"
+      style={
+        {
+          "marginTop": "1rem",
+        }
+      }
+    >
+      The video player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;
 
@@ -144,6 +180,18 @@ exports[`VideoPlayer renders the UI snapshot correctly 4`] = `
       }
     }
   />
+  <noscript>
+    <div
+      className="css-0"
+      style={
+        {
+          "marginTop": "1rem",
+        }
+      }
+    >
+      The video player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;
 
@@ -170,6 +218,18 @@ exports[`VideoPlayer renders the UI snapshot correctly 5`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="css-0"
+      style={
+        {
+          "marginTop": "1rem",
+        }
+      }
+    >
+      The video player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;
 
@@ -196,5 +256,17 @@ exports[`VideoPlayer renders the UI snapshot correctly 6`] = `
       />
     </div>
   </div>
+  <noscript>
+    <div
+      className="css-0"
+      style={
+        {
+          "marginTop": "1rem",
+        }
+      }
+    >
+      The video player requires JavaScript to function. Please enable JavaScript in your browser settings and refresh the page.
+    </div>
+  </noscript>
 </div>
 `;

--- a/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
+++ b/src/components/VideoPlayer/__snapshots__/VideoPlayer.test.tsx.snap
@@ -25,10 +25,13 @@ exports[`VideoPlayer renders the UI snapshot correctly 1`] = `
   </div>
   <noscript>
     <div
-      className="css-0"
       style={
         {
-          "marginTop": "1rem",
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "height": "auto",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
         }
       }
     >
@@ -90,10 +93,13 @@ exports[`VideoPlayer renders the UI snapshot correctly 2`] = `
   </div>
   <noscript>
     <div
-      className="css-0"
       style={
         {
-          "marginTop": "1rem",
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "height": "auto",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
         }
       }
     >
@@ -154,10 +160,13 @@ exports[`VideoPlayer renders the UI snapshot correctly 3`] = `
   </div>
   <noscript>
     <div
-      className="css-0"
       style={
         {
-          "marginTop": "1rem",
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "height": "auto",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
         }
       }
     >
@@ -182,10 +191,13 @@ exports[`VideoPlayer renders the UI snapshot correctly 4`] = `
   />
   <noscript>
     <div
-      className="css-0"
       style={
         {
-          "marginTop": "1rem",
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "height": "auto",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
         }
       }
     >
@@ -220,10 +232,13 @@ exports[`VideoPlayer renders the UI snapshot correctly 5`] = `
   </div>
   <noscript>
     <div
-      className="css-0"
       style={
         {
-          "marginTop": "1rem",
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "height": "auto",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
         }
       }
     >
@@ -258,10 +273,13 @@ exports[`VideoPlayer renders the UI snapshot correctly 6`] = `
   </div>
   <noscript>
     <div
-      className="css-0"
       style={
         {
-          "marginTop": "1rem",
+          "backgroundColor": "var(--nypl-colors-ui-bg-default)",
+          "border": "1px solid var(--nypl-colors-ui-border-default)",
+          "height": "auto",
+          "margin": "1rem 0",
+          "padding": "var(--nypl-space-s)",
         }
       }
     >

--- a/src/components/VideoPlayer/videoPlayerChangelogData.ts
+++ b/src/components/VideoPlayer/videoPlayerChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "2025-06-12",
+    version: "3.6.3",
+    type: "Update",
+    affects: ["Accessibility"],
+    notes: [
+      "Display a fallback warning message on JavaScript-disabled browsers.",
+    ],
+  },
+  {
     date: "2024-03-14",
     version: "3.0.0",
     type: "Update",

--- a/src/components/VideoPlayer/videoPlayerChangelogData.ts
+++ b/src/components/VideoPlayer/videoPlayerChangelogData.ts
@@ -11,7 +11,7 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 export const changelogData: ChangelogData[] = [
   {
     date: "2025-06-12",
-    version: "3.6.3",
+    version: "Prerelease",
     type: "Update",
     affects: ["Accessibility"],
     notes: [


### PR DESCRIPTION
Jira tickets:
[DSD-2053](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2053)
[DSD-2054](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2054)

## This PR does the following:

- Renders a `noscript` tag with a JavaScript disabled fallback warning for AudioPlayer and VideoPlayer.

## Accessibility concerns or updates

- This will only work when rendered via Server-Side Generation or Server-Side Rendering.

## How has this been tested?

- I verified by publishing the DS package with `yalc` and consuming in the `research-catalog` app to test the functionality with JS disabled. Here's a screenshot:

![Screenshot 2025-06-13 at 12 05 50 PM](https://github.com/user-attachments/assets/54595f05-cec8-4c72-8e3b-8ae3cc2e8941)

## Open Questions

- Should we get formal approval/input on the copy? If so from whom?

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

[DSD-2053]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DSD-2054]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2054?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ