### PR TITLE
DSD-2029: contentCopy icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds the `"contentCopy"` option to the `Icon` component.
+
 ## 4.0.1 (September 11, 2025)
 
 ### Adds

--- a/icons/svg/content-copy.svg
+++ b/icons/svg/content-copy.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path id="icon/content/copy_24px" fill-rule="evenodd" clip-rule="evenodd" d="M16.5 1H4.5C3.4 1 2.5 1.9 2.5 3V17H4.5V3H16.5V1ZM19.5 5H8.5C7.4 5 6.5 5.9 6.5 7V21C6.5 22.1 7.4 23 8.5 23H19.5C20.6 23 21.5 22.1 21.5 21V7C21.5 5.9 20.6 5 19.5 5ZM8.5 21H19.5V7H8.5V21Z" />
+</svg>

--- a/src/components/Icons/Icon.mdx
+++ b/src/components/Icons/Icon.mdx
@@ -19,7 +19,7 @@ import { changelogData } from "./iconChangelogData";
   componentName="Icon"
   summary="Renders commonly used icons in SVG format"
   versionAdded="0.0.4"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={IconStories.WithControls} />

--- a/src/components/Icons/IconSvgs.tsx
+++ b/src/components/Icons/IconSvgs.tsx
@@ -28,6 +28,7 @@ import building from "../../../icons/svg/building.svg";
 import communicationCall from "../../../icons/svg/communication-call.svg";
 import communicationChatBubble from "../../../icons/svg/communication-chat-bubble.svg";
 import communicationEmail from "../../../icons/svg/communication-email.svg";
+import contentCopy from "../../../icons/svg/content-copy.svg";
 import contentFilterList from "../../../icons/svg/content-filter-list.svg";
 import check from "../../../icons/svg/check.svg";
 import clock from "../../../icons/svg/clock.svg";
@@ -116,6 +117,7 @@ export default {
   communicationCall,
   communicationChatBubble,
   communicationEmail,
+  contentCopy,
   contentFilterList,
   decorativeBookBroken,
   decorativeEnvelope,

--- a/src/components/Icons/iconChangelogData.ts
+++ b/src/components/Icons/iconChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Added the `contentCopy` icon."],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",

--- a/src/components/Icons/iconVariables.ts
+++ b/src/components/Icons/iconVariables.ts
@@ -141,6 +141,7 @@ export const iconNamesArray = [
   "communicationCall",
   "communicationChatBubble",
   "communicationEmail",
+  "contentCopy",
   "contentFilterList",
   "decorativeBookBroken",
   "decorativeEnvelope",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2029](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2029)

## This PR does the following:

- Adds the `"contentCopy"` option to the `Icon` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2029]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2029?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ