### PR TITLE
DSD-2077: Story headers for Feedback components

### DIFF
--- a/src/components/Notification/Notification.mdx
+++ b/src/components/Notification/Notification.mdx
@@ -3,16 +3,20 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 import * as NotificationStories from "./Notification.stories";
 import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import { changelogData } from "./notificationChangelogData";
 
 <Meta of={NotificationStories} />
 
-# Notification
+<ComponentDocsHeader
+  category="Feedback component"
+  componentName="Notification"
+  summary="Callout that displays important messages"
+  versionAdded="0.23.2"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.23.2`     |
-| Latest            | `Prerelease` |
+<Canvas of={NotificationStories.WithControls} />
 
 ## Table of Contents
 
@@ -36,8 +40,6 @@ component. It has been added to help illustrate how the `Notification` sits
 within a parent element.
 
 ## Component Props
-
-<Canvas of={NotificationStories.WithControls} />
 
 `Notification` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/ProgressIndicator/ProgressIndicator.mdx
+++ b/src/components/ProgressIndicator/ProgressIndicator.mdx
@@ -3,16 +3,20 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 import * as ProgressIndicatorStories from "./ProgressIndicator.stories";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import { changelogData } from "./progressIndicatorChangelogData";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta of={ProgressIndicatorStories} />
 
-# ProgressIndicator
+<ComponentDocsHeader
+  category="Feedback component"
+  componentName="ProgressIndicator"
+  summary="Displays progress status of a task"
+  versionAdded="0.25.4"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.25.4`     |
-| Latest            | `Prerelease` |
+<Canvas of={ProgressIndicatorStories.WithControls} />
 
 ## Table of Contents
 
@@ -32,8 +36,6 @@ import Link from "../Link/Link";
 <Description of={ProgressIndicatorStories} />
 
 ## Component Props
-
-<Canvas of={ProgressIndicatorStories.WithControls} />
 
 The `ProgressIndicator` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/SkeletonLoader/SkeletonLoader.mdx
+++ b/src/components/SkeletonLoader/SkeletonLoader.mdx
@@ -3,16 +3,20 @@ import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
 import * as SkeletonLoaderStories from "./SkeletonLoader.stories";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import { changelogData } from "./skeletonLoaderChangelogData";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta of={SkeletonLoaderStories} />
 
-# SkeletonLoader
+<ComponentDocsHeader
+  category="Feedback component"
+  componentName="SkeletonLoader"
+  summary="Placeholder to indicate loading state"
+  versionAdded="0.17.3"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.17.3`     |
-| Latest            | `Prerelease` |
+<Canvas of={SkeletonLoaderStories.WithControls} />
 
 ## Table of Contents
 
@@ -35,8 +39,6 @@ Please note that the initial rendering below has the `width` prop set to `300px`
 to better view the example. The default value is `100%`.
 
 ## Component Props
-
-<Canvas of={SkeletonLoaderStories.WithControls} />
 
 The `SkeletonLoader` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2077](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2077)

## This PR does the following:

- Updates story headers for `Notification`, `ProgressIndicator`, and `SkeletonLoader` (`Banner` already done)

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2077]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ