### PR TITLE
DSD-2082: story headers for Page Layout components

### DIFF
--- a/src/components/Grid/SimpleGrid.mdx
+++ b/src/components/Grid/SimpleGrid.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 
-import * as SimpleGridStories from "./SimpleGrid.stories";
-import Link from "../Link/Link";
-import { changelogData } from "./simpleGridChangelogData";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as SimpleGridStories from "./SimpleGrid.stories";
+import { changelogData } from "./simpleGridChangelogData";
 
 <Meta of={SimpleGridStories} />
 
-# SimpleGrid
+<ComponentDocsHeader
+  category="Page layout component"
+  componentName="SimpleGrid"
+  summary="Container for rendering a basic grid layout"
+  versionAdded="0.25.1"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.25.1`     |
-| Latest            | `Prerelease` |
+<Canvas of={SimpleGridStories.WithControls} />
 
 ## Table of Contents
 
@@ -36,8 +40,6 @@ tablet breakpoint will be dropped and only the mobile breakpoint (1 item per
 row) will be triggered.
 
 ## Component Props
-
-<Canvas of={SimpleGridStories.WithControls} />
 
 You may pass any Chakra `Box` props, as well as the props below.
 

--- a/src/components/HorizontalRule/HorizontalRule.mdx
+++ b/src/components/HorizontalRule/HorizontalRule.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 
-import * as HorizontalRuleStories from "./HorizontalRule.stories";
-import Link from "../Link/Link";
-import { changelogData } from "./horizontalRuleChangelogData";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as HorizontalRuleStories from "./HorizontalRule.stories";
+import { changelogData } from "./horizontalRuleChangelogData";
 
 <Meta of={HorizontalRuleStories} />
 
-# HorizontalRule
+<ComponentDocsHeader
+  category="Page layout component"
+  componentName="HorizontalRule"
+  summary="Used to visually separate content for clarity"
+  versionAdded="0.23.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.23.0`     |
-| Latest            | `Prerelease` |
+<Canvas of={HorizontalRuleStories.WithControls} />
 
 ## Table of Contents
 
@@ -31,8 +35,6 @@ number, a `px` value, a `em` value, or a `rem` value. Otherwise, the default
 value of "2px" will be used.
 
 ## Component Props
-
-<Canvas of={HorizontalRuleStories.WithControls} />
 
 `HorizontalRule` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/StructuredContent/StructuredContent.mdx
+++ b/src/components/StructuredContent/StructuredContent.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as StructuredContentStories from "./StructuredContent.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as StructuredContentStories from "./StructuredContent.stories";
 import { changelogData } from "./structuredContentChangelogData";
 
 <Meta of={StructuredContentStories} />
 
-# StructuredContent
+<ComponentDocsHeader
+  category="Page layout component"
+  componentName="StructuredContent"
+  summary="Container that provides a standardized layout for generic page content"
+  versionAdded="0.25.9"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.25.9`     |
-| Latest            | `Prerelease` |
+<Canvas of={StructuredContentStories.Controls} />
 
 ## Table of Contents
 
@@ -30,8 +34,6 @@ import { changelogData } from "./structuredContentChangelogData";
 <Description of={StructuredContentStories} />
 
 ## Component Props
-
-<Canvas of={StructuredContentStories.Controls} />
 
 `StructuredContent` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/Table/Table.mdx
+++ b/src/components/Table/Table.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as TableStories from "./Table.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as TableStories from "./Table.stories";
 import { changelogData } from "./tableChangelogData";
 
 <Meta of={TableStories} />
 
-# Table
+<ComponentDocsHeader
+  category="Page layout component"
+  componentName="Table"
+  summary="Used to efficiently organize and display tabular data"
+  versionAdded="0.25.9"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.25.9`     |
-| Latest            | `Prerelease` |
+<Canvas of={TableStories.WithControls} />
 
 ## Table of Contents
 
@@ -34,8 +38,6 @@ import { changelogData } from "./tableChangelogData";
 <Description of={TableStories} />
 
 ## Component Props
-
-<Canvas of={TableStories.WithControls} />
 
 You may pass any Chakra `Box` props, as well as the props below.
 

--- a/src/components/Template/Template.mdx
+++ b/src/components/Template/Template.mdx
@@ -1,7 +1,6 @@
 import { Box } from "@chakra-ui/react";
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as TemplateStories from "./Template.stories";
 import {
   Template,
   TemplateBreakout,
@@ -12,12 +11,18 @@ import {
   TemplateBottom,
 } from "./Template";
 import Banner from "../Banner/Banner";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import DocsWithImage from "../../utils/components/DocsWithImage";
 import Heading from "../Heading/Heading";
 import Image from "../Image/Image";
 import Link from "../Link/Link";
 import List from "../List/List";
 import Table from "../Table/Table";
 import Text from "../Text/Text";
+import * as TemplateStories from "./Template.stories";
+import { changelogData } from "./templateChangelogData";
+import { exampleWrapperStyles } from "../../utils/utils.ts";
 
 import templateBreakout from "/template/templateBreakout.png";
 import templateBottom from "/template/templateBottom.png";
@@ -27,19 +32,13 @@ import templateMainWide from "/template/templateMainWide.png";
 import templateSidebarLeft from "/template/templateSidebarLeft.png";
 import templateSidebarRight from "/template/templateSidebarRight.png";
 import templateTop from "/template/templateTop.png";
-import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
-import DocsWithImage from "../../utils/components/DocsWithImage";
-import { exampleWrapperStyles } from "../../utils/utils.ts";
-
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import { changelogData } from "./templateChangelogData";
 
 <Meta of={TemplateStories} />
 
 <ComponentDocsHeader
   category="Page layout component"
   componentName="Template"
-  summary="A structural skeleton for composing a standard page layout"
+  summary="Structural skeleton for composing a standard page layout"
   versionAdded="0.3.6"
   versionLatest="Prerelease"
 />


### PR DESCRIPTION
Fixes JIRA ticket xxx

## This PR does the following:

- Updated story headers for `Page Layout` category

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
