### PR TITLE
ISW-5151: final cleanup for Card hover styles

### DIFF
--- a/src/components/DevelopmentGuide/CardsAsNavigation.mdx
+++ b/src/components/DevelopmentGuide/CardsAsNavigation.mdx
@@ -176,7 +176,7 @@ distinct and full-click functionality should not be used.
     layout="column"
   >
     <CardHeading level="h4" size="heading7" url="https://nypl.org">
-      Etiam venenatis justo!
+      Etiam venenatis justo
     </CardHeading>
     <CardContent>
       Sequi id at{" "}

--- a/src/components/StyleGuide/CardsAsNavigation.tsx
+++ b/src/components/StyleGuide/CardsAsNavigation.tsx
@@ -41,7 +41,7 @@ export const distinctLinksCard = (
     layout="column"
   >
     <CardHeading level="h4" size="heading7" url="https://nypl.org">
-      Etiam venenatis justo!
+      Etiam venenatis justo
     </CardHeading>
     <CardContent>
       Sequi id at{" "}

--- a/src/theme/components/card.ts
+++ b/src/theme/components/card.ts
@@ -136,7 +136,7 @@ const ReservoirCard = defineMultiStyleConfig({
             outline: "0 solid",
             outlineColor: "ui.bg.defaultAsAlpha",
             transition:
-              "background-color ease-out outline ease-out transform ease-out",
+              "background-color ease-out, outline ease-out, transform ease-out",
             transitionDuration: "normal",
             ".chakra-heading a": {
               textDecorationColor: "transparent !important",


### PR DESCRIPTION
Fixes JIRA ticket ISW-5151

## This PR does the following:

- Fixed `transition` attribute used for the `Card` component hover styles.
- Removed errant punctuation from full-click card example.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.
