### PR TITLE
ISW-5151: styles for full-click Card hover state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 - Adds `Images in Cards` to the `Style Guide`.
 - Adds `Cards as Navigation Links` to the `Development Guide`.
 - Adds hover state styles for "full-click" functionality in the `Card` component.
+- Adds `bg` color palette options that are defined using alpha transparency (rgba).
 
 ### Removes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,9 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 - Adds `Images in Cards` to the `Style Guide`.
 - Adds `Cards as Navigation Links` to the `Development Guide`.
+- Adds hover state styles for "full-click" functionality in the `Card` component.
 
-### Updates
+### Removes
 
 - Removes `New Arrivals` from the description of the `Books and More` colors.
 - Removes `iframe` and `[tabIndex]` selector from the global set focus styles

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -4,6 +4,7 @@ import {
   Description,
   Meta,
   Source,
+  Unstyled,
 } from "@storybook/addon-docs/blocks";
 import Banner from "../Banner/Banner";
 import * as CardStories from "./Card.stories";
@@ -33,13 +34,13 @@ import Link from "../Link/Link";
 - [Image size](#image-size)
 - [Custom image component](#custom-image-component)
 - [Fallback image](#fallback-image)
-- [Card with link heading](#card-with-link-heading)
-- [Card with full-click functionality](#card-with-full-click-functionality)
-- [Card with full-click functionality and tooltip](#card-with-full-click-functionality-and-tooltip)
-- [Card with right side CardActions](#card-with-right-side-cardactions)
-- [Cards in a grid](#cards-in-a-grid)
-- [Cards in a stack](#cards-in-a-stack)
-- [Cards without images](#cards-without-images)
+- [Linked heading](#linked-heading)
+- [Full-click functionality](#full-click-functionality)
+- [Full-click functionality and tooltip](#full-click-functionality-and-tooltip)
+- [Right side CardActions](#right-side-cardactions)
+- [Grid layout](#grid-layout)
+- [Stacked layout](#stacked-layout)
+- [Without image](#without-image)
 - [Changelog](#changelog)
 
 ## Overview
@@ -144,7 +145,7 @@ When adding `CardHeading` components, make sure to do the same.
   language="jsx"
 />
 
-### Full-click functionality
+### Full-click
 
 Passing a URL to the `mainActionLink` prop will make the entire `Card` clickable.
 Other links in the `CardActions` component can still be accessed by tabbing
@@ -157,17 +158,19 @@ a column layout and on the left in a row layout). However, you can use the
 `imageProps.isAtEnd` boolean prop to override the default placement and move the
 image to the last element within a `Card`.
 
-<Banner
-  content={
-    <>
-      <strong>NOTE:</strong> <code>Card</code> always displays as a column at
-      smaller container widths.
-    </>
-  }
-  mt="s"
-  mb="s"
-  variant="informative"
-/>
+<Unstyled>
+  <Banner
+    content={
+      <>
+        <strong>NOTE:</strong> <code>Card</code> always displays as a column at
+        smaller container widths.
+      </>
+    }
+    mt="s"
+    mb="s"
+    variant="informative"
+  />
+</Unstyled>
 
 ### Column cards
 
@@ -214,23 +217,23 @@ a general example.
 
 <Source
   code={`
-<Card
-  imageProps={{
-    alt: "Alt text",
-    fallbackSrc="https://loremflickr.com/540/420/cat"
-    onError: (_event) => console.log("Card fallback image loaded"),
-    src: "some-broken-image-url",
-  }}
->
-  // ...
-</Card>
+  <Card
+    imageProps={{
+      alt: "Alt text",
+      fallbackSrc="https://loremflickr.com/540/420/cat"
+      onError: (_event) => console.log("Card fallback image loaded"),
+      src: "some-broken-image-url",
+    }}
+  >
+    // ...
+  </Card>
   `}
   language="jsx"
 />
 
 <Canvas of={CardStories.FallbackImage} />
 
-## Card with link heading
+## Linked heading
 
 Making a `CardHeading` a link works just like the DS `Heading` component. This
 means that a URL can be passed in the `url` prop for `CardHeading` or a `Link`
@@ -238,7 +241,7 @@ component can be used as a child.
 
 <Canvas of={CardStories.HeadingAsLink} />
 
-## Card with full-click functionality
+## Full-click functionality
 
 To enable the full-click functionality in the `Card` component, pass a URL in
 the `mainActionLink` prop. This will make the entire `Card` component clickable.
@@ -249,13 +252,36 @@ Internally, if multiple `CardHeading` components are passed, only the first one
 will have the full-click link. This, however, does not affect the `Card` itself
 from being having the full-click functionality.
 
+See the [Cards as Navigation Links](/docs/development-guide-cards-as-navigation-links--docs)
+Development Guide for best practices when using cards as navigation elements.
+
+<Unstyled>
+  <Banner
+    content={
+      <>
+        <strong>IMPORTANT:</strong> Using full-click functionality will add
+        hover state styles to the <code>Card</code> component.
+      </>
+    }
+    mt="s"
+    mb="s"
+    variant="informative"
+  />
+</Unstyled>
+
 <Canvas of={CardStories.FullClick} />
+
+### Additional full-click examples
+
+<Canvas of={CardStories.FullClickGridLayout} />
+
+<Canvas of={CardStories.FullClickStackedLayout} />
 
 This example can be found in the [Turbine homepage](https://nypl-ds-test-app.vercel.app/).
 
 <Canvas of={CardStories.CardFullClickTurbineExample} />
 
-## Card with full-click functionality and tooltip
+## Full-click functionality and tooltip
 
 When the `Card` is fully clickable, an internal component wraps everything in a
 link, which in turn overrides the pointer events that trigger a tooltip.
@@ -302,7 +328,7 @@ accordingly– see below example.
 
 <Canvas of={CardStories.FullClickWithTooltip} />
 
-## Card with right side CardActions
+## Right side CardActions
 
 It's possible to set only the `CardActions` component on the right side of the
 main content area of the `Card`. This is possible only in the `layout="row"`
@@ -311,15 +337,15 @@ must be set to `true`.
 
 <Canvas of={CardStories.CardWithRightSideCardActions} />
 
-## Cards in a `Grid`
+## Grid layout
 
-<Canvas of={CardStories.GridExample} />
+<Canvas of={CardStories.GridLayout} />
 
-## Cards in a `Stack`
+## Stacked layout
 
-<Canvas of={CardStories.StackExample} />
+<Canvas of={CardStories.StackedLayout} />
 
-## Cards without images
+## Without image
 
 <Canvas of={CardStories.WithoutImages} />
 

--- a/src/components/Card/Card.mdx
+++ b/src/components/Card/Card.mdx
@@ -20,7 +20,7 @@ import Link from "../Link/Link";
   componentName="Card"
   summary="A flexible container used to group single-subject content in a self-contained format"
   versionAdded="0.24.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={CardStories.WithControls} />

--- a/src/components/Card/Card.stories.tsx
+++ b/src/components/Card/Card.stories.tsx
@@ -690,6 +690,229 @@ export const FullClick: Story = {
   name: "Full-Click Functionality",
 };
 
+export const FullClickGridLayout: Story = {
+  render: () => (
+    <SimpleGrid columns={3}>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="grid1-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+          libero, a pharetra augue.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="grid2-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+          libero, a pharetra augue.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="grid3-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+          libero, a pharetra augue.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="grid4-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+          libero, a pharetra augue.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="grid5-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+          libero, a pharetra augue.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="grid6-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Vestibulum id ligula porta felis euismod semper. Nulla vitae elit
+          libero, a pharetra augue.
+        </CardContent>
+      </Card>
+    </SimpleGrid>
+  ),
+  tags: ["!dev"], // exclude story from sidebar
+};
+
+export const FullClickStackedLayout: Story = {
+  render: () => (
+    <SimpleGrid columns={1}>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        isCentered
+        layout="row"
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="stack1-heading1"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+          Sed posuere consectetur est at lobortis. Cras justo odio, dapibus ac
+          facilisis in, egestas eget quam.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        isCentered
+        layout="row"
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="stack2-heading2"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+          Sed posuere consectetur est at lobortis. Cras justo odio, dapibus ac
+          facilisis in, egestas eget quam.
+        </CardContent>
+      </Card>
+      <Card
+        imageProps={{
+          alt: "Alt text",
+          aspectRatio: "twoByOne",
+          isLazy: true,
+          src: getPlaceholderImage("smaller"),
+        }}
+        isCentered
+        layout="row"
+        mainActionLink="http://nypl.org"
+      >
+        <CardHeading
+          level="h3"
+          id="stack3-heading3"
+          overline="New York Public Library"
+          size="heading5"
+        >
+          Card Heading
+        </CardHeading>
+        <CardContent>
+          Praesent commodo cursus magna, vel scelerisque nisl consectetur et.
+          Sed posuere consectetur est at lobortis. Cras justo odio, dapibus ac
+          facilisis in, egestas eget quam.
+        </CardContent>
+      </Card>
+    </SimpleGrid>
+  ),
+  tags: ["!dev"], // exclude story from sidebar
+};
+
 export const CardFullClickTurbineExample: Story = {
   render: () => (
     <SimpleGrid columns={3}>
@@ -757,6 +980,7 @@ export const CardFullClickTurbineExample: Story = {
     </SimpleGrid>
   ),
   name: "Full-Click Turbine Example",
+  tags: ["!dev"], // exclude story from sidebar
 };
 
 function FullClickWithTooltipExample() {
@@ -820,6 +1044,7 @@ function FullClickWithTooltipExample() {
 export const FullClickWithTooltip: Story = {
   name: "Full-Click With Tooltip",
   render: () => <FullClickWithTooltipExample />,
+  tags: ["!dev"], // exclude story from sidebar
 };
 
 export const CardWithRightSideCardActions: Story = {
@@ -869,7 +1094,7 @@ export const CardWithRightSideCardActions: Story = {
   ),
   name: "Right Side CardActions",
 };
-export const GridExample: Story = {
+export const GridLayout: Story = {
   render: () => (
     <SimpleGrid columns={3}>
       <Card
@@ -1002,7 +1227,7 @@ export const GridExample: Story = {
   ),
 };
 
-export const StackExample: Story = {
+export const StackedLayout: Story = {
   render: () => (
     <SimpleGrid columns={1}>
       <Card

--- a/src/components/Card/cardChangelogData.ts
+++ b/src/components/Card/cardChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ['Adds hover state styles for "full-click" functionality.'],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",

--- a/src/components/DevelopmentGuide/CardsAsNavigation.mdx
+++ b/src/components/DevelopmentGuide/CardsAsNavigation.mdx
@@ -8,7 +8,7 @@ import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import ImageRevamp from "../../utils/ImageExample";
 import { getPlaceholderImage } from "../../utils/utils";
 
-import { distinctLinksCard, fullClickCard } from "./CardsAsNavigation";
+import { distinctLinksCard, fullClickCard } from "../StyleGuide/CardsAsNavigation";
 
 <Meta title="Development Guide/Cards as Navigation Links" />
 

--- a/src/components/DevelopmentGuide/CardsAsNavigation.mdx
+++ b/src/components/DevelopmentGuide/CardsAsNavigation.mdx
@@ -8,7 +8,10 @@ import ComponentDocsHeader from "../../utils/components/ComponentDocsHeader";
 import ImageRevamp from "../../utils/ImageExample";
 import { getPlaceholderImage } from "../../utils/utils";
 
-import { distinctLinksCard, fullClickCard } from "../StyleGuide/CardsAsNavigation";
+import {
+  distinctLinksCard,
+  fullClickCard,
+} from "../StyleGuide/CardsAsNavigation";
 
 <Meta title="Development Guide/Cards as Navigation Links" />
 
@@ -35,19 +38,18 @@ sections. They may contain a single link or present multiple links and buttons.
 
 Navigational cards designed to link to a singular destination should be
 configured with [full-click
-functionality](/docs/components-basic-elements-card--docs#card-with-full-click-functionality),
+functionality](/docs/components-basic-elements-card--docs#full-click-functionality),
 rendering the entire card as a clickable element.
 
 It is recommended for NYPL web apps to utilize the DS `Card` component, as it
-provides the full-click functionality (via the `mainActionLink` prop), and will
-eventually include a hover state (thereby indicating that the complete card is a
-clickable element). To review the future DS `Card` styling, please consult
-the <Link href="https://nypl.github.io/design-team-prototypes/full-click-card-styles/#background-image-fade" variant="external">Default background color & image fade</Link> POC.
+provides the full-click functionality (via the `mainActionLink` prop) and
+includes a hover state (indicating that the complete card is a clickable
+element).
 
-Non-DS cards frequently apply identical links to both the heading and image
-within the card, resulting in a scenario where two distinct elements direct to
-the same destination. Using the DS `Card` component to implement full-click
-functionality will alleviate this redundancy.
+Additionally, non-DS cards frequently apply identical links to both the heading
+and image within the card, resulting in a scenario where two distinct elements
+direct to the same destination. Using the DS `Card` component to implement
+full-click functionality will alleviate this redundancy.
 
 ### Examples of full-click cards
 

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -129,10 +129,55 @@ const ReservoirCard = defineMultiStyleConfig({
           bodyMargin = "0";
         }
       }
+      // Hover state styles to be used with full-click functionality (mainActionLink)
+      const hoverState = () => {
+        if (mainActionLink) {
+          return {
+            outline: "0 solid",
+            outlineColor: "ui.bg.defaultAsAlpha",
+            transition: [
+              "background-color ease-out",
+              "outline ease-out",
+              "transform ease-out",
+            ].join(", "),
+            transitionDuration: "normal",
+            ".chakra-heading a": {
+              textDecorationColor: "transparent !important",
+              transition: "text-decoration-color ease-out",
+              transitionDuration: "normal",
+            },
+            img: {
+              transition: "opacity ease-out, filter ease-out",
+              transitionDuration: "normal",
+            },
+            _hover: {
+              backgroundColor: "ui.bg.defaultAsAlpha",
+              outline: "8px solid",
+              outlineColor: "ui.bg.defaultAsAlpha",
+              ".chakra-heading a": {
+                textDecorationColor:
+                  "var(--nypl-color-ui-link-secondary) !important",
+                _dark: {
+                  textDecorationColor:
+                    "var(--nypl-color-dark-ui-link-secondary) !important",
+                },
+              },
+              _dark: {
+                backgroundColor: "dark.ui.bg.defaultAsAlpha",
+                outlineColor: "dark.ui.bg.defaultAsAlpha",
+              },
+              img: {
+                filter: "brightness(75%)",
+              },
+            },
+          };
+        }
+      };
       // These sizes are only for the "row" layout.
       return {
         base: {
           containerType: "inline-size",
+          ...hoverState(),
           ...setContainerStyles({
             breakpoint: "base",
             styles: {

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -129,17 +129,14 @@ const ReservoirCard = defineMultiStyleConfig({
           bodyMargin = "0";
         }
       }
-      // Hover state styles to be used with full-click functionality (mainActionLink)
+      // Hover state styles to be used with full-click functionality
       const hoverState = () => {
         if (mainActionLink) {
           return {
             outline: "0 solid",
             outlineColor: "ui.bg.defaultAsAlpha",
-            transition: [
-              "background-color ease-out",
-              "outline ease-out",
-              "transform ease-out",
-            ].join(", "),
+            transition:
+              "background-color ease-out outline ease-out transform ease-out",
             transitionDuration: "normal",
             ".chakra-heading a": {
               textDecorationColor: "transparent !important",

--- a/src/theme/foundations/colors.ts
+++ b/src/theme/foundations/colors.ts
@@ -407,6 +407,9 @@ const colors: Colors = {
       default: grayxLightCool,
       hover: grayLightCool,
       active: grayMedium,
+      defaultAsAlpha: hexToRGB(black, 0.04),
+      hoverAsAlpha: hexToRGB(black, 0.09),
+      activeAsAlpha: hexToRGB(black, 0.26),
     },
     border: {
       default: grayMedium,
@@ -507,6 +510,9 @@ const colors: Colors = {
         default: grayxxxDark,
         hover: grayxxDark,
         active: grayxDark,
+        defaultAsAlpha: hexToRGB(white, 0.04),
+        hoverAsAlpha: hexToRGB(white, 0.09),
+        activeAsAlpha: hexToRGB(white, 0.26),
       },
       border: {
         default: graySemiDark,


### PR DESCRIPTION
Fixes JIRA ticket [ISW-5151](https://newyorkpubliclibrary.atlassian.net/browse/ISW-5151)

## This PR does the following:

- Adds hover state styles for "full-click" functionality in the `Card` component.
- Adds `bg` color palette options that are defined using alpha transparency (rgba).

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[ISW-5151]: https://newyorkpubliclibrary.atlassian.net/browse/ISW-5151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ