### PR TITLE
DSD-2102: story headers for Development Guide pages

### DIFF
--- a/src/components/DevelopmentGuide/ConditionalViewport.mdx
+++ b/src/components/DevelopmentGuide/ConditionalViewport.mdx
@@ -8,7 +8,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Development Guide"
   componentName="Conditional Viewport"
-  summary="Recommendations for mitigating the iOS auto-zoom"
+  summary="Recommendations for preventing the iOS auto-zoom"
 />
 
 ## Table of Contents

--- a/src/components/DevelopmentGuide/ConditionalViewport.mdx
+++ b/src/components/DevelopmentGuide/ConditionalViewport.mdx
@@ -1,10 +1,15 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Conditional Viewport" />
 
-# Conditional Viewport
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Conditional Viewport"
+  summary="Recommendations for mitigating the iOS auto-zoom"
+/>
 
 ## Table of Contents
 
@@ -15,17 +20,25 @@ import Link from "../Link/Link";
 
 ## Background on the viewport and input auto-zoom issue
 
-The viewport is the visible area of a web page, which varies from device to device.
-The user interacts with the viewport by scrolling or zooming in and out. The viewport's dimensions and scale can be set from the `<meta>` tag.
+The viewport is the visible area of a web page, which varies from device to
+device. The user interacts with the viewport by scrolling or zooming in and out.
+The viewport's dimensions and scale can be set from the `<meta>` tag.
 
-On iOS devices, non-native websites will automatically zoom in when a user selects an input element (changing the scale of the viewport). This default is meant to ensure any input field is accessible for the visually impaired, but it generally forces users to zoom back out to continue viewing the page.
+On iOS devices, non-native websites will automatically zoom in when a user
+selects an input element (changing the scale of the viewport). This default is
+meant to ensure any input field is accessible for the visually impaired, but it
+generally forces users to zoom back out to continue viewing the page.
 
-This auto-zoom does not occur on Android mobile devices, so NYPL recommends preventing the auto-zoom on iOS to create a consistent experience across all devices. 
-Since design system components should be able to render regardless of browser/device context, **this requires a device-specific solution to be implemented by the consuming app**.
+This auto-zoom does not occur on Android mobile devices, so NYPL recommends
+preventing the auto-zoom on iOS to create a consistent experience across all
+devices. Since design system components should be able to render regardless of
+browser/device context, **this requires a device-specific solution to be
+implemented by the consuming app**.
 
 ## How to resolve
 
-The general solution to prevent auto-zoom on iOS devices is to conditionally set the `<meta>` viewport tag.
+The general solution to prevent auto-zoom on iOS devices is to conditionally set
+the `<meta>` viewport tag.
 
 For iOS:
 
@@ -54,10 +67,17 @@ How you do this will depend on your app.
 
 ### Approach for Next.js App Router apps
 
-Using the App router, you can customize the initial viewport with the dynamic [`generateViewport()`](https://nextjs.org/docs/app/api-reference/functions/generate-viewport) function. This only works in a server component, so most likely will be defined near the root of your project in
-the `page.tsx` or `layout.tsx` file.
+Using the App router, you can customize the initial viewport with the dynamic
+[`generateViewport()`](https://nextjs.org/docs/app/api-reference/functions/generate-viewport)
+function. This only works in a server component, so most likely will be defined
+near the root of your project in the `page.tsx` or `layout.tsx` file.
 
-Then, you can access the [`userAgent`](https://nextjs.org/docs/app/api-reference/functions/userAgent) object from Next's [`headers()`](https://nextjs.org/docs/app/api-reference/functions/headers) function. If the current device is an iPhone, return the necessary viewport object.
+Then, you can access the
+[`userAgent`](https://nextjs.org/docs/app/api-reference/functions/userAgent)
+object from Next's
+[`headers()`](https://nextjs.org/docs/app/api-reference/functions/headers)
+function. If the current device is an iPhone, return the necessary viewport
+object.
 
 <Source
   code={`
@@ -76,12 +96,14 @@ export async function generateViewport() {
 language="js"
 />
 
-This approach is currently implemented on [Digital Collections](https://github.com/NYPL/digital-collections/blob/8758f1106af59c4a76015d978700ec8baba6deb4/app/layout.tsx#L45).
+This approach is currently implemented on [Digital
+Collections](https://github.com/NYPL/digital-collections/blob/8758f1106af59c4a76015d978700ec8baba6deb4/app/layout.tsx#L45).
 
 ### Approach for Next.js Pages Router apps
 
-In a Pages router app, you need to find the `userAgent` object from a client component (again, probably near the root of your project).
-There are more ways to do this (and many packages), but here's an option:
+In a Pages router app, you need to find the `userAgent` object from a client
+component (again, probably near the root of your project). There are more ways
+to do this (and many packages), but here's an option:
 
 <Source
   code={`
@@ -108,7 +130,11 @@ return(
 ) 
 `} language="js" />
 
-[`Helmet`](https://www.npmjs.com/package/react-helmet) is a React package that injects html into the `<header>` from the client component, necessary here because the `useEffect()` is reading
-`window.navigator` object to get `userAgent` above. Once the device is known, you set the state to `isIOS` and inject the viewport tag accordingly.
+[`Helmet`](https://www.npmjs.com/package/react-helmet) is a React package that
+injects html into the `<header>` from the client component, necessary here
+because the `useEffect()` is reading `window.navigator` object to get
+`userAgent` above. Once the device is known, you set the state to `isIOS` and
+inject the viewport tag accordingly.
 
-This approach is currently implemented on [Turbine](https://github.com/NYPL/nypl-ds-test-app/blob/main/pages/_app.tsx).
+This approach is currently implemented on
+[Turbine](https://github.com/NYPL/nypl-ds-test-app/blob/main/pages/_app.tsx).

--- a/src/components/DevelopmentGuide/DesignTokens.mdx
+++ b/src/components/DevelopmentGuide/DesignTokens.mdx
@@ -1,16 +1,22 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import Banner from "../Banner/Banner";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Design Tokens" />
 
-# Design Tokens
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Design Tokens"
+  summary="Recommendations for using Reservoir design tokens in JavaScript and CSS"
+/>
 
 ## Table of Contents
 
 - {<Link href="#what-are-design-tokens" target="_self">What are Design Tokens?</Link>}
 - {<Link href="#how-to-use-the-reservoir-design-tokens" target="_self">How to Use the Reservoir Design Tokens</Link>}
-- {<Link href="#using-reservoir-design-tokens-in-javascript" target="_self">Using Reservoir Design Tokens in Javascript</Link>}
+- {<Link href="#using-reservoir-design-tokens-in-javascript" target="_self">Using Reservoir Design Tokens in JavaScript</Link>}
 - {<Link href="#using-reservoir-design-tokens-in-css" target="_self">Using Reservoir Design Tokens in CSS</Link>}
 - {<Link href="#reservoir-design-token-categories" target="_self">Reservoir Design Token Categories</Link>}
 
@@ -30,17 +36,17 @@ quickly and easily build various applications with the same look and feel.
 ## How to Use the Reservoir Design Tokens
 
 The NYPL design tokens are built into the Reservoir Design System (DS) and are
-offered in two formats for consumption: Javascript theme objects (recommended)
+offered in two formats for consumption: JavaScript theme objects (recommended)
 and CSS variables. To access either of these formats, the DS `v0.25.9` or higher
 needs to be properly installed in a consuming React application.
 
-## Using Reservoir Design Tokens in Javascript
+## Using Reservoir Design Tokens in JavaScript
 
-It is recommended that consuming apps use Javascript (rather than CSS) to apply
+It is recommended that consuming apps use JavaScript (rather than CSS) to apply
 styles to UI elements whenever possible.
 
 To use the DS <Link href="#reservoir-design-token-categories"
-target="_self">Javascript design tokens</Link>, the `DSProvider` wrapper
+target="_self">JavaScript design tokens</Link>, the `DSProvider` wrapper
 component must first be imported and implemented properly in a consuming app.
 Please refer to the `DSProvider` section of the [DS Chakra
 UI](../?path=/docs/chakra-ui--docs#dsprovider) page for instructions on how to
@@ -48,15 +54,23 @@ do this.
 
 #### Design Tokens for DS and Chakra Components
 
-**IMPORTANT:** The general rule of thumb is that the styles and functionality of
-the DS components should not be altered. The components should be used with the
-styles and variants as they are depicted in Storybook. There may be times,
-however, when a component does require a modification. If a DS component does
-need a style change in a consuming app, designers/developers should first
-contact the Reservoir team about the change before it is implemented.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> The general rule of thumb is that the styles
+      and functionality of the DS components should not be altered. The
+      components should be used with the styles and variants as they are
+      depicted in Storybook. There may be times, however, when a component does
+      require a modification. If a DS component does need a style change in a
+      consuming app, designers/developers should first contact the Reservoir
+      team about the change before it is implemented.
+    </>
+  }
+  variant="warning"
+/>
 
-The Javascript design tokens can be used to populate the values for style props
-added directly to the components. The shorthard nature of the Javascript tokens
+The JavaScript design tokens can be used to populate the values for style props
+added directly to the components. The shorthard nature of the JavaScript tokens
 make it easy to quickly and logically add styles to a DS component.
 
 For example, if a `Heading` component needs to sit within a wrapper element and
@@ -81,12 +95,20 @@ font weight, the following can be done:
 
 #### Design Tokens for Custom Components and Native HTML Elements
 
-**IMPORTANT:** Javascript design tokens **cannot be used** with custom
-components and native HTML elements as they are not compatible with the way
-styles are passed into these elements. Instead, CSS design tokens must be used.
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> JavaScript design tokens{" "}
+      <strong>cannot be used</strong> with custom components and native HTML
+      elements as they are not compatible with the way styles are passed into
+      these elements. Instead, CSS design tokens must be used.
+    </>
+  }
+  variant="warning"
+/>
 
 To pass style attributes to custom components and native HTML elements, the
-React `style` prop must be used rather than the individual Javascript style
+React `style` prop must be used rather than the individual JavaScript style
 props. The `style` prop can be populated in a number of ways.
 
 <Source

--- a/src/components/DevelopmentGuide/DisablingGlobalStyles.mdx
+++ b/src/components/DevelopmentGuide/DisablingGlobalStyles.mdx
@@ -8,7 +8,7 @@ import Link from "../Link/Link";
 <ComponentDocsHeader
   category="Development Guide"
   componentName="Disabling Global Styles"
-  summary="Recommendations for using Reservoir global styles"
+  summary="Guidelines for removing Chakra-reset base CSS styles"
 />
 
 ## Table of Contents

--- a/src/components/DevelopmentGuide/DisablingGlobalStyles.mdx
+++ b/src/components/DevelopmentGuide/DisablingGlobalStyles.mdx
@@ -1,10 +1,15 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Disabling Global Styles" />
 
-# Disabling Global Styles
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Disabling Global Styles"
+  summary="Recommendations for using Reservoir global styles"
+/>
 
 ## Table of Contents
 

--- a/src/components/DevelopmentGuide/Footer.mdx
+++ b/src/components/DevelopmentGuide/Footer.mdx
@@ -1,10 +1,15 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Footer" />
 
-# Footer
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Footer"
+  summary="Recommendations for using the NYPL universal footer"
+/>
 
 ## Table of Contents
 

--- a/src/components/DevelopmentGuide/Header.mdx
+++ b/src/components/DevelopmentGuide/Header.mdx
@@ -1,10 +1,15 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Header" />
 
-# Header
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Header"
+  summary="Recommendations for using the NYPL universal header"
+/>
 
 ## Table of Contents
 

--- a/src/components/DevelopmentGuide/SupportingDarkMode.mdx
+++ b/src/components/DevelopmentGuide/SupportingDarkMode.mdx
@@ -1,10 +1,15 @@
 import { Meta, Source } from "@storybook/blocks";
 
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 
 <Meta title="Development Guide/Supporting Dark Mode" />
 
-# Supporting Dark Mode
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Supporting Dark Mode"
+  summary="Recommendations for using Reservoir dark mode styles"
+/>
 
 ## Table of Contents
 

--- a/src/components/DevelopmentGuide/V3MigrationGuide.mdx
+++ b/src/components/DevelopmentGuide/V3MigrationGuide.mdx
@@ -1,12 +1,16 @@
 import { Meta, Source } from "@storybook/blocks";
 
 import Button from "../Button/Button";
+import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import Link from "../Link/Link";
 import Text from "../Text/Text";
 
 <Meta title="Development Guide/v3 Migration Guide" />
 
-# Reservoir v3 Migration Guide
+<ComponentDocsHeader
+  category="Development Guide"
+  componentName="Reservoir v3 Migration Guide"
+/>
 
 ## Table of Contents
 


### PR DESCRIPTION
Fixes JIRA ticket xxx

## This PR does the following:

- Updated story headers for `Development Guide` pages.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
