### PR TITLE
DSD-2135: Fixing Select helper text alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -560,6 +560,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Removes console warnings from the `CheckboxGroup` component when a non-`Checkbox` component is passed as a child.
 - Fixes the responsive styles related to the image in the `FeaturedContent` component.
+- Fixes helper error text alignment in the `Select` component when label is not shown and it is inlined.
 
 ### Breaking Changes
 

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -105,6 +105,7 @@ export const Select: ChakraComponent<
       const styles = useMultiStyleConfig("ReservoirSelect", {
         variant,
         labelPosition,
+        showLabel,
       });
       const finalInvalidText = invalidText
         ? invalidText

--- a/src/components/Select/Select.tsx
+++ b/src/components/Select/Select.tsx
@@ -105,6 +105,7 @@ export const Select: ChakraComponent<
       const styles = useMultiStyleConfig("ReservoirSelect", {
         variant,
         labelPosition,
+        labelWidth,
         showLabel,
       });
       const finalInvalidText = invalidText

--- a/src/components/Select/selectChangelogData.ts
+++ b/src/components/Select/selectChangelogData.ts
@@ -21,6 +21,7 @@ export const changelogData: ChangelogData[] = [
       "Rename `selectType` to `variant`.",
       "Updates the `id` prop to be optional and generates a random id if not provided.",
       "Adds `data-testid` value of `ds-select` to the parent element.",
+      "Fixes helper error text alignment when label is not shown and it is inlined.",
     ],
   },
   {

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -66,7 +66,7 @@ const select = (labelPosition: string) => ({
 
 const Select = defineMultiStyleConfig({
   baseStyle: definePartsStyle(
-    ({ labelPosition, showLabel }: SelectBaseStyle) => {
+    ({ labelPosition, labelWidth, showLabel }: SelectBaseStyle) => {
       return {
         inline: {
           display: { md: "flex" },
@@ -76,7 +76,8 @@ const Select = defineMultiStyleConfig({
         label: { marginBottom: "label.default" },
         select: select(labelPosition),
         "div[data-testid='ds-helperErrorText']": {
-          marginLeft: !showLabel && labelPosition === "inline" ? "0" : null,
+          marginLeft:
+            !showLabel && labelPosition === "inline" ? "0" : `${labelWidth}px`,
         },
       };
     }

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -10,10 +10,11 @@ import {
 // This function creates a set of function that helps us
 // create multipart component styles.
 const { defineMultiStyleConfig, definePartsStyle } =
-  createMultiStyleConfigHelpers(["helperText", "inline", "select"]);
+  createMultiStyleConfigHelpers(["inline", "select"]);
 
 interface SelectBaseStyle extends StyleFunctionProps {
   labelPosition: string;
+  showLabel: boolean;
 }
 
 const select = (labelPosition: string) => ({
@@ -64,17 +65,22 @@ const select = (labelPosition: string) => ({
 });
 
 const Select = defineMultiStyleConfig({
-  baseStyle: definePartsStyle(({ labelPosition }: SelectBaseStyle) => {
-    return {
-      inline: {
-        display: { md: "flex" },
-        gap: { md: "xs" },
-        alignItems: { md: "center" },
-      },
-      label: { marginBottom: "label.default" },
-      select: select(labelPosition),
-    };
-  }),
+  baseStyle: definePartsStyle(
+    ({ labelPosition, showLabel }: SelectBaseStyle) => {
+      return {
+        inline: {
+          display: { md: "flex" },
+          gap: { md: "xs" },
+          alignItems: { md: "center" },
+        },
+        label: { marginBottom: "label.default" },
+        select: select(labelPosition),
+        "div[data-testid='ds-helperErrorText']": {
+          marginLeft: !showLabel && labelPosition === "inline" ? "0" : null,
+        },
+      };
+    }
+  ),
   variants: {
     searchbar: definePartsStyle({
       select: {


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2135](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2135)

## This PR does the following:

- Pr branch says "slider" but the ticket's title was initially wrong. The issue is in the `Select` component. The helper text does not align properly when `labelPosition` is "inline" and `showLabel` is false. 

<img width="435" height="188" alt="Screenshot 2025-07-30 at 5 22 30 PM" src="https://github.com/user-attachments/assets/ed3ebfb7-42cb-41e2-8c15-c4c6a8455d6f" />


## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Storybook.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2135]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2135?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ