### PR TITLE
ISW-5445: RTL styles for Select arrow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Fixes
 
 - Fixed the double application of styles when a custom svg is passed into the `Icon` component.
+- Fixes the RTL styles for the dropdown arrow in the `Select` component.
 
 ## 4.1.4 (February 26, 2026)
 

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -20,7 +20,7 @@ import { changelogData } from "./selectChangelogData";
   componentName="Select"
   summary="Input element that allows a user to pick a single value from a list of related options"
   versionAdded="0.7.0"
-  versionLatest="Prerlease"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={SelectStories.WithControls} />

--- a/src/components/Select/Select.mdx
+++ b/src/components/Select/Select.mdx
@@ -20,7 +20,7 @@ import { changelogData } from "./selectChangelogData";
   componentName="Select"
   summary="Input element that allows a user to pick a single value from a list of related options"
   versionAdded="0.7.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerlease"
 />
 
 <Canvas of={SelectStories.WithControls} />

--- a/src/components/Select/selectChangelogData.ts
+++ b/src/components/Select/selectChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Fixes the RTL styles for the dropdown arrow."],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",

--- a/src/theme/components/select.ts
+++ b/src/theme/components/select.ts
@@ -79,6 +79,19 @@ const Select = defineMultiStyleConfig({
           marginLeft:
             !showLabel && labelPosition === "inline" ? "0" : `${labelWidth}px`,
         },
+        /**
+         * Overriding Chakra default styles with styles that are RTL-aware to
+         * properly position the dropdown icon.
+         *
+         * To work properly, the `right` attribute needs to be unset before the
+         * `inset-inline-end` attribute is set. Additionally, `insetInlineEnd`
+         * which should map to `inset-inline-end` actually maps to `right`,
+         * which does not solve the problem. Maybe these are bugs in Chakra.
+         * */
+        ".chakra-select__icon-wrapper": {
+          right: "unset",
+          "inset-inline-end": "var(--nypl-space-2)",
+        },
       };
     }
   ),


### PR DESCRIPTION
Fixes JIRA ticket [ISW-5445](https://newyorkpubliclibrary.atlassian.net/browse/ISW-5445)

## This PR does the following:

- Fixes the RTL styles for the dropdown arrow in the `Select` component.

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- local Storybook and unit tests

**NOTE:** Final testing should be done in Turbine with a release candidate. In Storybook, testing was completed by manually adding `dir="rtl"` to the `<body>` tag.

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

- n/a

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the Storybook documentation and changelog accordingly.
- [ ] I have added relevant accessibility documentation for this pull request.
- [ ] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[ISW-5445]: https://newyorkpubliclibrary.atlassian.net/browse/ISW-5445?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ