### PR TITLE
DSD-2124: Heading component text color bug

### DIFF
--- a/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
+++ b/src/components/FeaturedContent/__snapshots__/FeaturedContent.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`Renders the UI snapshot correctly 1`] = `
             Featured
           </p>
           <h1
-            className="chakra-heading css-0"
+            className="chakra-heading css-1xdhyk6"
             data-testid="ds-heading"
           >
             Spotlight on the Public Domain
@@ -115,7 +115,7 @@ exports[`Renders the UI snapshot correctly 2`] = `
             Featured
           </p>
           <h1
-            className="chakra-heading css-0"
+            className="chakra-heading css-1xdhyk6"
             data-testid="ds-heading"
           >
             Spotlight on the Public Domain
@@ -184,7 +184,7 @@ exports[`Renders the UI snapshot correctly 3`] = `
             Featured
           </p>
           <h1
-            className="chakra-heading css-0"
+            className="chakra-heading css-1xdhyk6"
             data-testid="ds-heading"
           >
             Spotlight on the Public Domain
@@ -253,7 +253,7 @@ exports[`Renders the UI snapshot correctly 4`] = `
             Featured
           </p>
           <h1
-            className="chakra-heading css-0"
+            className="chakra-heading css-1xdhyk6"
             data-testid="ds-heading"
           >
             Spotlight on the Public Domain
@@ -322,7 +322,7 @@ exports[`Renders the UI snapshot correctly 5`] = `
             Featured
           </p>
           <h1
-            className="chakra-heading css-0"
+            className="chakra-heading css-1xdhyk6"
             data-testid="ds-heading"
           >
             Spotlight on the Public Domain
@@ -391,7 +391,7 @@ exports[`Renders the UI snapshot correctly 6`] = `
             Featured
           </p>
           <h1
-            className="chakra-heading css-0"
+            className="chakra-heading css-1xdhyk6"
             data-testid="ds-heading"
           >
             Spotlight on the Public Domain

--- a/src/components/Heading/Heading.mdx
+++ b/src/components/Heading/Heading.mdx
@@ -1,4 +1,10 @@
-import { ArgTypes, Canvas, Description, Meta, Source } from "@storybook/addon-docs/blocks";
+import {
+  ArgTypes,
+  Canvas,
+  Description,
+  Meta,
+  Source,
+} from "@storybook/addon-docs/blocks";
 
 import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import * as HeadingStories from "./Heading.stories";
@@ -29,6 +35,7 @@ import { changelogData } from "./headingChangelogData";
 - {<Link href="#overline-and-subtitle" target="_self">Overline and Subtitle Elements</Link>}
 - {<Link href="#heading-with-bold-text" target="_self">Heading with Bold Text</Link>}
 - {<Link href="#heading-with-links" target="_self">Heading with Links</Link>}
+- {<Link href="#custom-color" target="_self">Custom Color</Link>}
 - {<Link href="#changelog" target="_self">Changelog</Link>}
 
 ## Overview
@@ -54,9 +61,9 @@ proper order and not skipping any. For example, the following is invalid HTML:
 
 <Source
   code={`
-<h1>Page Title</h1>
-<h2>Subtitle</h2>
-<h4>Sub-subtitle</h4>
+  <h1>Page Title</h1>
+  <h2>Subtitle</h2>
+  <h4>Sub-subtitle</h4>
 `}
   language="html"
 />
@@ -69,11 +76,11 @@ recognizable term - for the `aria-roledescription` attribute.
 
 <Source
   code={`
-<hgroup role="group" aria-roledescription="Heading group">
-  <p aria-roledescription="Subtitle">Overline</p>
-  <h2>Heading Title</h2>
-  <p aria-roledescription="Subtitle">Subtitle</p>
-</hgroup>
+  <hgroup role="group" aria-roledescription="Heading group">
+    <p aria-roledescription="Subtitle">Overline</p>
+    <h2>Heading Title</h2>
+    <p aria-roledescription="Subtitle">Subtitle</p>
+  </hgroup>
 `}
   language="html"
 />
@@ -91,7 +98,7 @@ The `level` prop can be used to set a native heading element (ex. `<h1>`,
 
 <Source
   code={`
-<Heading level="h1" />
+  <Heading level="h1" />
 `}
   language="jsx"
 />
@@ -114,7 +121,7 @@ elements.
 
 <Source
   code={`
-<Heading size="heading1" />
+  <Heading size="heading1" />
 `}
   language="jsx"
 />
@@ -156,10 +163,10 @@ above the heading text. The overline text is styled to be all uppercase.
 
 <Source
   code={`
-<Heading
-  overline="Overline"
-  text="Lorem ipsum dolor"
-/>
+  <Heading
+    overline="Overline"
+    text="Lorem ipsum dolor"
+  />
 `}
   language="jsx"
 />
@@ -173,10 +180,10 @@ heading text.
 
 <Source
   code={`
-<Heading
-  subtitle="The subtitle text sits below the main heading text."
-  text="Lorem ipsum dolor"
-/>
+  <Heading
+    subtitle="The subtitle text sits below the main heading text"
+    text="Lorem ipsum dolor"
+  />
 `}
   language="jsx"
 />
@@ -190,11 +197,11 @@ composed heading lockup.
 
 <Source
   code={`
-<Heading
-  overline="Overline"
-  subtitle="The subtitle text sits below the main heading text."
-  text="Lorem ipsum dolor"
-/>
+  <Heading
+    overline="Overline"
+    subtitle="The subtitle text sits below the main heading text"
+    text="Lorem ipsum dolor"
+  />
 `}
   language="jsx"
 />
@@ -224,6 +231,25 @@ set as a link, however, this is not a recommended pattern. While this treatment
 is possible with the `Heading` component, this pattern SHOULD NOT be used.
 
 <Canvas of={HeadingStories.Links} />
+
+## Custom Color
+
+The `Heading` component can be configured to render a custom color by passing
+the native `color` style prop.
+
+<Source
+  code={`
+  <Heading
+    color="brand.primary"
+    overline="Overline"
+    subtitle="The subtitle text sits below the main heading text"
+    text="Lorem ipsum dolor"
+  />
+`}
+  language="jsx"
+/>
+
+<Canvas of={HeadingStories.CustomColor} />
 
 ## Changelog
 

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -56,19 +56,7 @@ export const WithControls: Story = {
     },
     jest: ["Heading.test.tsx"],
   },
-  render: (args) => (
-    <VStack align="left" spacing="l">
-      <Heading {...args} />
-      <Heading {...args} color="brand.primary" />
-      <Heading
-        {...args}
-        bgColor="brand.primary"
-        color="ui.white"
-        px="s"
-        py="xs"
-      />
-    </VStack>
-  ),
+  render: (args) => <Heading {...args} />,
 };
 
 // The following are additional Heading example Stories.
@@ -224,63 +212,63 @@ export const Subtitle: Story = {
         id="heading-display1"
         level="h1"
         size="display1"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading1"
         level="h1"
         size="heading1"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading2"
         level="h1"
         size="heading2"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading3"
         level="h1"
         size="heading3"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading4"
         level="h1"
         size="heading4"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading5"
         level="h1"
         size="heading5"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading6"
         level="h1"
         size="heading6"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading7"
         level="h1"
         size="heading7"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
         id="heading-heading8"
         level="h1"
         size="heading8"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
     </VStack>
@@ -296,7 +284,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="display1"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -304,7 +292,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading1"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -312,7 +300,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading2"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -320,7 +308,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading3"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -328,7 +316,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading4"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -336,7 +324,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading5"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -344,7 +332,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading6"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -352,7 +340,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading7"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
       <Heading
@@ -360,7 +348,7 @@ export const OverlineAndSubtitle: Story = {
         level="h1"
         overline="Overline"
         size="heading8"
-        subtitle="The subtitle text sits below the main heading text."
+        subtitle="The subtitle text sits below the main heading text"
         text="Lorem ipsum dolor"
       />
     </VStack>
@@ -414,6 +402,38 @@ export const Links: Story = {
           <span> Not a recommended pattern</span>
         </>
       </Heading>
+    </VStack>
+  ),
+};
+
+export const CustomColor: Story = {
+  render: () => (
+    <VStack align="left" spacing="l">
+      <Heading
+        color="brand.primary"
+        overline="Overline"
+        subtitle="The subtitle text sits below the main heading text"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        color="section.research-library.schwarzman"
+        overline="Overline"
+        text="Lorem ipsum dolor"
+      />
+      <Heading
+        color="section.research.primary"
+        subtitle="The subtitle text sits below the main heading text"
+        text="Lorem ipsum dolor"
+      />
+      <Heading color="section.education.primary" text="Lorem ipsum dolor" />
+      <Heading
+        bgColor="section.connect.secondary"
+        color="ui.white"
+        overline="Overline"
+        p="l"
+        subtitle="The subtitle text sits below the main heading text"
+        text="Lorem ipsum dolor"
+      />
     </VStack>
   ),
 };

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -164,9 +164,11 @@ export const Heading: ChakraComponent<
         ? "subtitle1"
         : "subtitle2";
 
-      /** The styles that should be applied to the outer-most wrapper of the
-       * Heading component. */
-      const wrapperStyles = styles.headingWrapper;
+      /** To circumvent how Chakra controls style props, the text color value
+       * was moved into its own theme "part" and then applied to the UI
+       * appropriately. This method allows custom colors to override the default
+       * color value. */
+      const colorStyle = styles.colorStyle;
 
       /** The styles for the actual native heading element. If the native
        * element is going to sit by itself, without the overline or subtitle
@@ -179,7 +181,7 @@ export const Heading: ChakraComponent<
             }
           : {
               ...styles.base,
-              ...wrapperStyles,
+              ...colorStyle,
             };
       /** If there is an `overline` or a `subtitle`, `...rest` will be passed to
        * the `<hgroup>`, otherwise, it will be passed directly to the `<h>`. */
@@ -232,7 +234,7 @@ export const Heading: ChakraComponent<
           aria-roledescription="Heading group"
           data-testid="ds-heading-group"
           role="group"
-          sx={{ ...wrapperStyles }}
+          sx={{ ...colorStyle }}
           {...rest}
         >
           {finalContent}

--- a/src/components/Heading/Heading.tsx
+++ b/src/components/Heading/Heading.tsx
@@ -164,28 +164,21 @@ export const Heading: ChakraComponent<
         ? "subtitle1"
         : "subtitle2";
 
-      /** To circumvent how Chakra controls style props, the text color value
-       * was moved into its own theme "part" and then applied to the UI
-       * appropriately. This method allows custom colors to override the default
-       * color value. */
-      const colorStyle = styles.colorStyle;
+      /** `colorStyle` defines the default color for the heading. Any custom
+       * color passed as a prop will override this default, following standard
+       * CSS precedence rules. */
+      const defaultColorStyle = styles.defaultColorStyle;
 
-      /** The styles for the actual native heading element. If the native
-       * element is going to sit by itself, without the overline or subtitle
-       * elements, then the wrapper styles can be applied directly to the native
-       * element. Otherwise, the wrapper styles will be used later. */
-      const headingStyles =
-        overline || subtitle
-          ? {
-              ...styles.base,
-            }
+      /** If there is an `overline` or a `subtitle`, `...rest` and
+       * `...defaultColorStyle` will be passed to the `<hgroup>`, otherwise,
+       * they will be passed directly to the `<h>`. */
+      const aggregatedProps =
+        overline && subtitle
+          ? { sx: { ...styles.base } }
           : {
-              ...styles.base,
-              ...colorStyle,
+              ...rest,
+              sx: { ...styles.base, ...defaultColorStyle },
             };
-      /** If there is an `overline` or a `subtitle`, `...rest` will be passed to
-       * the `<hgroup>`, otherwise, it will be passed directly to the `<h>`. */
-      const headingRest = !overline && !subtitle && { ...rest };
 
       /** The final text elements that will make up the rendered component. */
       const finalContent = (
@@ -205,10 +198,7 @@ export const Heading: ChakraComponent<
             data-testid="ds-heading"
             id={id}
             ref={ref}
-            sx={{
-              ...headingStyles,
-            }}
-            {...headingRest}
+            {...aggregatedProps}
           >
             {content}
           </ChakraHeading>
@@ -234,7 +224,7 @@ export const Heading: ChakraComponent<
           aria-roledescription="Heading group"
           data-testid="ds-heading-group"
           role="group"
-          sx={{ ...colorStyle }}
+          sx={{ ...defaultColorStyle }}
           {...rest}
         >
           {finalContent}

--- a/src/components/Heading/__snapshots__/Heading.test.tsx.snap
+++ b/src/components/Heading/__snapshots__/Heading.test.tsx.snap
@@ -112,7 +112,7 @@ exports[`Heading renders the UI snapshot correctly 9`] = `
     Overline
   </p>
   <h1
-    className="chakra-heading css-0"
+    className="chakra-heading css-1xdhyk6"
     data-testid="ds-heading"
     id="customDisplaySize"
   >
@@ -129,7 +129,7 @@ exports[`Heading renders the UI snapshot correctly 10`] = `
   role="group"
 >
   <h1
-    className="chakra-heading css-0"
+    className="chakra-heading css-1xdhyk6"
     data-testid="ds-heading"
     id="customDisplaySize"
   >

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -5,7 +5,7 @@ import { baseLinkStyles } from "./link";
 // This function creates a set of function that helps us
 // create multipart component styles.
 const { defineMultiStyleConfig, definePartsStyle } =
-  createMultiStyleConfigHelpers(["base", "headingWrapper"]);
+  createMultiStyleConfigHelpers(["base", "colorStyle"]);
 
 // Heading Styles
 export const headings = {
@@ -153,7 +153,6 @@ const Heading = defineMultiStyleConfig({
           ...baseLinkStyles,
           textDecoration: "none",
         },
-        color: "ui.typography.heading",
         margin: "0",
         textTransform: isCapitalized
           ? "capitalize"
@@ -162,6 +161,9 @@ const Heading = defineMultiStyleConfig({
           : isLowercase
           ? "lowercase"
           : null,
+      },
+      colorStyle: {
+        color: "ui.typography.heading",
         _dark: {
           color: "dark.ui.typography.heading",
         },

--- a/src/theme/components/heading.ts
+++ b/src/theme/components/heading.ts
@@ -5,7 +5,7 @@ import { baseLinkStyles } from "./link";
 // This function creates a set of function that helps us
 // create multipart component styles.
 const { defineMultiStyleConfig, definePartsStyle } =
-  createMultiStyleConfigHelpers(["base", "colorStyle"]);
+  createMultiStyleConfigHelpers(["base", "defaultColorStyle"]);
 
 // Heading Styles
 export const headings = {
@@ -162,7 +162,7 @@ const Heading = defineMultiStyleConfig({
           ? "lowercase"
           : null,
       },
-      colorStyle: {
+      defaultColorStyle: {
         color: "ui.typography.heading",
         _dark: {
           color: "dark.ui.typography.heading",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2124](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2124)

## This PR does the following:

- Adjusted `Heading` styles to support custom colors.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook and new examples in Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2124]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2124?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ