### PR TITLE
ISW-5048: Add `as` prop to `SubNavLink`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Adds
+
+- Adds `as` prop to `SubNavLink`.
+
 ## 4.0.2 (September 30, 2025)
 
 ### Adds

--- a/src/components/SubNav/SubNav.mdx
+++ b/src/components/SubNav/SubNav.mdx
@@ -21,7 +21,7 @@ import { changelogData } from "./subNavChangelogData";
   componentName="SubNav"
   summary="Renders a group of secondary navigation and action items"
   versionAdded="3.5.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={SubNavStories.WithControls} />

--- a/src/components/SubNav/SubNav.mdx
+++ b/src/components/SubNav/SubNav.mdx
@@ -101,6 +101,22 @@ the DS `Button` and `Link` components, respectively, with the addition of the
 
 ### SubNavLink
 
+<Banner
+  content={
+    <>
+      <strong>NOTE:</strong> <code>SubNavLink</code>s can also use a custom link
+      component passed in the <code>as</code> prop– see{" "}
+      <a href="./?path=/docs/components-navigation-link--docs#link-with-routers">
+        Link with routers
+      </a>
+      .
+    </>
+  }
+  mt="s"
+  mb="s"
+  variant="informative"
+/>
+
 <Source
   code={`
   <SubNavLink

--- a/src/components/SubNav/SubNav.tsx
+++ b/src/components/SubNav/SubNav.tsx
@@ -7,7 +7,6 @@ import {
   Flex,
   BoxProps,
 } from "@chakra-ui/react";
-import type { As } from "@chakra-ui/react";
 import Button from "../Button/Button";
 import Link from "../Link/Link";
 import List from "../List/List";
@@ -49,9 +48,8 @@ interface SubNavItemProps {
   screenreaderOnlyText?: string;
 }
 
-interface SubNavLinkProps extends SubNavItemProps {
+interface SubNavLinkProps extends SubNavItemProps, Pick<BoxProps, "as"> {
   href: string;
-  as?: As;
 }
 
 interface SubNavButtonProps extends SubNavItemProps {

--- a/src/components/SubNav/SubNav.tsx
+++ b/src/components/SubNav/SubNav.tsx
@@ -6,8 +6,8 @@ import {
   useMultiStyleConfig,
   Flex,
   BoxProps,
-  As,
 } from "@chakra-ui/react";
+import type { As } from "@chakra-ui/react";
 import Button from "../Button/Button";
 import Link from "../Link/Link";
 import List from "../List/List";

--- a/src/components/SubNav/SubNav.tsx
+++ b/src/components/SubNav/SubNav.tsx
@@ -6,6 +6,7 @@ import {
   useMultiStyleConfig,
   Flex,
   BoxProps,
+  As,
 } from "@chakra-ui/react";
 import Button from "../Button/Button";
 import Link from "../Link/Link";
@@ -50,6 +51,7 @@ interface SubNavItemProps {
 
 interface SubNavLinkProps extends SubNavItemProps {
   href: string;
+  as?: As;
 }
 
 interface SubNavButtonProps extends SubNavItemProps {
@@ -88,6 +90,7 @@ export const SubNavButton: React.FC<
 };
 
 export const SubNavLink: React.FC<React.PropsWithChildren<SubNavLinkProps>> = ({
+  as = "a",
   id,
   children,
   isOutlined,
@@ -111,6 +114,7 @@ export const SubNavLink: React.FC<React.PropsWithChildren<SubNavLinkProps>> = ({
         screenreaderOnlyText={screenreaderOnlyText}
         type="action"
         sx={childrenStyles.outLine}
+        as={as}
       >
         {children}
       </Link>

--- a/src/components/SubNav/subNavChangelogData.ts
+++ b/src/components/SubNav/subNavChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Adds `as` prop to `SubNavLink`."],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [ISW-5048](https://newyorkpubliclibrary.atlassian.net/browse/ISW-5048)

## This PR does the following:

- Adds the `as` prop to the `SubNavLink`
- Doesn't add to docs since I think this just allows what would already be expected given the `Link` behavior

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Hard to really test until it's in another app but follows the pattern of `Link`

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->


### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->


### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [x] Review the Vercel preview deployment once it is ready.


[ISW-5048]: https://newyorkpubliclibrary.atlassian.net/browse/ISW-5048?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ