### PR TITLE
DSD-2148: spacing for label in MultiSelectGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `labelAsAriaLabel` prop to `Menu` to fix incorrect ARIA label on button.
 
+### Fixes
+
+- Fixes the spacing for the label in the `MultiSelectGroup` component.
+
 ## 4.0.0 (August 11, 2025)
 
 ### Adds

--- a/src/components/FilterBarInline/__snapshots__/FilterBarInline.test.tsx.snap
+++ b/src/components/FilterBarInline/__snapshots__/FilterBarInline.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 1`] = `
     className="chakra-stack css-ucbec2"
   >
     <fieldset
-      className="css-1u8qly9"
+      className="css-17kb4cl"
       data-testid="ds-multiSelectGroup"
       id="MultiSelectGroup-fieldset"
     >
@@ -1178,7 +1178,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 2`] = `
     className="chakra-stack css-ucbec2"
   >
     <fieldset
-      className="css-1u8qly9"
+      className="css-17kb4cl"
       data-testid="ds-multiSelectGroup"
       id="MultiSelectGroup-fieldset"
     >
@@ -2354,7 +2354,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 3`] = `
     className="chakra-stack css-ucbec2"
   >
     <fieldset
-      className="css-1u8qly9"
+      className="css-17kb4cl"
       data-testid="ds-multiSelectGroup"
       id="MultiSelectGroup-fieldset"
     >
@@ -3530,7 +3530,7 @@ exports[`FilterBarInline renders the UI snapshots correctly 4`] = `
     className="chakra-stack css-ucbec2"
   >
     <fieldset
-      className="css-1u8qly9"
+      className="css-17kb4cl"
       data-testid="ds-multiSelectGroup"
       id="MultiSelectGroup-fieldset"
     >

--- a/src/components/MultiSelectGroup/MultiSelectGroup.mdx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.mdx
@@ -20,7 +20,7 @@ import { changelogData } from "./multiSelectGroupChangelogData";
   componentName="MultiSelectGroup"
   summary="Grouping of related MultiSelect components"
   versionAdded="1.4.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={MultiSelectGroupStories.WithControls} />

--- a/src/components/MultiSelectGroup/MultiSelectGroup.tsx
+++ b/src/components/MultiSelectGroup/MultiSelectGroup.tsx
@@ -57,6 +57,7 @@ export const MultiSelectGroup: ChakraComponent<
         legendText={labelText}
         isLegendHidden={!showLabel}
         {...rest}
+        __css={{ legend: { mb: "legend.asLabel" } }}
       >
         <Stack
           columnGap="xs"

--- a/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
+++ b/src/components/MultiSelectGroup/__snapshots__/MultiSelectGroup.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] = `
 <fieldset
-  className="css-1u8qly9"
+  className="css-17kb4cl"
   data-testid="ds-multiSelectGroup"
   id="MultiSelectGroup-fieldset"
 >
@@ -1148,7 +1148,7 @@ exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 1`] =
 
 exports[`MulitSelectGroup Accessibility renders the UI snapshots correctly 2`] = `
 <fieldset
-  className="css-1u8qly9"
+  className="css-17kb4cl"
   data-testid="ds-multiSelectGroup"
   id="MultiSelectGroup-fieldset"
 >

--- a/src/components/MultiSelectGroup/multiSelectGroupChangelogData.ts
+++ b/src/components/MultiSelectGroup/multiSelectGroupChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Fixes the spacing for the label."],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2148](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2148)

## This PR does the following:

- Fixes the spacing for the label in the `MultiSelectGroup` component. It now aligns with the spacing value used in components like `TextInput` and `Select`.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook build

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2148]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ