### PR TITLE
DSD-2133: TagSet onClick type fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Removes `noSpace` prop from Text component.
 - Removes default spacing values set on the `DatePicker`, `Heading`, `HelperErrorText`, `HorizontalRule`, `Label`, `List`, `StyledList`, and `Text` components.
 - Removes all files related to the `Autosuggest` component guidelines.
+- Removes the exported `TagSetTypeProps` type.
 
 ### Fixes
 

--- a/src/components/TagSet/TagSet.test.tsx
+++ b/src/components/TagSet/TagSet.test.tsx
@@ -236,10 +236,16 @@ describe("TagSet Filter", () => {
 
   it("renders close icons when `isDismissible` is true", () => {
     onClick = jest.fn();
+    const onClickHandler = (tagSet: TagSetFilterDataProps) => {
+      if ((tagSet as TagSetFilterDataProps).id === "clear-filters") {
+        return;
+      }
+      console.log("test");
+    };
     render(
       <TagSet
         isDismissible
-        onClick={onClick}
+        onClick={onClickHandler}
         tagSetData={filterTagSetData.withIcon}
         variant="filter"
       />

--- a/src/components/TagSet/TagSet.tsx
+++ b/src/components/TagSet/TagSet.tsx
@@ -1,5 +1,4 @@
 import {
-  BoxProps,
   chakra,
   ChakraComponent,
   Flex,
@@ -16,12 +15,8 @@ import TagSetFilter, {
   TagSetFilterProps,
 } from "./TagSetFilter";
 
-export interface BaseTagSetProps extends Omit<BoxProps, "onClick"> {}
-
 // We want either the "explore" or "filter" type props.
-export type TagSetTypeProps = TagSetFilterProps | TagSetExploreProps;
-// And here combine the special types with the base props.
-export type TagSetProps = BaseTagSetProps & TagSetTypeProps;
+export type TagSetProps = TagSetFilterProps | TagSetExploreProps;
 
 // Type guard so we can make sure we have a "filter" `TagSet` variant.
 export function isFilterVariant(

--- a/src/components/TagSet/TagSet.tsx
+++ b/src/components/TagSet/TagSet.tsx
@@ -16,8 +16,7 @@ import TagSetFilter, {
   TagSetFilterProps,
 } from "./TagSetFilter";
 
-export interface BaseTagSetProps
-  extends Omit<BoxProps, "onClick" | "onChange"> {}
+export interface BaseTagSetProps extends Omit<BoxProps, "onClick"> {}
 
 // We want either the "explore" or "filter" type props.
 export type TagSetTypeProps = TagSetFilterProps | TagSetExploreProps;

--- a/src/components/TagSet/TagSet.tsx
+++ b/src/components/TagSet/TagSet.tsx
@@ -16,7 +16,8 @@ import TagSetFilter, {
   TagSetFilterProps,
 } from "./TagSetFilter";
 
-export interface BaseTagSetProps extends BoxProps {}
+export interface BaseTagSetProps
+  extends Omit<BoxProps, "onClick" | "onChange"> {}
 
 // We want either the "explore" or "filter" type props.
 export type TagSetTypeProps = TagSetFilterProps | TagSetExploreProps;

--- a/src/components/TagSet/tagSetChangelogData.ts
+++ b/src/components/TagSet/tagSetChangelogData.ts
@@ -19,6 +19,8 @@ export const changelogData: ChangelogData[] = [
       "Renames `type` to `variant`.",
       "Updated the internal use of ids to reduce `undefined` ids in the DOM.",
       "Adds `data-testid` value of `ds-tagSet` to the parent element.",
+      "Consolidates prop types to `TagSetProps`.",
+      "Removes `BaseTagSetProps` and `TagSetTypeProps` as separate types.",
     ],
   },
   {

--- a/src/index.ts
+++ b/src/index.ts
@@ -260,7 +260,7 @@ export {
 } from "./components/Tabs/Tabs";
 export type { TabsDataProps, TabsProps } from "./components/Tabs/Tabs";
 export { default as TagSet } from "./components/TagSet/TagSet";
-export type { TagSetProps, TagSetTypeProps } from "./components/TagSet/TagSet";
+export type { TagSetProps } from "./components/TagSet/TagSet";
 export type {
   TagSetExploreDataProps,
   TagSetExploreProps,


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2133](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2133)

## This PR does the following:

- Fixes a type error caused by trying to override `onClick`, but extending `BoxProps` twice.
- Did not update the changelog since this is a bug fix that we created in this branch.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Added a test that replicates the issue found in Turbine.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2133]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2133?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ