### PR TITLE
DSD-2156: Hero background color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,12 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds the `"contentCopy"` option to the `Icon` component.
 - Adds the `Voice` section to the `Style Guide`.
-- Adds the `textColor` prop to the `Hero` component.
+- Adds the `textBackgroundColor` and `textColor` props to the `Hero` component.
 
 ### Updates
 
 - Updates padding around clearable X button to avoid overlap in `TextInput`.
+- Updates the `Hero` component to use the `textBackgroundColor` prop in lieu of the `backgroundColor` prop.
 
 ### Deprecates
 
@@ -42,7 +43,6 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `MultiSelect` view for options that have an item count number.
-- Updates the `Hero` component to add the `textBackgroundColor` prop to be used in lieu of the `backgroundColor` prop,
 
 ## 4.0.0 (August 11, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Updates padding around clearable X button to avoid overlap in `TextInput`.
 - Updates the `Hero` component to use the `textBackgroundColor` prop in lieu of the `backgroundColor` prop.
+- Updates the `Hero` component to use the `textColor` prop in lieu of the `foregroundColor` prop.
 
 ### Deprecates
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the `"contentCopy"` option to the `Icon` component.
+- Adds the `textColor` prop to the `Hero` component.
 
 ### Updates
 
 - Updates padding around clearable X button to avoid overlap in `TextInput`.
+
+### Deprecates
+
+- Deprecates the `foregroundColor` prop in the `Hero` component.
 
 ## 4.0.1 (September 11, 2025)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates the `MultiSelect` view for options that have an item count number.
+- Updates the `Hero` component to add the `textBackgroundColor` prop to be used in lieu of the `backgroundColor` prop,
 
 ## 4.0.0 (August 11, 2025)
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -100,7 +100,7 @@ Each `Hero` variation can be rendered through the `variant` prop.
 ### Primary
 
 The `"primary"` hero variant should be used with a `backgroundImageSrc` and a
-`heading`. `backgroundColor`, `foregroundColor`, and `subHeaderText` props may
+`heading`. `subHeaderText`, `textBackgroundColor`, and `textColor` props may
 also be used.
 
 <Story of={HeroStories.Primary} />
@@ -127,7 +127,7 @@ also be used.
 ### Tertiary
 
 The `"tertiary"` hero variant should be used with a `heading` prop.
-`backgroundColor`, `foregroundColor`, and `subHeaderText` props may also be used.
+`subHeaderText`, `textBackgroundColor`, and `textColor` props may also be used.
 
 <Story of={HeroStories.Tertiary} />
 
@@ -201,16 +201,16 @@ The `"tertiary"` hero variant should be used with a `heading` prop.
 
 ### Campaign
 
-The `"campaign"` hero variant should be used with `backgroundImageSrc`, `heading`,
-and `imageProps` props. `backdropBackgroundColor`, `backgroundColor`, `foregroundColor`,
-and `subHeaderText` props may also be used.
+The `"campaign"` hero variant should be used with `backgroundImageSrc`,
+`heading`, and `imageProps` props. `backdropBackgroundColor`, `subHeaderText`,
+`textBackgroundColor`, and `textColor` props may also be used.
 
 The `"campaign"` variant is special in that it has both a background and foreground.
 We understand that this naming can be confusing, but it helps to think of this
 variant having two layers.
 
-To modify the foreground, the `backgroundColor`, `foregroundColor`, `imageProps`
-props should be used.
+To modify the foreground, the `textBackgroundColor`, `textColor`, and
+`imageProps` props should be used.
 
 <Story of={HeroStories.Campaign} />
 
@@ -387,7 +387,6 @@ content.
   code={`
   <Hero
     backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
-    foregroundColor="ui.white"
     heading={
       <Heading
         id="primary-hero"
@@ -397,6 +396,7 @@ content.
         text="Hero Primary"
       />
     }
+    textColor="ui.white"
     textBackgroundColor="brand.primary"
     variant="primary"
   />
@@ -407,7 +407,6 @@ content.
 <Source
   code={`
   <Hero
-    foregroundColor="ui.white"
     heading={
       <Heading
         level="h1"
@@ -418,6 +417,7 @@ content.
       />
     }
     subHeaderText={otherSubHeaderText}
+    textColor="ui.white"
     textBackgroundColor="brand.primary"
     variant="tertiary"
   />
@@ -429,7 +429,6 @@ content.
   code={`
   <Hero
     backgroundImageSrc={getPlaceholderImage()}
-    foregroundColor="ui.white"
     heading={
       <Heading
         level="h1"
@@ -443,6 +442,7 @@ content.
       src: "https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg",
     }}
     subHeaderText={otherSubHeaderText}
+    textColor="ui.white"
     textBackgroundColor="brand.primary"
     variant="campaign"
   />
@@ -454,18 +454,18 @@ content.
 
 By default, the `Hero` component renders a dark background color with light
 text. This color treatment can be overridden using a combination of the
-`foregroundColor`, `textBackgroundColor`, and `isDarkText` props.
+`textBackgroundColor`, `textColor`, and `isDarkText` props.
 
-- `foregroundColor`: custom color value for the text
 - `textBackgroundColor`: custom color value for the text background
+- `textColor`: custom color value for the text
 - `isDarkText`: used to render default dark color value for the text
 
 <Banner
   content={
     <>
-      <strong>IMPORTANT:</strong> The <code>foregroundColor</code> prop will
-      override the <code>isDarkText</code> prop, so they should not be used at
-      the same time.
+      <strong>IMPORTANT:</strong> The <code>textColor</code> prop will override
+      the <code>isDarkText</code> prop, so they should not be used at the same
+      time.
     </>
   }
   mt="s"
@@ -501,7 +501,6 @@ applies to all variants.
   code={`
   <Hero
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-    foregroundColor="ui.error.secondary"
     heading={
       <Heading
         level="h1"
@@ -512,6 +511,7 @@ applies to all variants.
     imageProps={imageProps}
     isDarkBackgroundImage
     subHeaderText={otherSubHeaderText}
+    textColor="ui.error.secondary"
     textBackgroundColor="ui.status.primary"
     variant="campaign"
   />

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -21,7 +21,7 @@ import { changelogData } from "./heroChangelogData";
   componentName="Hero"
   summary="A full-width banner at the top of a page"
   versionAdded="0.2.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={HeroStories.WithControls} />
@@ -31,8 +31,9 @@ import { changelogData } from "./heroChangelogData";
 - [Overview](#overview)
 - [Component props](#component-props)
 - [Accessibility](#accessibility)
-- [Active variants](#active-variants)
-- [Text colors](#text-colors)
+- [Variants](#variants)
+- [Text background color](#text-background-color)
+- [Text color](#text-color)
 - [Fallback campaign image](#fallback-campaign-image)
 - [Changelog](#changelog)
 
@@ -51,7 +52,6 @@ used:
   code={`
   <Hero
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_243025&t=w"
-    variant="campaign"
     heading={<Heading level="h1" id="campaign-hero" text="Hero Campaign" />}
     imageProps={{
       alt: "Image example",
@@ -60,6 +60,7 @@ used:
       src: "https://images.nypl.org/index.php?id=swope_243048&t=w",
     }}
     subHeaderText="Campaign Hero Subheader Text"
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -92,7 +93,7 @@ The `Hero` component is commonly used as a banner, below the page's header and
 breadcrumbs and above the main content. This means that if the `Hero` displays
 a heading element, it should be an `h1` and the first on the page.
 
-## Active variants
+## Variants
 
 Each `Hero` variation can be rendered through the `variant` prop.
 
@@ -142,7 +143,6 @@ The `"tertiary"` hero variant should be used with a `heading` prop.
         text="Hero Tertiary with Subtitle & Sub-Heading"
       />
     }
-    variant="tertiary"
     subHeaderText={
       <>
         With 92 locations across the Bronx, Manhattan, and Staten Island,{" "}
@@ -152,6 +152,7 @@ The `"tertiary"` hero variant should be used with a `heading` prop.
         is an essential part of neighborhoods across the city. Visit us today.
       </>
     }
+    variant="tertiary"
   />
 `}
   language="jsx"
@@ -167,7 +168,6 @@ The `"tertiary"` hero variant should be used with a `heading` prop.
         text="Hero Tertiary with Sub-Heading"
       />
     }
-    variant="tertiary"
     subHeaderText={
       <>
         With 92 locations across the Bronx, Manhattan, and Staten Island,{" "}
@@ -177,6 +177,7 @@ The `"tertiary"` hero variant should be used with a `heading` prop.
         is an essential part of neighborhoods across the city. Visit us today.
       </>
     }
+    variant="tertiary"
   />
 `}
   language="jsx"
@@ -217,7 +218,6 @@ props should be used.
   code={`
   <Hero
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -238,6 +238,7 @@ props should be used.
         is an essential part of neighborhoods across the city. Visit us today.
       </>
     }
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -246,7 +247,6 @@ props should be used.
   code={`
   <Hero
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -293,6 +293,7 @@ props should be used.
         </ButtonGroup>
       </>
     }
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -309,7 +310,6 @@ be converted to black & white and darkened to 60% black.
   code={`
   <Hero
     backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -331,6 +331,7 @@ be converted to black & white and darkened to 60% black.
         is an essential part of neighborhoods across the city. Visit us today.
       </>
     }
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -348,7 +349,6 @@ the `backgroundImageSrc` will take precedence.
   code={`
   <Hero
     backdropBackgroundColor="section.research.primary"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -370,51 +370,107 @@ the `backgroundImageSrc` will take precedence.
         is an essential part of neighborhoods across the city. Visit us today.
       </>
     }
+    variant="campaign"
   />
 `}
   language="jsx"
 />
+
+## Text background color
+
+Use the `textBackgroundColor` prop to set a custom background color for the text
+content.
+
+<Story of={HeroStories.TextBackgroundColor} />
+
 <Source
   code={`
   <Hero
-    backdropBackgroundColor="section.education.primary"
-    backgroundColor="ui.warning.primary"
-    foregroundColor="ui.typography.heading"
-    variant="campaign"
+    backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
+    foregroundColor="ui.white"
     heading={
       <Heading
+        id="primary-hero"
         level="h1"
-        id="campaign-hero-long-text-heading"
-        text="Hero Campaign"
+        overline="Hero Example"
+        subtitle="Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec sed odio dui. Vestibulum id ligula porta felis euismod semper. Aenean eu leo quam."
+        text="Hero Primary"
       />
     }
-    imageProps={
-      alt: "Image example",
-      src: "https://images.nypl.org/index.php?id=swope_244712&t=w",
-    }
-    isDarkBackgroundImage
-    subHeaderText={
-      <>
-        With 92 locations across the Bronx, Manhattan, and Staten Island,{" "}
-        <Link href="https://www.nypl.org/locations/snfl/childrens">
-          The New York Public Library
-        </Link>{" "}
-        is an essential part of neighborhoods across the city. Visit us today.
-      </>
-    }
+    textBackgroundColor="brand.primary"
+    variant="primary"
   />
 `}
   language="jsx"
 />
 
-## Text colors
+<Source
+  code={`
+  <Hero
+    foregroundColor="ui.white"
+    heading={
+      <Heading
+        level="h1"
+        id="tertiary-hero-subtitle-subheading"
+        size="heading2"
+        subtitle="This is the subtitle"
+        text="Hero Tertiary with Subtitle & Sub-Heading"
+      />
+    }
+    subHeaderText={otherSubHeaderText}
+    textBackgroundColor="brand.primary"
+    variant="tertiary"
+  />
+`}
+  language="jsx"
+/>
+
+<Source
+  code={`
+  <Hero
+    backgroundImageSrc={getPlaceholderImage()}
+    foregroundColor="ui.white"
+    heading={
+      <Heading
+        level="h1"
+        id="campaign-hero-default-heading"
+        text="Hero Campaign"
+        mb="s"
+      />
+    }
+    imageProps={{
+      alt: "",
+      src: "https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg",
+    }}
+    subHeaderText={otherSubHeaderText}
+    textBackgroundColor="brand.primary"
+    variant="campaign"
+  />
+`}
+  language="jsx"
+/>
+
+## Text color
 
 By default, the `Hero` component renders a dark background color with light
 text. This color treatment can be overridden using a combination of the
-`backgroundColor`, `foregroundColor` and `isDarkText` props.
+`foregroundColor`, `textBackgroundColor`, and `isDarkText` props.
 
-**NOTE:** The `foregroundColor` prop will override the `isDarkText` prop, so they
-should not be used at the same time.
+The examples below only show the `"campaign"` variant, but this same treatment
+applies to all variants.
+
+<Banner
+  content={
+    <>
+      <strong>IMPORTANT:</strong> The <code>foregroundColor</code> prop will
+      override the <code>isDarkText</code> prop, so they should not be used at
+      the same time.
+    </>
+  }
+  mt="s"
+  mb="s"
+  variant="warning"
+/>
 
 <Story of={HeroStories.TextColorStyles} />
 
@@ -422,7 +478,6 @@ should not be used at the same time.
   code={`
   <Hero
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -433,6 +488,7 @@ should not be used at the same time.
     imageProps={imageProps}
     isDarkBackgroundImage
     subHeaderText={otherSubHeaderText}
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -440,10 +496,8 @@ should not be used at the same time.
 <Source
   code={`
   <Hero
-    backgroundColor="ui.status.primary"
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
     foregroundColor="ui.error.secondary"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -454,6 +508,8 @@ should not be used at the same time.
     imageProps={imageProps}
     isDarkBackgroundImage
     subHeaderText={otherSubHeaderText}
+    textBackgroundColor="ui.status.primary"
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -461,9 +517,7 @@ should not be used at the same time.
 <Source
   code={`
   <Hero
-    backgroundColor="ui.status.primary"
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-    variant="campaign"
     heading={
       <Heading
         level="h1"
@@ -475,6 +529,8 @@ should not be used at the same time.
     isDarkBackgroundImage
     isDarkText
     subHeaderText={otherSubHeaderText}
+    textBackgroundColor="ui.status.primary"
+    variant="campaign"
   />
 `}
   language="jsx"
@@ -511,7 +567,6 @@ and background images should be the same.
     return (
       <Hero
         backgroundImageSrc={imageSrc}
-        variant="campaign"
         heading={
           <Heading
             level="h1"
@@ -528,6 +583,7 @@ and background images should be the same.
           }
         }}
         subHeaderText={otherSubHeaderText}
+        variant="campaign"
       />
     );
   };

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -456,8 +456,9 @@ By default, the `Hero` component renders a dark background color with light
 text. This color treatment can be overridden using a combination of the
 `foregroundColor`, `textBackgroundColor`, and `isDarkText` props.
 
-The examples below only show the `"campaign"` variant, but this same treatment
-applies to all variants.
+- `foregroundColor`: custom color value for the text
+- `textBackgroundColor`: custom color value for the text background
+- `isDarkText`: used to render default dark color value for the text
 
 <Banner
   content={
@@ -471,6 +472,9 @@ applies to all variants.
   mb="s"
   variant="warning"
 />
+
+The examples below only show the `"campaign"` variant, but this same treatment
+applies to all variants.
 
 <Story of={HeroStories.TextColorStyles} />
 

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -428,7 +428,7 @@ export const TextColorStyles: Story = {
           id="campaign-hero-long-text"
           mb="s"
           size="heading6"
-          text='Custom Background Color and "Dark" Text'
+          text='Custom Background Color and Default "dark" Text'
         />
         <Hero
           backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -274,7 +274,6 @@ export const Campaign: Story = {
     </Stack>
   ),
 };
-
 export const CampaignDarkBackgroundImage: Story = {
   render: () => (
     <Hero
@@ -296,52 +295,78 @@ export const CampaignDarkBackgroundImage: Story = {
 };
 export const CampaignBackgroundColors: Story = {
   render: () => (
+    <Hero
+      backdropBackgroundColor="section.research.primary"
+      variant="campaign"
+      heading={
+        <Heading
+          level="h1"
+          id="campaign-hero-long-text-heading"
+          mb="s"
+          text="Hero Campaign"
+        />
+      }
+      imageProps={imageProps}
+      subHeaderText={otherSubHeaderTextLong}
+    />
+  ),
+};
+export const TextBackgroundColor: Story = {
+  render: () => (
     <Stack spacing="l">
       <div>
-        <Heading
-          id="campaign-hero-custom-background-color"
-          level="h4"
-          mb="s"
-          size="heading6"
-          text="Campaign Hero with backdrop background color"
-        />
         <Hero
-          backdropBackgroundColor="section.research.primary"
-          variant="campaign"
+          backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
+          foregroundColor="ui.white"
           heading={
             <Heading
+              id="primary-hero"
               level="h1"
-              id="campaign-hero-long-text-heading"
-              mb="s"
-              text="Hero Campaign"
+              overline="Hero Example"
+              subtitle="Integer posuere erat a ante venenatis dapibus posuere velit aliquet. Donec sed odio dui. Vestibulum id ligula porta felis euismod semper. Aenean eu leo quam."
+              text="Hero Primary"
             />
           }
-          imageProps={imageProps}
-          subHeaderText={otherSubHeaderTextLong}
+          textBackgroundColor="brand.primary"
+          variant="primary"
         />
       </div>
       <div>
-        <Heading
-          id="campaign-hero-custom-background-and-foreground-colors"
-          mb="s"
-          size="heading6"
-          text="Campaign Hero with separate backdrop and foreground background design token color"
-        />
         <Hero
-          backdropBackgroundColor="section.education.primary"
-          backgroundColor="ui.warning.primary"
-          foregroundColor="ui.typography.heading"
-          variant="campaign"
+          foregroundColor="ui.white"
           heading={
             <Heading
               level="h1"
-              id="campaign-hero-long-text-heading"
-              mb="s"
-              text="Hero Campaign"
+              id="tertiary-hero-subtitle-subheading"
+              size="heading2"
+              subtitle="This is the subtitle"
+              text="Hero Tertiary with Subtitle & Sub-Heading"
             />
           }
-          imageProps={imageProps}
-          subHeaderText={otherSubHeaderTextLong}
+          subHeaderText={otherSubHeaderText}
+          textBackgroundColor="brand.primary"
+          variant="tertiary"
+        />
+      </div>
+      <div>
+        <Hero
+          backgroundImageSrc={getPlaceholderImage()}
+          foregroundColor="ui.white"
+          heading={
+            <Heading
+              level="h1"
+              id="campaign-hero-default-heading"
+              text="Hero Campaign"
+              mb="s"
+            />
+          }
+          imageProps={{
+            alt: "",
+            src: "https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg",
+          }}
+          subHeaderText={otherSubHeaderText}
+          textBackgroundColor="brand.primary"
+          variant="campaign"
         />
       </div>
     </Stack>
@@ -355,11 +380,10 @@ export const TextColorStyles: Story = {
           id="campaign-hero-default"
           mb="s"
           size="heading6"
-          text="Campaign Hero with Default Colors"
+          text="Default Colors"
         />
         <Hero
           backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-          variant="campaign"
           heading={
             <Heading
               level="h1"
@@ -371,6 +395,7 @@ export const TextColorStyles: Story = {
           imageProps={imageProps}
           isDarkBackgroundImage
           subHeaderText={otherSubHeaderText}
+          variant="campaign"
         />
       </div>
       <div>
@@ -378,13 +403,11 @@ export const TextColorStyles: Story = {
           id="campaign-hero-default"
           mb="s"
           size="heading6"
-          text="Campaign Hero with Custom Background and Text Colors"
+          text="Custom Background and Text Colors"
         />
         <Hero
-          backgroundColor="ui.status.primary"
           backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
           foregroundColor="ui.error.secondary"
-          variant="campaign"
           heading={
             <Heading
               level="h1"
@@ -396,6 +419,8 @@ export const TextColorStyles: Story = {
           imageProps={imageProps}
           isDarkBackgroundImage
           subHeaderText={otherSubHeaderText}
+          textBackgroundColor="ui.status.primary"
+          variant="campaign"
         />
       </div>
       <div>
@@ -403,12 +428,10 @@ export const TextColorStyles: Story = {
           id="campaign-hero-long-text"
           mb="s"
           size="heading6"
-          text='Campaign Hero with Custom Background Color and "Dark" Text'
+          text='Custom Background Color and "Dark" Text'
         />
         <Hero
-          backgroundColor="ui.status.primary"
           backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-          variant="campaign"
           heading={
             <Heading
               level="h1"
@@ -421,12 +444,13 @@ export const TextColorStyles: Story = {
           isDarkBackgroundImage
           isDarkText
           subHeaderText={otherSubHeaderTextLong}
+          textBackgroundColor="ui.status.primary"
+          variant="campaign"
         />
       </div>
     </Stack>
   ),
 };
-
 const CampaignFallBackExample = () => {
   const [imageSrc, setImageSrc] = useState("foobar.jpg");
   const fallbackImageSrc =

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -75,6 +75,8 @@ const meta: Meta<typeof Hero> = {
     },
     isDarkText: { control: false },
     subHeaderText: { control: false },
+    textBackgroundColor: { control: false },
+    textColor: { control: false },
     variant: {
       control: { type: "select" },
       options: heroVariantsArray,
@@ -103,6 +105,8 @@ export const WithControls: Story = {
     isDarkBackgroundImage: undefined,
     isDarkText: undefined,
     subHeaderText: undefined,
+    textBackgroundColor: undefined,
+    textColor: undefined,
     variant: "primary",
   },
   render: (args) =>
@@ -317,7 +321,6 @@ export const TextBackgroundColor: Story = {
       <div>
         <Hero
           backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
-          foregroundColor="ui.white"
           heading={
             <Heading
               id="primary-hero"
@@ -328,12 +331,12 @@ export const TextBackgroundColor: Story = {
             />
           }
           textBackgroundColor="brand.primary"
+          textColor="ui.white"
           variant="primary"
         />
       </div>
       <div>
         <Hero
-          foregroundColor="ui.white"
           heading={
             <Heading
               level="h1"
@@ -345,13 +348,13 @@ export const TextBackgroundColor: Story = {
           }
           subHeaderText={otherSubHeaderText}
           textBackgroundColor="brand.primary"
+          textColor="ui.white"
           variant="tertiary"
         />
       </div>
       <div>
         <Hero
           backgroundImageSrc={getPlaceholderImage()}
-          foregroundColor="ui.white"
           heading={
             <Heading
               level="h1"
@@ -366,6 +369,7 @@ export const TextBackgroundColor: Story = {
           }}
           subHeaderText={otherSubHeaderText}
           textBackgroundColor="brand.primary"
+          textColor="ui.white"
           variant="campaign"
         />
       </div>
@@ -407,7 +411,6 @@ export const TextColorStyles: Story = {
         />
         <Hero
           backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-          foregroundColor="ui.error.secondary"
           heading={
             <Heading
               level="h1"
@@ -420,6 +423,7 @@ export const TextColorStyles: Story = {
           isDarkBackgroundImage
           subHeaderText={otherSubHeaderText}
           textBackgroundColor="ui.status.primary"
+          textColor="ui.error.secondary"
           variant="campaign"
         />
       </div>

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -149,7 +149,7 @@ describe("Hero", () => {
           />
         }
         backgroundImageSrc={getPlaceholderImage("smaller", 0)}
-        foregroundColor="#123456"
+        textColor="#123456"
         textBackgroundColor="#654321"
       />
     );
@@ -344,6 +344,26 @@ describe("Hero", () => {
     );
   });
 
+  it("logs a warning if `textColor` and `isDarkText` props are both passed", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      <Hero
+        variant="campaign"
+        imageProps={imageProps}
+        isDarkBackgroundImage
+        isDarkText
+        subHeaderText={otherSubHeaderText}
+        textColor="ui.black"
+      />
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Hero: The `textColor` and `isDarkText` props " +
+        "have both been passed. Thse props can not be used at the same time, " +
+        "so the `textColor` prop will override the `isDarkText` prop."
+    );
+  });
+
   it("logs a warning when the main image fails to load and the fallback image is rendered", () => {
     const warn = jest.spyOn(console, "warn");
     const onError = jest.fn();
@@ -453,112 +473,133 @@ describe("Hero", () => {
   });
 });
 describe("Test getTextColor function (hero.ts)", () => {
-  let type, mode, foregroundColor, isDarkText;
+  let type, mode, foregroundColor, isDarkText, textColor;
   it("returns foregroundColor", () => {
     type = "heading";
     mode = "light";
     foregroundColor = "brand.primary";
     isDarkText = false;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, foregroundColor, isDarkText })).toBe(
       "brand.primary"
     );
     type = "body";
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, foregroundColor, isDarkText })).toBe(
+      "brand.primary"
+    );
+  });
+  it("returns textColor", () => {
+    type = "heading";
+    mode = "light";
+    isDarkText = false;
+    textColor = "brand.primary";
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
+      "brand.primary"
+    );
+    type = "body";
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "brand.primary"
     );
   });
   it("returns default heading text color", () => {
     type = "heading";
     mode = "light";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.inverse.heading"
     );
   });
   it("returns dark heading text color", () => {
     type = "heading";
     mode = "light";
-    foregroundColor = undefined;
+    textColor = undefined;
     isDarkText = true;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.heading"
     );
   });
   it("returns default body text color", () => {
     type = "body";
     mode = "light";
-    foregroundColor = undefined;
+    textColor = undefined;
     isDarkText = false;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.inverse.body"
     );
   });
   it("returns dark body text color", () => {
     type = "body";
     mode = "light";
-    foregroundColor = undefined;
+    textColor = undefined;
     isDarkText = true;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.body"
     );
   });
 });
 describe("Test getLinkColor function (hero.ts)", () => {
-  let state, foregroundColor, isDarkText;
+  let state, foregroundColor, isDarkText, textColor;
   it("returns foregroundColor", () => {
     state = "default";
     foregroundColor = "brand.primary";
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    expect(getLinkColor({ state, foregroundColor, isDarkText })).toBe(
+      "brand.primary"
+    );
+  });
+  it("returns textColor", () => {
+    state = "default";
+    isDarkText = false;
+    textColor = "brand.primary";
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "brand.primary"
     );
   });
   it("returns default link color", () => {
     state = "default";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "dark.ui.link.primary"
     );
   });
   it("returns default dark text link color", () => {
     state = "default";
-    foregroundColor = undefined;
     isDarkText = true;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "var(--nypl-colors-ui-link-primary) !important"
     );
   });
   it("returns hover link color", () => {
     state = "hover";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "dark.ui.link.secondary"
     );
   });
   it("returns dark text hover link color", () => {
     state = "hover";
-    foregroundColor = undefined;
     isDarkText = true;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "var(--nypl-colors-ui-link-secondary) !important"
     );
   });
   it("returns visted link color", () => {
     state = "visited";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "dark.ui.link.tertiary"
     );
   });
   it("returns dark text visted link color", () => {
     state = "visited";
-    foregroundColor = undefined;
     isDarkText = true;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "var(--nypl-colors-ui-link-tertiary) !important"
     );
   });

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -150,7 +150,7 @@ describe("Hero", () => {
         }
         backgroundImageSrc={getPlaceholderImage("smaller", 0)}
         foregroundColor="#123456"
-        backgroundColor="#654321"
+        textBackgroundColor="#654321"
       />
     );
 

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -35,7 +35,7 @@ export interface HeroProps extends BoxProps {
    * Note: not all `Hero` variants utilize this prop. */
   backgroundImageSrc?: string;
   /** Optional hex color value used to override the default text color for a
-   * given `Hero` variation.
+   * given `Hero` variant.
    * Note: not all `Hero` variants utilize this prop. */
   foregroundColor?: string;
   /** Optional heading element. */
@@ -56,6 +56,9 @@ export interface HeroProps extends BoxProps {
   /** Optional string used for the subheader that displays
    * underneath the heading element. */
   subHeaderText?: string | JSX.Element;
+  /** Optional hex color value used to override the default background color for
+   * a text content area in a given `Hero` variant. */
+  textBackgroundColor?: string;
   /** Used to control how the `Hero` component will be rendered. */
   variant?: HeroVariants;
 }
@@ -84,6 +87,7 @@ export const Hero: ChakraComponent<
         isDarkText,
         isDarkBackgroundImage = false,
         subHeaderText,
+        textBackgroundColor,
         ...rest
       } = props;
       const styles = useMultiStyleConfig("Hero", {
@@ -243,11 +247,17 @@ export const Hero: ChakraComponent<
           : { bgColor: tertiaryBgColor };
       }
 
+      /** The "tertiary" variant doesn't have an apparent content box, so that
+       * element will default to a transparent background in the "teriary"
+       * variant. */
       contentBoxStyling = {
         ...(foregroundColor && { color: foregroundColor }),
-        ...(backgroundColor
-          ? { backgroundColor }
-          : { bgColor: defaultBackgroundColor }),
+        ...(textBackgroundColor
+          ? { backgroundColor: textBackgroundColor }
+          : {
+              bgColor:
+                variant !== "tertiary" ? defaultBackgroundColor : undefined,
+            }),
       };
 
       if (foregroundColor && isDarkText) {

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -263,8 +263,8 @@ export const Hero: ChakraComponent<
        * element will default to a transparent background in the "teriary"
        * variant. */
       contentBoxStyling = {
-        ...((foregroundColor || textColor) && {
-          color: foregroundColor || textColor,
+        ...((textColor || foregroundColor) && {
+          color: textColor || foregroundColor,
         }),
         ...(textBackgroundColor
           ? { bgColor: textBackgroundColor }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -26,16 +26,16 @@ export interface HeroProps extends BoxProps {
    * the `backgroundImageSrc` will take precedence.
    */
   backdropBackgroundColor?: string;
-  /** Optional hex color value used to override the default background
-   * color for a given `Hero` variant.
+  /** Optional color value used to override the default background color for a
+   * given `Hero` variant.
    * Note: not all `Hero` variants utilize this prop. */
   backgroundColor?: string;
   /** Optional path to an image that will be used as a background image for the
    * `Hero` component.
    * Note: not all `Hero` variants utilize this prop. */
   backgroundImageSrc?: string;
-  /** Optional hex color value used to override the default text color for a
-   * given `Hero` variant.
+  /** Optional color value used to override the default text color for a given
+   * `Hero` variant.
    * Note: not all `Hero` variants utilize this prop. */
   foregroundColor?: string;
   /** Optional heading element. */
@@ -53,11 +53,11 @@ export interface HeroProps extends BoxProps {
    * the "campaign" variant. If true, the background image will be converted to
    * black & white and darkened to 60% black. */
   isDarkBackgroundImage?: boolean;
-  /** Optional string used for the subheader that displays
-   * underneath the heading element. */
+  /** Optional string used for the subheader that displays underneath the
+   * heading element. */
   subHeaderText?: string | JSX.Element;
-  /** Optional hex color value used to override the default background color for
-   * a text content area in a given `Hero` variant. */
+  /** Optional color value used to override the default background color for a
+   * text content area in a given `Hero` variant. */
   textBackgroundColor?: string;
   /** Used to control how the `Hero` component will be rendered. */
   variant?: HeroVariants;
@@ -253,7 +253,7 @@ export const Hero: ChakraComponent<
       contentBoxStyling = {
         ...(foregroundColor && { color: foregroundColor }),
         ...(textBackgroundColor
-          ? { backgroundColor: textBackgroundColor }
+          ? { bgColor: textBackgroundColor }
           : {
               bgColor:
                 variant !== "tertiary" ? defaultBackgroundColor : undefined,

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -28,14 +28,19 @@ export interface HeroProps extends BoxProps {
   backdropBackgroundColor?: string;
   /** Optional color value used to override the default background color for a
    * given `Hero` variant.
+   *
    * Note: not all `Hero` variants utilize this prop. */
   backgroundColor?: string;
   /** Optional path to an image that will be used as a background image for the
    * `Hero` component.
+   *
    * Note: not all `Hero` variants utilize this prop. */
   backgroundImageSrc?: string;
-  /** Optional color value used to override the default text color for a given
+  /** **This prop has been deprecated in favor of the `textColor` prop.**
+   *
+   * Optional color value used to override the default text color for a given
    * `Hero` variant.
+   *
    * Note: not all `Hero` variants utilize this prop. */
   foregroundColor?: string;
   /** Optional heading element. */
@@ -47,7 +52,8 @@ export interface HeroProps extends BoxProps {
    * `imageProps.src`, it will only work for the "campaign" `Hero` type. */
   imageProps?: HeroImageProps;
   /** Optional boolean used to toggle the default text color from light to dark.
-   * Set isDarkText to `true` if the backgroundColor is set to a light color. */
+   * Set `isDarkText` to `true` if the `textBackgroundColor` is set to a light
+   * color. */
   isDarkText?: boolean;
   /** Optional boolean used to toggle the treatment of the background image in
    * the "campaign" variant. If true, the background image will be converted to
@@ -59,6 +65,12 @@ export interface HeroProps extends BoxProps {
   /** Optional color value used to override the default background color for a
    * text content area in a given `Hero` variant. */
   textBackgroundColor?: string;
+  /** Optional color value used to override the default text color for a given
+   * `Hero` variant. This prop should be used in lieu of the deprecated
+   * `foregroundColor` prop.
+   *
+   * Note: not all `Hero` variants utilize this prop. */
+  textColor?: string;
   /** Used to control how the `Hero` component will be rendered. */
   variant?: HeroVariants;
 }
@@ -88,11 +100,13 @@ export const Hero: ChakraComponent<
         isDarkBackgroundImage = false,
         subHeaderText,
         textBackgroundColor,
+        textColor,
         ...rest
       } = props;
       const styles = useMultiStyleConfig("Hero", {
         foregroundColor,
         isDarkText,
+        textColor,
         variant,
       });
       const headingStyles = styles.heading;
@@ -239,19 +253,19 @@ export const Hero: ChakraComponent<
               },
             };
       } else if (variant === "tertiary") {
-        const tertiaryBgColor = backgroundColor
-          ? backgroundColor
-          : defaultBackgroundColor;
-        backgroundImageStyle = backgroundColor
-          ? { bgColor: backgroundColor }
-          : { bgColor: tertiaryBgColor };
+        backgroundImageStyle =
+          backgroundColor || textBackgroundColor
+            ? { bgColor: backgroundColor || textBackgroundColor }
+            : { bgColor: defaultBackgroundColor };
       }
 
       /** The "tertiary" variant doesn't have an apparent content box, so that
        * element will default to a transparent background in the "teriary"
        * variant. */
       contentBoxStyling = {
-        ...(foregroundColor && { color: foregroundColor }),
+        ...((foregroundColor || textColor) && {
+          color: foregroundColor || textColor,
+        }),
         ...(textBackgroundColor
           ? { bgColor: textBackgroundColor }
           : {
@@ -265,6 +279,14 @@ export const Hero: ChakraComponent<
           "NYPL Reservoir Hero: The `foregroundColor` and `isDarkText` props " +
             "have both been passed. Thse props can not be used at the same time, " +
             "so the `foregroundColor` prop will override the `isDarkText` prop."
+        );
+      }
+
+      if (textColor && isDarkText) {
+        console.warn(
+          "NYPL Reservoir Hero: The `textColor` and `isDarkText` props " +
+            "have both been passed. Thse props can not be used at the same time, " +
+            "so the `textColor` prop will override the `isDarkText` prop."
         );
       }
 

--- a/src/components/Hero/__snapshots__/Hero.test.tsx.snap
+++ b/src/components/Hero/__snapshots__/Hero.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Hero Renders the UI snapshot correctly 2`] = `
   data-testid="ds-hero"
 >
   <div
-    className="css-14tngpx"
+    className="css-0"
     data-testid="ds-hero-content"
   >
     <h1

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -10,6 +10,15 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: [
+      "Adds the `textBackgroundColor` prop to be used in lieu of the `backgroundColor` prop",
+    ],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",

--- a/src/components/Hero/heroChangelogData.ts
+++ b/src/components/Hero/heroChangelogData.ts
@@ -13,9 +13,12 @@ export const changelogData: ChangelogData[] = [
     date: "Prerelease",
     version: "Prerelease",
     type: "Update",
-    affects: ["Functionality"],
+    affects: ["Documentation", "Functionality", "Styles"],
     notes: [
-      "Adds the `textBackgroundColor` prop to be used in lieu of the `backgroundColor` prop",
+      "Adds the `textBackgroundColor` and `textColor` props.",
+      "Updates to use the `textBackgroundColor` prop in lieu of the `backgroundColor` prop.",
+      "Updates to use the `textColor` prop in lieu of the `foregroundColor` prop.",
+      "Deprecates the `foregroundColor` prop.",
     ],
   },
   {

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -408,7 +408,7 @@ export const NarrowExample = {
           />
           <Hero
             backgroundColor="section.research.primary"
-            foregroundColor="ui.white"
+            textColor="ui.white"
             variant="tertiary"
             heading={<Heading level="h1" id="1" text="Narrow content" />}
           />

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -105,35 +105,39 @@ const getSecondaryVariantStyles = (bgColor: string = "") => {
     },
   };
 };
-export const getTextColor = (type, mode, foregroundColor, isDarkText) => {
+export const getTextColor = (props) => {
+  const { type, mode, foregroundColor, isDarkText, textColor } = props;
   const prefix = mode === "dark" ? "dark.ui." : "ui.";
-  const colorLight = foregroundColor
-    ? foregroundColor
+  const finalTextColor = textColor || foregroundColor;
+  const colorLight = finalTextColor
+    ? finalTextColor
     : isDarkText
     ? `${prefix}typography.${type}`
     : `${prefix}typography.inverse.${type}`;
-  const colorDark = foregroundColor
-    ? foregroundColor
+  const colorDark = finalTextColor
+    ? finalTextColor
     : isDarkText
     ? `${prefix}typography.inverse.${type}`
     : `${prefix}typography.${type}`;
   const finalColor = mode === "dark" ? colorDark : colorLight;
   return finalColor;
 };
-export const getLinkColor = (state, foregroundColor, isDarkText) => {
+export const getLinkColor = (props) => {
+  const { state, foregroundColor, isDarkText, textColor } = props;
+  const finalTextColor = textColor || foregroundColor;
   let finalColor;
   switch (state) {
     case "hover": {
-      finalColor = foregroundColor
-        ? foregroundColor
+      finalColor = finalTextColor
+        ? finalTextColor
         : isDarkText
         ? `var(--nypl-colors-ui-link-secondary) !important`
         : `dark.ui.link.secondary`; // light mode and dark mode should use the same value, so there is no need to differentiate based on color mode
       break;
     }
     case "visited": {
-      finalColor = foregroundColor
-        ? foregroundColor
+      finalColor = finalTextColor
+        ? finalTextColor
         : isDarkText
         ? `var(--nypl-colors-ui-link-tertiary) !important`
         : `dark.ui.link.tertiary`; // light mode and dark mode should use the same value, so there is no need to differentiate based on color mode
@@ -141,8 +145,8 @@ export const getLinkColor = (state, foregroundColor, isDarkText) => {
     }
     case "default":
     default:
-      finalColor = foregroundColor
-        ? foregroundColor
+      finalColor = finalTextColor
+        ? finalTextColor
         : isDarkText
         ? `var(--nypl-colors-ui-link-primary) !important`
         : `dark.ui.link.primary`; // light mode and dark mode should use the same value, so there is no need to differentiate based on color mode
@@ -150,52 +154,84 @@ export const getLinkColor = (state, foregroundColor, isDarkText) => {
   return finalColor;
 };
 // Variant styling
-const primary = definePartsStyle(({ foregroundColor, isDarkText }) => {
-  return {
-    base: {
-      alignItems: "center",
-      backgroundSize: "cover",
-      backgroundPosition: "center",
-      display: "flex",
-      minHeight: "352px",
-      py: "l",
-    },
-    grid: {
-      display: "grid",
-      gridTemplateColumns: "repeat(12, 1fr)",
-      gap: responsiveSpacing.gridGap,
-      margin: "auto",
-      maxWidth: "1280px",
-      px: { base: "l", md: "s" },
-    },
-    content: {
-      bg: "ui.black",
-      color: getTextColor("body", "light", foregroundColor, isDarkText),
-      gridColumn: { base: "1 / -1", md: "2 / 12", lg: "3 / 11" },
-      p: "l",
-      a: {
-        color: "inherit",
-        display: "inline-block",
+const primary = definePartsStyle(
+  ({ foregroundColor, isDarkText, textColor }) => {
+    return {
+      base: {
+        alignItems: "center",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        display: "flex",
+        minHeight: "352px",
+        py: "l",
       },
-      bodyText: {
-        marginBottom: "0",
+      grid: {
+        display: "grid",
+        gridTemplateColumns: "repeat(12, 1fr)",
+        gap: responsiveSpacing.gridGap,
+        margin: "auto",
+        maxWidth: "1280px",
+        px: { base: "l", md: "s" },
       },
-      ".chakra-heading": {
-        color: getTextColor("heading", "light", foregroundColor, isDarkText),
-      },
-      _dark: {
-        bgColor: "dark.ui.bg.default",
-        color: getTextColor("body", "dark", foregroundColor, isDarkText),
+      content: {
+        bg: "ui.black",
+        color: getTextColor({
+          type: "body",
+          mode: "light",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+        gridColumn: { base: "1 / -1", md: "2 / 12", lg: "3 / 11" },
+        p: "l",
+        a: {
+          color: "inherit",
+          display: "inline-block",
+        },
+        bodyText: {
+          marginBottom: "0",
+        },
         ".chakra-heading": {
-          color: getTextColor("heading", "dark", foregroundColor, isDarkText),
+          color: getTextColor({
+            type: "heading",
+            mode: "light",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+        },
+        _dark: {
+          bgColor: "dark.ui.bg.default",
+          color: getTextColor({
+            type: "body",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+          ".chakra-heading": {
+            color: getTextColor({
+              type: "heading",
+              mode: "dark",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+          },
         },
       },
-    },
-    heading: {
-      color: getTextColor("heading", "dark", foregroundColor, isDarkText),
-    },
-  };
-});
+      heading: {
+        color: getTextColor({
+          type: "heading",
+          mode: "dark",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+      },
+    };
+  }
+);
 const secondary = getSecondaryVariantStyles();
 const secondaryBooksAndMore = getSecondaryVariantStyles(
   "section.books-and-more.primary"
@@ -209,152 +245,286 @@ const secondaryResearch = definePartsStyle(
 const secondaryWhatsOn = definePartsStyle(
   getSecondaryVariantStyles("section.whats-on.primary")
 );
-const tertiary = definePartsStyle(({ foregroundColor, isDarkText }) => ({
-  base: {
-    // Is this needed?
-    p: {
-      marginBottom: "0",
-    },
-  },
-  content: {
-    ...wrapperStyles,
-    color: getTextColor("body", "light", foregroundColor, isDarkText),
-    display: "flex",
-    flexFlow: "column nowrap",
-    px: responsiveSpacing.padding,
-    py: { base: "inset.default", xl: "inset.wide" },
-    a: {
-      color: getLinkColor("default", foregroundColor, isDarkText),
-      _hover: {
-        color: getLinkColor("hover", foregroundColor, isDarkText),
-      },
-      _visited: {
-        color: getLinkColor("visited", foregroundColor, isDarkText),
-        svg: {
-          fill: getLinkColor("visited", foregroundColor, isDarkText),
-        },
+const tertiary = definePartsStyle(
+  ({ foregroundColor, isDarkText, textColor }) => ({
+    base: {
+      // Is this needed?
+      p: {
+        marginBottom: "0",
       },
     },
-    p: {
-      marginBottom: "0",
-      marginTop: { base: "xxs", xl: "xs" },
-    },
-    ".chakra-heading": {
-      color: getTextColor("heading", "light", foregroundColor, isDarkText),
-    },
-    _dark: {
+    content: {
+      ...wrapperStyles,
+      color: getTextColor({
+        type: "body",
+        mode: "light",
+        foregroundColor,
+        isDarkText,
+        textColor,
+      }),
+      display: "flex",
+      flexFlow: "column nowrap",
+      px: responsiveSpacing.padding,
+      py: { base: "inset.default", xl: "inset.wide" },
       a: {
-        color: getLinkColor("default", foregroundColor, isDarkText),
+        color: getLinkColor({
+          stage: "default",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
         _hover: {
-          color: getLinkColor("hover", foregroundColor, isDarkText),
+          color: getLinkColor({
+            state: "hover",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
         },
         _visited: {
-          color: getLinkColor("visited", foregroundColor, isDarkText),
+          color: getLinkColor({
+            stage: "visited",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
           svg: {
-            fill: getLinkColor("visited", foregroundColor, isDarkText),
+            fill: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
           },
         },
       },
-      p: { color: getTextColor("body", "dark", foregroundColor, isDarkText) },
+      p: {
+        marginBottom: "0",
+        marginTop: { base: "xxs", xl: "xs" },
+      },
       ".chakra-heading": {
-        color: getTextColor("heading", "dark", foregroundColor, isDarkText),
+        color: getTextColor({
+          type: "heading",
+          mode: "light",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
       },
-    },
-  },
-  heading: {
-    color: "ui.typography.inverse.heading",
-    marginBottom: "0",
-    _lastChild: {
-      marginBottom: "0",
-    },
-  },
-}));
-const campaign = definePartsStyle(({ foregroundColor, isDarkText }) => ({
-  base: {
-    alignItems: "center",
-    display: "flex",
-    justifyContent: "center",
-    padding: {
-      base: "inset.wide",
-      md: "calc(var(--nypl-space-xxl) + var(--nypl-space-s)) var(--nypl-space-s) 0",
-    },
-    position: "relative",
-    a: {
-      color: "inherit",
-      display: "inline-block",
-    },
-    img: screenreaderOnly(),
-  },
-  content: {
-    alignItems: "stretch",
-    bg: "ui.black",
-    color: getTextColor("body", "light", foregroundColor, isDarkText),
-    display: "flex",
-    flexFlow: {
-      base: "column nowrap",
-      lg: "row nowrap",
-    },
-    minHeight: "320px",
-    flex: { md: "0 100%" },
-    maxWidth: { md: "1248px" },
-    position: { md: "relative" },
-    zIndex: 2,
-    a: {
-      color: getLinkColor("default", foregroundColor, isDarkText),
-      _hover: {
-        color: getLinkColor("hover", foregroundColor, isDarkText),
-      },
-      _visited: {
-        color: getLinkColor("visited", foregroundColor, isDarkText),
-        svg: {
-          fill: getLinkColor("visited", foregroundColor, isDarkText),
+      _dark: {
+        a: {
+          color: getLinkColor({
+            state: "default",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+          _hover: {
+            color: getLinkColor({
+              state: "hover",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+          },
+          _visited: {
+            color: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+            svg: {
+              fill: getLinkColor({
+                state: "visited",
+                foregroundColor,
+                isDarkText,
+                textColor,
+              }),
+            },
+          },
+        },
+        p: {
+          color: getTextColor({
+            type: "body",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+        },
+        ".chakra-heading": {
+          color: getTextColor({
+            type: "heading",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
         },
       },
     },
-    ".chakra-heading": {
-      color: getTextColor("heading", "light", foregroundColor, isDarkText),
+    heading: {
+      color: "ui.typography.inverse.heading",
+      marginBottom: "0",
+      _lastChild: {
+        marginBottom: "0",
+      },
     },
-    _dark: {
-      color: getTextColor("body", "dark", foregroundColor, isDarkText),
+  })
+);
+const campaign = definePartsStyle(
+  ({ foregroundColor, isDarkText, textColor }) => ({
+    base: {
+      alignItems: "center",
+      display: "flex",
+      justifyContent: "center",
+      padding: {
+        base: "inset.wide",
+        md: "calc(var(--nypl-space-xxl) + var(--nypl-space-s)) var(--nypl-space-s) 0",
+      },
+      position: "relative",
       a: {
-        color: getLinkColor("default", foregroundColor, isDarkText),
+        color: "inherit",
+        display: "inline-block",
+      },
+      img: screenreaderOnly(),
+    },
+    content: {
+      alignItems: "stretch",
+      bg: "ui.black",
+      color: getTextColor({
+        type: "body",
+        mode: "light",
+        foregroundColor,
+        isDarkText,
+        textColor,
+      }),
+      display: "flex",
+      flexFlow: {
+        base: "column nowrap",
+        lg: "row nowrap",
+      },
+      minHeight: "320px",
+      flex: { md: "0 100%" },
+      maxWidth: { md: "1248px" },
+      position: { md: "relative" },
+      zIndex: 2,
+      a: {
+        color: getLinkColor({
+          state: "default",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
         _hover: {
-          color: getLinkColor("hover", foregroundColor, isDarkText),
+          color: getLinkColor({
+            state: "hover",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
         },
         _visited: {
-          color: getLinkColor("visited", foregroundColor, isDarkText),
+          color: getLinkColor({
+            state: "visited",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
           svg: {
-            fill: getLinkColor("visited", foregroundColor, isDarkText),
+            fill: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
           },
         },
       },
       ".chakra-heading": {
-        color: getTextColor("heading", "dark", foregroundColor, isDarkText),
+        color: getTextColor({
+          type: "heading",
+          mode: "light",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+      },
+      _dark: {
+        color: getTextColor({
+          ype: "body",
+          mode: "dark",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+        a: {
+          color: getLinkColor({
+            state: "default",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+          _hover: {
+            color: getLinkColor({
+              state: "hover",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+          },
+          _visited: {
+            color: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+            svg: {
+              fill: getLinkColor({
+                state: "visited",
+                foregroundColor,
+                isDarkText,
+                textColor,
+              }),
+            },
+          },
+        },
+        ".chakra-heading": {
+          color: getTextColor({
+            type: "heading",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+        },
       },
     },
-  },
-  heading: {
-    color: "ui.typography.inverse.heading",
-  },
-  imgWrapper: {
-    backgroundPosition: "center",
-    backgroundSize: "cover",
-    minHeight: "230px",
-    width: {
-      base: "100%",
-      lg: "50%",
+    heading: {
+      color: "ui.typography.inverse.heading",
     },
-  },
-  interior: {
-    alignSelf: "center",
-    maxWidth: { md: "960px" },
-    padding: "inset.wide",
-    width: {
-      base: "100%",
-      lg: "50%",
+    imgWrapper: {
+      backgroundPosition: "center",
+      backgroundSize: "cover",
+      minHeight: "230px",
+      width: {
+        base: "100%",
+        lg: "50%",
+      },
     },
-  },
-}));
+    interior: {
+      alignSelf: "center",
+      maxWidth: { md: "960px" },
+      padding: "inset.wide",
+      width: {
+        base: "100%",
+        lg: "50%",
+      },
+    },
+  })
+);
 const fiftyFifty = definePartsStyle({
   base: {
     img: screenreaderOnly(),


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2156](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2156)

## This PR does the following:

- Updates the `Hero` component to add the `textBackgroundColor` prop to be used in lieu of the `backgroundColor` prop.

**NOTE:** Ultimately, extracting the `backgroundColor` prop from `rest` was not feasible. Instead, a new textBackgroundColor` props was added and used where backgroundColor was used previously to set the background color behind the text. 

**QUESTION:** For backward compatibility, should `backgroundColor` still be supported? Should conditions be added to use that prop if it is passed?

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2156]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ