### PR TITLE
DSD-2066: SearchBar UI issues

### DIFF
--- a/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -36,9 +36,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="basic-datePicker-start-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -54,15 +57,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
                 <input
                   aria-label="From, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="basic-datePicker-start-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -90,9 +91,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="basic-datePicker-end-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -108,15 +112,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 1`] = `
                 <input
                   aria-label="To, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="basic-datePicker-end-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -180,9 +182,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="no-label-datePicker-start-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -198,15 +203,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
                 <input
                   aria-label="From, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="no-label-datePicker-start-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -234,9 +237,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="no-label-datePicker-end-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -252,15 +258,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 2`] = `
                 <input
                   aria-label="To, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="no-label-datePicker-end-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -324,9 +328,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="custom-format-datePicker-start-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -342,15 +349,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
                 <input
                   aria-label="From, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="custom-format-datePicker-start-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -378,9 +383,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="custom-format-datePicker-end-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -396,15 +404,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 3`] = `
                 <input
                   aria-label="To, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="custom-format-datePicker-end-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -468,9 +474,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="invalid-datePicker-start-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -488,15 +497,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                   aria-invalid={true}
                   aria-label="From, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="invalid-datePicker-start-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -541,9 +548,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="invalid-datePicker-end-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -561,15 +571,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 4`] = `
                   aria-invalid={true}
                   aria-label="To, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={false}
                   id="invalid-datePicker-end-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -655,9 +663,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="disabled-datePicker-start-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -673,15 +684,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
                 <input
                   aria-label="From, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={true}
                   id="disabled-datePicker-start-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -709,9 +718,12 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
               role="alert"
             />
             <div
-              className="css-1xdhyk6"
+              className="css-1u8qly9"
               data-testid="ds-textInput"
               id="disabled-datePicker-end-textInput-componentWrapper"
+              onBlur={[Function]}
+              onKeyDown={[Function]}
+              readOnly={false}
             >
               <label
                 className="css-1xdhyk6"
@@ -727,15 +739,13 @@ exports[`DatePicker Date Range renders the UI snapshot correctly 5`] = `
                 <input
                   aria-label="To, Press tab to access the calendar."
                   autoComplete={null}
-                  className="chakra-input css-1xdhyk6"
+                  className="chakra-input css-0"
                   disabled={true}
                   id="disabled-datePicker-end-textInput"
                   onBlur={[Function]}
                   onChange={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  readOnly={false}
                   required={false}
                   step={null}
                   type="text"
@@ -791,9 +801,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="basic-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <label
             className="css-1xdhyk6"
@@ -809,15 +822,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 1`] = `
             <input
               aria-label="Select the full date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={false}
               id="basic-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"
@@ -862,9 +873,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="no-label-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <div
             className="css-79elbk"
@@ -872,15 +886,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 2`] = `
             <input
               aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={false}
               id="no-label-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"
@@ -925,9 +937,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="custom-format-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <label
             className="css-1xdhyk6"
@@ -943,15 +958,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 3`] = `
             <input
               aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={false}
               id="custom-format-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"
@@ -996,9 +1009,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="invalid-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <label
             className="css-1xdhyk6"
@@ -1016,15 +1032,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 4`] = `
               aria-invalid={true}
               aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={false}
               id="invalid-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"
@@ -1086,9 +1100,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="disabled-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <label
             className="css-1xdhyk6"
@@ -1105,15 +1122,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 5`] = `
               aria-describedby="disabled-datePicker-start-textInput-helperText"
               aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={true}
               id="disabled-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"
@@ -1175,9 +1190,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="chakra-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <label
             className="css-1xdhyk6"
@@ -1194,15 +1212,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 6`] = `
               aria-describedby="chakra-datePicker-start-textInput-helperText"
               aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={false}
               id="chakra-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"
@@ -1264,9 +1280,12 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
           role="alert"
         />
         <div
-          className="css-1xdhyk6"
+          className="css-1u8qly9"
           data-testid="ds-textInput"
           id="props-datePicker-start-textInput-componentWrapper"
+          onBlur={[Function]}
+          onKeyDown={[Function]}
+          readOnly={false}
         >
           <label
             className="css-1xdhyk6"
@@ -1283,15 +1302,13 @@ exports[`DatePicker Single input renders the UI snapshot correctly 7`] = `
               aria-describedby="props-datePicker-start-textInput-helperText"
               aria-label="Select the date you want to visit NYPL, Press tab to access the calendar."
               autoComplete={null}
-              className="chakra-input css-1xdhyk6"
+              className="chakra-input css-0"
               disabled={false}
               id="props-datePicker-start-textInput"
               onBlur={[Function]}
               onChange={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onKeyDown={[Function]}
-              readOnly={false}
               required={false}
               step={null}
               type="text"

--- a/src/components/NewsletterSignup/__snapshots__/NewsletterSignup.test.tsx.snap
+++ b/src/components/NewsletterSignup/__snapshots__/NewsletterSignup.test.tsx.snap
@@ -61,7 +61,7 @@ exports[`NewsletterSignup Snapshots Renders the bad email UI snapshot correctly 
           id="test-id-form-child0"
         >
           <div
-            className="css-1xdhyk6"
+            className="css-1u8qly9"
             data-testid="ds-textInput"
             id="test-id-textInput-componentWrapper"
           >
@@ -84,7 +84,7 @@ exports[`NewsletterSignup Snapshots Renders the bad email UI snapshot correctly 
                 aria-invalid={true}
                 aria-required={true}
                 autoComplete="email"
-                className="chakra-input css-1xdhyk6"
+                className="chakra-input css-0"
                 disabled={false}
                 id="test-id-textInput"
                 name="email"
@@ -425,7 +425,7 @@ exports[`NewsletterSignup Snapshots Renders the default form UI snapshot correct
           id="test-id-form-child0"
         >
           <div
-            className="css-1xdhyk6"
+            className="css-1u8qly9"
             data-testid="ds-textInput"
             id="test-id-textInput-componentWrapper"
           >
@@ -447,7 +447,7 @@ exports[`NewsletterSignup Snapshots Renders the default form UI snapshot correct
                 aria-describedby="test-id-textInput-helperText"
                 aria-required={true}
                 autoComplete="email"
-                className="chakra-input css-1xdhyk6"
+                className="chakra-input css-0"
                 disabled={false}
                 id="test-id-textInput"
                 name="email"
@@ -566,7 +566,7 @@ exports[`NewsletterSignup Snapshots Renders the form UI with description snapsho
           id="test-id-form-child0"
         >
           <div
-            className="css-1xdhyk6"
+            className="css-1u8qly9"
             data-testid="ds-textInput"
             id="test-id-textInput-componentWrapper"
           >
@@ -588,7 +588,7 @@ exports[`NewsletterSignup Snapshots Renders the form UI with description snapsho
                 aria-describedby="test-id-textInput-helperText"
                 aria-required={true}
                 autoComplete="email"
-                className="chakra-input css-1xdhyk6"
+                className="chakra-input css-0"
                 disabled={false}
                 id="test-id-textInput"
                 name="email"
@@ -701,7 +701,7 @@ exports[`NewsletterSignup Snapshots Renders the form UI with formHelperText snap
           id="test-id-form-child0"
         >
           <div
-            className="css-1xdhyk6"
+            className="css-1u8qly9"
             data-testid="ds-textInput"
             id="test-id-textInput-componentWrapper"
           >
@@ -723,7 +723,7 @@ exports[`NewsletterSignup Snapshots Renders the form UI with formHelperText snap
                 aria-describedby="test-id-textInput-helperText"
                 aria-required={true}
                 autoComplete="email"
-                className="chakra-input css-1xdhyk6"
+                className="chakra-input css-0"
                 disabled={false}
                 id="test-id-textInput"
                 name="email"
@@ -837,7 +837,7 @@ exports[`NewsletterSignup Snapshots Renders the submitting state snapshot correc
           id="test-id-form-child0"
         >
           <div
-            className="css-1xdhyk6"
+            className="css-1u8qly9"
             data-testid="ds-textInput"
             id="test-id-textInput-componentWrapper"
           >
@@ -859,7 +859,7 @@ exports[`NewsletterSignup Snapshots Renders the submitting state snapshot correc
                 aria-describedby="test-id-textInput-helperText"
                 aria-required={true}
                 autoComplete="email"
-                className="chakra-input css-1xdhyk6"
+                className="chakra-input css-0"
                 disabled={true}
                 id="test-id-textInput"
                 name="email"

--- a/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
+++ b/src/components/SearchBar/__snapshots__/SearchBar.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="basic-textInput-componentWrapper"
       >
@@ -27,7 +27,7 @@ exports[`SearchBar renders the UI snapshot correctly 1`] = `
             aria-describedby="basic-helperText"
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="basic-textInput"
             name="textInputName"
@@ -197,7 +197,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="withSelect-textInput-componentWrapper"
       >
@@ -208,7 +208,7 @@ exports[`SearchBar renders the UI snapshot correctly 2`] = `
             aria-describedby="withSelect-helperText"
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="withSelect-textInput"
             name="textInputName"
@@ -280,7 +280,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="withoutHelperText-textInput-componentWrapper"
       >
@@ -290,7 +290,7 @@ exports[`SearchBar renders the UI snapshot correctly 3`] = `
           <input
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="withoutHelperText-textInput"
             name="textInputName"
@@ -345,7 +345,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="withClearButton-textInput-componentWrapper"
       >
@@ -356,7 +356,7 @@ exports[`SearchBar renders the UI snapshot correctly 4`] = `
             aria-describedby="withClearButton-helperText"
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="withClearButton-textInput"
             name="textInputName"
@@ -428,7 +428,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="invalidState-textInput-componentWrapper"
       >
@@ -440,7 +440,7 @@ exports[`SearchBar renders the UI snapshot correctly 5`] = `
             aria-invalid={true}
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="invalidState-textInput"
             name="textInputName"
@@ -503,7 +503,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="disabledState-textInput-componentWrapper"
       >
@@ -513,7 +513,7 @@ exports[`SearchBar renders the UI snapshot correctly 6`] = `
           <input
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={true}
             id="disabledState-textInput"
             name="textInputName"
@@ -569,7 +569,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="requiredState-textInput-componentWrapper"
       >
@@ -580,7 +580,7 @@ exports[`SearchBar renders the UI snapshot correctly 7`] = `
             aria-label="Item Search"
             aria-required={true}
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={true}
             id="requiredState-textInput"
             name="textInputName"
@@ -636,7 +636,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="noBrandButtonType-textInput-componentWrapper"
       >
@@ -647,7 +647,7 @@ exports[`SearchBar renders the UI snapshot correctly 8`] = `
             aria-label="Item Search"
             aria-required={true}
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={true}
             id="noBrandButtonType-textInput"
             name="textInputName"
@@ -849,7 +849,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="chakra-textInput-componentWrapper"
       >
@@ -860,7 +860,7 @@ exports[`SearchBar renders the UI snapshot correctly 12`] = `
             aria-describedby="chakra-helperText"
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="chakra-textInput"
             name="textInputName"
@@ -932,7 +932,7 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
       className="css-1ik4laa"
     >
       <div
-        className="css-1xdhyk6"
+        className="ds-searchBar-textInput css-1u8qly9"
         data-testid="ds-textInput"
         id="props-textInput-componentWrapper"
       >
@@ -943,7 +943,7 @@ exports[`SearchBar renders the UI snapshot correctly 13`] = `
             aria-describedby="props-helperText"
             aria-label="Item Search"
             autoComplete={null}
-            className="chakra-input ds-searchBar-textInput css-1xdhyk6"
+            className="chakra-input css-0"
             disabled={false}
             id="props-textInput"
             name="textInputName"

--- a/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
     className="css-0"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-ho21zx"
       data-testid="ds-textInput"
       id="defaultRangeSlider-textInput-start-componentWrapper"
     >
@@ -28,7 +28,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
         <input
           aria-label="Label - start value"
           autoComplete={null}
-          className="chakra-input css-bunm4f"
+          className="chakra-input css-0"
           disabled={false}
           id="defaultRangeSlider-textInput-start"
           max={100}
@@ -148,7 +148,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="defaultRangeSlider-textInput-end-componentWrapper"
     >
@@ -158,7 +158,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 1`] = `
         <input
           aria-label="Label - end value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="defaultRangeSlider-textInput-end"
           max={100}
@@ -212,7 +212,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
     className="css-0"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-ho21zx"
       data-testid="ds-textInput"
       id="errored-textInput-start-componentWrapper"
     >
@@ -224,7 +224,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
           aria-invalid={true}
           aria-label="Label - start value"
           autoComplete={null}
-          className="chakra-input css-bunm4f"
+          className="chakra-input css-0"
           disabled={false}
           id="errored-textInput-start"
           max={100}
@@ -352,7 +352,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="errored-textInput-end-componentWrapper"
     >
@@ -364,7 +364,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 2`] = `
           aria-invalid={true}
           aria-label="Label - end value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="errored-textInput-end"
           max={100}
@@ -429,7 +429,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
     className="css-0"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-ho21zx"
       data-testid="ds-textInput"
       id="required-textInput-start-componentWrapper"
     >
@@ -440,7 +440,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
           aria-label="Label - start value"
           aria-required={true}
           autoComplete={null}
-          className="chakra-input css-bunm4f"
+          className="chakra-input css-0"
           disabled={false}
           id="required-textInput-start"
           max={100}
@@ -560,7 +560,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="required-textInput-end-componentWrapper"
     >
@@ -571,7 +571,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 3`] = `
           aria-label="Label - end value"
           aria-required={true}
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="required-textInput-end"
           max={100}
@@ -625,7 +625,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
     className="css-0"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-ho21zx"
       data-testid="ds-textInput"
       id="disabled-textInput-start-componentWrapper"
     >
@@ -635,7 +635,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
         <input
           aria-label="Label - start value"
           autoComplete={null}
-          className="chakra-input css-bunm4f"
+          className="chakra-input css-0"
           disabled={true}
           id="disabled-textInput-start"
           max={100}
@@ -757,7 +757,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="disabled-textInput-end-componentWrapper"
     >
@@ -767,7 +767,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 4`] = `
         <input
           aria-label="Label - end value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={true}
           id="disabled-textInput-end"
           max={100}
@@ -813,7 +813,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
     className="css-0"
   >
     <div
-      className="css-1xdhyk6"
+      className="css-ho21zx"
       data-testid="ds-textInput"
       id="noLabels-textInput-start-componentWrapper"
     >
@@ -823,7 +823,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
         <input
           aria-label="Label - start value"
           autoComplete={null}
-          className="chakra-input css-bunm4f"
+          className="chakra-input css-0"
           disabled={false}
           id="noLabels-textInput-start"
           max={100}
@@ -943,7 +943,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="noLabels-textInput-end-componentWrapper"
     >
@@ -953,7 +953,7 @@ exports[`Slider Range Slider renders the UI snapshot correctly 5`] = `
         <input
           aria-label="Label - end value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="noLabels-textInput-end"
           max={100}
@@ -1325,7 +1325,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="defaultSlider-textInput-end-componentWrapper"
     >
@@ -1335,7 +1335,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 1`] = `
         <input
           aria-label="Label - value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="defaultSlider-textInput-end"
           max={100}
@@ -1469,7 +1469,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="errored-textInput-end-componentWrapper"
     >
@@ -1481,7 +1481,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 2`] = `
           aria-invalid={true}
           aria-label="Label - value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="errored-textInput-end"
           max={100}
@@ -1626,7 +1626,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="required-textInput-end-componentWrapper"
     >
@@ -1637,7 +1637,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 3`] = `
           aria-label="Label - value"
           aria-required={true}
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="required-textInput-end"
           max={100}
@@ -1773,7 +1773,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="disabled-textInput-end-componentWrapper"
     >
@@ -1783,7 +1783,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 4`] = `
         <input
           aria-label="Label - value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={true}
           id="disabled-textInput-end"
           max={100}
@@ -1909,7 +1909,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="noLabels-textInput-end-componentWrapper"
     >
@@ -1919,7 +1919,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 5`] = `
         <input
           aria-label="Label - value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="noLabels-textInput-end"
           max={100}
@@ -2243,7 +2243,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="chakra-textInput-end-componentWrapper"
     >
@@ -2253,7 +2253,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 8`] = `
         <input
           aria-label="Label - value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="chakra-textInput-end"
           max={100}
@@ -2387,7 +2387,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
       100
     </div>
     <div
-      className="css-1xdhyk6"
+      className="css-1f1uedm"
       data-testid="ds-textInput"
       id="props-textInput-end-componentWrapper"
     >
@@ -2397,7 +2397,7 @@ exports[`Slider Single Slider renders the UI snapshot correctly 9`] = `
         <input
           aria-label="Label - value"
           autoComplete={null}
-          className="chakra-input css-1ebeaqx"
+          className="chakra-input css-0"
           disabled={false}
           id="props-textInput-end"
           max={100}

--- a/src/components/TextInput/TextInput.tsx
+++ b/src/components/TextInput/TextInput.tsx
@@ -237,7 +237,6 @@ export const TextInput: ChakraComponent<
             name,
             onChange: internalOnChange,
             ref: finalRef,
-            ...rest,
           }
         : {
             "aria-required": isRequired,
@@ -268,7 +267,6 @@ export const TextInput: ChakraComponent<
             ref: finalRef,
             // The `step` attribute is useful for the number type.
             step: type === "number" ? step : null,
-            ...rest,
             ...ariaAttributes,
           };
       // For `input` and `textarea`, all attributes are the same but `input`
@@ -311,6 +309,7 @@ export const TextInput: ChakraComponent<
           isInvalid={finalIsInvalid}
           showHelperInvalidText={showHelperInvalidText && !isHidden}
           __css={styles}
+          {...rest}
         >
           {labelText && showLabel && !isHidden && (
             <Label

--- a/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
+++ b/src/components/TextInput/__snapshots__/TextInput.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextarea-componentWrapper"
 >
@@ -19,7 +19,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
   >
     <textarea
       autoComplete={null}
-      className="chakra-textarea css-1xdhyk6"
+      className="chakra-textarea css-0"
       disabled={false}
       id="myTextarea"
       onBlur={[Function]}
@@ -35,7 +35,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 1`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -56,7 +56,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
     <input
       aria-required={true}
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -73,7 +73,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 2`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -94,7 +94,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
     <input
       aria-required={true}
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -111,7 +111,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 3`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -128,7 +128,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
   >
     <input
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -145,7 +145,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 4`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -156,7 +156,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
       aria-label="Custom Input Label"
       aria-required={true}
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -173,7 +173,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 5`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -195,7 +195,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
       aria-describedby="myTextInput-helperText"
       aria-required={true}
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -229,7 +229,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 6`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -252,7 +252,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
       aria-invalid={true}
       aria-required={true}
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -286,7 +286,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 7`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -307,7 +307,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
     <input
       aria-required={true}
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={true}
       id="myTextInput"
       onBlur={[Function]}
@@ -324,7 +324,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 8`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 9`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="myTextInput-componentWrapper"
 >
@@ -341,7 +341,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 9`] = `
   >
     <input
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="myTextInput"
       onBlur={[Function]}
@@ -358,7 +358,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 9`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 10`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1y4kn3e"
   data-testid="ds-textInput"
   id="chakra-componentWrapper"
 >
@@ -375,7 +375,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 10`] = `
   >
     <input
       autoComplete={null}
-      className="chakra-input css-kle7zy"
+      className="chakra-input css-0"
       disabled={false}
       id="chakra"
       onBlur={[Function]}
@@ -392,8 +392,8 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 10`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 11`] = `
 <div
-  className="css-1xdhyk6"
-  data-testid="ds-textInput"
+  className="css-1u8qly9"
+  data-testid="props"
   id="props-componentWrapper"
 >
   <label
@@ -409,8 +409,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 11`] = `
   >
     <input
       autoComplete={null}
-      className="chakra-input css-1xdhyk6"
-      data-testid="props"
+      className="chakra-input css-0"
       disabled={false}
       id="props"
       onBlur={[Function]}
@@ -427,7 +426,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 11`] = `
 
 exports[`UI Snapshots renders the text input UI snapshot correctly 12`] = `
 <div
-  className="css-1xdhyk6"
+  className="css-1u8qly9"
   data-testid="ds-textInput"
   id="autocomplete-componentWrapper"
 >
@@ -444,7 +443,7 @@ exports[`UI Snapshots renders the text input UI snapshot correctly 12`] = `
   >
     <input
       autoComplete="name"
-      className="chakra-input css-1xdhyk6"
+      className="chakra-input css-0"
       disabled={false}
       id="autocomplete"
       onBlur={[Function]}

--- a/src/theme/components/searchBar.ts
+++ b/src/theme/components/searchBar.ts
@@ -51,7 +51,6 @@ const SearchBar = defineMultiStyleConfig({
         },
         "[data-button]": {
           borderRightRadius: "sm",
-          maxWidth: "80px",
           paddingTop: "xs",
           paddingLeft: "s",
           paddingBottom: "xs",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2066](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2066)

## This PR does the following:

- Updates the `TextInput` component to change how `...rest` is applied.
- Updates the `SearchBar` component to remove the `maxWidth` applied to the button element.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2066]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ