### PR TITLE
DSD-2073: `Multiselect` missing key bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Fixes
+
+- Fixes the keyless fragments for `Checkbox` items in the `Multiselect` component.
+
 ## 3.6.3 (June 9, 2025)
 
 ### Adds

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -430,9 +430,11 @@ export const MultiSelect: ChakraComponent<
                   showLabel={false}
                   name="multi-select-checkbox-group"
                 >
-                  {itemsList.flatMap((item: MultiSelectItem) =>
-                    getMultiSelectCheckboxItem(item)
-                  )}
+                  {itemsList.map((item: MultiSelectItem) => (
+                    <React.Fragment key={item.id}>
+                      {getMultiSelectCheckboxItem(item)}
+                    </React.Fragment>
+                  ))}
                 </CheckboxGroup>
                 {isOverflowExpand && <ExpandToggleButton />}
               </>

--- a/src/components/MultiSelect/MultiSelect.tsx
+++ b/src/components/MultiSelect/MultiSelect.tsx
@@ -430,9 +430,9 @@ export const MultiSelect: ChakraComponent<
                   showLabel={false}
                   name="multi-select-checkbox-group"
                 >
-                  {itemsList.map((item: MultiSelectItem) => (
-                    <>{getMultiSelectCheckboxItem(item)}</>
-                  ))}
+                  {itemsList.flatMap((item: MultiSelectItem) =>
+                    getMultiSelectCheckboxItem(item)
+                  )}
                 </CheckboxGroup>
                 {isOverflowExpand && <ExpandToggleButton />}
               </>

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Bug Fix",
+    affects: ["Functionality"],
+    notes: [
+      "Fixes the array of checkbox items so it's not returned as React fragments without keys.",
+    ],
+  },
+  {
     date: "2025-04-24",
     version: "3.6.1",
     type: "Bug Fix",

--- a/src/components/MultiSelect/multiSelectChangelogData.ts
+++ b/src/components/MultiSelect/multiSelectChangelogData.ts
@@ -14,9 +14,7 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Bug Fix",
     affects: ["Functionality"],
-    notes: [
-      "Fixes the array of checkbox items so it's not returned as React fragments without keys.",
-    ],
+    notes: ["Fixes the array of checkbox items to return with unique keys."],
   },
   {
     date: "2025-04-24",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2073](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2073)

## This PR does the following:

- Adds a key to the fragment wrapping each `Checkbox` item in `Multiselect`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Warning no longer appears 

(currently on `development`):
<img width="1465" alt="Screenshot 2025-06-16 at 3 52 23 PM" src="https://github.com/user-attachments/assets/3d2d3654-e04f-4708-8673-05753cda46de" />


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2073]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2073?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ