### PR TITLE
ISW-5652: Update Feedback Box confirmation copy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 ### Updates
 
 - Updates `iconColorsArray` to include `ui.warning.tertiary`.
+- Updates the email-specific confirmation message in the `FeedbackBox` component.
 
 ## 4.1.6 (April 2, 2026)
 

--- a/src/components/FeedbackBox/FeedbackBox.mdx
+++ b/src/components/FeedbackBox/FeedbackBox.mdx
@@ -18,7 +18,7 @@ import { changelogData } from "./feedbackBoxChangelogData";
   componentName="FeedbackBox"
   summary="Used to render and control the full NYPL website feeback experience"
   versionAdded="1.3.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={FeedbackBoxStories.WithControls} />

--- a/src/components/FeedbackBox/FeedbackBox.test.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.test.tsx
@@ -201,9 +201,7 @@ describe("FeedbackBox", () => {
       screen.getByText(/thank you for submitting your feedback/i)
     ).toBeInTheDocument();
     expect(
-      screen.queryByText(
-        /if you provided an email address and require a response/i
-      )
+      screen.queryByText(/if you asked a question and provided an email/i)
     ).not.toBeInTheDocument();
   });
 
@@ -222,9 +220,7 @@ describe("FeedbackBox", () => {
     button.click();
 
     expect(
-      screen.getByText(
-        /if you provided an email address and require a response/i
-      )
+      screen.getByText(/if you asked a question and provided an email/i)
     ).toBeInTheDocument();
   });
 

--- a/src/components/FeedbackBox/FeedbackBox.tsx
+++ b/src/components/FeedbackBox/FeedbackBox.tsx
@@ -468,9 +468,8 @@ export const FeedbackBox: ChakraComponent<
                         </Text>
                         {showEmailField && (
                           <Text mt="s">
-                            If you provided an email address and require a
-                            response, our service staff will reach out to you
-                            via email.
+                            If you asked a question and provided an email, allow
+                            us a few days to respond.
                           </Text>
                         )}
                         {confirmationText ? (

--- a/src/components/FeedbackBox/feedbackBoxChangelogData.ts
+++ b/src/components/FeedbackBox/feedbackBoxChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Styles"],
+    notes: ["Updates the email-specific confirmation message."],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",


### PR DESCRIPTION
Fixes JIRA ticket [ISW-5652](https://newyorkpubliclibrary.atlassian.net/browse/ISW-5652)

## This PR does the following:

- Updates the email-specific confirmation message to "If you asked a question and provided an email, allow us a few days to respond."

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Tested using a local build of Storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

-

### Accessibility Checklist

- [x] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [x] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [x] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [x] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [x] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

-

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[ISW-5652]: https://newyorkpubliclibrary.atlassian.net/browse/ISW-5652?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ