### PR TITLE
DSD-2157: Hero textColor prop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,15 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Adds
 
 - Adds the `"contentCopy"` option to the `Icon` component.
+- Adds the `textColor` prop to the `Hero` component.
 
 ### Updates
 
 - Updates padding around clearable X button to avoid overlap in `TextInput`.
+
+### Deprecates
+
+- Deprecates the `foregroundColor` prop in the `Hero` component.
 
 ## 4.0.1 (September 11, 2025)
 

--- a/src/components/Hero/Hero.mdx
+++ b/src/components/Hero/Hero.mdx
@@ -100,7 +100,7 @@ Each `Hero` variation can be rendered through the `variant` prop.
 ### Primary
 
 The `"primary"` hero variant should be used with a `backgroundImageSrc` and a
-`heading`. `backgroundColor`, `foregroundColor`, and `subHeaderText` props may
+`heading`. `subHeaderText`, `textBackgroundColor`, and `textColor` props may
 also be used.
 
 <Story of={HeroStories.Primary} />
@@ -127,7 +127,7 @@ also be used.
 ### Tertiary
 
 The `"tertiary"` hero variant should be used with a `heading` prop.
-`backgroundColor`, `foregroundColor`, and `subHeaderText` props may also be used.
+`subHeaderText`, `textBackgroundColor`, and `textColor` props may also be used.
 
 <Story of={HeroStories.Tertiary} />
 
@@ -201,16 +201,16 @@ The `"tertiary"` hero variant should be used with a `heading` prop.
 
 ### Campaign
 
-The `"campaign"` hero variant should be used with `backgroundImageSrc`, `heading`,
-and `imageProps` props. `backdropBackgroundColor`, `backgroundColor`, `foregroundColor`,
-and `subHeaderText` props may also be used.
+The `"campaign"` hero variant should be used with `backgroundImageSrc`,
+`heading`, and `imageProps` props. `backdropBackgroundColor`, `subHeaderText`,
+`textBackgroundColor`, and `textColor` props may also be used.
 
 The `"campaign"` variant is special in that it has both a background and foreground.
 We understand that this naming can be confusing, but it helps to think of this
 variant having two layers.
 
-To modify the foreground, the `backgroundColor`, `foregroundColor`, `imageProps`
-props should be used.
+To modify the foreground, the `textBackgroundColor`, `textColor`, and
+`imageProps` props should be used.
 
 <Story of={HeroStories.Campaign} />
 
@@ -387,7 +387,6 @@ content.
   code={`
   <Hero
     backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
-    foregroundColor="ui.white"
     heading={
       <Heading
         id="primary-hero"
@@ -397,6 +396,7 @@ content.
         text="Hero Primary"
       />
     }
+    textColor="ui.white"
     textBackgroundColor="brand.primary"
     variant="primary"
   />
@@ -407,7 +407,6 @@ content.
 <Source
   code={`
   <Hero
-    foregroundColor="ui.white"
     heading={
       <Heading
         level="h1"
@@ -418,6 +417,7 @@ content.
       />
     }
     subHeaderText={otherSubHeaderText}
+    textColor="ui.white"
     textBackgroundColor="brand.primary"
     variant="tertiary"
   />
@@ -429,7 +429,6 @@ content.
   code={`
   <Hero
     backgroundImageSrc={getPlaceholderImage()}
-    foregroundColor="ui.white"
     heading={
       <Heading
         level="h1"
@@ -443,6 +442,7 @@ content.
       src: "https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg",
     }}
     subHeaderText={otherSubHeaderText}
+    textColor="ui.white"
     textBackgroundColor="brand.primary"
     variant="campaign"
   />
@@ -454,18 +454,18 @@ content.
 
 By default, the `Hero` component renders a dark background color with light
 text. This color treatment can be overridden using a combination of the
-`foregroundColor`, `textBackgroundColor`, and `isDarkText` props.
+`textBackgroundColor`, `textColor`, and `isDarkText` props.
 
-- `foregroundColor`: custom color value for the text
 - `textBackgroundColor`: custom color value for the text background
+- `textColor`: custom color value for the text
 - `isDarkText`: used to render default dark color value for the text
 
 <Banner
   content={
     <>
-      <strong>IMPORTANT:</strong> The <code>foregroundColor</code> prop will
-      override the <code>isDarkText</code> prop, so they should not be used at
-      the same time.
+      <strong>IMPORTANT:</strong> The <code>textColor</code> prop will override
+      the <code>isDarkText</code> prop, so they should not be used at the same
+      time.
     </>
   }
   mt="s"
@@ -501,7 +501,6 @@ applies to all variants.
   code={`
   <Hero
     backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-    foregroundColor="ui.error.secondary"
     heading={
       <Heading
         level="h1"
@@ -512,6 +511,7 @@ applies to all variants.
     imageProps={imageProps}
     isDarkBackgroundImage
     subHeaderText={otherSubHeaderText}
+    textColor="ui.error.secondary"
     textBackgroundColor="ui.status.primary"
     variant="campaign"
   />

--- a/src/components/Hero/Hero.stories.tsx
+++ b/src/components/Hero/Hero.stories.tsx
@@ -75,6 +75,8 @@ const meta: Meta<typeof Hero> = {
     },
     isDarkText: { control: false },
     subHeaderText: { control: false },
+    textBackgroundColor: { control: false },
+    textColor: { control: false },
     variant: {
       control: { type: "select" },
       options: heroVariantsArray,
@@ -103,6 +105,8 @@ export const WithControls: Story = {
     isDarkBackgroundImage: undefined,
     isDarkText: undefined,
     subHeaderText: undefined,
+    textBackgroundColor: undefined,
+    textColor: undefined,
     variant: "primary",
   },
   render: (args) =>
@@ -317,7 +321,6 @@ export const TextBackgroundColor: Story = {
       <div>
         <Hero
           backgroundImageSrc="https://iiif.nypl.org/iiif/2/5164274/full/!900,900/0/default.jpg"
-          foregroundColor="ui.white"
           heading={
             <Heading
               id="primary-hero"
@@ -328,12 +331,12 @@ export const TextBackgroundColor: Story = {
             />
           }
           textBackgroundColor="brand.primary"
+          textColor="ui.white"
           variant="primary"
         />
       </div>
       <div>
         <Hero
-          foregroundColor="ui.white"
           heading={
             <Heading
               level="h1"
@@ -345,13 +348,13 @@ export const TextBackgroundColor: Story = {
           }
           subHeaderText={otherSubHeaderText}
           textBackgroundColor="brand.primary"
+          textColor="ui.white"
           variant="tertiary"
         />
       </div>
       <div>
         <Hero
           backgroundImageSrc={getPlaceholderImage()}
-          foregroundColor="ui.white"
           heading={
             <Heading
               level="h1"
@@ -366,6 +369,7 @@ export const TextBackgroundColor: Story = {
           }}
           subHeaderText={otherSubHeaderText}
           textBackgroundColor="brand.primary"
+          textColor="ui.white"
           variant="campaign"
         />
       </div>
@@ -407,7 +411,6 @@ export const TextColorStyles: Story = {
         />
         <Hero
           backgroundImageSrc="https://images.nypl.org/index.php?id=swope_244712&t=w"
-          foregroundColor="ui.error.secondary"
           heading={
             <Heading
               level="h1"
@@ -420,6 +423,7 @@ export const TextColorStyles: Story = {
           isDarkBackgroundImage
           subHeaderText={otherSubHeaderText}
           textBackgroundColor="ui.status.primary"
+          textColor="ui.error.secondary"
           variant="campaign"
         />
       </div>

--- a/src/components/Hero/Hero.test.tsx
+++ b/src/components/Hero/Hero.test.tsx
@@ -149,7 +149,7 @@ describe("Hero", () => {
           />
         }
         backgroundImageSrc={getPlaceholderImage("smaller", 0)}
-        foregroundColor="#123456"
+        textColor="#123456"
         textBackgroundColor="#654321"
       />
     );
@@ -344,6 +344,26 @@ describe("Hero", () => {
     );
   });
 
+  it("logs a warning if `textColor` and `isDarkText` props are both passed", () => {
+    const warn = jest.spyOn(console, "warn");
+    render(
+      <Hero
+        variant="campaign"
+        imageProps={imageProps}
+        isDarkBackgroundImage
+        isDarkText
+        subHeaderText={otherSubHeaderText}
+        textColor="ui.black"
+      />
+    );
+
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Hero: The `textColor` and `isDarkText` props " +
+        "have both been passed. Thse props can not be used at the same time, " +
+        "so the `textColor` prop will override the `isDarkText` prop."
+    );
+  });
+
   it("logs a warning when the main image fails to load and the fallback image is rendered", () => {
     const warn = jest.spyOn(console, "warn");
     const onError = jest.fn();
@@ -453,112 +473,133 @@ describe("Hero", () => {
   });
 });
 describe("Test getTextColor function (hero.ts)", () => {
-  let type, mode, foregroundColor, isDarkText;
+  let type, mode, foregroundColor, isDarkText, textColor;
   it("returns foregroundColor", () => {
     type = "heading";
     mode = "light";
     foregroundColor = "brand.primary";
     isDarkText = false;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, foregroundColor, isDarkText })).toBe(
       "brand.primary"
     );
     type = "body";
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, foregroundColor, isDarkText })).toBe(
+      "brand.primary"
+    );
+  });
+  it("returns textColor", () => {
+    type = "heading";
+    mode = "light";
+    isDarkText = false;
+    textColor = "brand.primary";
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
+      "brand.primary"
+    );
+    type = "body";
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "brand.primary"
     );
   });
   it("returns default heading text color", () => {
     type = "heading";
     mode = "light";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.inverse.heading"
     );
   });
   it("returns dark heading text color", () => {
     type = "heading";
     mode = "light";
-    foregroundColor = undefined;
+    textColor = undefined;
     isDarkText = true;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.heading"
     );
   });
   it("returns default body text color", () => {
     type = "body";
     mode = "light";
-    foregroundColor = undefined;
+    textColor = undefined;
     isDarkText = false;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.inverse.body"
     );
   });
   it("returns dark body text color", () => {
     type = "body";
     mode = "light";
-    foregroundColor = undefined;
+    textColor = undefined;
     isDarkText = true;
-    expect(getTextColor(type, mode, foregroundColor, isDarkText)).toBe(
+    expect(getTextColor({ type, mode, isDarkText, textColor })).toBe(
       "ui.typography.body"
     );
   });
 });
 describe("Test getLinkColor function (hero.ts)", () => {
-  let state, foregroundColor, isDarkText;
+  let state, foregroundColor, isDarkText, textColor;
   it("returns foregroundColor", () => {
     state = "default";
     foregroundColor = "brand.primary";
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    expect(getLinkColor({ state, foregroundColor, isDarkText })).toBe(
+      "brand.primary"
+    );
+  });
+  it("returns textColor", () => {
+    state = "default";
+    isDarkText = false;
+    textColor = "brand.primary";
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "brand.primary"
     );
   });
   it("returns default link color", () => {
     state = "default";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "dark.ui.link.primary"
     );
   });
   it("returns default dark text link color", () => {
     state = "default";
-    foregroundColor = undefined;
     isDarkText = true;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "var(--nypl-colors-ui-link-primary) !important"
     );
   });
   it("returns hover link color", () => {
     state = "hover";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "dark.ui.link.secondary"
     );
   });
   it("returns dark text hover link color", () => {
     state = "hover";
-    foregroundColor = undefined;
     isDarkText = true;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "var(--nypl-colors-ui-link-secondary) !important"
     );
   });
   it("returns visted link color", () => {
     state = "visited";
-    foregroundColor = undefined;
     isDarkText = false;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "dark.ui.link.tertiary"
     );
   });
   it("returns dark text visted link color", () => {
     state = "visited";
-    foregroundColor = undefined;
     isDarkText = true;
-    expect(getLinkColor(state, foregroundColor, isDarkText)).toBe(
+    textColor = undefined;
+    expect(getLinkColor({ state, isDarkText, textColor })).toBe(
       "var(--nypl-colors-ui-link-tertiary) !important"
     );
   });

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -263,8 +263,8 @@ export const Hero: ChakraComponent<
        * element will default to a transparent background in the "teriary"
        * variant. */
       contentBoxStyling = {
-        ...((foregroundColor || textColor) && {
-          color: foregroundColor || textColor,
+        ...((textColor || foregroundColor) && {
+          color: textColor || foregroundColor,
         }),
         ...(textBackgroundColor
           ? { bgColor: textBackgroundColor }

--- a/src/components/Hero/Hero.tsx
+++ b/src/components/Hero/Hero.tsx
@@ -28,14 +28,19 @@ export interface HeroProps extends BoxProps {
   backdropBackgroundColor?: string;
   /** Optional color value used to override the default background color for a
    * given `Hero` variant.
+   *
    * Note: not all `Hero` variants utilize this prop. */
   backgroundColor?: string;
   /** Optional path to an image that will be used as a background image for the
    * `Hero` component.
+   *
    * Note: not all `Hero` variants utilize this prop. */
   backgroundImageSrc?: string;
-  /** Optional color value used to override the default text color for a given
+  /** **This prop has been deprecated in favor of the `textColor` prop.**
+   *
+   * Optional color value used to override the default text color for a given
    * `Hero` variant.
+   *
    * Note: not all `Hero` variants utilize this prop. */
   foregroundColor?: string;
   /** Optional heading element. */
@@ -47,7 +52,8 @@ export interface HeroProps extends BoxProps {
    * `imageProps.src`, it will only work for the "campaign" `Hero` type. */
   imageProps?: HeroImageProps;
   /** Optional boolean used to toggle the default text color from light to dark.
-   * Set isDarkText to `true` if the backgroundColor is set to a light color. */
+   * Set `isDarkText` to `true` if the `textBackgroundColor` is set to a light
+   * color. */
   isDarkText?: boolean;
   /** Optional boolean used to toggle the treatment of the background image in
    * the "campaign" variant. If true, the background image will be converted to
@@ -59,6 +65,12 @@ export interface HeroProps extends BoxProps {
   /** Optional color value used to override the default background color for a
    * text content area in a given `Hero` variant. */
   textBackgroundColor?: string;
+  /** Optional color value used to override the default text color for a given
+   * `Hero` variant. This prop should be used in lieu of the deprecated
+   * `foregroundColor` prop.
+   *
+   * Note: not all `Hero` variants utilize this prop. */
+  textColor?: string;
   /** Used to control how the `Hero` component will be rendered. */
   variant?: HeroVariants;
 }
@@ -88,11 +100,13 @@ export const Hero: ChakraComponent<
         isDarkBackgroundImage = false,
         subHeaderText,
         textBackgroundColor,
+        textColor,
         ...rest
       } = props;
       const styles = useMultiStyleConfig("Hero", {
         foregroundColor,
         isDarkText,
+        textColor,
         variant,
       });
       const headingStyles = styles.heading;
@@ -239,19 +253,19 @@ export const Hero: ChakraComponent<
               },
             };
       } else if (variant === "tertiary") {
-        const tertiaryBgColor = backgroundColor
-          ? backgroundColor
-          : defaultBackgroundColor;
-        backgroundImageStyle = backgroundColor
-          ? { bgColor: backgroundColor }
-          : { bgColor: tertiaryBgColor };
+        backgroundImageStyle =
+          backgroundColor || textBackgroundColor
+            ? { bgColor: backgroundColor || textBackgroundColor }
+            : { bgColor: defaultBackgroundColor };
       }
 
       /** The "tertiary" variant doesn't have an apparent content box, so that
        * element will default to a transparent background in the "teriary"
        * variant. */
       contentBoxStyling = {
-        ...(foregroundColor && { color: foregroundColor }),
+        ...((foregroundColor || textColor) && {
+          color: foregroundColor || textColor,
+        }),
         ...(textBackgroundColor
           ? { bgColor: textBackgroundColor }
           : {
@@ -265,6 +279,14 @@ export const Hero: ChakraComponent<
           "NYPL Reservoir Hero: The `foregroundColor` and `isDarkText` props " +
             "have both been passed. Thse props can not be used at the same time, " +
             "so the `foregroundColor` prop will override the `isDarkText` prop."
+        );
+      }
+
+      if (textColor && isDarkText) {
+        console.warn(
+          "NYPL Reservoir Hero: The `textColor` and `isDarkText` props " +
+            "have both been passed. Thse props can not be used at the same time, " +
+            "so the `textColor` prop will override the `isDarkText` prop."
         );
       }
 

--- a/src/components/Template/Template.stories.tsx
+++ b/src/components/Template/Template.stories.tsx
@@ -408,7 +408,7 @@ export const NarrowExample = {
           />
           <Hero
             backgroundColor="section.research.primary"
-            foregroundColor="ui.white"
+            textColor="ui.white"
             variant="tertiary"
             heading={<Heading level="h1" id="1" text="Narrow content" />}
           />

--- a/src/theme/components/hero.ts
+++ b/src/theme/components/hero.ts
@@ -105,35 +105,39 @@ const getSecondaryVariantStyles = (bgColor: string = "") => {
     },
   };
 };
-export const getTextColor = (type, mode, foregroundColor, isDarkText) => {
+export const getTextColor = (props) => {
+  const { type, mode, foregroundColor, isDarkText, textColor } = props;
   const prefix = mode === "dark" ? "dark.ui." : "ui.";
-  const colorLight = foregroundColor
-    ? foregroundColor
+  const finalTextColor = textColor || foregroundColor;
+  const colorLight = finalTextColor
+    ? finalTextColor
     : isDarkText
     ? `${prefix}typography.${type}`
     : `${prefix}typography.inverse.${type}`;
-  const colorDark = foregroundColor
-    ? foregroundColor
+  const colorDark = finalTextColor
+    ? finalTextColor
     : isDarkText
     ? `${prefix}typography.inverse.${type}`
     : `${prefix}typography.${type}`;
   const finalColor = mode === "dark" ? colorDark : colorLight;
   return finalColor;
 };
-export const getLinkColor = (state, foregroundColor, isDarkText) => {
+export const getLinkColor = (props) => {
+  const { state, foregroundColor, isDarkText, textColor } = props;
+  const finalTextColor = textColor || foregroundColor;
   let finalColor;
   switch (state) {
     case "hover": {
-      finalColor = foregroundColor
-        ? foregroundColor
+      finalColor = finalTextColor
+        ? finalTextColor
         : isDarkText
         ? `var(--nypl-colors-ui-link-secondary) !important`
         : `dark.ui.link.secondary`; // light mode and dark mode should use the same value, so there is no need to differentiate based on color mode
       break;
     }
     case "visited": {
-      finalColor = foregroundColor
-        ? foregroundColor
+      finalColor = finalTextColor
+        ? finalTextColor
         : isDarkText
         ? `var(--nypl-colors-ui-link-tertiary) !important`
         : `dark.ui.link.tertiary`; // light mode and dark mode should use the same value, so there is no need to differentiate based on color mode
@@ -141,8 +145,8 @@ export const getLinkColor = (state, foregroundColor, isDarkText) => {
     }
     case "default":
     default:
-      finalColor = foregroundColor
-        ? foregroundColor
+      finalColor = finalTextColor
+        ? finalTextColor
         : isDarkText
         ? `var(--nypl-colors-ui-link-primary) !important`
         : `dark.ui.link.primary`; // light mode and dark mode should use the same value, so there is no need to differentiate based on color mode
@@ -150,52 +154,84 @@ export const getLinkColor = (state, foregroundColor, isDarkText) => {
   return finalColor;
 };
 // Variant styling
-const primary = definePartsStyle(({ foregroundColor, isDarkText }) => {
-  return {
-    base: {
-      alignItems: "center",
-      backgroundSize: "cover",
-      backgroundPosition: "center",
-      display: "flex",
-      minHeight: "352px",
-      py: "l",
-    },
-    grid: {
-      display: "grid",
-      gridTemplateColumns: "repeat(12, 1fr)",
-      gap: responsiveSpacing.gridGap,
-      margin: "auto",
-      maxWidth: "1280px",
-      px: { base: "l", md: "s" },
-    },
-    content: {
-      bg: "ui.black",
-      color: getTextColor("body", "light", foregroundColor, isDarkText),
-      gridColumn: { base: "1 / -1", md: "2 / 12", lg: "3 / 11" },
-      p: "l",
-      a: {
-        color: "inherit",
-        display: "inline-block",
+const primary = definePartsStyle(
+  ({ foregroundColor, isDarkText, textColor }) => {
+    return {
+      base: {
+        alignItems: "center",
+        backgroundSize: "cover",
+        backgroundPosition: "center",
+        display: "flex",
+        minHeight: "352px",
+        py: "l",
       },
-      bodyText: {
-        marginBottom: "0",
+      grid: {
+        display: "grid",
+        gridTemplateColumns: "repeat(12, 1fr)",
+        gap: responsiveSpacing.gridGap,
+        margin: "auto",
+        maxWidth: "1280px",
+        px: { base: "l", md: "s" },
       },
-      ".chakra-heading": {
-        color: getTextColor("heading", "light", foregroundColor, isDarkText),
-      },
-      _dark: {
-        bgColor: "dark.ui.bg.default",
-        color: getTextColor("body", "dark", foregroundColor, isDarkText),
+      content: {
+        bg: "ui.black",
+        color: getTextColor({
+          type: "body",
+          mode: "light",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+        gridColumn: { base: "1 / -1", md: "2 / 12", lg: "3 / 11" },
+        p: "l",
+        a: {
+          color: "inherit",
+          display: "inline-block",
+        },
+        bodyText: {
+          marginBottom: "0",
+        },
         ".chakra-heading": {
-          color: getTextColor("heading", "dark", foregroundColor, isDarkText),
+          color: getTextColor({
+            type: "heading",
+            mode: "light",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+        },
+        _dark: {
+          bgColor: "dark.ui.bg.default",
+          color: getTextColor({
+            type: "body",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+          ".chakra-heading": {
+            color: getTextColor({
+              type: "heading",
+              mode: "dark",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+          },
         },
       },
-    },
-    heading: {
-      color: getTextColor("heading", "dark", foregroundColor, isDarkText),
-    },
-  };
-});
+      heading: {
+        color: getTextColor({
+          type: "heading",
+          mode: "dark",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+      },
+    };
+  }
+);
 const secondary = getSecondaryVariantStyles();
 const secondaryBooksAndMore = getSecondaryVariantStyles(
   "section.books-and-more.primary"
@@ -209,152 +245,286 @@ const secondaryResearch = definePartsStyle(
 const secondaryWhatsOn = definePartsStyle(
   getSecondaryVariantStyles("section.whats-on.primary")
 );
-const tertiary = definePartsStyle(({ foregroundColor, isDarkText }) => ({
-  base: {
-    // Is this needed?
-    p: {
-      marginBottom: "0",
-    },
-  },
-  content: {
-    ...wrapperStyles,
-    color: getTextColor("body", "light", foregroundColor, isDarkText),
-    display: "flex",
-    flexFlow: "column nowrap",
-    px: responsiveSpacing.padding,
-    py: { base: "inset.default", xl: "inset.wide" },
-    a: {
-      color: getLinkColor("default", foregroundColor, isDarkText),
-      _hover: {
-        color: getLinkColor("hover", foregroundColor, isDarkText),
-      },
-      _visited: {
-        color: getLinkColor("visited", foregroundColor, isDarkText),
-        svg: {
-          fill: getLinkColor("visited", foregroundColor, isDarkText),
-        },
+const tertiary = definePartsStyle(
+  ({ foregroundColor, isDarkText, textColor }) => ({
+    base: {
+      // Is this needed?
+      p: {
+        marginBottom: "0",
       },
     },
-    p: {
-      marginBottom: "0",
-      marginTop: { base: "xxs", xl: "xs" },
-    },
-    ".chakra-heading": {
-      color: getTextColor("heading", "light", foregroundColor, isDarkText),
-    },
-    _dark: {
+    content: {
+      ...wrapperStyles,
+      color: getTextColor({
+        type: "body",
+        mode: "light",
+        foregroundColor,
+        isDarkText,
+        textColor,
+      }),
+      display: "flex",
+      flexFlow: "column nowrap",
+      px: responsiveSpacing.padding,
+      py: { base: "inset.default", xl: "inset.wide" },
       a: {
-        color: getLinkColor("default", foregroundColor, isDarkText),
+        color: getLinkColor({
+          stage: "default",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
         _hover: {
-          color: getLinkColor("hover", foregroundColor, isDarkText),
+          color: getLinkColor({
+            state: "hover",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
         },
         _visited: {
-          color: getLinkColor("visited", foregroundColor, isDarkText),
+          color: getLinkColor({
+            stage: "visited",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
           svg: {
-            fill: getLinkColor("visited", foregroundColor, isDarkText),
+            fill: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
           },
         },
       },
-      p: { color: getTextColor("body", "dark", foregroundColor, isDarkText) },
+      p: {
+        marginBottom: "0",
+        marginTop: { base: "xxs", xl: "xs" },
+      },
       ".chakra-heading": {
-        color: getTextColor("heading", "dark", foregroundColor, isDarkText),
+        color: getTextColor({
+          type: "heading",
+          mode: "light",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
       },
-    },
-  },
-  heading: {
-    color: "ui.typography.inverse.heading",
-    marginBottom: "0",
-    _lastChild: {
-      marginBottom: "0",
-    },
-  },
-}));
-const campaign = definePartsStyle(({ foregroundColor, isDarkText }) => ({
-  base: {
-    alignItems: "center",
-    display: "flex",
-    justifyContent: "center",
-    padding: {
-      base: "inset.wide",
-      md: "calc(var(--nypl-space-xxl) + var(--nypl-space-s)) var(--nypl-space-s) 0",
-    },
-    position: "relative",
-    a: {
-      color: "inherit",
-      display: "inline-block",
-    },
-    img: screenreaderOnly(),
-  },
-  content: {
-    alignItems: "stretch",
-    bg: "ui.black",
-    color: getTextColor("body", "light", foregroundColor, isDarkText),
-    display: "flex",
-    flexFlow: {
-      base: "column nowrap",
-      lg: "row nowrap",
-    },
-    minHeight: "320px",
-    flex: { md: "0 100%" },
-    maxWidth: { md: "1248px" },
-    position: { md: "relative" },
-    zIndex: 2,
-    a: {
-      color: getLinkColor("default", foregroundColor, isDarkText),
-      _hover: {
-        color: getLinkColor("hover", foregroundColor, isDarkText),
-      },
-      _visited: {
-        color: getLinkColor("visited", foregroundColor, isDarkText),
-        svg: {
-          fill: getLinkColor("visited", foregroundColor, isDarkText),
+      _dark: {
+        a: {
+          color: getLinkColor({
+            state: "default",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+          _hover: {
+            color: getLinkColor({
+              state: "hover",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+          },
+          _visited: {
+            color: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+            svg: {
+              fill: getLinkColor({
+                state: "visited",
+                foregroundColor,
+                isDarkText,
+                textColor,
+              }),
+            },
+          },
+        },
+        p: {
+          color: getTextColor({
+            type: "body",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+        },
+        ".chakra-heading": {
+          color: getTextColor({
+            type: "heading",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
         },
       },
     },
-    ".chakra-heading": {
-      color: getTextColor("heading", "light", foregroundColor, isDarkText),
+    heading: {
+      color: "ui.typography.inverse.heading",
+      marginBottom: "0",
+      _lastChild: {
+        marginBottom: "0",
+      },
     },
-    _dark: {
-      color: getTextColor("body", "dark", foregroundColor, isDarkText),
+  })
+);
+const campaign = definePartsStyle(
+  ({ foregroundColor, isDarkText, textColor }) => ({
+    base: {
+      alignItems: "center",
+      display: "flex",
+      justifyContent: "center",
+      padding: {
+        base: "inset.wide",
+        md: "calc(var(--nypl-space-xxl) + var(--nypl-space-s)) var(--nypl-space-s) 0",
+      },
+      position: "relative",
       a: {
-        color: getLinkColor("default", foregroundColor, isDarkText),
+        color: "inherit",
+        display: "inline-block",
+      },
+      img: screenreaderOnly(),
+    },
+    content: {
+      alignItems: "stretch",
+      bg: "ui.black",
+      color: getTextColor({
+        type: "body",
+        mode: "light",
+        foregroundColor,
+        isDarkText,
+        textColor,
+      }),
+      display: "flex",
+      flexFlow: {
+        base: "column nowrap",
+        lg: "row nowrap",
+      },
+      minHeight: "320px",
+      flex: { md: "0 100%" },
+      maxWidth: { md: "1248px" },
+      position: { md: "relative" },
+      zIndex: 2,
+      a: {
+        color: getLinkColor({
+          state: "default",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
         _hover: {
-          color: getLinkColor("hover", foregroundColor, isDarkText),
+          color: getLinkColor({
+            state: "hover",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
         },
         _visited: {
-          color: getLinkColor("visited", foregroundColor, isDarkText),
+          color: getLinkColor({
+            state: "visited",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
           svg: {
-            fill: getLinkColor("visited", foregroundColor, isDarkText),
+            fill: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
           },
         },
       },
       ".chakra-heading": {
-        color: getTextColor("heading", "dark", foregroundColor, isDarkText),
+        color: getTextColor({
+          type: "heading",
+          mode: "light",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+      },
+      _dark: {
+        color: getTextColor({
+          ype: "body",
+          mode: "dark",
+          foregroundColor,
+          isDarkText,
+          textColor,
+        }),
+        a: {
+          color: getLinkColor({
+            state: "default",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+          _hover: {
+            color: getLinkColor({
+              state: "hover",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+          },
+          _visited: {
+            color: getLinkColor({
+              state: "visited",
+              foregroundColor,
+              isDarkText,
+              textColor,
+            }),
+            svg: {
+              fill: getLinkColor({
+                state: "visited",
+                foregroundColor,
+                isDarkText,
+                textColor,
+              }),
+            },
+          },
+        },
+        ".chakra-heading": {
+          color: getTextColor({
+            type: "heading",
+            mode: "dark",
+            foregroundColor,
+            isDarkText,
+            textColor,
+          }),
+        },
       },
     },
-  },
-  heading: {
-    color: "ui.typography.inverse.heading",
-  },
-  imgWrapper: {
-    backgroundPosition: "center",
-    backgroundSize: "cover",
-    minHeight: "230px",
-    width: {
-      base: "100%",
-      lg: "50%",
+    heading: {
+      color: "ui.typography.inverse.heading",
     },
-  },
-  interior: {
-    alignSelf: "center",
-    maxWidth: { md: "960px" },
-    padding: "inset.wide",
-    width: {
-      base: "100%",
-      lg: "50%",
+    imgWrapper: {
+      backgroundPosition: "center",
+      backgroundSize: "cover",
+      minHeight: "230px",
+      width: {
+        base: "100%",
+        lg: "50%",
+      },
     },
-  },
-}));
+    interior: {
+      alignSelf: "center",
+      maxWidth: { md: "960px" },
+      padding: "inset.wide",
+      width: {
+        base: "100%",
+        lg: "50%",
+      },
+    },
+  })
+);
 const fiftyFifty = definePartsStyle({
   base: {
     img: screenreaderOnly(),


### PR DESCRIPTION
Fixes JIRA ticket [DSD-2157](https://newyorkpubliclibrary.atlassian.net/browse/DSD-2157)

## This PR does the following:

- Updates the `Hero` component to add a new `textColor` prop.
- Updates the `Hero` component to deprecate the `foregroundColor` prop.

NOTE: I considered removing the use of `backgroundColor` in the `tertiary` variant, but realized that would be a breaking change. Instead, both `backgroundColor` and `textBackgroundColor` will do the same thing in the `tertiary` variant.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-2157]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-2157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ