### PR TITLE
DSD-2083: updated story headers for Typography & Styles

### DIFF
--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -11,7 +11,7 @@ import { changelogData } from "./headingChangelogData";
 <ComponentDocsHeader
   category="Typography & styles component"
   componentName="Heading"
-  summary="Component that renders a standard HTML heading element with DS styles."
+  summary="Renders a native HTML heading element in different sizes and styles"
   versionAdded="0.0.4"
   versionLatest="Prerelease"
 />

--- a/src/components/List/List.mdx
+++ b/src/components/List/List.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import * as ListStories from "./List.stories";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as ListStories from "./List.stories";
 import { changelogData } from "./listChangelogData";
 
 <Meta of={ListStories} />
 
-# List
+<ComponentDocsHeader
+  category="Typography & styles component"
+  componentName="List"
+  summary="Renders related items in a list format using a <ul>, <ol>, or <dl> element"
+  versionAdded="0.7.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.7.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={ListStories.WithControls} />
 
 ## Table of Contents
 
@@ -26,8 +30,6 @@ import { changelogData } from "./listChangelogData";
 ## Overview
 
 <Description of={ListStories} />
-
-<Canvas of={ListStories.WithControls} />
 
 `List` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/StyledList/StyledList.mdx
+++ b/src/components/StyledList/StyledList.mdx
@@ -1,19 +1,23 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
 import StyledList from "./StyledList";
 import * as StyledListStories from "./StyledList.stories";
-import Link from "../Link/Link";
 import { changelogData } from "./styledListChangelogData";
 
 <Meta of={StyledListStories} />
 
-# StyledList
+<ComponentDocsHeader
+  category="Typography & styles component"
+  componentName="StyledList"
+  summary="Renders a stylized list element that does not adhere to standard list styles"
+  versionAdded="1.3.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `1.3.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={StyledListStories.WithControls} />
 
 ## Table of Contents
 
@@ -29,8 +33,6 @@ import { changelogData } from "./styledListChangelogData";
 <Description of={StyledListStories} />
 
 ## Component Props
-
-<Canvas of={StyledListStories.WithControls} />
 
 `StyledList` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/Text/Text.mdx
+++ b/src/components/Text/Text.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import * as TextStories from "./Text.stories";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as TextStories from "./Text.stories";
 import { changelogData } from "./textChangelogData";
 
 <Meta of={TextStories} />
 
-# Text
+<ComponentDocsHeader
+  category="Typography & styles component"
+  componentName="Text"
+  summary="Text container used for paragraph text elements"
+  versionAdded="0.25.1"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.25.1`     |
-| Latest            | `Prerelease` |
+<Canvas of={TextStories.WithControls} />
 
 ## Table of Contents
 
@@ -29,8 +33,6 @@ The `Text` component renders a basic `<p>` element and can be used to render
 text for differing content types, including multiple subtitle variants.
 
 ## Component Props
-
-<Canvas of={TextStories.WithControls} />
 
 You may pass any Chakra `Box` props, as well as the props below.
 


### PR DESCRIPTION
Fixes JIRA ticket xxx

## This PR does the following:

- Updates the story headers for Typography & Styles category

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
