### PR TITLE
No ref: Fix `search` role story

### DIFF
--- a/src/components/AccessibilityGuide/AriaLandmarks.mdx
+++ b/src/components/AccessibilityGuide/AriaLandmarks.mdx
@@ -123,7 +123,7 @@ Note: There's not always a clear line between `complementary` content and conten
 
 The `search` landmark contains the page's search and filter functionality, which will likely include form controls (such as an `input type="search"`).
 
-Inspect below to see `<search>` in the DOM&mdash;notice that it wraps the `h2`, all of the `input` elements, and the `button`, not just the searchbar:
+Inspect below to see `<search>` in the DOM&mdash;notice that it wraps the `h4`, all of the `input` elements, and the `button`, not just the searchbar:
 
 <Canvas of={SearchBarStories.WithSearchElement} />
 

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -5,8 +5,6 @@ import { useState } from "react";
 import SearchBar from "./SearchBar";
 import Heading from "../Heading/Heading";
 import { argsBooleanType } from "../../helpers/storybookUtils";
-import { Box, Button, Flex, TextInput } from "../..";
-import Checkbox from "../Checkbox/Checkbox";
 
 const meta: Meta<typeof SearchBar> = {
   title: "Components/Form Elements/SearchBar",
@@ -227,15 +225,17 @@ export const DisabledState: Story = {
 export const WithSearchElement: Story = {
   render: () => (
     <search>
-      {/* TODO: Replace with Searchbar component. */}
-      <Heading size="heading6"> Search items </Heading>
-      <Flex justifyContent="align-content">
-        <TextInput id="search-input" labelText="Search" showLabel={false} />
-        <Button id="search-btn">Search</Button>
-      </Flex>
-      <Box sx={{ marginTop: "s" }}>
-        <Checkbox id="public-domain" labelText="Only public domain" />
-      </Box>
+      <SearchBar
+        headingText={<Heading level="h4">Search items</Heading>}
+        id="custom-heading"
+        labelText="Custom Heading example"
+        onSubmit={() => {}}
+        textInputProps={{
+          labelText: "Item Search",
+          name: "textInputName",
+          placeholder: "Item Search",
+        }}
+      />
     </search>
   ),
   name: "Search Landmark Element Example",

--- a/src/components/SearchBar/SearchBar.stories.tsx
+++ b/src/components/SearchBar/SearchBar.stories.tsx
@@ -227,8 +227,7 @@ export const WithSearchElement: Story = {
     <search>
       <SearchBar
         headingText={<Heading level="h4">Search items</Heading>}
-        id="custom-heading"
-        labelText="Custom Heading example"
+        labelText="Search items"
         onSubmit={() => {}}
         textInputProps={{
           labelText: "Item Search",


### PR DESCRIPTION
## This PR does the following:

- Updates the story using a searchbar in ARIA Landmarks guide to use the actual `Searchbar` component

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->


## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
