### PR TITLE
DSD-2098: Remove mdxtype logic check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Removes default spacing values set on the `DatePicker`, `Heading`, `HelperErrorText`, `HorizontalRule`, `Label`, `List`, `StyledList`, and `Text` components.
 - Removes all files related to the `Autosuggest` component guidelines.
 - Removes the exported `TagSetTypeProps` type.
+- Removes `.mdxtype` DOM children logic check in `Card`, `Form`, `Icon`, and `Tabs` components.
 
 ### Fixes
 

--- a/src/components/Card/Card.tsx
+++ b/src/components/Card/Card.tsx
@@ -271,12 +271,9 @@ export const Card: ChakraComponent<
       });
 
       childrenArray.forEach((child, key) => {
-        const isCardActions =
-          child.type === CardActions || child.props.mdxType === "CardActions";
-        const isCardContent =
-          child.type === CardContent || child.props.mdxType === "CardContent";
-        const isCardHeading =
-          child.type === CardHeading || child.props.mdxType === "CardHeading";
+        const isCardActions = child.type === CardActions;
+        const isCardContent = child.type === CardContent;
+        const isCardHeading = child.type === CardHeading;
 
         if (isCardHeading) {
           // If the child is a `CardHeading` component, then we add the

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -38,7 +38,7 @@ export const FormRow: ChakraComponent<
     children as JSX.Element,
     (child: React.ReactElement, i) => {
       if (!child) return null;
-      if (child.type === FormField || child.props.mdxType === "FormField") {
+      if (child.type === FormField) {
         return React.cloneElement(child, { id: `${id}-grandchild${i}` });
       }
       return null;

--- a/src/components/Icons/Icon.tsx
+++ b/src/components/Icons/Icon.tsx
@@ -121,8 +121,7 @@ export const Icon: ChakraComponent<
     // Apply icon props to the SVG child.
     if (
       (children as JSX.Element).type === "svg" ||
-      (children as JSX.Element).props?.type === "svg" ||
-      (children as JSX.Element).props?.mdxType === "svg"
+      (children as JSX.Element).props?.type === "svg"
     ) {
       childSVG = React.cloneElement(children as JSX.Element, {
         ...iconProps,

--- a/src/components/Tabs/Tabs.tsx
+++ b/src/components/Tabs/Tabs.tsx
@@ -118,7 +118,7 @@ const getElementsFromChildren = (children): TabPanelProps => {
   }
 
   children.forEach((child: JSX.Element) => {
-    if (child.type === TabList || child.props.mdxType === "TabList") {
+    if (child.type === TabList) {
       tabs.push(child);
 
       const childTabs = React.Children.count(child.props.children);
@@ -130,7 +130,7 @@ const getElementsFromChildren = (children): TabPanelProps => {
       }
     }
 
-    if (child.type === TabPanels || child.props.mdxType === "TabPanels") {
+    if (child.type === TabPanels) {
       panels.push(child);
     }
   });


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2098](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2098)

## This PR does the following:

- Removes the children type `.mdxType` check. It was originally used to make sure that component children elements were rendered in Storybook but those issues are seemingly resolved.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Storybook, comparing against prod.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- N/A

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2098]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2098?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ