### PR TITLE
DSD-2080: story headers for Navigation component

### DIFF
--- a/src/components/AlphabetFilter/AlphabetFilter.mdx
+++ b/src/components/AlphabetFilter/AlphabetFilter.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as AlphabetFilterStories from "./AlphabetFilter.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as AlphabetFilterStories from "./AlphabetFilter.stories";
 import { changelogData } from "./alphabetFilterChangelogData";
 
 <Meta of={AlphabetFilterStories} />
 
-# AlphabetFilter
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="AlphabetFilter"
+  summary="Navigation element used to apply an alphabetic filter to a list of items"
+  versionAdded="1.2.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `1.2.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={AlphabetFilterStories.WithControls} />
 
 ## Table of Contents
 
@@ -43,8 +47,6 @@ button was clicked), all filtering should be removed from the list of items the
 component is addressing and the full list of items should be displayed.
 
 ## Component Props
-
-<Canvas of={AlphabetFilterStories.WithControls} />
 
 The `AlphabetFilter` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/AlphabetFilter/AlphabetFilter.stories.tsx
+++ b/src/components/AlphabetFilter/AlphabetFilter.stories.tsx
@@ -28,8 +28,8 @@ export const WithControls: Story = {
   args: {
     activeLetters: undefined,
     currentLetter: undefined,
-    descriptionText: "This is description text.",
-    headingText: "AlphabetFilter",
+    descriptionText: "",
+    headingText: "",
     id: "alphabet-filter-id",
     isDisabled: false,
     onClick: undefined,

--- a/src/components/Breadcrumbs/Breadcrumbs.mdx
+++ b/src/components/Breadcrumbs/Breadcrumbs.mdx
@@ -1,9 +1,9 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as BreadcrumbsStories from "./Breadcrumbs.stories";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import * as BreadcrumbsStories from "./Breadcrumbs.stories";
 import { changelogData } from "./breadcrumbsChangelogData";
 
 <Meta of={BreadcrumbsStories} />

--- a/src/components/Link/Link.mdx
+++ b/src/components/Link/Link.mdx
@@ -1,21 +1,25 @@
 import { Box } from "@chakra-ui/react";
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 import { cloneElement } from "react";
-import { changelogData } from "./linkChangelogData";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import Link from "./Link";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Icon from "../Icons/Icon";
+import Link from "./Link";
 import * as LinkStories from "./Link.stories";
+import { changelogData } from "./linkChangelogData";
 
 <Meta of={LinkStories} />
 
-# Link
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="Link"
+  summary="Renders a native anchor element used for navigating to other pages"
+  versionAdded="0.0.4"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.0.4`      |
-| Latest            | `Prerelease` |
+<Canvas of={LinkStories.WithControls} />
 
 ## Table of Contents
 
@@ -34,8 +38,6 @@ import * as LinkStories from "./Link.stories";
 <Description of={LinkStories} />
 
 ## Component Props
-
-<Canvas of={LinkStories.WithControls} />
 
 `Link` composes an HTML `a` element, so you may pass any HTML `a` attributes,
 as well as the Chakra `as` prop, any of the Chakra style props, and the props below.

--- a/src/components/Link/Link.stories.tsx
+++ b/src/components/Link/Link.stories.tsx
@@ -47,7 +47,7 @@ export const WithControls: Story = {
   },
   render: (args: any) => (
     <Link className="custom-class" {...args}>
-      {args.children}
+      Link
     </Link>
   ),
   parameters: {

--- a/src/components/Menu/Menu.mdx
+++ b/src/components/Menu/Menu.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-import Link from "../Link/Link";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
 import * as MenuStories from "./Menu.stories";
 import { changelogData } from "./menuChangelogData";
 
 <Meta of={MenuStories} />
 
-# Menu
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="Menu"
+  summary="List of interactive elements rendered in a dropdown format and used for executing actions or navigating"
+  versionAdded="3.0.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `3.0.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={MenuStories.WithControls} />
 
 ## Table of Contents
 
@@ -33,8 +37,6 @@ The Menu component renders a collection of button and/or link elements within a 
 The component allows users to perform multiple actions from an element with a small footprint.
 
 ## Component Props
-
-<Canvas of={MenuStories.WithControls} />
 
 The `Menu` composes a Chakra `Box` component, so you may pass any Chakra `Box` props, as well as the props below.
 

--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -16,6 +16,8 @@ import { changelogData } from "./paginationChangelogData";
   versionLatest="Prerelease"
 />
 
+<Canvas of={PaginationStories.UnchangingURL} />
+
 ## Table of Contents
 
 - {<Link href="#overview" target="_self">Overview</Link>}

--- a/src/components/Pagination/Pagination.mdx
+++ b/src/components/Pagination/Pagination.mdx
@@ -1,18 +1,20 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import { changelogData } from "./paginationChangelogData";
 
-import * as PaginationStories from "./Pagination.stories";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as PaginationStories from "./Pagination.stories";
+import { changelogData } from "./paginationChangelogData";
 
 <Meta of={PaginationStories} />
 
-# Pagination
-
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.0.10`     |
-| Latest            | `Prerelease` |
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="Pagination"
+  summary="Used to navigate to the next or previous page within an experience or list of results"
+  versionAdded="0.0.10"
+  versionLatest="Prerelease"
+/>
 
 ## Table of Contents
 

--- a/src/components/SkipNavigation/SkipNavigation.mdx
+++ b/src/components/SkipNavigation/SkipNavigation.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import { changelogData } from "./skipNavigationChangelogData";
 
-import * as SkipNavigationStories from "./SkipNavigation.stories";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as SkipNavigationStories from "./SkipNavigation.stories";
+import { changelogData } from "./skipNavigationChangelogData";
 
 <Meta of={SkipNavigationStories} />
 
-# SkipNavigation
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="SkipNavigation"
+  summary="Provides an accessible method to jump to the main page content"
+  versionAdded="0.28.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.28.0`     |
-| Latest            | `Prerelease` |
+<Canvas of={SkipNavigationStories.WithControls} />
 
 ## Table of Contents
 
@@ -31,8 +35,6 @@ first link and press "tab" again to see the second link. Hiding the links
 intentional as the links should initially be visually hidden.**
 
 ## Component Props
-
-<Canvas of={SkipNavigationStories.WithControls} />
 
 `SkipNavigation` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/SocialMediaLinks/SocialMediaLinks.mdx
+++ b/src/components/SocialMediaLinks/SocialMediaLinks.mdx
@@ -1,18 +1,23 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
+
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
 import Table from "../Table/Table";
 import * as SocialMediaLinksStories from "./SocialMediaLinks.stories";
-import Link from "../Link/Link";
 import { changelogData } from "./socialMediaLinksChangelogData";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 
 <Meta of={SocialMediaLinksStories} />
 
-# SocialMediaLinks
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="SocialMediaLinks"
+  summary="Renders a list of links for accessing social media sites"
+  versionAdded="2.0.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `2.0.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={SocialMediaLinksStories.WithControls} />
 
 ## Table of Contents
 
@@ -28,8 +33,6 @@ import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 <Description of={SocialMediaLinksStories} />
 
 ## With Controls
-
-<Canvas of={SocialMediaLinksStories.WithControls} />
 
 `SocialMediaLinks` composes a Chakra `Box` component, so you may pass any Chakra
 `Box` prop, as well as the props below.

--- a/src/components/SubNav/SubNav.mdx
+++ b/src/components/SubNav/SubNav.mdx
@@ -1,21 +1,25 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import Banner from "../Banner/Banner";
+import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Heading from "../Heading/Heading";
 import Link from "../Link/Link";
 import List from "../List/List";
 import * as SubNavStories from "./SubNav.stories";
-import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
 import { changelogData } from "./subNavChangelogData";
 
 <Meta of={SubNavStories} />
 
-# SubNav
+<ComponentDocsHeader
+  category="Navigation component"
+  componentName="SubNav"
+  summary="Renders a group of secondary navigation and action items"
+  versionAdded="3.5.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `3.5.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={SubNavStories.WithControls} />
 
 ## Table of Contents
 
@@ -36,8 +40,6 @@ import { changelogData } from "./subNavChangelogData";
 <Description of={SubNavStories} />
 
 ## Component Props
-
-<Canvas of={SubNavStories.WithControls} />
 
 `SubNav` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2080](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2080)

## This PR does the following:

- Updated story headers for `Navigation` components

NOTE: The `Pagination` component does not have a `With Controls` story, so there is no example to move to the top of the story page.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2080]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ