### PR TITLE
DSD-2100: Story headers for Accessibility Guides

### DIFF
--- a/src/components/AccessibilityGuide/AriaLandmarks.mdx
+++ b/src/components/AccessibilityGuide/AriaLandmarks.mdx
@@ -3,10 +3,15 @@ import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/blocks";
 import * as SearchBarStories from "../SearchBar/SearchBar.stories";
 import Link from "../Link/Link";
 import Banner from "../Banner/Banner";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 
 <Meta title="Accessibility Guide/ARIA Landmarks" />
 
-# ARIA Landmarks
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Aria Landmarks"
+  summary="Guide to Aria landmark roles"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/AriaLandmarks.mdx
+++ b/src/components/AccessibilityGuide/AriaLandmarks.mdx
@@ -10,7 +10,6 @@ import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Aria Landmarks"
-  summary="Guide to Aria landmark roles"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/AudioAndVideo.mdx
+++ b/src/components/AccessibilityGuide/AudioAndVideo.mdx
@@ -1,10 +1,14 @@
 import { Meta } from "@storybook/blocks";
-
 import Link from "../Link/Link";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 
 <Meta title="Accessibility Guide/Audio and Video" />
 
-# Audio and Video
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Audio and Video"
+  summary="Guide to audio and video players"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/AudioAndVideo.mdx
+++ b/src/components/AccessibilityGuide/AudioAndVideo.mdx
@@ -7,7 +7,6 @@ import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Audio and Video"
-  summary="Guide to audio and video players"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/DynamicContent.mdx
+++ b/src/components/AccessibilityGuide/DynamicContent.mdx
@@ -1,10 +1,14 @@
 import { Meta, Source } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Dynamic Content" />
 
-# Dynamic Content
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Dynamic Content"
+  summary="Guide to dynamically updating elements"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/Errors.mdx
+++ b/src/components/AccessibilityGuide/Errors.mdx
@@ -4,11 +4,7 @@ import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Errors" />
 
-<ComponentDocsHeader
-  category="Accessibility Guide"
-  componentName="Errors"
-  summary="Guide to error handling"
-/>
+<ComponentDocsHeader category="Accessibility Guide" componentName="Errors" />
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/Errors.mdx
+++ b/src/components/AccessibilityGuide/Errors.mdx
@@ -1,10 +1,14 @@
 import { Meta, Source } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Errors" />
 
-# Error Messages
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Errors"
+  summary="Guide to error handling"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/HighlightingText.mdx
+++ b/src/components/AccessibilityGuide/HighlightingText.mdx
@@ -1,10 +1,15 @@
 import { Meta, Source } from "@storybook/blocks";
 import { Box } from "@chakra-ui/react";
 import Link from "../Link/Link";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 
 <Meta title="Accessibility Guide/Highlighting Text" />
 
-# Highlighting Text
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Highlighting Text"
+  summary="Guide to visually emphasizing text"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/Links.mdx
+++ b/src/components/AccessibilityGuide/Links.mdx
@@ -1,10 +1,14 @@
 import { Meta } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Links" />
 
-# Links
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Links"
+  summary="Guide to indicating links"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/Links.mdx
+++ b/src/components/AccessibilityGuide/Links.mdx
@@ -7,7 +7,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Links"
-  summary="Guide to indicating links"
+  summary="Guide to visual and semantic presentation of links"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/ManagingFocus.mdx
+++ b/src/components/AccessibilityGuide/ManagingFocus.mdx
@@ -1,10 +1,14 @@
 import { Meta, Source } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Managing Focus" />
 
-# Managing Focus
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Managing Focus"
+  summary="Guide to focus management"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/ManagingFocus.mdx
+++ b/src/components/AccessibilityGuide/ManagingFocus.mdx
@@ -7,7 +7,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Managing Focus"
-  summary="Guide to focus management"
+  summary="Guide to programmatically controlling focus for user navigation"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/ProgressiveEnhancement.mdx
+++ b/src/components/AccessibilityGuide/ProgressiveEnhancement.mdx
@@ -3,13 +3,17 @@ import { Meta, Source } from "@storybook/blocks";
 import { Banner } from "../Banner/Banner";
 import Image from "../Image/Image";
 import Link from "../Link/Link";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import progressiveEnhancementExample from "/static/progressive-enhancement.png";
 import { exampleWrapperStyles } from "../../utils/utils.ts";
 
 <Meta title="Accessibility Guide/Progressive Enhancement" />
 
-# Progressive Enhancement
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Progressive Enhancement"
+  summary="Guide to progressive enhancement"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/ProgressiveEnhancement.mdx
+++ b/src/components/AccessibilityGuide/ProgressiveEnhancement.mdx
@@ -12,7 +12,7 @@ import { exampleWrapperStyles } from "../../utils/utils.ts";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Progressive Enhancement"
-  summary="Guide to progressive enhancement"
+  summary="Guide to building basic web functionality and user experience first, then layering features incrementally"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/RepetitiveActions.mdx
+++ b/src/components/AccessibilityGuide/RepetitiveActions.mdx
@@ -7,7 +7,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Repetitive Actions"
-  summary="Guide to repeating elements"
+  summary="Guide to repeating elements and functionality"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/RepetitiveActions.mdx
+++ b/src/components/AccessibilityGuide/RepetitiveActions.mdx
@@ -1,10 +1,14 @@
 import { Meta, Source } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Repetitive Actions" />
 
-# Repetitive Actions
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Repetitive Actions"
+  summary="Guide to repeating elements"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/RepetitiveActions.mdx
+++ b/src/components/AccessibilityGuide/RepetitiveActions.mdx
@@ -7,7 +7,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Repetitive Actions"
-  summary="Guide to repeating elements and functionality"
+  summary="Guide to repeating elements and functionality on a page"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/SkipNavigation.mdx
+++ b/src/components/AccessibilityGuide/SkipNavigation.mdx
@@ -1,10 +1,14 @@
 import { Meta } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Skip Navigation" />
 
-# Skip Navigation
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Skip Navigation"
+  summary="Guide to skip navigation"
+/>
 
 ## Table of Contents
 

--- a/src/components/AccessibilityGuide/SkipNavigation.mdx
+++ b/src/components/AccessibilityGuide/SkipNavigation.mdx
@@ -7,7 +7,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Accessibility Guide"
   componentName="Skip Navigation"
-  summary="Guide to skip navigation"
+  summary="Guide to screenreader navigation over page content"
 />
 
 ## Table of Contents

--- a/src/components/AccessibilityGuide/StickyElements.mdx
+++ b/src/components/AccessibilityGuide/StickyElements.mdx
@@ -1,10 +1,14 @@
 import { Meta, Source } from "@storybook/blocks";
-
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Accessibility Guide/Sticky Elements" />
 
-# Sticky Elements
+<ComponentDocsHeader
+  category="Accessibility Guide"
+  componentName="Sticky Elements"
+  summary="Guide to fixed position elements"
+/>
 
 ## Table of Contents
 

--- a/src/utils/components/ComponentDocsHeader.tsx
+++ b/src/utils/components/ComponentDocsHeader.tsx
@@ -10,9 +10,9 @@ export interface ComponentDocsHeaderProps {
   /** A brief summary of the component */
   summary: string;
   /** The DS version when the component was added */
-  versionAdded: string;
+  versionAdded?: string;
   /** The DS version with the most recent version of the component */
-  versionLatest: string;
+  versionLatest?: string;
 }
 
 export const ComponentDocsHeader = ({
@@ -34,9 +34,11 @@ export const ComponentDocsHeader = ({
           {componentName}
         </Heading>
       }
-      <Box display="flex" justifyContent={{ base: undefined, md: "right" }}>
-        <ComponentVersionTable added={versionAdded} latest={versionLatest} />
-      </Box>
+      {versionAdded && versionLatest && (
+        <Box display="flex" justifyContent={{ base: undefined, md: "right" }}>
+          <ComponentVersionTable added={versionAdded} latest={versionLatest} />
+        </Box>
+      )}
     </Box>
   );
 };

--- a/src/utils/components/ComponentDocsHeader.tsx
+++ b/src/utils/components/ComponentDocsHeader.tsx
@@ -8,7 +8,7 @@ export interface ComponentDocsHeaderProps {
   /** The name of the component */
   componentName: string;
   /** A brief summary of the component */
-  summary: string;
+  summary?: string;
   /** The DS version when the component was added */
   versionAdded?: string;
   /** The DS version with the most recent version of the component */
@@ -29,7 +29,7 @@ export const ComponentDocsHeader = ({
           level="h1"
           overline={category}
           size="display1"
-          subtitle={summary}
+          subtitle={summary ? summary : ""}
         >
           {componentName}
         </Heading>


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2100](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2100)

## This PR does the following:

- Updates the `ComponentDocsHeader` to make the `versionLatest` , `versionAdded`, and `summary` optional (and not display them when they're not passed)
- Adds new headers to the Accessibility Guide docs
- Some of these summaries... needless to say I am open to any suggestions

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[DSD-2100]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ