### PR TITLE
DSD-2079: story headers for Media & Icons components

### DIFF
--- a/src/components/AudioPlayer/AudioPlayer.mdx
+++ b/src/components/AudioPlayer/AudioPlayer.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Meta, Source } from "@storybook/blocks";
 
-import * as AudioPlayerStories from "./AudioPlayer.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as AudioPlayerStories from "./AudioPlayer.stories";
 import { changelogData } from "./audioPlayerChangelogData";
 
 <Meta of={AudioPlayerStories} />
 
-# Audio Player
+<ComponentDocsHeader
+  category="Media & icon component"
+  componentName="AudioPlayer"
+  summary="Used to embed an audio stream from a 3rd party provider"
+  versionAdded="1.2.0"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `1.2.0`      |
-| Latest            | `Prerelease` |
+<Canvas of={AudioPlayerStories.WithControls} />
 
 ## Table of Contents
 
@@ -36,8 +40,6 @@ of locally hosted audio files. That functionality will be added in a future
 version of the component.
 
 ## Component Props
-
-<Canvas of={AudioPlayerStories.WithControls} />
 
 The `AudioPlayer` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.

--- a/src/components/Icons/Icon.mdx
+++ b/src/components/Icons/Icon.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
 import * as IconStories from "./Icon.stories";
 import { changelogData } from "./iconChangelogData";
-import Link from "../Link/Link";
 
 <Meta of={IconStories} />
 
-# Icon
+<ComponentDocsHeader
+  category="Media & icon component"
+  componentName="Icon"
+  summary="Renders commonly used icons in SVG format"
+  versionAdded="0.0.4"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.0.4`      |
-| Latest            | `Prerelease` |
+<Canvas of={IconStories.WithControls} />
 
 ## Table of Contents
 
@@ -31,8 +35,6 @@ import Link from "../Link/Link";
 <Description of={IconStories.WithControls} />
 
 ## Component Props
-
-<Canvas of={IconStories.WithControls} />
 
 You may pass any Chakra style props, as well as the props below.
 

--- a/src/components/Image/Image.mdx
+++ b/src/components/Image/Image.mdx
@@ -12,7 +12,7 @@ import { changelogData } from "./imageChangelogData";
 <ComponentDocsHeader
   category="Media & icon component"
   componentName="Image"
-  summary="Component that renders an image with DS styles."
+  summary="Renders a formatted image"
   versionAdded="0.0.6"
   versionLatest="Prerelease"
 />

--- a/src/components/Logo/Logo.mdx
+++ b/src/components/Logo/Logo.mdx
@@ -1,17 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
-import { changelogData } from "./logoChangelogData";
+
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
-import * as LogoStories from "./Logo.stories";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
+import * as LogoStories from "./Logo.stories";
+import { changelogData } from "./logoChangelogData";
 
 <Meta of={LogoStories} />
 
-# Logo
+<ComponentDocsHeader
+  category="Media & icon component"
+  componentName="Logo"
+  summary="Renders commonly used logos in SVG format"
+  versionAdded="0.25.9"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.25.9`     |
-| Latest            | `Prerelease` |
+<Canvas of={LogoStories.WithControls} />
 
 ## Table of Contents
 
@@ -28,8 +33,6 @@ import Link from "../Link/Link";
 <Description of={LogoStories} />
 
 ## Component Props
-
-<Canvas of={LogoStories.WithControls} />
 
 You may pass any Chakra style props, as well as the props below.
 

--- a/src/components/VideoPlayer/VideoPlayer.mdx
+++ b/src/components/VideoPlayer/VideoPlayer.mdx
@@ -1,18 +1,22 @@
 import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 
-import * as VideoPlayerStories from "./VideoPlayer.stories";
-import Link from "../Link/Link";
 import ComponentChangelogTable from "../../utils/ComponentChangelogTable";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
+import Link from "../Link/Link";
+import * as VideoPlayerStories from "./VideoPlayer.stories";
 import { changelogData } from "./videoPlayerChangelogData";
 
 <Meta of={VideoPlayerStories} />
 
-# Video Player
+<ComponentDocsHeader
+  category="Media & icon component"
+  componentName="VideoPlayer"
+  summary="Used to embed a video from a 3rd party provider"
+  versionAdded="0.23.2"
+  versionLatest="Prerelease"
+/>
 
-| Component Version | DS Version   |
-| ----------------- | ------------ |
-| Added             | `0.23.2`     |
-| Latest            | `Prerelease` |
+<Canvas of={VideoPlayerStories.WithControls} />
 
 ## Table of Contents
 
@@ -44,8 +48,6 @@ the aspect ratio of the video that is being rendered. The default aspect ratio
 is `16:9`.
 
 ## Component Props
-
-<Canvas of={VideoPlayerStories.WithControls} />
 
 The `VideoPlayer` composes a Chakra `Box` component, so you may pass
 any Chakra `Box` props, as well as the props below.


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2079](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2079)

## This PR does the following:

- Updates the story headers for the `Media & Icons` components.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2079]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ