### PR TITLE
DSD-2050: Menu ARIA label fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds `labelAsAriaLabel` prop to `Menu` to fix incorrect ARIA label on button.
+
 ## 4.0.0 (August 11, 2025)
 
 ### Adds

--- a/src/components/Menu/Menu.mdx
+++ b/src/components/Menu/Menu.mdx
@@ -13,7 +13,7 @@ import { changelogData } from "./menuChangelogData";
   componentName="Menu"
   summary="List of interactive elements rendered in a dropdown format and used for executing actions or navigating"
   versionAdded="3.0.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={MenuStories.WithControls} />

--- a/src/components/Menu/Menu.mdx
+++ b/src/components/Menu/Menu.mdx
@@ -77,10 +77,11 @@ type when there is limited space such as a table or on mobile.
 
 ## Menu label
 
-The default label of the menu will be `labelText`. With `showSelectionAsLabel`
+The default label of the menu will be `labelText`.
+
+With `showSelectionAsLabel`
 enabled, the selected item will then display as the menu's label. This is useful
-when the choice
-should be displayed after selection, like choosing sort/filter criteria, or if
+when the choice should be displayed after selection, like choosing sort/filter criteria, or if
 an option needs to be selected and displayed when the page first loads.
 
 `labelText` is still required even if `showSelectionAsLabel` is true, because it
@@ -99,6 +100,10 @@ is used for the `aria-label`.
   mb="s"
   variant="recommendation"
 />
+
+`labelAsAriaLabel` uses the `labelText` as the button's `aria-label`, regardless of the selected item.
+This is recommended when the `labelText` already includes the selected item,
+as in the fourth example below.
 
 <Canvas of={MenuStories.MenuLabel} />
 

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -15,6 +15,10 @@ const meta: Meta<typeof Menu> = {
       options: sectionTypeArray,
       defaultValue: { summary: "blogs" },
     },
+    labelAsAriaLabel: {
+      control: { type: "boolean" },
+      defaultValue: { summary: "false" },
+    },
     labelText: { description: "Set menu button text." },
     listAlignment: {
       options: ["left", "right"],
@@ -33,10 +37,6 @@ const meta: Meta<typeof Menu> = {
     showLabel: {
       control: { type: "boolean" },
       defaultValue: { summary: "true" },
-    },
-    labelAsAriaLabel: {
-      control: { type: "boolean" },
-      defaultValue: { summary: "false" },
     },
   },
 };

--- a/src/components/Menu/Menu.stories.tsx
+++ b/src/components/Menu/Menu.stories.tsx
@@ -1,9 +1,10 @@
 import { HStack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import Menu, { ListItemsData } from "./Menu";
+import Menu, { ActionItem, ListItemsData } from "./Menu";
 import { sectionTypeArray } from "../../helpers/types";
 import { getPlaceholderImage } from "../../utils/utils";
+import { useState } from "react";
 
 const meta: Meta<typeof Menu> = {
   title: "Components/Navigation/Menu",
@@ -32,6 +33,10 @@ const meta: Meta<typeof Menu> = {
     showLabel: {
       control: { type: "boolean" },
       defaultValue: { summary: "true" },
+    },
+    labelAsAriaLabel: {
+      control: { type: "boolean" },
+      defaultValue: { summary: "false" },
     },
   },
 };
@@ -434,22 +439,53 @@ export const MenuTypes: Story = {
 };
 
 export const MenuLabel: Story = {
-  render: () => (
-    <HStack>
-      <Menu labelText={"Sort By"} listItemsData={labelListItems} />
-      <Menu
-        showSelectionAsLabel
-        labelText={"Sort By"}
-        listItemsData={labelListItems}
-      />
-      <Menu
-        showSelectionAsLabel
-        selectedItem="ascending"
-        labelText={"Sort By"}
-        listItemsData={labelListItems}
-      />
-    </HStack>
-  ),
+  render: () => {
+    const MenuLabelExample = () => {
+      const [selectedSort, setSelectedSort] = useState("ascending");
+      const stateListItems = [
+        { type: "action" as const, id: "ascending", label: "Ascending" },
+        { type: "action" as const, id: "descending", label: "Descending" },
+        { type: "action" as const, id: "alphabetical", label: "Alphabetical" },
+      ];
+
+      const items: ActionItem[] = stateListItems.map((item) => ({
+        ...item,
+        onClick: () => {
+          console.log(`${item.label} clicked`);
+          setSelectedSort(item.id);
+        },
+      }));
+
+      const selectedItemLabel =
+        stateListItems.find((i) => i.id === selectedSort)?.label ?? "";
+
+      return (
+        <HStack>
+          <Menu labelText={"Sort By"} listItemsData={labelListItems} />
+          <Menu
+            showSelectionAsLabel
+            labelText={"Sort By"}
+            listItemsData={labelListItems}
+          />
+          <Menu
+            showSelectionAsLabel
+            selectedItem="ascending"
+            labelText={"Sort By"}
+            listItemsData={labelListItems}
+          />
+          <Menu
+            showLabel
+            selectedItem={selectedSort}
+            labelText={`Sort by: ${selectedItemLabel}`}
+            listItemsData={items}
+            labelAsAriaLabel
+          />
+        </HStack>
+      );
+    };
+
+    return <MenuLabelExample />;
+  },
   parameters: {
     docs: {
       story: { height: "200px" },

--- a/src/components/Menu/Menu.test.tsx
+++ b/src/components/Menu/Menu.test.tsx
@@ -148,6 +148,34 @@ describe("Menu allows selection", () => {
   });
 });
 
+describe("Menu sets correct aria label given props", () => {
+  it("uses labelText as aria label when labelAsAriaLabel is passed", () => {
+    render(
+      <Menu
+        showLabel
+        labelAsAriaLabel
+        selectedItem="item-title-1"
+        labelText={"Menu label: item 1"}
+        listItemsData={defaultListItems}
+      />
+    );
+    const openButton = screen.getByText("Menu label: item 1").closest("button");
+    expect(openButton).toHaveAttribute("aria-label", "Menu label: item 1");
+  });
+  it("default builds aria label from labelText and selected item", () => {
+    render(
+      <Menu
+        showLabel
+        selectedItem="item-title-1"
+        labelText={"Menu label"}
+        listItemsData={defaultListItems}
+      />
+    );
+    const openButton = screen.getByText("Menu label").closest("button");
+    expect(openButton).toHaveAttribute("aria-label", "Menu label: I'm item 1");
+  });
+});
+
 describe("Menu logs errors when props are incorrect or missing", () => {
   it("logs an error if Menu is missing listItemsData", () => {
     const warn = jest.spyOn(console, "warn");

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -25,6 +25,9 @@ export interface MenuProps extends BoxProps {
   showSelectionAsLabel?: boolean;
   /** Used to set the highlight color for the current item.  The values correspond with the NYPL section colors */
   highlightColor?: SectionTypes;
+  /** Optional boolean value used to pass the labelText as the button element's aria-label.
+   * If false, the aria-label will be built from the labelText and the selected item. */
+  labelAsAriaLabel?: boolean;
   /** Required string used to set the label text for the button element. If showLabel is false,
    * this value is instead used to set an aria-label attribute on the button.  The labelText prop is
    * required for accessibility compliance. */
@@ -39,9 +42,6 @@ export interface MenuProps extends BoxProps {
   /** Optional boolean value used to toggle the visibility of the label text for the button element.
    * If false, this value will be used to set an aria-label attribute on the button element.  */
   showLabel?: boolean;
-  /** Optional boolean value used to pass the labelText as the button element's aria-label.
-   * If false, the aria-label will be built from the labelText and the selected item. */
-  labelAsAriaLabel?: boolean;
 }
 
 /**Type for the icons/images displayed inline with menu items. */

--- a/src/components/Menu/Menu.tsx
+++ b/src/components/Menu/Menu.tsx
@@ -39,6 +39,9 @@ export interface MenuProps extends BoxProps {
   /** Optional boolean value used to toggle the visibility of the label text for the button element.
    * If false, this value will be used to set an aria-label attribute on the button element.  */
   showLabel?: boolean;
+  /** Optional boolean value used to pass the labelText as the button element's aria-label.
+   * If false, the aria-label will be built from the labelText and the selected item. */
+  labelAsAriaLabel?: boolean;
 }
 
 /**Type for the icons/images displayed inline with menu items. */
@@ -91,6 +94,7 @@ export const Menu: ChakraComponent<
         showBorder = true,
         showLabel = true,
         listItemsData,
+        labelAsAriaLabel = false,
         ...rest
       },
       ref?
@@ -215,7 +219,13 @@ export const Menu: ChakraComponent<
       const getButton = (isOpen) => (
         <MenuButton
           sx={styles.menuButton}
-          aria-label={selected ? `${labelText}: ${selected.label}` : labelText}
+          aria-label={
+            labelAsAriaLabel
+              ? labelText
+              : selected
+              ? `${labelText}: ${selected.label}`
+              : labelText
+          }
           backgroundColor={isOpen ? "ui.link.primary-05 !important" : "unset"}
         >
           {showLabel && (

--- a/src/components/Menu/menuChangelogData.ts
+++ b/src/components/Menu/menuChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality", "Accessibility"],
+    notes: [
+      "Adds `labelAsAriaLabel` prop to override incorrect ARIA labels on the button.",
+    ],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2050](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2050)

## This PR does the following:

- Adds `labelAsAriaLabel` prop to the `Menu`
- Adds a story and updates docs

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- Should resolve a11y issue with "labelText: selectedItem : selectedItem" ARIA label on the `Menu` button by allowing devs to override

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- See [this](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2050?focusedCommentId=137868) for explanation of approach– trying to avoid breaking changes

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2050]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ