### PR TITLE
DSD-2081: story headers for Overlays & Switchers components

### DIFF
--- a/src/components/Accordion/Accordion.mdx
+++ b/src/components/Accordion/Accordion.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import * as AccordionStories from "./Accordion.stories";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as AccordionStories from "./Accordion.stories";
 import { changelogData } from "./accordionChangelogData";
 
 <Meta of={AccordionStories} />
 
-# Accordion
+<ComponentDocsHeader
+  category="Overlays & Switchers component"
+  componentName="Accordion"
+  summary="Interactive container used to reveal a hidden content block"
+  versionAdded="0.1.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.1.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={AccordionStories.WithControls} />
 
 ## Table of Contents
 
@@ -102,8 +106,6 @@ present as a key in the `accordionData` entries, the key will override
 the `aria-label` passed to the `Accordion`.
 
 ## Component Props
-
-<Canvas of={AccordionStories.WithControls} />
 
 You may pass any Chakra `Box` props, as well as the props below.
 

--- a/src/components/Modal/Modal.mdx
+++ b/src/components/Modal/Modal.mdx
@@ -1,19 +1,23 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import { changelogData } from "./modalChangelogData";
 
-import * as ModalStories from "./Modal.stories";
-import { ModalTrigger, useModal } from "./Modal";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as ModalStories from "./Modal.stories";
+import { changelogData } from "./modalChangelogData";
+import { ModalTrigger, useModal } from "./Modal";
 
 <Meta of={ModalStories} />
 
-# Modal
+<ComponentDocsHeader
+  category="Overlays & Switchers component"
+  componentName="Modal"
+  summary="Overlay used to display important information that requires user interaction"
+  versionAdded="0.1.0"
+  versionLatest="3.6.2"
+/>
 
-| Component Version | DS Version |
-| ----------------- | ---------- |
-| Added             | `0.1.0`    |
-| Latest            | `3.6.2`    |
+<Canvas of={ModalStories.WithControls} />
 
 ## Table of Contents
 
@@ -163,8 +167,6 @@ import { ModalTrigger } from "@nypl/design-system-react-components";
 `} language="jsx" />
 
 ## ModalTrigger Component Props
-
-<Canvas of={ModalStories.WithControls} />
 
 <ArgTypes of={ModalStories.WithControls} />
 

--- a/src/components/Modal/Modal.stories.tsx
+++ b/src/components/Modal/Modal.stories.tsx
@@ -34,12 +34,13 @@ type Story = StoryObj<typeof ModalTrigger>;
  */
 export const WithControls: Story = {
   args: {
-    buttonText: "Button Text",
+    buttonText: "Open Modal",
     id: "modal-trigger",
     modalProps: {
       variant: "default",
-      bodyContent: "body text",
-      closeButtonLabel: "Close Button",
+      bodyContent:
+        "Modal body text. Et perspiciatis ad nulla vel autem sed. Ad sequi cupiditate veritatis voluptas itaque aspernatur illo nostrum sequi eius soluta consectetur dolorem. Odit eum est officiis et natus doloribus sed in id. Voluptatum sed repellendus delectus voluptas sit omnis aut eius laboriosam corrupti.",
+      closeButtonLabel: "Close Modal",
       headingText: (
         <Heading
           level="h3"

--- a/src/components/Tabs/Tabs.mdx
+++ b/src/components/Tabs/Tabs.mdx
@@ -1,16 +1,16 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as TabsStories from "./Tabs.stories";
 import Banner from "../Banner/Banner";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as TabsStories from "./Tabs.stories";
 import { changelogData } from "./tabsChangelogData";
 
 <Meta of={TabsStories} />
 
 <ComponentDocsHeader
-  category="Overlays & Switchers"
+  category="Overlays & Switchers component"
   componentName="Tabs"
   summary="Displays related content in a tabbed interface"
   versionAdded="0.24.0"

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -11,7 +11,7 @@ import { changelogData } from "./tooltipChangelogData";
 <ComponentDocsHeader
   category="Overlays & Switchers component"
   componentName="Tooltip"
-  summary="Used to display contextual information when interacting with an element"
+  summary="Display contextual information when a user interacts with an element"
   versionAdded="1.1.0"
   versionLatest="Prerelease"
 />

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta } from "@storybook/blocks";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import { changelogData } from "./tooltipChangelogData";
 
-import * as TooltipStories from "./Tooltip.stories";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as TooltipStories from "./Tooltip.stories";
+import { changelogData } from "./tooltipChangelogData";
 
 <Meta of={TooltipStories} />
 
-# Tooltip
+<ComponentDocsHeader
+  category="Overlays & Switchers component"
+  componentName="Tooltip"
+  summary="Used to display contextual information when interacting with an element"
+  versionAdded="1.1.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `1.1.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={TooltipStories.WithControls} />
 
 ## Table of Contents
 
@@ -31,8 +35,6 @@ A brief, informative message that appears when a user hovers or focuses on an
 element.
 
 ## Component Props
-
-<Canvas of={TooltipStories.WithControls} />
 
 You may pass any Chakra `Box` props, as well as the props below.
 

--- a/src/components/Tooltip/Tooltip.mdx
+++ b/src/components/Tooltip/Tooltip.mdx
@@ -11,7 +11,7 @@ import { changelogData } from "./tooltipChangelogData";
 <ComponentDocsHeader
   category="Overlays & Switchers component"
   componentName="Tooltip"
-  summary="Display contextual information when a user interacts with an element"
+  summary="Displays contextual information when a user interacts with an element"
   versionAdded="1.1.0"
   versionLatest="Prerelease"
 />


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2081](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2081)

## This PR does the following:

- Updates story headers for `Overlays & Switchers` components

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2081]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2081?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ