### PR TITLE
DSD-2076: Story headers for Content Display

### DIFF
--- a/src/components/HelperErrorText/HelperErrorText.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.mdx
@@ -11,7 +11,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Content Display"
   componentName="HelperErrorText"
-  summary="Accessible container for supporting text that renders regardless of content"
+  summary="Accessible container for rendering supporting text"
   versionAdded="0.0.10"
   versionLatest="Prerelease"
 />

--- a/src/components/HelperErrorText/HelperErrorText.mdx
+++ b/src/components/HelperErrorText/HelperErrorText.mdx
@@ -3,16 +3,20 @@ import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 import * as HelperErrorTextStories from "./HelperErrorText.stories";
 import { changelogData } from "./helperErrorTextChangelogData";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta of={HelperErrorTextStories} />
 
-# HelperErrorText
+<ComponentDocsHeader
+  category="Content Display"
+  componentName="HelperErrorText"
+  summary="Accessible container for supporting text that renders regardless of content"
+  versionAdded="0.0.10"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.0.10`     |
-| Latest            | `Prerelease` |
+<Canvas of={HelperErrorTextStories.WithControls} />
 
 ## Table of Contents
 
@@ -28,8 +32,6 @@ import Link from "../Link/Link";
 <Description of={HelperErrorTextStories} />
 
 ## Component Props
-
-<Canvas of={HelperErrorTextStories.WithControls} />
 
 `HelperErrorText` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/StatusBadge/StatusBadge.mdx
+++ b/src/components/StatusBadge/StatusBadge.mdx
@@ -4,15 +4,19 @@ import * as StatusBadgeStories from "./StatusBadge.stories";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import Link from "../Link/Link";
 import { changelogData } from "./statusBadgeChangelogData";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 
 <Meta of={StatusBadgeStories} />
 
-# StatusBadge
+<ComponentDocsHeader
+  category="Content Display"
+  componentName="StatusBadge"
+  summary="Label to indicate status or importance"
+  versionAdded="0.18.7"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.18.7`     |
-| Latest            | `Prerelease` |
+<Canvas of={StatusBadgeStories.WithControls} />
 
 ## Table of Contents
 
@@ -30,8 +34,6 @@ import { changelogData } from "./statusBadgeChangelogData";
 <Description of={StatusBadgeStories} />
 
 ## Component Props
-
-<Canvas of={StatusBadgeStories.WithControls} />
 
 `StatusBadge` composes a Chakra `Box` component, so you may pass any Chakra `Box` props,
 as well as the props below.

--- a/src/components/TagSet/TagSet.mdx
+++ b/src/components/TagSet/TagSet.mdx
@@ -4,15 +4,20 @@ import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import * as TagSetStories from "./TagSet.stories";
 import Link from "../Link/Link";
 import { changelogData } from "./tagSetChangelogData";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 
 <Meta of={TagSetStories} />
 
-# TagSet
+<ComponentDocsHeader
+  category="Content Display"
+  componentName="TagSet"
+  summary="Group of tags that allow content to be explored or filtered"
+  versionAdded="1.2.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `1.2.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={TagSetStories.ExploreVariant} />
+<Canvas of={TagSetStories.FilterVariantDismiss} />
 
 ## Table of Contents
 


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2076](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2076)

## This PR does the following:

- Updates story headers for `HelperErrorText`, `StatusBadge`, and `TagSet`

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2076]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2076?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ