### PR TITLE
DSD-1756: Banner onClose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Currently, this repo is in Prerelease. When it is released, this project will ad
 
 ## Prerelease
 
+### Updates
+
+- Adds `onClose` prop to the `Banner` component.
+
 ## 4.2.0 (June 9, 2026)
 
 ### Adds

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -21,7 +21,7 @@ import { changelogData } from "./bannerChangelogData";
   componentName="Banner"
   summary="Provides contextual messages about page content and user actions"
   versionAdded="3.1.0"
-  versionLatest="4.0.0"
+  versionLatest="Prerelease"
 />
 
 <Canvas of={BannerStories.WithControls} />

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -265,6 +265,8 @@ order to override the predefined variants.
 A dismissible `Banner` component can be created by setting the `isDismissible`
 prop to `true`. Once the "X" close icon on the upper right is clicked, the
 `Banner` will be removed from the DOM. Therefore, it only renders once.
+If the `onClose` prop is set, it will be called as well. `onClose` will be
+ignored if the `isDismissible` prop is `false`.
 
 <Canvas of={BannerStories.Dismissible} />
 

--- a/src/components/Banner/Banner.mdx
+++ b/src/components/Banner/Banner.mdx
@@ -24,7 +24,7 @@ import { changelogData } from "./bannerChangelogData";
   versionLatest="Prerelease"
 />
 
-<Canvas of={BannerStories.WithControls} />
+<Canvas of={BannerStories.WithControls} story={{ autoplay: true }} />
 
 ## Table of contents
 

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -1,5 +1,6 @@
 import { VStack } from "@chakra-ui/react";
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, expect, userEvent, screen } from "storybook/test";
 
 import Banner from "./Banner";
 
@@ -59,10 +60,8 @@ export const WithControls: Story = {
     heading: "Heading text",
     highlightColor: undefined,
     icon: undefined,
-    isDismissible: false,
-    onClose: () => {
-      console.log("custom close");
-    },
+    isDismissible: true,
+    onClose: fn(),
     variant: "neutral",
   },
   parameters: {
@@ -71,6 +70,14 @@ export const WithControls: Story = {
       url: "https://www.figma.com/file/qShodlfNCJHb8n03IFyApM/Main?type=design&node-id=86601-97661&mode=design&t=wZy1nqVOOZ4Dzuu2-11",
     },
     jest: ["Banner.test.tsx"],
+  },
+  play: async ({ args }) => {
+    const heading = screen.getByText("Heading text");
+    expect(heading).toBeInTheDocument();
+    const button = screen.getByRole("button");
+    await userEvent.click(button);
+    expect(args.onClose).toBeCalled();
+    expect(heading).not.toBeInTheDocument();
   },
   render: (args) => <Banner {...args} />,
 };

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -32,6 +32,7 @@ const meta: Meta<typeof Banner> = {
     },
     icon: { control: false },
     isDismissible: { control: { type: "boolean" } },
+    onClose: { control: false },
     variant: {
       control: { type: "select" },
       options: messageVariantsArray,
@@ -59,6 +60,9 @@ export const WithControls: Story = {
     highlightColor: undefined,
     icon: undefined,
     isDismissible: false,
+    onClose: () => {
+      console.log("custom close");
+    },
     variant: "neutral",
   },
   parameters: {
@@ -388,6 +392,9 @@ export const Dismissible: Story = {
       }
       heading="Dismissible Banner"
       isDismissible
+      onClose={() => {
+        console.log("custom close");
+      }}
       variant="neutral"
     />
   ),

--- a/src/components/Banner/Banner.stories.tsx
+++ b/src/components/Banner/Banner.stories.tsx
@@ -71,15 +71,21 @@ export const WithControls: Story = {
     },
     jest: ["Banner.test.tsx"],
   },
-  play: async ({ args }) => {
+  play: async ({ args, mount }) => {
+    // Mount the component initially
+    await mount(<Banner {...args} />);
+
     const heading = screen.getByText("Heading text");
     expect(heading).toBeInTheDocument();
-    const button = screen.getByRole("button");
+    const button = screen.getAllByRole("button")[0];
     await userEvent.click(button);
     expect(args.onClose).toBeCalled();
     expect(heading).not.toBeInTheDocument();
+
+    // Re-render the banner after tests complete for manual testing
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    await mount(<Banner {...args} isDismissible onClose={fn()} />);
   },
-  render: (args) => <Banner {...args} />,
 };
 
 // The following are additional Banner example Stories.

--- a/src/components/Banner/Banner.test.tsx
+++ b/src/components/Banner/Banner.test.tsx
@@ -44,6 +44,9 @@ describe("Banner Accessibility", () => {
         heading="Banner Heading"
         isDismissible
         id="bannerID"
+        onClose={() => {
+          console.log("custom close");
+        }}
       />
     );
     expect(await axe(container)).toHaveNoViolations();
@@ -167,6 +170,22 @@ describe("Banner", () => {
     );
   });
 
+  it("calls onClose correctly", () => {
+    const log = jest.spyOn(console, "log");
+
+    utils.rerender(
+      <Banner
+        content={<>Banner content.</>}
+        heading="Banner Heading"
+        isDismissible
+        onClose={() => console.log("custom close")}
+      />
+    );
+    const button = screen.getByRole("button");
+    button.click();
+    expect(log).toHaveBeenCalledWith("custom close");
+  });
+
   it("renders the informative Banner type", () => {
     utils.rerender(
       <Banner
@@ -282,6 +301,22 @@ describe("Banner", () => {
     );
   });
 
+  it("logs warnings when onClose is passed to a non-dismissible banner", () => {
+    const warn = jest.spyOn(console, "warn");
+
+    utils.rerender(
+      <Banner
+        content={<>Banner content.</>}
+        heading="Banner Heading"
+        onClose={() => console.log("custom close")}
+      />
+    );
+    expect(warn).toHaveBeenCalledWith(
+      "NYPL Reservoir Banner: The `onClose` prop has been passed, but the " +
+        "banner is not dismissible, so `onClose` will be ignored."
+    );
+  });
+
   it("renders the UI snapshot correctly", () => {
     const informative = renderer
       .create(
@@ -347,7 +382,14 @@ describe("Banner", () => {
       .toJSON();
     const isDismissible = renderer
       .create(
-        <Banner isDismissible id="bannerID7" content={<>Banner content.</>} />
+        <Banner
+          isDismissible
+          id="bannerID7"
+          content={<>Banner content.</>}
+          onClose={() => {
+            console.log("custom close");
+          }}
+        />
       )
       .toJSON();
     const withChakraProps = renderer

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -39,7 +39,7 @@ export interface BannerProps extends Omit<BoxProps, "content"> {
   /** Optional prop to control whether a `Banner` can be dismissed
    * (closed) by a user. */
   isDismissible?: boolean;
-  /** Function to call when the modal is closed. */
+  /** Function to call when the banner is closed. */
   onClose?: () => void;
   /** Used to control the component's semantic coloring and iconography. */
   variant?: BannerVariants;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -39,7 +39,7 @@ export interface BannerProps extends Omit<BoxProps, "content"> {
   /** Optional prop to control whether a `Banner` can be dismissed
    * (closed) by a user. */
   isDismissible?: boolean;
-  /* Function to call when the modal is closed. */
+  /** Function to call when the modal is closed. */
   onClose?: () => void;
   /** Used to control the component's semantic coloring and iconography. */
   variant?: BannerVariants;

--- a/src/components/Banner/Banner.tsx
+++ b/src/components/Banner/Banner.tsx
@@ -39,6 +39,8 @@ export interface BannerProps extends Omit<BoxProps, "content"> {
   /** Optional prop to control whether a `Banner` can be dismissed
    * (closed) by a user. */
   isDismissible?: boolean;
+  /* Function to call when the modal is closed. */
+  onClose?: () => void;
   /** Used to control the component's semantic coloring and iconography. */
   variant?: BannerVariants;
 }
@@ -92,12 +94,16 @@ export const Banner: ChakraComponent<
       icon,
       id,
       isDismissible = false,
+      onClose,
       variant = "neutral",
       ...rest
     } = props;
     const mainId = useSafeId(id);
     const [isOpen, setIsOpen] = useState(true);
-    const handleClose = () => setIsOpen(false);
+    const handleClose = () => {
+      onClose && onClose();
+      setIsOpen(false);
+    };
     const overrideVariant = !!(backgroundColor && highlightColor);
     const styles = useMultiStyleConfig("Banner", {
       // Only set the custom `backgroundColor` and `highlightColor` values
@@ -170,6 +176,11 @@ export const Banner: ChakraComponent<
           "this, the `highlightColor` prop will be ignored."
       );
     }
+    if (!isDismissible && onClose)
+      console.warn(
+        "NYPL Reservoir Banner: The `onClose` prop has been passed, but the " +
+          "banner is not dismissible, so `onClose` will be ignored."
+      );
 
     return (
       <Box

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -10,6 +10,13 @@ import { ChangelogData } from "../../utils/ComponentChangelogTable";
 
 export const changelogData: ChangelogData[] = [
   {
+    date: "Prerelease",
+    version: "Prerelease",
+    type: "Update",
+    affects: ["Functionality"],
+    notes: ["Adds `onClose` prop."],
+  },
+  {
     date: "2025-08-11",
     version: "4.0.0",
     type: "Update",

--- a/src/components/Banner/bannerChangelogData.ts
+++ b/src/components/Banner/bannerChangelogData.ts
@@ -14,7 +14,9 @@ export const changelogData: ChangelogData[] = [
     version: "Prerelease",
     type: "Update",
     affects: ["Functionality"],
-    notes: ["Adds `onClose` prop."],
+    notes: [
+      "Adds `onClose` prop (only used when `isDismissible` is set to true).",
+    ],
   },
   {
     date: "2025-08-11",


### PR DESCRIPTION
Fixes JIRA ticket [DSD-1756](https://newyorkpubliclibrary.atlassian.net/browse/DSD-1756)

## This PR does the following:

- Adds the onClose prop to the Banner component

## How has this been tested?

<!-- Please describe in detail how you tested your changes. -->

- Local build of storybook

## Accessibility concerns or updates

<!-- Describe any accessibility concerns or updates that were made that should be known. -->

### Accessibility Checklist

- [ ] Checked Storybook's "Accessibility" tab for color contrast and other issues.
- [ ] The feature works with keyboard inputs including tabbing back and forward and pressing space, enter, arrow, and esc keys.
- [ ] For hidden text or when `aria-live` is used, a screenreader was used to verify the text is read.
- [ ] For features that involve UI updates and focusing on DOM `ref`s, focus management was reviewed.
- [ ] The feature works when the page is zoomed in to 200% and 400%.

## Open Questions

<!-- Any questions you want to ask the reviewer? -->

- I added in the warning for non-dismissible banners, should that be taken out?

### Checklist:

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have updated the Storybook documentation and changelog accordingly.
- [x] I have added relevant accessibility documentation for this pull request.
- [x] All new and existing tests passed.

### Front End Review:

<!-- This step is done AFTER creating a PR. -->
<!-- Vercel creates a static Storybook preview URL once the PR is created. -->
<!-- That preview URL is added by Vercel as a comment. -->

- [ ] Review the Vercel preview deployment once it is ready.


[DSD-1756]: https://newyorkpubliclibrary.atlassian.net/browse/DSD-1756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ